### PR TITLE
Adds rtr_dlsym() to cache function ptrs

### DIFF
--- a/char.c
+++ b/char.c
@@ -32,8 +32,8 @@
 int
 RETRACE_IMPLEMENTATION(putc)(int c, FILE *stream)
 {
-	real_putc = dlsym(RTLD_NEXT, "putc");
-	real_fileno = dlsym(RTLD_NEXT, "fileno");
+	real_putc = rtr_dlsym(rtr_putc);
+	real_fileno = rtr_dlsym(rtr_fileno);
 	int fd = real_fileno(stream);
 
 	trace_printf(1, "putc(");
@@ -58,7 +58,7 @@ RETRACE_REPLACE (putc)
 int
 RETRACE_IMPLEMENTATION(toupper)(int c)
 {
-	real_toupper = dlsym(RTLD_NEXT, "toupper");
+	real_toupper = rtr_dlsym(rtr_toupper);
 	trace_printf(1, "toupper(\"%s\");\n", &c);
 	return real_toupper(c);
 }
@@ -68,7 +68,7 @@ RETRACE_REPLACE (toupper)
 int
 RETRACE_IMPLEMENTATION(tolower)(int c)
 {
-	real_tolower = dlsym(RTLD_NEXT, "tolower");
+	real_tolower = rtr_dlsym(rtr_tolower);
 	trace_printf(1, "tolower(\"%c\");\n", &c);
 	return real_tolower(c);
 }

--- a/common.c
+++ b/common.c
@@ -55,7 +55,7 @@ trace_printf(int hdr, char *buf, ...)
 	if (!get_tracing_enabled())
 		return;
 
-	real_getpid = dlsym(RTLD_NEXT, "getpid");
+	real_getpid = rtr_dlsym(rtr_getpid);
 
 	char str[1024];
 
@@ -82,7 +82,7 @@ trace_printf_str(const char *string)
 	if (!get_tracing_enabled())
 		return;
 
-	real_strlen = dlsym(RTLD_NEXT, "strlen");
+	real_strlen = rtr_dlsym(rtr_strlen);
 
 	int    i;
 	size_t len = real_strlen(string);
@@ -144,7 +144,7 @@ get_redirect(const char *function, ...)
 	// Other functions that we have replaced
 	int old_tracing_enabled = set_tracing_enabled(0);
 
-	real_fopen = dlsym(RTLD_NEXT, "fopen");
+	real_fopen = rtr_dlsym(rtr_fopen);
 
 	config_file = real_fopen("/etc/retrace.conf", "r");
 
@@ -233,4 +233,67 @@ Cleanup:
 	set_tracing_enabled(old_tracing_enabled);
 
 	return retval;
+}
+
+void *
+rtr_dlsym(rtr_func_id id)
+{
+    static void * func_ptrs[rtr_end_func];
+
+    if (func_ptrs[id] == NULL) {
+        func_ptrs[rtr_accept] = dlsym(RTLD_NEXT, "accept");
+        func_ptrs[rtr_atoi] = dlsym(RTLD_NEXT, "atoi");
+        func_ptrs[rtr_bind] = dlsym(RTLD_NEXT, "bind");
+        func_ptrs[rtr_chmod] = dlsym(RTLD_NEXT, "chmod");
+        func_ptrs[rtr_close] = dlsym(RTLD_NEXT, "close");
+        func_ptrs[rtr_closedir] = dlsym(RTLD_NEXT, "closedir");
+        func_ptrs[rtr_connect] = dlsym(RTLD_NEXT, "connect");
+        func_ptrs[rtr_ctime] = dlsym(RTLD_NEXT, "ctime");
+        func_ptrs[rtr_ctime_r] = dlsym(RTLD_NEXT, "ctime_r");
+        func_ptrs[rtr_dup2] = dlsym(RTLD_NEXT, "dup2");
+        func_ptrs[rtr_dup] = dlsym(RTLD_NEXT, "dup");
+        func_ptrs[rtr_execve] = dlsym(RTLD_NEXT, "execve");
+        func_ptrs[rtr_exit] = dlsym(RTLD_NEXT, "exit");
+        func_ptrs[rtr_fchmod] = dlsym(RTLD_NEXT, "fchmod");
+        func_ptrs[rtr_fclose] = dlsym(RTLD_NEXT, "fclose");
+        func_ptrs[rtr_fileno] = dlsym(RTLD_NEXT, "fileno");
+        func_ptrs[rtr_fopen] = dlsym(RTLD_NEXT, "fopen");
+        func_ptrs[rtr_fork] = dlsym(RTLD_NEXT, "fork");
+        func_ptrs[rtr_free] = dlsym(RTLD_NEXT, "free");
+        func_ptrs[rtr_fseek] = dlsym(RTLD_NEXT, "fseek");
+        func_ptrs[rtr_getegid] = dlsym(RTLD_NEXT, "getegid");
+        func_ptrs[rtr_getenv] = dlsym(RTLD_NEXT, "getenv");
+        func_ptrs[rtr_geteuid] = dlsym(RTLD_NEXT, "geteuid");
+        func_ptrs[rtr_getgid] = dlsym(RTLD_NEXT, "getgid");
+        func_ptrs[rtr_getpid] = dlsym(RTLD_NEXT, "getpid");
+        func_ptrs[rtr_getppid] = dlsym(RTLD_NEXT, "getppid");
+        func_ptrs[rtr_getuid] = dlsym(RTLD_NEXT, "getuid");
+        func_ptrs[rtr_malloc] = dlsym(RTLD_NEXT, "malloc");
+        func_ptrs[rtr_opendir] = dlsym(RTLD_NEXT, "opendir");
+        func_ptrs[rtr_pclose] = dlsym(RTLD_NEXT, "pclose");
+        func_ptrs[rtr_perror] = dlsym(RTLD_NEXT, "perror");
+        func_ptrs[rtr_pipe2] = dlsym(RTLD_NEXT, "pipe2");
+        func_ptrs[rtr_pipe] = dlsym(RTLD_NEXT, "pipe");
+        func_ptrs[rtr_popen] = dlsym(RTLD_NEXT, "popen");
+        func_ptrs[rtr_putenv] = dlsym(RTLD_NEXT, "putenv");
+        func_ptrs[rtr_read] = dlsym(RTLD_NEXT, "read");
+        func_ptrs[rtr_seteuid] = dlsym(RTLD_NEXT, "seteuid");
+        func_ptrs[rtr_setgid] = dlsym(RTLD_NEXT, "setgid");
+        func_ptrs[rtr_setuid] = dlsym(RTLD_NEXT, "setuid");
+        func_ptrs[rtr_stat] = dlsym(RTLD_NEXT, "stat");
+        func_ptrs[rtr_strcat] = dlsym(RTLD_NEXT, "strcat");
+        func_ptrs[rtr_strcmp] = dlsym(RTLD_NEXT, "strcmp");
+        func_ptrs[rtr_strcpy] = dlsym(RTLD_NEXT, "strcpy");
+        func_ptrs[rtr_strlen] = dlsym(RTLD_NEXT, "strlen");
+        func_ptrs[rtr_strncat] = dlsym(RTLD_NEXT, "strncat");
+        func_ptrs[rtr_strncmp] = dlsym(RTLD_NEXT, "strncmp");
+        func_ptrs[rtr_strncpy] = dlsym(RTLD_NEXT, "strncpy");
+        func_ptrs[rtr_strstr] = dlsym(RTLD_NEXT, "strstr");
+        func_ptrs[rtr_system] = dlsym(RTLD_NEXT, "system");
+        func_ptrs[rtr_tolower] = dlsym(RTLD_NEXT, "tolower");
+        func_ptrs[rtr_toupper] = dlsym(RTLD_NEXT, "toupper");
+        func_ptrs[rtr_unsetenv] = dlsym(RTLD_NEXT, "unsetenv");
+        func_ptrs[rtr_write] = dlsym(RTLD_NEXT, "write");
+    }
+    return func_ptrs[id];
 }

