### PR TITLE
get_redirect small fixes

### DIFF
--- a/common.c
+++ b/common.c
@@ -203,6 +203,11 @@ get_redirect(const char *function, ...)
 
 			if (arg_end)
 				*arg_end = '\0';
+			else {
+				// skip the newline for the last string argument
+				if (arg_start && strlen(arg_start) && arg_start[strlen(arg_start) - 1] == '\n')
+					arg_start[strlen(arg_start) - 1] = '\0';
+			}
 
 			switch (current_argument) {
 			case ARGUMENT_TYPE_INT:

--- a/sock.c
+++ b/sock.c
@@ -76,6 +76,7 @@ connect(int fd, const struct sockaddr *address, socklen_t len)
 			inet_pton(
 			  AF_INET, redirect_ip, (struct in_addr *) &redirect_addr.sa_data[2]);
 
+
 			trace_printf(
 			  1,
 			  "connect(%d, \"%hu.%hu.%hu.%hu:%u\", %zu); [redirection in effect: "
@@ -93,6 +94,10 @@ connect(int fd, const struct sockaddr *address, socklen_t len)
 			  (unsigned short) redirect_addr.sa_data[5] & 0xFF,
 			  redirect_port);
 
+            // cleanup
+            free(redirect_ip);
+            free(match_ip);
+
 			return real_connect(fd, &redirect_addr, len);
 		}
 	}
@@ -106,6 +111,10 @@ connect(int fd, const struct sockaddr *address, socklen_t len)
 		     (unsigned short) address->sa_data[5] & 0xFF,
 		     port,
 		     len);
+
+    // cleanup
+    free(redirect_ip);
+    free(match_ip);
 
 	return real_connect(fd, address, len);
 }


### PR DESCRIPTION
Two small fixes:
* free memory after strdup()
* skip newline for the last string argument