### PR TITLE
Fix deadlocks by using an internal glibc function rathern than dlsym.

### DIFF
--- a/malloc.c
+++ b/malloc.c
@@ -55,7 +55,6 @@ void RETRACE_IMPLEMENTATION(free)(void *mem)
 
 RETRACE_REPLACE(free)
 
-#if 0
 void *RETRACE_IMPLEMENTATION(calloc)(size_t nmemb, size_t size)
 {
         void *p;
@@ -85,4 +84,3 @@ void *RETRACE_IMPLEMENTATION(realloc)(void *ptr, size_t size)
 }
 
 RETRACE_REPLACE(realloc)
-#endif

--- a/malloc.h
+++ b/malloc.h
@@ -3,15 +3,12 @@
 
 typedef void *(*rtr_malloc_t)(size_t bytes);
 typedef void (*rtr_free_t)(void *mem);
+typedef void *(*rtr_calloc_t)(size_t nmemb, size_t size);
+typedef void *(*rtr_realloc_t)();
 
 RETRACE_DECL(malloc);
 RETRACE_DECL(free);
-
-#if 0
-typedef void *(*rtr_calloc_t)(size_t nmemb, size_t size);
-typedef void *(*rtr_realloc_t)();
 RETRACE_DECL(calloc);
 RETRACE_DECL(realloc);
-#endif
 
 #endif /* __RETRACE_MALLOC_H__  */

--- a/sock.c
+++ b/sock.c
@@ -259,15 +259,17 @@ RETRACE_REPLACE(accept)
 int RETRACE_IMPLEMENTATION(setsockopt)(int fd, int level, int optname, const void *optval, socklen_t optlen)
 {
 	rtr_setsockopt_t real_setsockopt;
-	int i, ret;
+	int ret;
 
 	real_setsockopt = RETRACE_GET_REAL(setsockopt);
 
 	ret = real_setsockopt(fd, level, optname, optval, optlen);
 
 	trace_printf(1, "setsockopt(%d, %d, %d, %p) [return:%d]\n", fd, level, optname, optval, ret);
+#if 0
 	for (i = 0; i < optlen; i++)
 		trace_dump_data((unsigned char *)optval + i, sizeof(socklen_t));
+#endif
 
 	return ret;
 }
@@ -277,14 +279,14 @@ RETRACE_REPLACE(setsockopt)
 ssize_t RETRACE_IMPLEMENTATION(send)(int sockfd, const void *buf, size_t len, int flags)
 {
 	rtr_send_t real_send;
-	int i, ret;
+	int ret;
 
 	real_send = RETRACE_GET_REAL(send);
 
 	ret = real_send(sockfd, buf, len, flags);
 	trace_printf(1, "send(%d, %p, %d, %d) [return: %d]\n", sockfd, buf, len, flags, ret);
-	for (i = 0; i < len; i++)
-		trace_dump_data((unsigned char *)buf, 1);
+	if (ret > 0)
+		trace_dump_data((unsigned char *)buf, ret);
 
 	return ret;
 }
@@ -295,7 +297,7 @@ ssize_t RETRACE_IMPLEMENTATION(sendto)(int sockfd, const void *buf, size_t len, 
 		const struct sockaddr *dest_addr, socklen_t addrlen)
 {
 	rtr_sendto_t real_sendto;
-	int i, ret;
+	int ret;
 
 	struct descriptor_info *di;
 
@@ -333,8 +335,8 @@ ssize_t RETRACE_IMPLEMENTATION(sendto)(int sockfd, const void *buf, size_t len, 
 			sockfd, buf, len, flags, ret);
 
 	/* dump sending data */
-	for (i = 0; i < len; i++)
-		trace_dump_data((unsigned char *)buf, 1);
+	if (ret > 0)
+		trace_dump_data((unsigned char *)buf, ret);
 
 	return ret;
 }