--- a/common.h
+++ b/common.h
@@ -34,7 +34,64 @@ __attribute__ ((section ("__DATA,__interpose"))) = { (const void*)(unsigned long
 #define RETRACE_REPLACE(func)
 #endif
 
+typedef enum {
+    rtr_accept,
+    rtr_atoi,
+    rtr_bind,
+    rtr_chmod,
+    rtr_close,
+    rtr_closedir,
+    rtr_connect,
+    rtr_ctime,
+    rtr_ctime_r,
+    rtr_dup,
+    rtr_dup2,
+    rtr_execve,
+    rtr_exit,
+    rtr_fchmod,
+    rtr_fclose,
+    rtr_fileno,
+    rtr_fopen,
+    rtr_fork,
+    rtr_free,
+    rtr_fseek,
+    rtr_getegid,
+    rtr_getenv,
+    rtr_geteuid,
+    rtr_getgid,
+    rtr_getpid,
+    rtr_getppid,
+    rtr_getuid,
+    rtr_malloc,
+    rtr_opendir,
+    rtr_pclose,
+    rtr_perror,
+    rtr_pipe,
+    rtr_pipe2,
+    rtr_popen,
+    rtr_putc,
+    rtr_putenv,
+    rtr_read,
+    rtr_seteuid,
+    rtr_setgid,
+    rtr_setuid,
+    rtr_stat,
+    rtr_strcat,
+    rtr_strcmp,
+    rtr_strcpy,
+    rtr_strlen,
+    rtr_strncat,
+    rtr_strncmp,
+    rtr_strncpy,
+    rtr_strstr,
+    rtr_system,
+    rtr_tolower,
+    rtr_toupper,
+    rtr_unsetenv,
+    rtr_write,
 
+    rtr_end_func
+} rtr_func_id;
 
 void trace_printf(int hdr, char *buf, ...);
 void trace_printf_str(const char *string);
@@ -43,5 +100,7 @@ int get_redirect(const char *function, ...);
 
 int get_tracing_enabled();
 int set_tracing_enabled(int enabled);
+
+void *rtr_dlsym(rtr_func_id id);
 
 #endif /* __RETRACE_COMMON_H__ */

--- a/env.c
+++ b/env.c
@@ -29,7 +29,7 @@
 int
 RETRACE_IMPLEMENTATION(unsetenv)(const char *name)
 {
-	real_unsetenv = dlsym(RTLD_NEXT, "unsetenv");
+	real_unsetenv = rtr_dlsym(rtr_unsetenv);
 	trace_printf(1, "unsetenv(\"%s\");\n", name);
 	return real_unsetenv(name);
 }
@@ -39,7 +39,7 @@ RETRACE_REPLACE (unsetenv)
 int
 RETRACE_IMPLEMENTATION(putenv)(char *string)
 {
-	real_putenv = dlsym(RTLD_NEXT, "putenv");
+	real_putenv = rtr_dlsym(rtr_putenv);
 	trace_printf(1, "putenv(\"%s\");\n", string);
 	return real_putenv(string);
 }
@@ -49,7 +49,7 @@ RETRACE_REPLACE (putenv)
 char *
 RETRACE_IMPLEMENTATION(getenv)(const char *envname)
 {
-	real_getenv = dlsym(RTLD_NEXT, "getenv");
+	real_getenv = rtr_dlsym(rtr_getenv);
 	char *env = real_getenv(envname);
 	trace_printf(1, "getenv(\"%s\"); [%s]\n", envname, env);
 	return real_getenv(envname);

--- a/exec.c
+++ b/exec.c
@@ -30,7 +30,7 @@
 int
 RETRACE_IMPLEMENTATION(system)(const char *command)
 {
-	real_system = dlsym(RTLD_NEXT, "system");
+	real_system = rtr_dlsym(rtr_system);
 	trace_printf(1, "system(\"%s\");\n", command);
 	return real_system(command);
 }
@@ -40,7 +40,7 @@ RETRACE_REPLACE (system)
 int
 RETRACE_IMPLEMENTATION(execve)(const char *path, char *const argv[], char *const envp[])
 {
-	real_execve = dlsym(RTLD_NEXT, "execve");
+	real_execve = rtr_dlsym(rtr_execve);
 
 	int i;
 

--- a/exit.c
+++ b/exit.c
@@ -29,7 +29,7 @@
 void
 RETRACE_IMPLEMENTATION(exit)(int status)
 {
-	real_exit = dlsym(RTLD_NEXT, "exit");
+	real_exit = rtr_dlsym(rtr_exit);
 	trace_printf(1, "exit(%s%d%s);\n", VAR, status, RST);
 	real_exit(status);
 }

--- a/file.c
+++ b/file.c
@@ -30,7 +30,7 @@
 int
 RETRACE_IMPLEMENTATION(stat)(const char *path, struct stat *buf)
 {
-	real_stat = dlsym(RTLD_NEXT, "stat");
+	real_stat = rtr_dlsym(rtr_stat);
 
 	trace_printf(1, "stat(\"%s\", \"\");\n", path);
 	return real_stat(path, buf);
@@ -41,7 +41,7 @@ RETRACE_REPLACE (stat)
 int
 RETRACE_IMPLEMENTATION(chmod)(const char *path, mode_t mode) 
 {
-	real_chmod = dlsym(RTLD_NEXT, "chmod");
+	real_chmod = rtr_dlsym(rtr_chmod);
 
 	trace_printf(1, "chmod(\"%s\", %o);\n", path, mode);
 	return real_chmod(path, mode);
@@ -52,7 +52,7 @@ RETRACE_REPLACE (chmod)
 int
 RETRACE_IMPLEMENTATION(fchmod)(int fd, mode_t mode)
 {
-	real_fchmod = dlsym(RTLD_NEXT, "fchmod");
+	real_fchmod = rtr_dlsym(rtr_fchmod);
 
 	trace_printf(1, "fchmod(%d, %o);\n", fd, mode);
 	return real_fchmod(fd, mode);
@@ -63,7 +63,7 @@ RETRACE_REPLACE (fchmod)
 int
 RETRACE_IMPLEMENTATION(fileno)(FILE *stream)
 {
-	real_fileno = dlsym(RTLD_NEXT, "fileno");
+	real_fileno = rtr_dlsym(rtr_fileno);
 	int fd = real_fileno(stream);
 
 	trace_printf(1, "fileno(%d);\n", fd);
@@ -75,8 +75,8 @@ RETRACE_REPLACE (fileno)
 int
 RETRACE_IMPLEMENTATION(fseek)(FILE *stream, long offset, int whence)
 {
-	real_fseek = dlsym(RTLD_NEXT, "fseek");
-	real_fileno = dlsym(RTLD_NEXT, "fileno");
+	real_fseek = rtr_dlsym(rtr_fseek);
+	real_fileno = rtr_dlsym(rtr_fileno);
 	int fd = real_fileno(stream);
 
 	trace_printf(1, "fseek(%d, %lx, ", fd, offset);
@@ -100,8 +100,8 @@ RETRACE_REPLACE (fseek)
 int
 RETRACE_IMPLEMENTATION(fclose)(FILE *stream)
 {
-	real_fclose = dlsym(RTLD_NEXT, "fclose");
-	real_fileno = dlsym(RTLD_NEXT, "fileno");
+	real_fclose = rtr_dlsym(rtr_fclose);
+	real_fileno = rtr_dlsym(rtr_fileno);
 	int fd = real_fileno(stream);
 
 	trace_printf(1, "fclose(%d);\n", fd);
@@ -113,8 +113,8 @@ RETRACE_REPLACE (fclose)
 FILE *
 RETRACE_IMPLEMENTATION(fopen)(const char *file, const char *mode)
 {
-	real_fopen = dlsym(RTLD_NEXT, "fopen");
-	real_fileno = dlsym(RTLD_NEXT, "fileno");
+	real_fopen = rtr_dlsym(rtr_fopen);
+	real_fileno = rtr_dlsym(rtr_fileno);
 	int fd = 0;
 
 	FILE *ret = real_fopen(file, mode);
@@ -132,7 +132,7 @@ RETRACE_REPLACE (fopen)
 DIR *
 RETRACE_IMPLEMENTATION(opendir)(const char *dirname)
 {
-	real_opendir = dlsym(RTLD_NEXT, "opendir");
+	real_opendir = rtr_dlsym(rtr_opendir);
 	trace_printf(1, "opendir(\"%s\");\n", dirname);
 	return real_opendir(dirname);
 }
@@ -142,7 +142,7 @@ RETRACE_REPLACE (opendir)
 int
 RETRACE_IMPLEMENTATION(closedir)(DIR *dirp)
 {
-	real_closedir = dlsym(RTLD_NEXT, "closedir");
+	real_closedir = rtr_dlsym(rtr_closedir);
 	trace_printf(1, "closedir();\n");
 	return real_closedir(dirp);
 }
@@ -152,7 +152,7 @@ RETRACE_REPLACE (closedir)
 int
 RETRACE_IMPLEMENTATION(close)(int fd)
 {
-	real_close = dlsym(RTLD_NEXT, "close");
+	real_close = rtr_dlsym(rtr_close);
 	trace_printf(1, "close(%d);\n", fd);
 	return real_close(fd);
 }
@@ -162,7 +162,7 @@ RETRACE_REPLACE (close)
 int
 RETRACE_IMPLEMENTATION(dup)(int oldfd)
 {
-	real_dup = dlsym(RTLD_NEXT, "dup");
+	real_dup = rtr_dlsym(rtr_dup);
 	trace_printf(1, "dup(%d)\n", oldfd);
 	return real_dup(oldfd);
 }
@@ -172,7 +172,7 @@ RETRACE_REPLACE (dup)
 int
 RETRACE_IMPLEMENTATION(dup2)(int oldfd, int newfd)
 {
-	real_dup2 = dlsym(RTLD_NEXT, "dup2");
+	real_dup2 = rtr_dlsym(rtr_dup2);
 	trace_printf(1, "dup2(%d, %d)\n", oldfd, newfd);
 	return real_dup2(oldfd, newfd);
 }

--- a/fork.c
+++ b/fork.c
@@ -31,7 +31,7 @@ RETRACE_IMPLEMENTATION(fork)(void)
 {
 	pid_t p;
 
-	real_fork = dlsym(RTLD_NEXT, "fork");
+	real_fork = rtr_dlsym(rtr_fork);
 	p = real_fork();
 	trace_printf(1, "fork(); [%d]\n", p);
 

--- a/id.c
+++ b/id.c
@@ -31,7 +31,7 @@
 int
 RETRACE_IMPLEMENTATION(setuid)(uid_t uid)
 {
-	real_setuid = dlsym(RTLD_NEXT, "setuid");
+	real_setuid = rtr_dlsym(rtr_setuid);
 	trace_printf(1, "setuid(%d);\n", uid);
 	return real_setuid(uid);
 }
@@ -41,7 +41,7 @@ RETRACE_REPLACE (setuid)
 int
 RETRACE_IMPLEMENTATION(seteuid)(uid_t uid)
 {
-	real_seteuid = dlsym(RTLD_NEXT, "seteuid");
+	real_seteuid = rtr_dlsym(rtr_seteuid);
 	trace_printf(1, "seteuid(%d);\n", uid);
 	return real_seteuid(uid);
 }
@@ -51,7 +51,7 @@ RETRACE_REPLACE (seteuid)
 int
 RETRACE_IMPLEMENTATION(setgid)(gid_t gid)
 {
-	real_setgid = dlsym(RTLD_NEXT, "setgid");
+	real_setgid = rtr_dlsym(rtr_setgid);
 	trace_printf(1, "setgid(%d);\n", gid);
 	return real_setgid(gid);
 }
@@ -61,7 +61,7 @@ RETRACE_REPLACE (setgid)
 gid_t
 RETRACE_IMPLEMENTATION(getgid)()
 {
-	real_getgid = dlsym(RTLD_NEXT, "getgid");
+	real_getgid = rtr_dlsym(rtr_getgid);
 	trace_printf(1, "getgid();\n");
 	return real_getgid();
 }
@@ -71,7 +71,7 @@ RETRACE_REPLACE (getgid)
 gid_t
 RETRACE_IMPLEMENTATION(getegid)()
 {
-	real_getegid = dlsym(RTLD_NEXT, "getegid");
+	real_getegid = rtr_dlsym(rtr_getegid);
 	trace_printf(1, "getegid();\n");
 	return real_getegid();
 }
@@ -88,7 +88,7 @@ RETRACE_IMPLEMENTATION(getuid)()
 		return redirect_id;
 	}
 
-	real_getuid = dlsym(RTLD_NEXT, "getuid");
+	real_getuid = rtr_dlsym(rtr_getuid);
 	trace_printf(1, "getuid();\n");
 	return real_getuid();
 }
@@ -105,7 +105,7 @@ RETRACE_IMPLEMENTATION(geteuid)()
 		return redirect_id;
 	}
 
-	real_geteuid = dlsym(RTLD_NEXT, "geteuid");
+	real_geteuid = rtr_dlsym(rtr_geteuid);
 	trace_printf(1, "geteuid();\n");
 	return real_geteuid();
 }
@@ -115,7 +115,7 @@ RETRACE_REPLACE (geteuid)
 pid_t
 RETRACE_IMPLEMENTATION(getpid)(void)
 {
-	real_getpid = dlsym(RTLD_NEXT, "getpid");
+	real_getpid = rtr_dlsym(rtr_getpid);
 	trace_printf(1, "getpid();\n");
 	return real_getpid();
 }
@@ -125,7 +125,7 @@ RETRACE_REPLACE (getpid)
 pid_t
 RETRACE_IMPLEMENTATION(getppid)(void)
 {
-	real_getppid = dlsym(RTLD_NEXT, "getppid");
+	real_getppid = rtr_dlsym(rtr_getppid);
 	trace_printf(1, "getppid(); [%d]\n", real_getppid());
 	return real_getppid();
 }

--- a/malloc.c
+++ b/malloc.c
@@ -29,7 +29,7 @@
 void
 RETRACE_IMPLEMENTATION(free)(void *mem)
 {
-	real_free = dlsym(RTLD_NEXT, "free");
+	real_free = rtr_dlsym(rtr_free);
 	trace_printf(1, "free(%p);\n", mem);
 	real_free(mem);
 }
@@ -41,7 +41,7 @@ RETRACE_IMPLEMENTATION(malloc)(size_t bytes)
 {
 	void *p;
 
-	real_malloc = dlsym(RTLD_NEXT, "malloc");
+	real_malloc = rtr_dlsym(rtr_malloc);
 	p = real_malloc(bytes);
 	trace_printf(1, "malloc(%d); [%p]\n", bytes, p);
 

--- a/perror.c
+++ b/perror.c
@@ -29,7 +29,7 @@
 void
 RETRACE_IMPLEMENTATION(perror)(const char *s)
 {
-	real_perror = dlsym(RTLD_NEXT, "perror");
+	real_perror = rtr_dlsym(rtr_perror);
 	trace_printf(1, "perror(\"%s\");\n", s);
 	return real_perror(s);
 }

--- a/pipe.c
+++ b/pipe.c
@@ -34,7 +34,7 @@ RETRACE_IMPLEMENTATION(pipe)(int pipefd[2])
 {
 	int ret;
 
-	real_pipe = dlsym(RTLD_NEXT, "pipe");
+	real_pipe = rtr_dlsym(rtr_pipe);
 	ret = real_pipe(pipefd);
 	trace_printf(1, "pipe(%p); [%d]\n", (void *) pipefd, ret);
 
@@ -50,7 +50,7 @@ RETRACE_IMPLEMENTATION(pipe2)(int pipefd[2], int flags)
 {
 	int ret;
 
-	real_pipe2 = dlsym(RTLD_NEXT, "pipe2");
+	real_pipe2 = rtr_dlsym(rtr_pipe2);
 	ret = real_pipe2(pipefd, flags);
 	trace_printf(1, "pipe2(%p, %d); [%d]\n", (void *) pipefd, flags, ret);
 

--- a/popen.c
+++ b/popen.c
@@ -32,8 +32,8 @@ RETRACE_IMPLEMENTATION(popen)(const char *command, const char *type)
 {
 	FILE *ret;
 
-	real_popen = dlsym(RTLD_NEXT, "popen");
-	real_fileno = dlsym(RTLD_NEXT, "fileno");
+	real_popen = rtr_dlsym(rtr_popen);
+	real_fileno = rtr_dlsym(rtr_fileno);
 
 	ret = real_popen(command, type);
 	trace_printf(1, "popen(\"%s\", \"%s\"); [%d]\n", command, type, real_fileno(ret));
@@ -48,8 +48,8 @@ RETRACE_IMPLEMENTATION(pclose)(FILE *stream)
 {
 	int ret;
 
-	real_pclose = dlsym(RTLD_NEXT, "pclose");
-	real_fileno = dlsym(RTLD_NEXT, "fileno");
+	real_pclose = rtr_dlsym(rtr_pclose);
+	real_fileno = rtr_dlsym(rtr_fileno);
 
 	ret = real_pclose(stream);
 	trace_printf(1, "pclose(%d); [%d]\n", real_fileno(stream), ret);

--- a/read.c
+++ b/read.c
@@ -31,7 +31,7 @@ RETRACE_IMPLEMENTATION(read)(int fd, void *buf, size_t nbytes)
 {
 	ssize_t ret;
 
-	real_read = dlsym(RTLD_NEXT, "read");
+	real_read = rtr_dlsym(rtr_read);
 	ret = real_read(fd, buf, nbytes);
 	trace_printf(1, "read(%d, %p, %d); [%d]\n", fd, buf, nbytes, ret);
 

--- a/sock.c
+++ b/sock.c
@@ -38,7 +38,7 @@ RETRACE_IMPLEMENTATION(connect)(int fd, const struct sockaddr *address, socklen_
 	int redirect_port;
 	unsigned short port = ntohs(*(unsigned short *)&address->sa_data[0]);
 
-	real_connect = dlsym(RTLD_NEXT, "connect");
+	real_connect = rtr_dlsym(rtr_connect);
 
 	// Only implemented for IPv4 right now
 	if (get_tracing_enabled() && address->sa_family == AF_INET &&
@@ -123,7 +123,7 @@ RETRACE_REPLACE(connect)
 int
 RETRACE_IMPLEMENTATION(bind)(int fd, const struct sockaddr *address, socklen_t len)
 {
-	real_bind = dlsym(RTLD_NEXT, "bind");
+	real_bind = rtr_dlsym(rtr_bind);
 
 	trace_printf(1,
 		     "bind(%d, \"%hu.%hu.%hu.%hu:%hu\", %zu);\n",
@@ -143,7 +143,7 @@ RETRACE_REPLACE(bind)
 int
 RETRACE_IMPLEMENTATION(accept)(int fd, struct sockaddr *address, socklen_t *len)
 {
-	real_accept = dlsym(RTLD_NEXT, "accept");
+	real_accept = rtr_dlsym(rtr_accept);
 	trace_printf(1,
 		     "accept(%d, \"%hu.%hu.%hu.%hu:%hu\", %zu);\n",
 		     fd,
@@ -162,7 +162,7 @@ RETRACE_REPLACE(accept)
 int
 RETRACE_IMPLEMENTATION(atoi)(const char *str)
 {
-	real_atoi = dlsym(RTLD_NEXT, "atoi");
+	real_atoi = rtr_dlsym(rtr_atoi);
 	trace_printf(1, "atoi(%s);\n", str);
 	return real_atoi(str);
 }

--- a/str.c
+++ b/str.c
@@ -30,7 +30,7 @@
 char *
 RETRACE_IMPLEMENTATION(strstr)(const char *s1, const char *s2)
 {
-	real_strstr = dlsym(RTLD_NEXT, "strstr");
+	real_strstr = rtr_dlsym(rtr_strstr);
 
 	trace_printf(1, "strstr(\"");
 	trace_printf_str(s1);
@@ -46,7 +46,7 @@ RETRACE_REPLACE (strstr)
 size_t
 RETRACE_IMPLEMENTATION(strlen)(const char *s)
 {
-	real_strlen = dlsym(RTLD_NEXT, "strlen");
+	real_strlen = rtr_dlsym(rtr_strlen);
 
 	size_t len = real_strlen(s);
 
@@ -62,7 +62,7 @@ RETRACE_REPLACE (strlen)
 int
 RETRACE_IMPLEMENTATION(strncmp)(const char *s1, const char *s2, size_t n)
 {
-	real_strncmp = dlsym(RTLD_NEXT, "strncmp");
+	real_strncmp = rtr_dlsym(rtr_strncmp);
 
 	trace_printf(1, "strncmp(\"");
 	trace_printf_str(s1);
@@ -78,7 +78,7 @@ RETRACE_REPLACE (strncmp)
 int
 RETRACE_IMPLEMENTATION(strcmp)(const char *s1, const char *s2)
 {
-	real_strcmp = dlsym(RTLD_NEXT, "strcmp");
+	real_strcmp = rtr_dlsym(rtr_strcmp);
 
 	trace_printf(1, "strcmp(\"");
 	trace_printf_str(s1);
@@ -94,8 +94,8 @@ RETRACE_REPLACE (strcmp)
 char *
 RETRACE_IMPLEMENTATION(strncpy)(char *s1, const char *s2, size_t n)
 {
-	real_strncpy = dlsym(RTLD_NEXT, "strncpy");
-	real_strlen = dlsym(RTLD_NEXT, "strlen");
+	real_strncpy = rtr_dlsym(rtr_strncpy);
+	real_strlen = rtr_dlsym(rtr_strlen);
 
 	size_t len = real_strlen(s2);
 
@@ -111,8 +111,8 @@ RETRACE_REPLACE (strncpy)
 char *
 RETRACE_IMPLEMENTATION(strcat)(char *s1, const char *s2)
 {
-	real_strcat = dlsym(RTLD_NEXT, "strcat");
-	real_strlen = dlsym(RTLD_NEXT, "strlen");
+	real_strcat = rtr_dlsym(rtr_strcat);
+	real_strlen = rtr_dlsym(rtr_strlen);
 
 	size_t len = real_strlen(s2);
 
@@ -128,8 +128,8 @@ RETRACE_REPLACE (strcat)
 char *
 RETRACE_IMPLEMENTATION(strncat)(char *s1, const char *s2, size_t n)
 {
-	real_strncat = dlsym(RTLD_NEXT, "strncat");
-	real_strlen = dlsym(RTLD_NEXT, "strlen");
+	real_strncat = rtr_dlsym(rtr_strncat);
+	real_strlen = rtr_dlsym(rtr_strlen);
 
 	size_t len = real_strlen(s2) + 1;
 
@@ -145,8 +145,8 @@ RETRACE_REPLACE (strncat)
 char *
 RETRACE_IMPLEMENTATION(strcpy)(char *s1, const char *s2)
 {
-	real_strcpy = dlsym(RTLD_NEXT, "strcpy");
-	real_strlen = dlsym(RTLD_NEXT, "strlen");
+	real_strcpy = rtr_dlsym(rtr_strcpy);
+	real_strlen = rtr_dlsym(rtr_strlen);
 
 	size_t len = real_strlen(s2);
 

--- a/time.c
+++ b/time.c
@@ -29,7 +29,7 @@
 char *
 RETRACE_IMPLEMENTATION(ctime_r)(const time_t *timep, char *buf)
 {
-	real_ctime_r = dlsym(RTLD_NEXT, "ctime_r");
+	real_ctime_r = rtr_dlsym(rtr_ctime_r);
 	trace_printf(1, "ctime_r(\"%s\", \"%s\");\n", timep, buf);
 	return real_ctime_r(timep, buf);
 }
@@ -39,7 +39,7 @@ RETRACE_REPLACE (ctime_r)
 char *
 RETRACE_IMPLEMENTATION(ctime)(const time_t *timep)
 {
-	real_ctime = dlsym(RTLD_NEXT, "ctime");
+	real_ctime = rtr_dlsym(rtr_ctime);
 	trace_printf(1, "ctime(\"%s\");\n", timep);
 	return real_ctime(timep);
 }

--- a/write.c
+++ b/write.c
@@ -31,7 +31,7 @@ RETRACE_IMPLEMENTATION(write)(int fd, const void *buf, size_t nbytes)
 {
 	ssize_t ret;
 
-	real_write = dlsym(RTLD_NEXT, "write");
+	real_write = rtr_dlsym(rtr_write);
 	ret = real_write(fd, buf, nbytes);
 	trace_printf(1, "write(%d, %p, %d); [%d]\n", fd, buf, nbytes, ret);
 


### PR DESCRIPTION
This addresses issue #47 which should improve performance as well as avoiding infinite dlsym() loop