### PR TITLE
Add file descriptor tracking, just for connect/close right now

### DIFF
--- a/common.h
+++ b/common.h
@@ -22,6 +22,12 @@
 #define ARGUMENT_TYPE_INT (int) 1
 #define ARGUMENT_TYPE_STRING (int) 2
 
+#define FILE_DESCRIPTOR_TYPE_UNKNOW		0
+#define FILE_DESCRIPTOR_TYPE_FILE		1 // from open()
+#define FILE_DESCRIPTOR_TYPE_IPV4_CONNECT	2 // from connect()
+#define FILE_DESCRIPTOR_TYPE_IPV4_BIND		3 // from bind()
+#define FILE_DESCRIPTOR_TYPE_IPV4_ACCEPT	4 // from accept()
+
 #ifdef __APPLE__
 
 #define DYLD_INTERPOSE(_replacment,_replacee) \
@@ -34,6 +40,12 @@ __attribute__ ((section ("__DATA,__interpose"))) = { (const void*)(unsigned long
 #define RETRACE_REPLACE(func)
 #endif
 
+typedef struct {
+	int fd;
+	unsigned int type;
+	char *location; // File name or address
+	int port;
+} descriptor_info_t;
 
 
 void trace_printf(int hdr, char *buf, ...);
@@ -43,5 +55,12 @@ int get_redirect(const char *function, ...);
 
 int get_tracing_enabled();
 int set_tracing_enabled(int enabled);
+
+
+/* Descriptor tracking */
+void file_descriptor_update(int fd, unsigned int type, char *location, int port);
+descriptor_info_t *file_descriptor_get (int fd);
+void file_descriptor_remove (int fd);
+
 
 #endif /* __RETRACE_COMMON_H__ */

--- a/file.c
+++ b/file.c
@@ -153,7 +153,16 @@ int
 RETRACE_IMPLEMENTATION(close)(int fd)
 {
 	real_close = dlsym(RTLD_NEXT, "close");
-	trace_printf(1, "close(%d);\n", fd);
+
+       descriptor_info_t *di = file_descriptor_get (fd);
+
+	if (di && di->location) {
+		trace_printf(1, "close(%d) [was pointing to %s];\n", fd, di->location);
+	} else {
+		trace_printf(1, "close(%d);\n", fd);
+	}
+
+	file_descriptor_remove (fd);
 	return real_close(fd);
 }
 


### PR DESCRIPTION
Keep track of file descriptors we see so we can print detailed info about them as they are used later on.

Only implemented for connect/close right now. Once this is merged I can go ahead and add it all everywhere it makes sense.