@@ -344,7 +346,7 @@ RETRACE_REPLACE(sendto)
 ssize_t RETRACE_IMPLEMENTATION(sendmsg)(int sockfd, const struct msghdr *msg, int flags)
 {
 	rtr_sendmsg_t real_sendmsg;
-	int i, j, ret;
+	int i, ret;
 
 	struct descriptor_info *di;
 
@@ -362,8 +364,8 @@ ssize_t RETRACE_IMPLEMENTATION(sendmsg)(int sockfd, const struct msghdr *msg, in
 	for (i = 0; i < msg->msg_iovlen; i++) {
 		struct iovec *msg_iov = &msg->msg_iov[i];
 
-		for (j = 0; j < msg_iov->iov_len; j++)
-			trace_dump_data((unsigned char *) msg_iov->iov_base, 1);
+		if (msg_iov->iov_len > 0)
+			trace_dump_data((unsigned char *) msg_iov->iov_base, msg_iov->iov_len);
 	}
 
 	return ret;
@@ -374,14 +376,15 @@ RETRACE_REPLACE(sendmsg)
 ssize_t RETRACE_IMPLEMENTATION(recv)(int sockfd, void *buf, size_t len, int flags)
 {
 	rtr_recv_t real_recv;
-	int i, recv_len;
+	int recv_len;
 
 	real_recv = RETRACE_GET_REAL(recv);
 
 	recv_len = real_recv(sockfd, buf, len, flags);
 	trace_printf(1, "recv(%d, %p, %d, %d) [return: %d]\n", sockfd, buf, len, flags, recv_len);
-	for (i = 0; i < recv_len; i++)
-		trace_dump_data((unsigned char *)buf, 1);
+
+	if (recv_len > 0)
+		trace_dump_data((unsigned char *)buf, recv_len);
 
 	return recv_len;
 }
@@ -392,7 +395,7 @@ ssize_t RETRACE_IMPLEMENTATION(recvfrom)(int sockfd, void *buf, size_t len, int 
 	struct sockaddr *src_addr, socklen_t *addrlen)
 {
 	rtr_recvfrom_t real_recvfrom;
-	int i, recv_len;
+	int recv_len;
 
 	real_recvfrom = RETRACE_GET_REAL(recvfrom);
 
@@ -417,8 +420,8 @@ ssize_t RETRACE_IMPLEMENTATION(recvfrom)(int sockfd, void *buf, size_t len, int 
 			sockfd, buf, len, flags, recv_len);
 
 	/* dump sending data */
-	for (i = 0; i < len; i++)
-		trace_dump_data((unsigned char *)buf, 1);
+	if (recv_len > 0)
+		trace_dump_data((unsigned char *)buf, recv_len);
 
 	return recv_len;
 }
@@ -428,7 +431,7 @@ RETRACE_REPLACE(recvfrom)
 ssize_t RETRACE_IMPLEMENTATION(recvmsg)(int sockfd, struct msghdr *msg, int flags)
 {
 	rtr_recvmsg_t real_recvmsg;
-	int i, j, recv_len;
+	int i, recv_len;
 
 	real_recvmsg = RETRACE_GET_REAL(recvmsg);
 
@@ -439,8 +442,8 @@ ssize_t RETRACE_IMPLEMENTATION(recvmsg)(int sockfd, struct msghdr *msg, int flag
 	for (i = 0; i < msg->msg_iovlen; i++) {
 		struct iovec *msg_iov = &msg->msg_iov[i];
 
-		for (j = 0; j < msg_iov->iov_len; j++)
-			trace_dump_data((unsigned char *) msg_iov->iov_base, 1);
+		if (msg_iov->iov_len > 0)
+			trace_dump_data((unsigned char *) msg_iov->iov_base, msg_iov->iov_len);
 	}
 
 	return recv_len;


### PR DESCRIPTION
Restore the memory allocation functions
Fix the data dump in the sock functions