### PR TITLE
MacOS and Linux fixes

### DIFF
--- a/char.c
+++ b/char.c
@@ -32,8 +32,8 @@
 int
 RETRACE_IMPLEMENTATION(putc)(int c, FILE *stream)
 {
-	real_putc = dlsym(RTLD_NEXT, "putc");
-	real_fileno = dlsym(RTLD_NEXT, "fileno");
+	real_putc = RETRACE_GET_REAL(putc);
+	real_fileno = RETRACE_GET_REAL(fileno);
 	int fd = real_fileno(stream);
 
 	trace_printf(1, "putc(");
@@ -58,7 +58,7 @@ RETRACE_REPLACE (putc)
 int
 RETRACE_IMPLEMENTATION(toupper)(int c)
 {
-	real_toupper = dlsym(RTLD_NEXT, "toupper");
+	real_toupper = RETRACE_GET_REAL(toupper);
 	trace_printf(1, "toupper(\"%s\");\n", &c);
 	return real_toupper(c);
 }
@@ -68,7 +68,7 @@ RETRACE_REPLACE (toupper)
 int
 RETRACE_IMPLEMENTATION(tolower)(int c)
 {
-	real_tolower = dlsym(RTLD_NEXT, "tolower");
+	real_tolower = RETRACE_GET_REAL(tolower);
 	trace_printf(1, "tolower(\"%c\");\n", &c);
 	return real_tolower(c);
 }

--- a/common.c
+++ b/common.c
@@ -26,6 +26,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+#include <unistd.h>
 
 #include "common.h"
 #include "str.h"
@@ -55,7 +56,7 @@ trace_printf(int hdr, char *buf, ...)
 	if (!get_tracing_enabled())
 		return;
 
-	real_getpid = dlsym(RTLD_NEXT, "getpid");
+	int old_tracing_enabled = set_tracing_enabled(0);
 
 	char str[1024];
 
@@ -69,11 +70,13 @@ trace_printf(int hdr, char *buf, ...)
 	str[sizeof(str) - 1] = '\0';
 
 	if (hdr == 1)
-		fprintf(stderr, "(%d) ", real_getpid());
+		fprintf(stderr, "(%d) ", getpid());
 
 	fprintf(stderr, "%s", str);
 
 	va_end(arglist);
+
+	set_tracing_enabled(old_tracing_enabled);
 }
 
 void
@@ -82,10 +85,10 @@ trace_printf_str(const char *string)
 	if (!get_tracing_enabled())
 		return;
 
-	real_strlen = dlsym(RTLD_NEXT, "strlen");
+	int old_tracing_enabled = set_tracing_enabled(0);
 
 	int    i;
-	size_t len = real_strlen(string);
+	size_t len = strlen(string);
 
 	if (len > MAXLEN)
 		len = MAXLEN;
@@ -104,6 +107,8 @@ trace_printf_str(const char *string)
 
 	if (len > (MAXLEN - 1))
 		trace_printf(0, "%s[SNIP]%s", VAR, RST);
+
+	set_tracing_enabled(old_tracing_enabled);
 }
 
 int

--- a/common.h
+++ b/common.h
@@ -29,9 +29,11 @@ __attribute__((used)) static struct{ const void* replacment; const void* replace
 __attribute__ ((section ("__DATA,__interpose"))) = { (const void*)(unsigned long)&_replacment, (const void*)(unsigned long)&_replacee };
 #define RETRACE_IMPLEMENTATION(func) retrace_impl_##func
 #define RETRACE_REPLACE(func) DYLD_INTERPOSE(retrace_impl_##func, func)
+#define RETRACE_GET_REAL(func) func
 #else
 #define RETRACE_IMPLEMENTATION(func) func
 #define RETRACE_REPLACE(func)
+#define RETRACE_GET_REAL(func) dlsym(RTLD_NEXT, #func)
 #endif
 
 

--- a/env.c
+++ b/env.c
@@ -29,7 +29,7 @@
 int
 RETRACE_IMPLEMENTATION(unsetenv)(const char *name)
 {
-	real_unsetenv = dlsym(RTLD_NEXT, "unsetenv");
+	real_unsetenv = RETRACE_GET_REAL(unsetenv);
 	trace_printf(1, "unsetenv(\"%s\");\n", name);
 	return real_unsetenv(name);
 }
@@ -39,7 +39,7 @@ RETRACE_REPLACE (unsetenv)
 int
 RETRACE_IMPLEMENTATION(putenv)(char *string)
 {
-	real_putenv = dlsym(RTLD_NEXT, "putenv");
+	real_putenv = RETRACE_GET_REAL(putenv);
 	trace_printf(1, "putenv(\"%s\");\n", string);
 	return real_putenv(string);
 }
@@ -49,7 +49,7 @@ RETRACE_REPLACE (putenv)
 char *
 RETRACE_IMPLEMENTATION(getenv)(const char *envname)
 {
-	real_getenv = dlsym(RTLD_NEXT, "getenv");
+	real_getenv = RETRACE_GET_REAL(getenv);
 	char *env = real_getenv(envname);
 	trace_printf(1, "getenv(\"%s\"); [%s]\n", envname, env);
 	return real_getenv(envname);

--- a/exec.c
+++ b/exec.c
@@ -30,7 +30,7 @@
 int
 RETRACE_IMPLEMENTATION(system)(const char *command)
 {
-	real_system = dlsym(RTLD_NEXT, "system");
+	real_system = RETRACE_GET_REAL(system);
 	trace_printf(1, "system(\"%s\");\n", command);
 	return real_system(command);
 }
@@ -40,7 +40,7 @@ RETRACE_REPLACE (system)
 int
 RETRACE_IMPLEMENTATION(execve)(const char *path, char *const argv[], char *const envp[])
 {
-	real_execve = dlsym(RTLD_NEXT, "execve");
+	real_execve = RETRACE_GET_REAL(execve);
 
 	int i;
 

--- a/exit.c
+++ b/exit.c
@@ -29,7 +29,7 @@
 void
 RETRACE_IMPLEMENTATION(exit)(int status)
 {
-	real_exit = dlsym(RTLD_NEXT, "exit");
+	real_exit = RETRACE_GET_REAL(exit);
 	trace_printf(1, "exit(%s%d%s);\n", VAR, status, RST);
 	real_exit(status);
 }

--- a/file.c
+++ b/file.c
@@ -30,7 +30,7 @@
 int
 RETRACE_IMPLEMENTATION(stat)(const char *path, struct stat *buf)
 {
-	real_stat = dlsym(RTLD_NEXT, "stat");
+	real_stat = RETRACE_GET_REAL(stat);
 
 	trace_printf(1, "stat(\"%s\", \"\");\n", path);
 	return real_stat(path, buf);
@@ -41,7 +41,7 @@ RETRACE_REPLACE (stat)
 int
 RETRACE_IMPLEMENTATION(chmod)(const char *path, mode_t mode) 
 {
-	real_chmod = dlsym(RTLD_NEXT, "chmod");
+	real_chmod = RETRACE_GET_REAL(chmod);
 
 	trace_printf(1, "chmod(\"%s\", %o);\n", path, mode);
 	return real_chmod(path, mode);
@@ -52,7 +52,7 @@ RETRACE_REPLACE (chmod)
 int
 RETRACE_IMPLEMENTATION(fchmod)(int fd, mode_t mode)
 {
-	real_fchmod = dlsym(RTLD_NEXT, "fchmod");
+	real_fchmod = RETRACE_GET_REAL(fchmod);
 
 	trace_printf(1, "fchmod(%d, %o);\n", fd, mode);
 	return real_fchmod(fd, mode);
@@ -63,7 +63,7 @@ RETRACE_REPLACE (fchmod)
 int
 RETRACE_IMPLEMENTATION(fileno)(FILE *stream)
 {
-	real_fileno = dlsym(RTLD_NEXT, "fileno");
+	real_fileno = RETRACE_GET_REAL(fileno);
 	int fd = real_fileno(stream);
 
 	trace_printf(1, "fileno(%d);\n", fd);
@@ -75,8 +75,8 @@ RETRACE_REPLACE (fileno)
 int
 RETRACE_IMPLEMENTATION(fseek)(FILE *stream, long offset, int whence)
 {
-	real_fseek = dlsym(RTLD_NEXT, "fseek");
-	real_fileno = dlsym(RTLD_NEXT, "fileno");
+	real_fseek = RETRACE_GET_REAL(fseek);
+	real_fileno = RETRACE_GET_REAL(fileno);
 	int fd = real_fileno(stream);
 
 	trace_printf(1, "fseek(%d, %lx, ", fd, offset);
@@ -100,8 +100,8 @@ RETRACE_REPLACE (fseek)
 int
 RETRACE_IMPLEMENTATION(fclose)(FILE *stream)
 {
-	real_fclose = dlsym(RTLD_NEXT, "fclose");
-	real_fileno = dlsym(RTLD_NEXT, "fileno");
+	real_fclose = RETRACE_GET_REAL(fclose);
+	real_fileno = RETRACE_GET_REAL(fileno);
 	int fd = real_fileno(stream);
 
 	trace_printf(1, "fclose(%d);\n", fd);
@@ -113,8 +113,8 @@ RETRACE_REPLACE (fclose)
 FILE *
 RETRACE_IMPLEMENTATION(fopen)(const char *file, const char *mode)
 {
-	real_fopen = dlsym(RTLD_NEXT, "fopen");
-	real_fileno = dlsym(RTLD_NEXT, "fileno");
+	real_fopen = RETRACE_GET_REAL(fopen);
+	real_fileno = RETRACE_GET_REAL(fileno);
 	int fd = 0;
 
 	FILE *ret = real_fopen(file, mode);
@@ -132,7 +132,7 @@ RETRACE_REPLACE (fopen)
 DIR *
 RETRACE_IMPLEMENTATION(opendir)(const char *dirname)
 {
-	real_opendir = dlsym(RTLD_NEXT, "opendir");
+	real_opendir = RETRACE_GET_REAL(opendir);
 	trace_printf(1, "opendir(\"%s\");\n", dirname);
 	return real_opendir(dirname);
 }
@@ -142,7 +142,7 @@ RETRACE_REPLACE (opendir)
 int
 RETRACE_IMPLEMENTATION(closedir)(DIR *dirp)
 {
-	real_closedir = dlsym(RTLD_NEXT, "closedir");
+	real_closedir = RETRACE_GET_REAL(closedir);
 	trace_printf(1, "closedir();\n");
 	return real_closedir(dirp);
 }
@@ -152,7 +152,7 @@ RETRACE_REPLACE (closedir)
 int
 RETRACE_IMPLEMENTATION(close)(int fd)
 {
-	real_close = dlsym(RTLD_NEXT, "close");
+	real_close = RETRACE_GET_REAL(close);
 	trace_printf(1, "close(%d);\n", fd);
 	return real_close(fd);
 }
@@ -162,7 +162,7 @@ RETRACE_REPLACE (close)
 int
 RETRACE_IMPLEMENTATION(dup)(int oldfd)
 {
-	real_dup = dlsym(RTLD_NEXT, "dup");
+	real_dup = RETRACE_GET_REAL(dup);
 	trace_printf(1, "dup(%d)\n", oldfd);
 	return real_dup(oldfd);
 }
@@ -172,7 +172,7 @@ RETRACE_REPLACE (dup)
 int
 RETRACE_IMPLEMENTATION(dup2)(int oldfd, int newfd)
 {
-	real_dup2 = dlsym(RTLD_NEXT, "dup2");
+	real_dup2 = RETRACE_GET_REAL(dup2);
 	trace_printf(1, "dup2(%d, %d)\n", oldfd, newfd);
 	return real_dup2(oldfd, newfd);
 }

--- a/fork.c
+++ b/fork.c
@@ -31,7 +31,7 @@ RETRACE_IMPLEMENTATION(fork)(void)
 {
 	pid_t p;
 
-	real_fork = dlsym(RTLD_NEXT, "fork");
+	real_fork = RETRACE_GET_REAL(fork);
 	p = real_fork();
 	trace_printf(1, "fork(); [%d]\n", p);
 

--- a/id.c
+++ b/id.c
@@ -31,7 +31,7 @@
 int
 RETRACE_IMPLEMENTATION(setuid)(uid_t uid)
 {
-	real_setuid = dlsym(RTLD_NEXT, "setuid");
+	real_setuid = RETRACE_GET_REAL(setuid);
 	trace_printf(1, "setuid(%d);\n", uid);
 	return real_setuid(uid);
 }
@@ -41,7 +41,7 @@ RETRACE_REPLACE (setuid)
 int
 RETRACE_IMPLEMENTATION(seteuid)(uid_t uid)
 {
-	real_seteuid = dlsym(RTLD_NEXT, "seteuid");
+	real_seteuid = RETRACE_GET_REAL(seteuid);
 	trace_printf(1, "seteuid(%d);\n", uid);
 	return real_seteuid(uid);
 }
@@ -51,7 +51,7 @@ RETRACE_REPLACE (seteuid)
 int
 RETRACE_IMPLEMENTATION(setgid)(gid_t gid)
 {
-	real_setgid = dlsym(RTLD_NEXT, "setgid");
+	real_setgid = RETRACE_GET_REAL(setgid);
 	trace_printf(1, "setgid(%d);\n", gid);
 	return real_setgid(gid);
 }
@@ -61,7 +61,7 @@ RETRACE_REPLACE (setgid)
 gid_t
 RETRACE_IMPLEMENTATION(getgid)()
 {
-	real_getgid = dlsym(RTLD_NEXT, "getgid");
+	real_getgid = RETRACE_GET_REAL(getgid);
 	trace_printf(1, "getgid();\n");
 	return real_getgid();
 }
@@ -71,7 +71,7 @@ RETRACE_REPLACE (getgid)
 gid_t
 RETRACE_IMPLEMENTATION(getegid)()
 {
-	real_getegid = dlsym(RTLD_NEXT, "getegid");
+	real_getegid = RETRACE_GET_REAL(getegid);
 	trace_printf(1, "getegid();\n");
 	return real_getegid();
 }
@@ -88,7 +88,7 @@ RETRACE_IMPLEMENTATION(getuid)()
 		return redirect_id;
 	}
 
-	real_getuid = dlsym(RTLD_NEXT, "getuid");
+	real_getuid = RETRACE_GET_REAL(getuid);
 	trace_printf(1, "getuid();\n");
 	return real_getuid();
 }
@@ -105,7 +105,7 @@ RETRACE_IMPLEMENTATION(geteuid)()
 		return redirect_id;
 	}
 
-	real_geteuid = dlsym(RTLD_NEXT, "geteuid");
+	real_geteuid = RETRACE_GET_REAL(geteuid);
 	trace_printf(1, "geteuid();\n");
 	return real_geteuid();
 }
@@ -115,7 +115,7 @@ RETRACE_REPLACE (geteuid)
 pid_t
 RETRACE_IMPLEMENTATION(getpid)(void)
 {
-	real_getpid = dlsym(RTLD_NEXT, "getpid");
+	real_getpid = RETRACE_GET_REAL(getpid);
 	trace_printf(1, "getpid();\n");
 	return real_getpid();
 }
@@ -125,7 +125,7 @@ RETRACE_REPLACE (getpid)
 pid_t
 RETRACE_IMPLEMENTATION(getppid)(void)
 {
-	real_getppid = dlsym(RTLD_NEXT, "getppid");
+	real_getppid = RETRACE_GET_REAL(getppid);
 	trace_printf(1, "getppid(); [%d]\n", real_getppid());
 	return real_getppid();
 }

--- a/malloc.c
+++ b/malloc.c
@@ -29,7 +29,7 @@
 void
 RETRACE_IMPLEMENTATION(free)(void *mem)
 {
-	real_free = dlsym(RTLD_NEXT, "free");
+	real_free = RETRACE_GET_REAL(free);
 	trace_printf(1, "free(%p);\n", mem);
 	real_free(mem);
 }
@@ -41,7 +41,7 @@ RETRACE_IMPLEMENTATION(malloc)(size_t bytes)
 {
 	void *p;
 
-	real_malloc = dlsym(RTLD_NEXT, "malloc");
+	real_malloc = RETRACE_GET_REAL(malloc);
 	p = real_malloc(bytes);
 	trace_printf(1, "malloc(%d); [%p]\n", bytes, p);
 

--- a/perror.c
+++ b/perror.c
@@ -29,7 +29,7 @@
 void
 RETRACE_IMPLEMENTATION(perror)(const char *s)
 {
-	real_perror = dlsym(RTLD_NEXT, "perror");
+	real_perror = RETRACE_GET_REAL(perror);
 	trace_printf(1, "perror(\"%s\");\n", s);
 	return real_perror(s);
 }

--- a/pipe.c
+++ b/pipe.c
@@ -34,7 +34,7 @@ RETRACE_IMPLEMENTATION(pipe)(int pipefd[2])
 {
 	int ret;
 
-	real_pipe = dlsym(RTLD_NEXT, "pipe");
+	real_pipe = RETRACE_GET_REAL(pipe);
 	ret = real_pipe(pipefd);
 	trace_printf(1, "pipe(%p); [%d]\n", (void *) pipefd, ret);
 
@@ -50,7 +50,7 @@ RETRACE_IMPLEMENTATION(pipe2)(int pipefd[2], int flags)
 {
 	int ret;
 
-	real_pipe2 = dlsym(RTLD_NEXT, "pipe2");
+	real_pipe2 = RETRACE_GET_REAL(pipe2);
 	ret = real_pipe2(pipefd, flags);
 	trace_printf(1, "pipe2(%p, %d); [%d]\n", (void *) pipefd, flags, ret);
 

--- a/popen.c
+++ b/popen.c
@@ -32,8 +32,8 @@ RETRACE_IMPLEMENTATION(popen)(const char *command, const char *type)
 {
 	FILE *ret;
 
-	real_popen = dlsym(RTLD_NEXT, "popen");
-	real_fileno = dlsym(RTLD_NEXT, "fileno");
+	real_popen = RETRACE_GET_REAL(popen);
+	real_fileno = RETRACE_GET_REAL(fileno);
 
 	ret = real_popen(command, type);
 	trace_printf(1, "popen(\"%s\", \"%s\"); [%d]\n", command, type, real_fileno(ret));
@@ -48,8 +48,8 @@ RETRACE_IMPLEMENTATION(pclose)(FILE *stream)
 {
 	int ret;
 
-	real_pclose = dlsym(RTLD_NEXT, "pclose");
-	real_fileno = dlsym(RTLD_NEXT, "fileno");
+	real_pclose = RETRACE_GET_REAL(pclose);
+	real_fileno = RETRACE_GET_REAL(fileno);
 
 	ret = real_pclose(stream);
 	trace_printf(1, "pclose(%d); [%d]\n", real_fileno(stream), ret);

--- a/read.c
+++ b/read.c
@@ -31,7 +31,7 @@ RETRACE_IMPLEMENTATION(read)(int fd, void *buf, size_t nbytes)
 {
 	ssize_t ret;
 
-	real_read = dlsym(RTLD_NEXT, "read");
+	real_read = RETRACE_GET_REAL(read);
 	ret = real_read(fd, buf, nbytes);
 	trace_printf(1, "read(%d, %p, %d); [%d]\n", fd, buf, nbytes, ret);
 

--- a/sock.c
+++ b/sock.c
@@ -38,7 +38,7 @@ RETRACE_IMPLEMENTATION(connect)(int fd, const struct sockaddr *address, socklen_
 	int redirect_port;
 	unsigned short port = ntohs(*(unsigned short *)&address->sa_data[0]);
 
-	real_connect = dlsym(RTLD_NEXT, "connect");
+	real_connect = RETRACE_GET_REAL(connect);
 
 	// Only implemented for IPv4 right now
 	if (get_tracing_enabled() && address->sa_family == AF_INET &&
@@ -123,7 +123,7 @@ RETRACE_REPLACE(connect)
 int
 RETRACE_IMPLEMENTATION(bind)(int fd, const struct sockaddr *address, socklen_t len)
 {
-	real_bind = dlsym(RTLD_NEXT, "bind");
+	real_bind = RETRACE_GET_REAL(bind);
 
 	trace_printf(1,
 		     "bind(%d, \"%hu.%hu.%hu.%hu:%hu\", %zu);\n",
@@ -143,7 +143,7 @@ RETRACE_REPLACE(bind)
 int
 RETRACE_IMPLEMENTATION(accept)(int fd, struct sockaddr *address, socklen_t *len)
 {
-	real_accept = dlsym(RTLD_NEXT, "accept");
+	real_accept = RETRACE_GET_REAL(accept);
 	trace_printf(1,
 		     "accept(%d, \"%hu.%hu.%hu.%hu:%hu\", %zu);\n",
 		     fd,
@@ -162,7 +162,7 @@ RETRACE_REPLACE(accept)
 int
 RETRACE_IMPLEMENTATION(atoi)(const char *str)
 {
-	real_atoi = dlsym(RTLD_NEXT, "atoi");
+	real_atoi = RETRACE_GET_REAL(atoi);
 	trace_printf(1, "atoi(%s);\n", str);
 	return real_atoi(str);
 }

--- a/str.c
+++ b/str.c
@@ -30,7 +30,7 @@
 char *
 RETRACE_IMPLEMENTATION(strstr)(const char *s1, const char *s2)
 {
-	real_strstr = dlsym(RTLD_NEXT, "strstr");
+	real_strstr = RETRACE_GET_REAL(strstr);
 
 	trace_printf(1, "strstr(\"");
 	trace_printf_str(s1);
@@ -46,7 +46,7 @@ RETRACE_REPLACE (strstr)
 size_t
 RETRACE_IMPLEMENTATION(strlen)(const char *s)
 {
-	real_strlen = dlsym(RTLD_NEXT, "strlen");
+	real_strlen = RETRACE_GET_REAL(strlen);
 
 	size_t len = real_strlen(s);
 
@@ -62,7 +62,7 @@ RETRACE_REPLACE (strlen)
 int
 RETRACE_IMPLEMENTATION(strncmp)(const char *s1, const char *s2, size_t n)
 {
-	real_strncmp = dlsym(RTLD_NEXT, "strncmp");
+	real_strncmp = RETRACE_GET_REAL(strncmp);
 
 	trace_printf(1, "strncmp(\"");
 	trace_printf_str(s1);
@@ -70,7 +70,7 @@ RETRACE_IMPLEMENTATION(strncmp)(const char *s1, const char *s2, size_t n)
 	trace_printf_str(s2);
 	trace_printf(0, "\", %zu);\n", n);
 
-	return real_strncmp(s1, s2, n);
+	return strncmp(s1, s2, n);
 }
 
 RETRACE_REPLACE (strncmp)
@@ -78,7 +78,7 @@ RETRACE_REPLACE (strncmp)
 int
 RETRACE_IMPLEMENTATION(strcmp)(const char *s1, const char *s2)
 {
-	real_strcmp = dlsym(RTLD_NEXT, "strcmp");
+	real_strcmp = RETRACE_GET_REAL(strcmp);
 
 	trace_printf(1, "strcmp(\"");
 	trace_printf_str(s1);
@@ -94,10 +94,13 @@ RETRACE_REPLACE (strcmp)
 char *
 RETRACE_IMPLEMENTATION(strncpy)(char *s1, const char *s2, size_t n)
 {
-	real_strncpy = dlsym(RTLD_NEXT, "strncpy");
-	real_strlen = dlsym(RTLD_NEXT, "strlen");
+	size_t len = 0;
 
-	size_t len = real_strlen(s2);
+	real_strncpy = RETRACE_GET_REAL(strncpy);
+	real_strlen = RETRACE_GET_REAL(strlen);
+
+	if (s2)
+		len = real_strlen(s2);
 
 	trace_printf(1, "strncpy(%p, \"", s2);
 	trace_printf_str(s2);
@@ -111,8 +114,8 @@ RETRACE_REPLACE (strncpy)
 char *
 RETRACE_IMPLEMENTATION(strcat)(char *s1, const char *s2)
 {
-	real_strcat = dlsym(RTLD_NEXT, "strcat");
-	real_strlen = dlsym(RTLD_NEXT, "strlen");
+	real_strcat = RETRACE_GET_REAL(strcat);
+	real_strlen = RETRACE_GET_REAL(strlen);
 
 	size_t len = real_strlen(s2);
 
@@ -128,8 +131,8 @@ RETRACE_REPLACE (strcat)
 char *
 RETRACE_IMPLEMENTATION(strncat)(char *s1, const char *s2, size_t n)
 {
-	real_strncat = dlsym(RTLD_NEXT, "strncat");
-	real_strlen = dlsym(RTLD_NEXT, "strlen");
+	real_strncat = RETRACE_GET_REAL(strncat);
+	real_strlen = RETRACE_GET_REAL(strlen);
 
 	size_t len = real_strlen(s2) + 1;
 
@@ -145,8 +148,8 @@ RETRACE_REPLACE (strncat)
 char *
 RETRACE_IMPLEMENTATION(strcpy)(char *s1, const char *s2)
 {
-	real_strcpy = dlsym(RTLD_NEXT, "strcpy");
-	real_strlen = dlsym(RTLD_NEXT, "strlen");
+	real_strcpy = RETRACE_GET_REAL(strcpy);
+	real_strlen = RETRACE_GET_REAL(strlen);
 
 	size_t len = real_strlen(s2);
 

--- a/str.c
+++ b/str.c
@@ -70,7 +70,7 @@ RETRACE_IMPLEMENTATION(strncmp)(const char *s1, const char *s2, size_t n)
 	trace_printf_str(s2);
 	trace_printf(0, "\", %zu);\n", n);
 
-	return strncmp(s1, s2, n);
+	return real_strncmp(s1, s2, n);
 }
 
 RETRACE_REPLACE (strncmp)

--- a/time.c
+++ b/time.c
@@ -29,7 +29,7 @@
 char *
 RETRACE_IMPLEMENTATION(ctime_r)(const time_t *timep, char *buf)
 {
-	real_ctime_r = dlsym(RTLD_NEXT, "ctime_r");
+	real_ctime_r = RETRACE_GET_REAL(ctime_r);
 	trace_printf(1, "ctime_r(\"%s\", \"%s\");\n", timep, buf);
 	return real_ctime_r(timep, buf);
 }
@@ -39,7 +39,7 @@ RETRACE_REPLACE (ctime_r)
 char *
 RETRACE_IMPLEMENTATION(ctime)(const time_t *timep)
 {
-	real_ctime = dlsym(RTLD_NEXT, "ctime");
+	real_ctime = RETRACE_GET_REAL(ctime);
 	trace_printf(1, "ctime(\"%s\");\n", timep);
 	return real_ctime(timep);
 }

--- a/write.c
+++ b/write.c
@@ -31,7 +31,7 @@ RETRACE_IMPLEMENTATION(write)(int fd, const void *buf, size_t nbytes)
 {
 	ssize_t ret;
 
-	real_write = dlsym(RTLD_NEXT, "write");
+	real_write = RETRACE_GET_REAL(write);
 	ret = real_write(fd, buf, nbytes);
 	trace_printf(1, "write(%d, %p, %d); [%d]\n", fd, buf, nbytes, ret);
 


### PR DESCRIPTION
This fixes crashes in Linux and macOS.

The biggest part of this is stop using dlsym in macOS as that is not actually needed and was leading to deadlocks.

In Linux the meat of the fix is disabling tracing when we are in the trace_printf functions to avoid loops.