### PR TITLE
new fixup

### DIFF
--- a/char.c
+++ b/char.c
@@ -41,12 +41,7 @@ static void
 trace_putc(const char *name, int c, FILE* stream)
 {
 	static char specials[] = "\nn\rr\tt";
-	rtr_fileno_t real_fileno;
-	rtr_strchr_t real_strchr;
 	char *p;
-
-	real_fileno = RETRACE_GET_REAL(fileno);
-	real_strchr = RETRACE_GET_REAL(strchr);
 
 	p = c == '\0' ? " 0" : real_strchr(specials, c);
 
@@ -60,10 +55,11 @@ RETRACE_IMPLEMENTATION(putc)(int c, FILE *stream)
 {
 	trace_putc("putc", c, stream);
 
-	return (RETRACE_GET_REAL(putc)(c, stream));
+	return (real_putc(c, stream));
 }
 
-RETRACE_REPLACE(putc)
+RETRACE_REPLACE(putc, int, (int c, FILE *stream), (c, stream))
+
 
 #ifndef __APPLE__
 int
@@ -71,28 +67,28 @@ RETRACE_IMPLEMENTATION(_IO_putc)(int c, FILE *stream)
 {
 	trace_putc("__IO_putc", c, stream);
 
-	return (RETRACE_GET_REAL(_IO_putc)(c, stream));
+	return (real__IO_putc(c, stream));
 }
 
-RETRACE_REPLACE(_IO_putc)
+RETRACE_REPLACE(_IO_putc, int, (int c, FILE *stream), (c, stream))
+
 #endif
 
 int
 RETRACE_IMPLEMENTATION(toupper)(int c)
 {
-	rtr_toupper_t real_toupper = RETRACE_GET_REAL(toupper);
 	trace_printf(1, "toupper('%c');\n", c);
 	return (real_toupper(c));
 }
 
-RETRACE_REPLACE(toupper)
+RETRACE_REPLACE(toupper, int, (int c), (c))
+
 
 int
 RETRACE_IMPLEMENTATION(tolower)(int c)
 {
-	rtr_tolower_t real_tolower = RETRACE_GET_REAL(tolower);
 	trace_printf(1, "tolower('%c');\n", c);
 	return (real_tolower(c));
 }
 
-RETRACE_REPLACE(tolower)
+RETRACE_REPLACE(tolower, int, (int c), (c))

--- a/ci/main.sh
+++ b/ci/main.sh
@@ -28,6 +28,8 @@ CHECKPATCH_FLAGS+=" --ignore ARRAY_SIZE"
 CHECKPATCH_FLAGS+=" --ignore NAKED_SSCANF"
 CHECKPATCH_FLAGS+=" --ignore SSCANF_TO_KSTRTO"
 CHECKPATCH_FLAGS+=" --ignore EXECUTE_PERMISSIONS"
+CHECKPATCH_FLAGS+=" --ignore MULTISTATEMENT_MACRO_USE_DO_WHILE"
+CHECKPATCH_FLAGS+=" --ignore STORAGE_CLASS"
 
 # checkpatch.pl will ignore the following paths
 CHECKPATCH_IGNORE+=" checkpatch.pl.patch Makefile test/Makefile"

--- a/common.c
+++ b/common.c
@@ -195,7 +195,6 @@ trace_dump_data(const unsigned char *buf, size_t nbytes)
 	static const char fmt[] = "\t%07u\t%s | %s\n";
 	static const size_t asc_len = DUMP_LINE_SIZE + 1;
 	static const size_t hex_len = DUMP_LINE_SIZE * 2 + DUMP_LINE_SIZE/2 + 2;
-	rtr_sprintf_t real_sprintf;
 	char *hex_str, *asc_str;
 	char *hexp, *ascp;
 	size_t i;
@@ -214,7 +213,6 @@ trace_dump_data(const unsigned char *buf, size_t nbytes)
 
 	hex_str = alloca(hex_len);
 	asc_str = alloca(asc_len);
-	real_sprintf = RETRACE_GET_REAL(sprintf);
 
 	for (i = 0; i < nbytes; i++) {
 		if (i % DUMP_LINE_SIZE == 0) {
@@ -256,10 +254,6 @@ is_main_thread(void)
 #elif defined(__NetBSD__)
 	return (_lwp_self() == 1);
 #else
-	rtr_getpid_t real_getpid;
-
-	real_getpid = RETRACE_GET_REAL(getpid);
-
 	return (syscall(SYS_gettid) == real_getpid());
 #endif
 }
@@ -313,18 +307,9 @@ get_config_file()
 {
 	FILE *config_file = NULL;
 	char *file_path;
-	rtr_fopen_t real_fopen;
-	rtr_malloc_t real_malloc;
-	rtr_free_t real_free;
-	rtr_getenv_t real_getenv;
 	int olderrno;
 
 	olderrno = errno;
-
-	real_fopen	= RETRACE_GET_REAL(fopen);
-	real_malloc	= RETRACE_GET_REAL(malloc);
-	real_free	= RETRACE_GET_REAL(free);
-	real_getenv	= RETRACE_GET_REAL(getenv);
 
 	/* If we have a RETRACE_CONFIG env var, try to open the config file from there. */
 	file_path = real_getenv("RETRACE_CONFIG");
@@ -374,15 +359,6 @@ get_config() {
 	char *buf = NULL, *p;
 	size_t buflen = 0;
 	ssize_t sz;
-	rtr_free_t real_free;
-	rtr_malloc_t real_malloc;
-	rtr_strchr_t real_strchr;
-	rtr_fclose_t real_fclose;
-
-	real_free = RETRACE_GET_REAL(free);
-	real_malloc = RETRACE_GET_REAL(malloc);
-	real_strchr = RETRACE_GET_REAL(strchr);
-	real_fclose = RETRACE_GET_REAL(fclose);
 
 	if (pconfig != NULL)
 		return (SLIST_FIRST(pconfig));
@@ -448,8 +424,6 @@ rtr_parse_config(const struct config_entry **pentry,
 	char *parg;
 	void *pvar;
 	va_list arg_values;
-	rtr_strcmp_t real_strcmp;
-	rtr_strlen_t real_strlen;
 
 	/*
 	 * If we disabled tracing because we are executing some internal code,
@@ -466,9 +440,6 @@ rtr_parse_config(const struct config_entry **pentry,
 
 	if (*pentry == NULL)
 		*pentry = get_config();
-
-	real_strcmp = RETRACE_GET_REAL(strcmp);
-	real_strlen = RETRACE_GET_REAL(strlen);
 
 	/*
 	 * Advance past the types until we find the values.

--- a/dir.c
+++ b/dir.c
@@ -29,11 +29,6 @@
 DIR *RETRACE_IMPLEMENTATION(opendir)(const char *dirname)
 {
 	DIR *dirp;
-	rtr_opendir_t real_opendir;
-	rtr_dirfd_t real_dirfd;
-
-	real_opendir	= RETRACE_GET_REAL(opendir);
-	real_dirfd	= RETRACE_GET_REAL(dirfd);
 
 	dirp = real_opendir(dirname);
 
@@ -45,45 +40,33 @@ DIR *RETRACE_IMPLEMENTATION(opendir)(const char *dirname)
 	return dirp;
 }
 
-RETRACE_REPLACE(opendir)
+RETRACE_REPLACE(opendir, DIR *, (const char *dirname), (dirname))
+
 
 int RETRACE_IMPLEMENTATION(closedir)(DIR *dirp)
 {
-	rtr_closedir_t real_closedir;
-	rtr_dirfd_t real_dirfd;
-
-	real_closedir	= RETRACE_GET_REAL(closedir);
-	real_dirfd	= RETRACE_GET_REAL(dirfd);
-
 	trace_printf(1, "closedir(%d);\n", real_dirfd(dirp));
 
 	return real_closedir(dirp);
 }
 
-RETRACE_REPLACE(closedir)
+RETRACE_REPLACE(closedir, int, (DIR *dirp), (dirp))
+
 
 DIR *RETRACE_IMPLEMENTATION(fdopendir)(int fd)
 {
-	rtr_fdopendir_t real_fdopendir;
-
-	real_fdopendir = RETRACE_GET_REAL(fdopendir);
-
 	trace_printf(1, "fdopendir(%d)\n", fd);
 
 	return real_fdopendir(fd);
 }
 
-RETRACE_REPLACE(fdopendir)
+RETRACE_REPLACE(fdopendir, DIR *, (int fd), (fd))
+
 
 int RETRACE_IMPLEMENTATION(readdir_r)(DIR *dirp, struct dirent *entry, struct dirent **result)
 {
 	int dir_fd;
 	int ret;
-	rtr_readdir_r_t real_readdir_r;
-	rtr_dirfd_t real_dirfd;
-
-	real_readdir_r	= RETRACE_GET_REAL(readdir_r);
-	real_dirfd	= RETRACE_GET_REAL(dirfd);
 
 	/* get directory file descriptor */
 	dir_fd = real_dirfd(dirp);
@@ -100,17 +83,15 @@ int RETRACE_IMPLEMENTATION(readdir_r)(DIR *dirp, struct dirent *entry, struct di
 	return ret;
 }
 
-RETRACE_REPLACE(readdir_r)
+RETRACE_REPLACE(readdir_r, int,
+	(DIR *dirp, struct dirent *entry, struct dirent **result),
+	(dirp, entry, result))
+
 
 long RETRACE_IMPLEMENTATION(telldir)(DIR *dirp)
 {
 	int dir_fd;
 	long offset;
-	rtr_telldir_t real_telldir;
-	rtr_dirfd_t real_dirfd;
-
-	real_telldir	= RETRACE_GET_REAL(telldir);
-	real_dirfd	= RETRACE_GET_REAL(dirfd);
 
 	dir_fd = real_dirfd(dirp);
 	offset = real_telldir(dirp);
@@ -120,16 +101,12 @@ long RETRACE_IMPLEMENTATION(telldir)(DIR *dirp)
 	return offset;
 }
 
-RETRACE_REPLACE(telldir)
+RETRACE_REPLACE(telldir, long, (DIR *dirp), (dirp))
+
 
 void RETRACE_IMPLEMENTATION(seekdir)(DIR *dirp, long loc)
 {
 	int dir_fd;
-	rtr_seekdir_t real_seekdir;
-	rtr_dirfd_t real_dirfd;
-
-	real_seekdir	= RETRACE_GET_REAL(seekdir);
-	real_dirfd	= RETRACE_GET_REAL(dirfd);
 
 	/* get dir fd */
 	dir_fd = real_dirfd(dirp);
@@ -138,16 +115,12 @@ void RETRACE_IMPLEMENTATION(seekdir)(DIR *dirp, long loc)
 	trace_printf(1, "seekdir(%d, %ld);\n", dir_fd, loc);
 }
 
-RETRACE_REPLACE(seekdir)
+RETRACE_REPLACE(seekdir, void, (DIR *dirp, long loc), (dirp, loc))
+
 
 void RETRACE_IMPLEMENTATION(rewinddir)(DIR *dirp)
 {
 	int dir_fd;
-	rtr_rewinddir_t real_rewinddir;
-	rtr_dirfd_t real_dirfd;
-
-	real_rewinddir	= RETRACE_GET_REAL(rewinddir);
-	real_dirfd	= RETRACE_GET_REAL(dirfd);
 
 	/* get dir fd */
 	dir_fd = real_dirfd(dirp);
@@ -156,14 +129,12 @@ void RETRACE_IMPLEMENTATION(rewinddir)(DIR *dirp)
 	trace_printf(1, "rewinddir(%d);\n", dir_fd);
 }
 
-RETRACE_REPLACE(rewinddir)
+RETRACE_REPLACE(rewinddir, void, (DIR *dirp), (dirp))
+
 
 int RETRACE_IMPLEMENTATION(dirfd)(DIR *dirp)
 {
 	int dir_fd;
-	rtr_dirfd_t real_dirfd;
-
-	real_dirfd = RETRACE_GET_REAL(dirfd);
 
 	/* get dir fd */
 	dir_fd = real_dirfd(dirp);
@@ -173,4 +144,4 @@ int RETRACE_IMPLEMENTATION(dirfd)(DIR *dirp)
 	return dir_fd;
 }
 
-RETRACE_REPLACE(dirfd)
+RETRACE_REPLACE(dirfd, int, (DIR *dirp), (dirp))

--- a/dlopen.c
+++ b/dlopen.c
@@ -28,10 +28,7 @@
 
 void *RETRACE_IMPLEMENTATION(dlopen)(const char *filename, int flag)
 {
-	rtr_dlopen_t real_dlopen;
 	void *r;
-
-	real_dlopen = RETRACE_GET_REAL(dlopen);
 
 	r = real_dlopen(filename, flag);
 
@@ -40,14 +37,13 @@ void *RETRACE_IMPLEMENTATION(dlopen)(const char *filename, int flag)
 	return r;
 }
 
-RETRACE_REPLACE(dlopen)
+RETRACE_REPLACE(dlopen, void *, (const char *filename, int flag),
+	(filename, flag))
+
 
 char *RETRACE_IMPLEMENTATION(dlerror)(void)
 {
-	rtr_dlerror_t real_dlerror;
 	char *r;
-
-	real_dlerror = RETRACE_GET_REAL(dlerror);
 
 	r = real_dlerror();
 
@@ -56,16 +52,14 @@ char *RETRACE_IMPLEMENTATION(dlerror)(void)
 	return r;
 }
 
-RETRACE_REPLACE(dlerror)
+RETRACE_REPLACE(dlerror, char *, (void), ())
+
 
 #if !defined(__FreeBSD__) && !defined(__NetBSD__) && !defined(__OpenBSD__)
 #ifdef HAVE_ATOMIC_BUILTINS
 void *RETRACE_IMPLEMENTATION(dlsym)(void *handle, const char *symbol)
 {
-	rtr_dlsym_t real_dlsym;
 	void *r;
-
-	real_dlsym = RETRACE_GET_REAL(dlsym);
 
 	r = real_dlsym(handle, symbol);
 
@@ -74,16 +68,14 @@ void *RETRACE_IMPLEMENTATION(dlsym)(void *handle, const char *symbol)
 	return r;
 }
 
-RETRACE_REPLACE(dlsym)
+RETRACE_REPLACE(dlsym, void *, (void *handle, const char *symbol),
+	(handle, symbol))
 #endif
 #endif
 
 int RETRACE_IMPLEMENTATION(dlclose)(void *handle)
 {
-	rtr_dlclose_t real_dlclose;
 	int r;
-
-	real_dlclose = RETRACE_GET_REAL(dlclose);
 
 	r = real_dlclose(handle);
 
@@ -92,4 +84,4 @@ int RETRACE_IMPLEMENTATION(dlclose)(void *handle)
 	return r;
 }
 
-RETRACE_REPLACE(dlclose)
+RETRACE_REPLACE(dlclose, int, (void *handle), (handle))

--- a/env.c
+++ b/env.c
@@ -32,33 +32,24 @@
 
 int RETRACE_IMPLEMENTATION(unsetenv)(const char *name)
 {
-	rtr_unsetenv_t real_unsetenv;
-
-	real_unsetenv = RETRACE_GET_REAL(unsetenv);
-
 	trace_printf(1, "unsetenv(\"%s\");\n", name);
 
 	return real_unsetenv(name);
 }
 
-RETRACE_REPLACE(unsetenv)
+RETRACE_REPLACE(unsetenv, int, (const char *name), (name))
 
 int RETRACE_IMPLEMENTATION(putenv)(char *string)
 {
-	rtr_putenv_t real_putenv;
-
-	real_putenv = RETRACE_GET_REAL(putenv);
-
 	trace_printf(1, "putenv(\"%s\");\n", string);
 
 	return real_putenv(string);
 }
 
-RETRACE_REPLACE(putenv)
+RETRACE_REPLACE(putenv, int, (char *string), (string))
 
 char *RETRACE_IMPLEMENTATION(getenv)(const char *envname)
 {
-	rtr_getenv_t real_getenv = RETRACE_GET_REAL(getenv);
 	char *env = real_getenv(envname);
 	if (env != NULL)
 	    trace_printf(1, "getenv(\"%s\"); [\"%s\"]\n", envname, env);
@@ -67,14 +58,11 @@ char *RETRACE_IMPLEMENTATION(getenv)(const char *envname)
 	return (env);
 }
 
-RETRACE_REPLACE(getenv)
+RETRACE_REPLACE(getenv, char *, (const char *envname), (envname))
 
 int RETRACE_IMPLEMENTATION(uname)(struct utsname *buf)
 {
 	int ret;
-	rtr_uname_t real_uname;
-
-	real_uname = RETRACE_GET_REAL(uname);
 
 	ret = real_uname(buf);
 	if (ret == 0)
@@ -86,4 +74,4 @@ int RETRACE_IMPLEMENTATION(uname)(struct utsname *buf)
 	return ret;
 }
 
-RETRACE_REPLACE(uname)
+RETRACE_REPLACE(uname, int, (struct utsname *buf), (buf))

--- a/exit.c
+++ b/exit.c
@@ -28,13 +28,9 @@
 
 void RETRACE_IMPLEMENTATION(exit)(int status)
 {
-	rtr_exit_t real_exit;
-
-	real_exit = RETRACE_GET_REAL(exit);
-
 	trace_printf(1, "exit(%s%d%s);\n", VAR, status, RST);
 
 	real_exit(status);
 }
 
-RETRACE_REPLACE(exit)
+RETRACE_REPLACE(exit, void, (int status), (status))

--- a/file.c
+++ b/file.c
@@ -38,11 +38,8 @@
 
 int RETRACE_IMPLEMENTATION(stat)(const char *path, struct stat *buf)
 {
-	rtr_stat_t real_stat;
 	char perm[10];
 	int r;
-
-	real_stat = RETRACE_GET_REAL(stat);
 
 	trace_printf(1, "stat(\"%s\", buf);\n", path);
 
@@ -74,14 +71,11 @@ int RETRACE_IMPLEMENTATION(stat)(const char *path, struct stat *buf)
 	return r;
 }
 
-RETRACE_REPLACE(stat)
+RETRACE_REPLACE(stat, int, (const char *path, struct stat *buf), (path, buf))
 
 int RETRACE_IMPLEMENTATION(chmod)(const char *path, mode_t mode)
 {
-	rtr_chmod_t real_chmod;
 	char perm[10];
-
-	real_chmod = RETRACE_GET_REAL(chmod);
 
 	trace_mode(mode, perm);
 
@@ -90,14 +84,11 @@ int RETRACE_IMPLEMENTATION(chmod)(const char *path, mode_t mode)
 	return real_chmod(path, mode);
 }
 
-RETRACE_REPLACE(chmod)
+RETRACE_REPLACE(chmod, int, (const char *path, mode_t mode), (path, mode))
 
 int RETRACE_IMPLEMENTATION(fchmod)(int fd, mode_t mode)
 {
-	rtr_fchmod_t real_fchmod;
 	char perm[10];
-
-	real_fchmod = RETRACE_GET_REAL(fchmod);
 
 	trace_mode(mode, perm);
 
@@ -106,14 +97,11 @@ int RETRACE_IMPLEMENTATION(fchmod)(int fd, mode_t mode)
 	return real_fchmod(fd, mode);
 }
 
-RETRACE_REPLACE(fchmod)
+RETRACE_REPLACE(fchmod, int, (int fd, mode_t mode), (fd, mode))
 
 int RETRACE_IMPLEMENTATION(fileno)(FILE *stream)
 {
 	int fd;
-	rtr_fileno_t real_fileno;
-
-	real_fileno = RETRACE_GET_REAL(fileno);
 
 	fd = real_fileno(stream);
 
@@ -122,16 +110,11 @@ int RETRACE_IMPLEMENTATION(fileno)(FILE *stream)
 	return real_fileno(stream);
 }
 
-RETRACE_REPLACE(fileno)
+RETRACE_REPLACE(fileno, int, (FILE *stream), (stream))
 
 int RETRACE_IMPLEMENTATION(fseek)(FILE *stream, long offset, int whence)
 {
 	int fd;
-	rtr_fseek_t real_fseek;
-	rtr_fileno_t real_fileno;
-
-	real_fseek	= RETRACE_GET_REAL(fseek);
-	real_fileno	= RETRACE_GET_REAL(fileno);
 
 	fd = real_fileno(stream);
 
@@ -151,17 +134,12 @@ int RETRACE_IMPLEMENTATION(fseek)(FILE *stream, long offset, int whence)
 	return real_fseek(stream, offset, whence);
 }
 
-RETRACE_REPLACE(fseek)
+RETRACE_REPLACE(fseek, int, (FILE *stream, long offset, int whence), (stream, offset, whence))
 
 int RETRACE_IMPLEMENTATION(fclose)(FILE *stream)
 {
 	int fd;
 	struct descriptor_info *di;
-	rtr_fclose_t real_fclose;
-	rtr_fileno_t real_fileno;
-
-	real_fclose = RETRACE_GET_REAL(fclose);
-	real_fileno = RETRACE_GET_REAL(fileno);
 
 	fd = real_fileno(stream);
 
@@ -179,7 +157,7 @@ int RETRACE_IMPLEMENTATION(fclose)(FILE *stream)
 	return real_fclose(stream);
 }
 
-RETRACE_REPLACE(fclose)
+RETRACE_REPLACE(fclose, int, (FILE *stream), (stream))
 
 FILE *RETRACE_IMPLEMENTATION(fopen)(const char *file, const char *mode)
 {
@@ -188,11 +166,6 @@ FILE *RETRACE_IMPLEMENTATION(fopen)(const char *file, const char *mode)
 	char *match_file = NULL;
 	FILE *ret;
 	char *redirect_file = NULL;
-	rtr_fopen_t real_fopen;
-	rtr_strcmp_t real_strcmp;
-
-	real_fopen	= RETRACE_GET_REAL(fopen);
-	real_strcmp	= RETRACE_GET_REAL(strcmp);
 
 	if (get_tracing_enabled() && file) {
 		RTR_CONFIG_HANDLE config = NULL;
@@ -230,14 +203,11 @@ FILE *RETRACE_IMPLEMENTATION(fopen)(const char *file, const char *mode)
 	return ret;
 }
 
-RETRACE_REPLACE(fopen)
+RETRACE_REPLACE(fopen, FILE *, (const char *file, const char *mode), (file, mode))
 
 int RETRACE_IMPLEMENTATION(close)(int fd)
 {
 	struct descriptor_info *di;
-	rtr_close_t real_close;
-
-	real_close = RETRACE_GET_REAL(close);
 
 	di = file_descriptor_get(fd);
 	if (di && di->location)
@@ -250,40 +220,29 @@ int RETRACE_IMPLEMENTATION(close)(int fd)
 	return real_close(fd);
 }
 
-RETRACE_REPLACE(close)
+RETRACE_REPLACE(close, int, (int fd), (fd))
 
 int RETRACE_IMPLEMENTATION(dup)(int oldfd)
 {
-	rtr_dup_t real_dup;
-
-	real_dup = RETRACE_GET_REAL(dup);
-
 	trace_printf(1, "dup(%d)\n", oldfd);
 
 	return real_dup(oldfd);
 }
 
-RETRACE_REPLACE(dup)
+RETRACE_REPLACE(dup, int, (int oldfd), (oldfd))
 
 int RETRACE_IMPLEMENTATION(dup2)(int oldfd, int newfd)
 {
-	rtr_dup2_t real_dup2;
-
-	real_dup2 = RETRACE_GET_REAL(dup2);
-
 	trace_printf(1, "dup2(%d, %d)\n", oldfd, newfd);
 
 	return real_dup2(oldfd, newfd);
 }
 
-RETRACE_REPLACE(dup2)
+RETRACE_REPLACE(dup2, int, (int oldfd, int newfd), (oldfd, newfd))
 
 mode_t RETRACE_IMPLEMENTATION(umask)(mode_t mask)
 {
 	mode_t old_mask;
-	rtr_umask_t real_umask;
-
-	real_umask = RETRACE_GET_REAL(umask);
 
 	old_mask = real_umask(mask);
 
@@ -292,14 +251,11 @@ mode_t RETRACE_IMPLEMENTATION(umask)(mode_t mask)
 	return old_mask;
 }
 
-RETRACE_REPLACE(umask)
+RETRACE_REPLACE(umask, mode_t, (mode_t mask), (mask))
 
 int RETRACE_IMPLEMENTATION(mkfifo)(const char *pathname, mode_t mode)
 {
 	int ret;
-	rtr_mkfifo_t real_mkfifo;
-
-	real_mkfifo = RETRACE_GET_REAL(mkfifo);
 
 	ret = real_mkfifo(pathname, mode);
 
@@ -308,25 +264,41 @@ int RETRACE_IMPLEMENTATION(mkfifo)(const char *pathname, mode_t mode)
 	return ret;
 }
 
-RETRACE_REPLACE(mkfifo)
+RETRACE_REPLACE(mkfifo, int, (const char *pathname, mode_t mode), (pathname, mode))
+
+typedef int (*rtr_open_mode_t)(const char *pathname, int flags, mode_t mode);
+typedef int (*rtr_open_nomode_t)(const char *pathname, int flags);
+
+#ifdef __APPLE__
+#define MODEFLAGS O_CREAT
+#else
+#define MODEFLAGS (O_CREAT | O_TMPFILE)
+#endif
+
+static int
+open_v(const char *pathname, int flags, va_list ap)
+{
+	if (flags & MODEFLAGS)
+		return real_open(pathname, flags, va_arg(ap, int));
+	return real_open(pathname, flags);
+}
 
 int RETRACE_IMPLEMENTATION(open)(const char *pathname, int flags, ...)
 {
 	int fd;
-	mode_t mode;
-	rtr_open_t real_open;
-	va_list arglist;
+	va_list ap;
 
-	real_open = RETRACE_GET_REAL(open);
+	va_start(ap, flags);
+	fd = open_v(pathname, flags, ap);
+	va_end(ap);
 
-	va_start(arglist, flags);
-	mode = va_arg(arglist, int);
-
-	fd = real_open(pathname, flags, mode);
-
-	va_end(arglist);
-
-	trace_printf(1, "open(%s, %u, %u) [return: fd]\n", pathname, flags, mode, fd);
+	if (flags & MODEFLAGS) {
+		va_start(ap, flags);
+		trace_printf(1, "open(%s, %u, %u) [return: fd]\n", pathname,
+		    flags, va_arg(ap, int), fd);
+		va_end(ap);
+	} else
+		trace_printf(1, "open(%s, %u) [return: fd]\n", pathname, flags, fd);
 
 	if (fd > 0) {
 		file_descriptor_update(
@@ -336,18 +308,13 @@ int RETRACE_IMPLEMENTATION(open)(const char *pathname, int flags, ...)
 	return fd;
 }
 
-RETRACE_REPLACE(open)
+RETRACE_REPLACE_V(open, int, (const char *pathname, int flags, ...), flags, open_v, (pathname, flags, ap))
 
 size_t RETRACE_IMPLEMENTATION(fwrite)(const void *ptr, size_t size, size_t nmemb, FILE *stream)
 {
 	size_t i;
 	int r, fd;
 	struct descriptor_info *di = NULL;
-	rtr_fwrite_t real_fwrite;
-	rtr_fileno_t real_fileno;
-
-	real_fwrite = RETRACE_GET_REAL(fwrite);
-	real_fileno = RETRACE_GET_REAL(fileno);
 
 	r = real_fwrite(ptr, size, nmemb, stream);
 
@@ -373,17 +340,12 @@ size_t RETRACE_IMPLEMENTATION(fwrite)(const void *ptr, size_t size, size_t nmemb
 	return r;
 }
 
-RETRACE_REPLACE(fwrite)
+RETRACE_REPLACE(fwrite, size_t, (const void *ptr, size_t size, size_t nmemb, FILE *stream), (ptr, size, nmemb, stream))
 
 size_t RETRACE_IMPLEMENTATION(fread)(void *ptr, size_t size, size_t nmemb, FILE *stream)
 {
 	int i, r, fd;
 	struct descriptor_info *di = NULL;
-	rtr_fread_t real_fread;
-	rtr_fileno_t real_fileno;
-
-	real_fread	= RETRACE_GET_REAL(fread);
-	real_fileno	= RETRACE_GET_REAL(fileno);
 
 	r = real_fread(ptr, size, nmemb, stream);
 
@@ -411,18 +373,13 @@ size_t RETRACE_IMPLEMENTATION(fread)(void *ptr, size_t size, size_t nmemb, FILE 
 	return r;
 }
 
-RETRACE_REPLACE(fread)
+RETRACE_REPLACE(fread, size_t, (void *ptr, size_t size, size_t nmemb, FILE *stream), (ptr, size, nmemb, stream))
 
 int RETRACE_IMPLEMENTATION(fputc)(int c, FILE *stream)
 {
 	int fd;
 	int r;
 	struct descriptor_info *di = NULL;
-	rtr_fputc_t real_fputc;
-	rtr_fileno_t real_fileno;
-
-	real_fputc	= RETRACE_GET_REAL(fputc);
-	real_fileno	= RETRACE_GET_REAL(fileno);
 
 	r = real_fputc(c, stream);
 
@@ -445,17 +402,12 @@ int RETRACE_IMPLEMENTATION(fputc)(int c, FILE *stream)
 	return r;
 }
 
-RETRACE_REPLACE(fputc)
+RETRACE_REPLACE(fputc, int, (int c, FILE *stream), (c, stream))
 
 int RETRACE_IMPLEMENTATION(fputs)(const char *s, FILE *stream)
 {
 	int r, fd;
 	struct descriptor_info *di = NULL;
-	rtr_fputs_t real_fputs;
-	rtr_fileno_t real_fileno;
-
-	real_fputs	= RETRACE_GET_REAL(fputs);
-	real_fileno	= RETRACE_GET_REAL(fileno);
 
 	r = real_fputs(s, stream);
 
@@ -478,18 +430,13 @@ int RETRACE_IMPLEMENTATION(fputs)(const char *s, FILE *stream)
 	return r;
 }
 
-RETRACE_REPLACE(fputs)
+RETRACE_REPLACE(fputs, int, (const char *s, FILE *stream), (s, stream))
 
 int RETRACE_IMPLEMENTATION(fgetc)(FILE *stream)
 {
 	int r;
 	int fd;
 	struct descriptor_info *di = NULL;
-	rtr_fgetc_t real_fgetc;
-	rtr_fileno_t real_fileno;
-
-	real_fgetc	= RETRACE_GET_REAL(fgetc);
-	real_fileno	= RETRACE_GET_REAL(fileno);
 
 	r = real_fgetc(stream);
 
@@ -514,17 +461,13 @@ int RETRACE_IMPLEMENTATION(fgetc)(FILE *stream)
 	return r;
 }
 
-RETRACE_REPLACE(fgetc)
+RETRACE_REPLACE(fgetc, int, (FILE *stream), (stream))
 
 void RETRACE_IMPLEMENTATION(strmode)(int mode, char *bp)
 {
-	rtr_strmode_t real_strmode;
-
-	real_strmode = RETRACE_GET_REAL(strmode);
-
 	real_strmode(mode, bp);
 
 	trace_printf(1, "strmode(%d, \"%s\");\n", mode, bp);
 }
 
-RETRACE_REPLACE(strmode)
+RETRACE_REPLACE(strmode, void, (int mode, char *bp), (mode, bp))

--- a/fork.c
+++ b/fork.c
@@ -29,9 +29,6 @@
 pid_t RETRACE_IMPLEMENTATION(fork)(void)
 {
 	pid_t p;
-	rtr_fork_t real_fork;
-
-	real_fork = RETRACE_GET_REAL(fork);
 
 	p = real_fork();
 
@@ -40,4 +37,4 @@ pid_t RETRACE_IMPLEMENTATION(fork)(void)
 	return p;
 }
 
-RETRACE_REPLACE(fork)
+RETRACE_REPLACE(fork, pid_t, (void), ())

--- a/id.c
+++ b/id.c
@@ -30,49 +30,34 @@
 
 int RETRACE_IMPLEMENTATION(setuid)(uid_t uid)
 {
-	rtr_setuid_t real_setuid;
-
-	real_setuid = RETRACE_GET_REAL(setuid);
-
 	trace_printf(1, "setuid(%d);\n", uid);
 
 	return real_setuid(uid);
 }
 
-RETRACE_REPLACE(setuid)
+RETRACE_REPLACE(setuid, int, (uid_t uid), (uid))
 
 int RETRACE_IMPLEMENTATION(seteuid)(uid_t uid)
 {
-	rtr_seteuid_t real_seteuid;
-
-	real_seteuid = RETRACE_GET_REAL(seteuid);
-
 	trace_printf(1, "seteuid(%d);\n", uid);
 
 	return real_seteuid(uid);
 }
 
-RETRACE_REPLACE(seteuid)
+RETRACE_REPLACE(seteuid, int, (uid_t uid), (uid))
 
 int RETRACE_IMPLEMENTATION(setgid)(gid_t gid)
 {
-	rtr_setgid_t real_setgid;
-
-	real_setgid = RETRACE_GET_REAL(setgid);
-
 	trace_printf(1, "setgid(%d);\n", gid);
 
 	return real_setgid(gid);
 }
 
-RETRACE_REPLACE(setgid)
+RETRACE_REPLACE(setgid, int, (gid_t gid), (gid))
 
 gid_t RETRACE_IMPLEMENTATION(getgid)()
 {
 	int gid;
-	rtr_getgid_t real_getgid;
-
-	real_getgid = RETRACE_GET_REAL(getgid);
 
 	gid = real_getgid();
 
@@ -81,14 +66,11 @@ gid_t RETRACE_IMPLEMENTATION(getgid)()
 	return gid;
 }
 
-RETRACE_REPLACE(getgid)
+RETRACE_REPLACE(getgid, gid_t, (), ())
 
 gid_t RETRACE_IMPLEMENTATION(getegid)()
 {
 	int egid;
-	rtr_getegid_t real_getegid;
-
-	real_getegid = RETRACE_GET_REAL(getegid);
 
 	egid = real_getegid();
 
@@ -97,21 +79,18 @@ gid_t RETRACE_IMPLEMENTATION(getegid)()
 	return egid;
 }
 
-RETRACE_REPLACE(getegid)
+RETRACE_REPLACE(getegid, gid_t, (), ())
 
 uid_t RETRACE_IMPLEMENTATION(getuid)()
 {
 	int redirect_id;
 	int uid;
-	rtr_getuid_t real_getuid;
 
 	if (rtr_get_config_single("getuid", ARGUMENT_TYPE_INT, ARGUMENT_TYPE_END, &redirect_id)) {
 		trace_printf(1, "getuid(); [redirection in effect: '%i']\n", redirect_id);
 
 		return redirect_id;
 	}
-
-	real_getuid = RETRACE_GET_REAL(getuid);
 
 	uid = real_getuid();
 
@@ -120,21 +99,18 @@ uid_t RETRACE_IMPLEMENTATION(getuid)()
 	return uid;
 }
 
-RETRACE_REPLACE(getuid)
+RETRACE_REPLACE(getuid, uid_t, (), ())
 
 uid_t RETRACE_IMPLEMENTATION(geteuid)()
 {
 	int euid;
 	int redirect_id;
-	rtr_geteuid_t real_geteuid;
 
 	if (rtr_get_config_single("geteuid", ARGUMENT_TYPE_INT, ARGUMENT_TYPE_END, &redirect_id)) {
 		trace_printf(1, "geteuid(); [redirection in effect: '%i']\n", redirect_id);
 
 		return redirect_id;
 	}
-
-	real_geteuid = RETRACE_GET_REAL(geteuid);
 
 	euid = real_geteuid();
 
@@ -143,14 +119,11 @@ uid_t RETRACE_IMPLEMENTATION(geteuid)()
 	return euid;
 }
 
-RETRACE_REPLACE(geteuid)
+RETRACE_REPLACE(geteuid, uid_t, (), ())
 
-pid_t RETRACE_IMPLEMENTATION(getpid)(void)
+pid_t RETRACE_IMPLEMENTATION(getpid)()
 {
 	int pid;
-	rtr_getpid_t real_getpid;
-
-	real_getpid = RETRACE_GET_REAL(getpid);
 
 	pid = real_getpid();
 
@@ -159,14 +132,11 @@ pid_t RETRACE_IMPLEMENTATION(getpid)(void)
 	return pid;
 }
 
-RETRACE_REPLACE(getpid)
+RETRACE_REPLACE(getpid, pid_t, (), ())
 
-pid_t RETRACE_IMPLEMENTATION(getppid)(void)
+pid_t RETRACE_IMPLEMENTATION(getppid)()
 {
 	int ppid;
-	rtr_getppid_t real_getppid;
-
-	real_getppid = RETRACE_GET_REAL(getppid);
 
 	ppid = real_getppid();
 
@@ -175,4 +145,4 @@ pid_t RETRACE_IMPLEMENTATION(getppid)(void)
 	return ppid;
 }
 
-RETRACE_REPLACE(getppid)
+RETRACE_REPLACE(getppid, pid_t, (), ())

--- a/malloc.c
+++ b/malloc.c
@@ -33,10 +33,7 @@ static int init_rand = 0;
 void *RETRACE_IMPLEMENTATION(malloc)(size_t bytes)
 {
         void *p;
-        rtr_malloc_t real_malloc;
 	double fail_chance = 0;
-
-        real_malloc = RETRACE_GET_REAL(malloc);
 
 	if (rtr_get_config_single("memoryfuzzing", ARGUMENT_TYPE_DOUBLE, ARGUMENT_TYPE_END, &fail_chance)) {
 		long int random_value;
@@ -62,28 +59,21 @@ void *RETRACE_IMPLEMENTATION(malloc)(size_t bytes)
         return p;
 }
 
-RETRACE_REPLACE(malloc)
+RETRACE_REPLACE(malloc, void *, (size_t bytes), (bytes))
 
 void RETRACE_IMPLEMENTATION(free)(void *mem)
 {
-	rtr_free_t real_free;
-
-	real_free = RETRACE_GET_REAL(free);
-
 	trace_printf(1, "free(%p);\n", mem);
 
 	real_free(mem);
 }
 
-RETRACE_REPLACE(free)
+RETRACE_REPLACE(free, void, (void *mem), (mem))
 
 void *RETRACE_IMPLEMENTATION(calloc)(size_t nmemb, size_t size)
 {
         void *p;
-        rtr_calloc_t real_calloc;
 	double fail_chance = 0;
-
-        real_calloc = RETRACE_GET_REAL(calloc);
 
 	if (rtr_get_config_single("memoryfuzzing", ARGUMENT_TYPE_DOUBLE, ARGUMENT_TYPE_END, &fail_chance)) {
 		long int random_value;
@@ -109,15 +99,12 @@ void *RETRACE_IMPLEMENTATION(calloc)(size_t nmemb, size_t size)
         return p;
 }
 
-RETRACE_REPLACE(calloc)
+RETRACE_REPLACE(calloc, void *, (size_t nmemb, size_t size), (nmemb, size))
 
 void *RETRACE_IMPLEMENTATION(realloc)(void *ptr, size_t size)
 {
         void *p;
-        rtr_realloc_t real_realloc;
 	double fail_chance;
-
-        real_realloc = RETRACE_GET_REAL(realloc);
 
 	if (size > 0 && rtr_get_config_single("memoryfuzzing", ARGUMENT_TYPE_DOUBLE, ARGUMENT_TYPE_END, &fail_chance)) {
 		long int random_value;
@@ -144,4 +131,4 @@ void *RETRACE_IMPLEMENTATION(realloc)(void *ptr, size_t size)
         return p;
 }
 
-RETRACE_REPLACE(realloc)
+RETRACE_REPLACE(realloc, void *, (void *ptr, size_t size), (ptr, size))

--- a/perror.c
+++ b/perror.c
@@ -28,13 +28,9 @@
 
 void RETRACE_IMPLEMENTATION(perror)(const char *s)
 {
-	rtr_perror_t real_perror;
-
-	real_perror = RETRACE_GET_REAL(perror);
-
 	trace_printf(1, "perror(\"%s\");\n", s);
 
 	real_perror(s);
 }
 
-RETRACE_REPLACE(perror)
+RETRACE_REPLACE(perror, void, (const char *s), (s))

--- a/pipe.c
+++ b/pipe.c
@@ -31,9 +31,6 @@
 int RETRACE_IMPLEMENTATION(pipe)(int pipefd[2])
 {
 	int ret;
-	rtr_pipe_t real_pipe;
-
-	real_pipe = RETRACE_GET_REAL(pipe);
 
 	ret = real_pipe(pipefd);
 
@@ -42,16 +39,14 @@ int RETRACE_IMPLEMENTATION(pipe)(int pipefd[2])
 	return ret;
 }
 
-RETRACE_REPLACE(pipe)
+RETRACE_REPLACE(pipe, int, (int pipefd[2]), (pipefd))
+
 
 #ifndef __APPLE__
 
 int RETRACE_IMPLEMENTATION(pipe2)(int pipefd[2], int flags)
 {
 	int ret;
-	rtr_pipe2_t real_pipe2;
-
-	real_pipe2 = RETRACE_GET_REAL(pipe2);
 
 	ret = real_pipe2(pipefd, flags);
 
@@ -60,6 +55,6 @@ int RETRACE_IMPLEMENTATION(pipe2)(int pipefd[2], int flags)
 	return ret;
 }
 
-RETRACE_REPLACE(pipe2)
+RETRACE_REPLACE(pipe2, int, (int pipefd[2], int flags), (pipefd, flags))
 
 #endif

--- a/pipe.h
+++ b/pipe.h
@@ -2,9 +2,15 @@
 #define __RETRACE_PIPE_H__
 
 typedef int (*rtr_pipe_t)(int pipefd[2]);
-typedef int (*rtr_pipe2_t)(int pipefd[2], int flags);
 
 RETRACE_DECL(pipe);
+
+#ifndef __APPLE__
+
+typedef int (*rtr_pipe2_t)(int pipefd[2], int flags);
+
 RETRACE_DECL(pipe2);
+
+#endif
 
 #endif /* __RETRACE_PIPE_H__ */

--- a/popen.c
+++ b/popen.c
@@ -30,11 +30,6 @@
 FILE *RETRACE_IMPLEMENTATION(popen)(const char *command, const char *type)
 {
 	FILE *ret;
-	rtr_popen_t real_popen;
-	rtr_fileno_t real_fileno;
-
-	real_popen	= RETRACE_GET_REAL(popen);
-	real_fileno	= RETRACE_GET_REAL(fileno);
 
 	ret = real_popen(command, type);
 
@@ -43,16 +38,13 @@ FILE *RETRACE_IMPLEMENTATION(popen)(const char *command, const char *type)
 	return ret;
 }
 
-RETRACE_REPLACE(popen)
+RETRACE_REPLACE(popen, FILE *, (const char *command, const char *type),
+	(command, type))
+
 
 int RETRACE_IMPLEMENTATION(pclose)(FILE *stream)
 {
 	int ret;
-	rtr_pclose_t real_pclose;
-	rtr_fileno_t real_fileno;
-
-	real_pclose = RETRACE_GET_REAL(pclose);
-	real_fileno = RETRACE_GET_REAL(fileno);
 
 	ret = real_pclose(stream);
 
@@ -61,4 +53,4 @@ int RETRACE_IMPLEMENTATION(pclose)(FILE *stream)
 	return ret;
 }
 
-RETRACE_REPLACE(pclose)
+RETRACE_REPLACE(pclose, int, (FILE *stream), (stream))

--- a/printf.c
+++ b/printf.c
@@ -39,11 +39,7 @@ trace(const char *func, bool showfd, int fd, int result,
 	char buf[1024];
 
 	if (str == NULL) {
-		rtr_vsnprintf_t vsnprintf_;
-
-		vsnprintf_ = RETRACE_GET_REAL(vsnprintf);
-
-		vsnprintf_(buf, 1024, fmt, ap);
+		real_vsnprintf(buf, 1024, fmt, ap);
 		str = buf;
 	}
 
@@ -61,13 +57,10 @@ int
 RETRACE_IMPLEMENTATION(printf)(const char *fmt, ...)
 {
 	int result;
-	rtr_vprintf_t vprintf_;
 	va_list ap;
 
-	vprintf_ = RETRACE_GET_REAL(vprintf);
-
 	va_start(ap, fmt);
-	result = vprintf_(fmt, ap);
+	result = real_vprintf(fmt, ap);
 	va_end(ap);
 
 	va_start(ap, fmt);
@@ -77,43 +70,35 @@ RETRACE_IMPLEMENTATION(printf)(const char *fmt, ...)
 	return result;
 }
 
-RETRACE_REPLACE(printf)
+RETRACE_REPLACE_V(printf, int, (const char *fmt, ...), fmt, real_vprintf, (fmt, ap))
 
 int
 RETRACE_IMPLEMENTATION(fprintf)(FILE *stream, const char *fmt, ...)
 {
 	int result;
-	rtr_vfprintf_t vfprintf_;
-	rtr_fileno_t fileno_;
 	va_list ap;
 
-	vfprintf_	= RETRACE_GET_REAL(vfprintf);
-	fileno_		= RETRACE_GET_REAL(fileno);
-
 	va_start(ap, fmt);
-	result = vfprintf_(stream, fmt, ap);
+	result = real_vfprintf(stream, fmt, ap);
 	va_end(ap);
 
 	va_start(ap, fmt);
-	trace(__func__, true, fileno_(stream), result, NULL, fmt, ap);
+	trace(__func__, true, real_fileno(stream), result, NULL, fmt, ap);
 	va_end(ap);
 
 	return result;
 }
 
-RETRACE_REPLACE(fprintf)
+RETRACE_REPLACE_V(fprintf, int, (FILE *stream, const char *fmt, ...), fmt, real_vfprintf, (stream, fmt, ap))
 
 int
 RETRACE_IMPLEMENTATION(dprintf)(int fd, const char *fmt, ...)
 {
 	int result;
-	rtr_vdprintf_t vdprintf_;
 	va_list ap;
 
-	vdprintf_ = RETRACE_GET_REAL(vdprintf);
-
 	va_start(ap, fmt);
-	result = vdprintf_(fd, fmt, ap);
+	result = real_vdprintf(fd, fmt, ap);
 	va_end(ap);
 
 	va_start(ap, fmt);
@@ -123,19 +108,16 @@ RETRACE_IMPLEMENTATION(dprintf)(int fd, const char *fmt, ...)
 	return result;
 }
 
-RETRACE_REPLACE(dprintf)
+RETRACE_REPLACE_V(dprintf, int, (int fd, const char *fmt, ...), fmt, vdprintf, (fd, fmt, ap))
 
 int
 RETRACE_IMPLEMENTATION(sprintf)(char *str, const char *fmt, ...)
 {
 	int result;
-	rtr_vsprintf_t vsprintf_;
 	va_list ap;
 
-	vsprintf_ = RETRACE_GET_REAL(vsprintf);
-
 	va_start(ap, fmt);
-	result = vsprintf_(str, fmt, ap);
+	result = real_vsprintf(str, fmt, ap);
 	va_end(ap);
 
 	va_start(ap, fmt);
@@ -145,19 +127,16 @@ RETRACE_IMPLEMENTATION(sprintf)(char *str, const char *fmt, ...)
 	return result;
 }
 
-RETRACE_REPLACE(sprintf)
+RETRACE_REPLACE_V(sprintf, int, (char *str, const char *fmt, ...), fmt, vsprintf, (str, fmt, ap))
 
 int
 RETRACE_IMPLEMENTATION(snprintf)(char *str, size_t size, const char *fmt, ...)
 {
 	int result;
-	rtr_vsnprintf_t vsnprintf_;
 	va_list ap;
 
-	vsnprintf_ = RETRACE_GET_REAL(vsnprintf);
-
 	va_start(ap, fmt);
-	result = vsnprintf_(str, size, fmt, ap);
+	result = real_vsnprintf(str, size, fmt, ap);
 	va_end(ap);
 
 	trace(__func__, false, 0, result, str, fmt, ap);
@@ -165,99 +144,82 @@ RETRACE_IMPLEMENTATION(snprintf)(char *str, size_t size, const char *fmt, ...)
 	return result;
 }
 
-RETRACE_REPLACE(snprintf)
+RETRACE_REPLACE_V(snprintf, int, (char *str, size_t size, const char *fmt, ...), fmt, vsnprintf, (str, size, fmt, ap))
 
 int
 RETRACE_IMPLEMENTATION(vprintf)(const char *fmt, va_list ap)
 {
 	int result;
-	rtr_vprintf_t vprintf_;
 	va_list ap1;
 
-	vprintf_ = RETRACE_GET_REAL(vprintf);
-
 	__va_copy(ap1, ap);
-	result = vprintf_(fmt, ap);
+	result = real_vprintf(fmt, ap);
 	trace(__func__, false, 0, result, NULL, fmt, ap1);
 	va_end(ap1);
 
 	return result;
 }
 
-RETRACE_REPLACE(vprintf)
+RETRACE_REPLACE(vprintf, int, (const char *fmt, va_list ap), (fmt, ap))
 
 int
 RETRACE_IMPLEMENTATION(vfprintf)(FILE *stream, const char *fmt, va_list ap)
 {
 	int result;
-	rtr_vfprintf_t vfprintf_;
-	rtr_fileno_t fileno_;
 	va_list ap1;
 
-	vfprintf_	= RETRACE_GET_REAL(vfprintf);
-	fileno_		= RETRACE_GET_REAL(fileno);
-
 	__va_copy(ap1, ap);
-	result = vfprintf_(stream, fmt, ap);
-	trace(__func__, true, fileno_(stream), result, NULL, fmt, ap1);
+	result = real_vfprintf(stream, fmt, ap);
+	trace(__func__, true, real_fileno(stream), result, NULL, fmt, ap1);
 	va_end(ap1);
 
 	return result;
 }
 
-RETRACE_REPLACE(vfprintf)
+RETRACE_REPLACE(vfprintf, int, (FILE *stream, const char *fmt, va_list ap), (stream, fmt, ap))
 
 int
 RETRACE_IMPLEMENTATION(vdprintf)(int fd, const char *fmt, va_list ap)
 {
 	int result;
-	rtr_vdprintf_t vdprintf_;
 	va_list ap1;
 
-	vdprintf_ = RETRACE_GET_REAL(vdprintf);
-
 	__va_copy(ap1, ap);
-	result = vdprintf_(fd, fmt, ap);
+	result = real_vdprintf(fd, fmt, ap);
 	trace(__func__, true, fd, result, NULL, fmt, ap1);
 	va_end(ap1);
 
 	return result;
 }
 
-RETRACE_REPLACE(vdprintf)
+RETRACE_REPLACE(vdprintf, int, (int fd, const char *fmt, va_list ap), (fd, fmt, ap))
 
 int
 RETRACE_IMPLEMENTATION(vsprintf)(char *str, const char *fmt, va_list ap)
 {
 	int result;
-	rtr_vsprintf_t vsprintf_;
 	va_list ap1;
 
-	vsprintf_ = RETRACE_GET_REAL(vsprintf);
-
 	__va_copy(ap1, ap);
-	result = vsprintf_(str, fmt, ap);
+	result = real_vsprintf(str, fmt, ap);
 	trace(__func__, false, 0, result, NULL, fmt, ap1);
 	va_end(ap1);
 
 	return result;
 }
 
-RETRACE_REPLACE(vsprintf)
+RETRACE_REPLACE(vsprintf, int, (char *str, const char *fmt, va_list ap), (str, fmt, ap))
 
 int
 RETRACE_IMPLEMENTATION(vsnprintf)(char *str, size_t size, const char *fmt, va_list ap)
 {
 	int result;
-	rtr_vsnprintf_t vsnprintf_;
 
-	vsnprintf_ = RETRACE_GET_REAL(vsnprintf);
-
-	result = vsnprintf_(str, size, fmt, ap);
+	result = real_vsnprintf(str, size, fmt, ap);
 
 	trace(__func__, false, 0, result, str, fmt, ap);
 
 	return result;
 }
 
-RETRACE_REPLACE(vsnprintf)
+RETRACE_REPLACE(vsnprintf, int, (char *str, size_t size, const char *fmt, va_list ap), (str, size, fmt, ap))

--- a/read.c
+++ b/read.c
@@ -30,9 +30,6 @@ ssize_t RETRACE_IMPLEMENTATION(read)(int fd, void *buf, size_t nbytes)
 {
 	ssize_t ret;
 	struct descriptor_info *di;
-	rtr_read_t real_read;
-
-	real_read = RETRACE_GET_REAL(read);
 
 	ret = real_read(fd, buf, nbytes);
 
@@ -49,4 +46,5 @@ ssize_t RETRACE_IMPLEMENTATION(read)(int fd, void *buf, size_t nbytes)
 	return ret;
 }
 
-RETRACE_REPLACE(read)
+RETRACE_REPLACE(read, ssize_t, (int fd, void *buf, size_t nbytes),
+	(fd, buf, nbytes))

--- a/scanf.c
+++ b/scanf.c
@@ -39,10 +39,7 @@ trace(const char *func, bool showfd, int fd, int result, const char *str, const 
 	char buf[1024];
 
 	if (str == NULL) {
-		rtr_vsnprintf_t vsnprintf_;
-
-		vsnprintf_ = RETRACE_GET_REAL(vsnprintf);
-		vsnprintf_(buf, 1024, fmt, ap);
+		real_vsnprintf(buf, 1024, fmt, ap);
 		str = buf;
 	}
 
@@ -59,11 +56,8 @@ trace(const char *func, bool showfd, int fd, int result, const char *str, const 
 int
 RETRACE_IMPLEMENTATION(scanf)(const char *format, ...)
 {
-	rtr_vscanf_t real_vscanf;
 	va_list ap;
 	int result;
-
-	real_vscanf = RETRACE_GET_REAL(vscanf);
 
 	va_start(ap, format);
 	result = real_vscanf(format, ap);
@@ -76,40 +70,34 @@ RETRACE_IMPLEMENTATION(scanf)(const char *format, ...)
 	return result;
 }
 
-RETRACE_REPLACE(scanf)
+RETRACE_REPLACE_V(scanf, int, (const char *format, ...), format, vscanf,
+	(format, ap))
 
 int
 RETRACE_IMPLEMENTATION(fscanf)(FILE *stream, const char *format, ...)
 {
-	rtr_vfscanf_t real_vfscanf;
-	rtr_fileno_t fileno_;
 	va_list ap;
 	int result;
-
-	real_vfscanf = RETRACE_GET_REAL(vfscanf);
-	fileno_ = RETRACE_GET_REAL(fileno);
 
 	va_start(ap, format);
 	result = real_vfscanf(stream, format, ap);
 	va_end(ap);
 
 	va_start(ap, format);
-	trace(__func__, true, fileno_(stream), result, NULL, format, ap);
+	trace(__func__, true, real_fileno(stream), result, NULL, format, ap);
 	va_end(ap);
 
 	return result;
 }
 
-RETRACE_REPLACE(fscanf)
+RETRACE_REPLACE_V(fscanf, int, (FILE *stream, const char *format, ...),
+	format, vfscanf, (stream, format, ap))
 
 int
 RETRACE_IMPLEMENTATION(sscanf)(const char *str, const char *format, ...)
 {
-	rtr_vsscanf_t real_vsscanf;
 	va_list ap;
 	int result;
-
-	real_vsscanf = RETRACE_GET_REAL(vsscanf);
 
 	va_start(ap, format);
 	result = real_vsscanf(str, format, ap);
@@ -122,16 +110,13 @@ RETRACE_IMPLEMENTATION(sscanf)(const char *str, const char *format, ...)
 	return result;
 }
 
-RETRACE_REPLACE(sscanf)
+RETRACE_REPLACE_V(sscanf, int, (const char *str, const char *format, ...), format, vsscanf, (str, format, ap))
 
 int
 RETRACE_IMPLEMENTATION(vscanf)(const char *format, va_list ap)
 {
-	rtr_vscanf_t real_vscanf;
 	va_list ap1;
 	int result;
-
-	real_vscanf = RETRACE_GET_REAL(vscanf);
 
 	__va_copy(ap1, ap);
 	result = real_vscanf(format, ap);
@@ -141,16 +126,13 @@ RETRACE_IMPLEMENTATION(vscanf)(const char *format, va_list ap)
 	return result;
 }
 
-RETRACE_REPLACE(vscanf)
+RETRACE_REPLACE(vscanf, int, (const char *format, va_list ap), (format, ap))
 
 int
 RETRACE_IMPLEMENTATION(vsscanf)(const char *str, const char *format, va_list ap)
 {
-	rtr_vsscanf_t real_vsscanf;
 	va_list ap1;
 	int result;
-
-	real_vsscanf = RETRACE_GET_REAL(vsscanf);
 
 	__va_copy(ap1, ap);
 	result = real_vsscanf(str, format, ap);
@@ -160,25 +142,23 @@ RETRACE_IMPLEMENTATION(vsscanf)(const char *str, const char *format, va_list ap)
 	return result;
 }
 
-RETRACE_REPLACE(vsscanf)
+RETRACE_REPLACE(vsscanf, int, (const char *str, const char *format, va_list ap),
+	(str, format, ap))
+
 
 int
 RETRACE_IMPLEMENTATION(vfscanf)(FILE *stream, const char *format, va_list ap)
 {
-	rtr_vfscanf_t real_vfscanf;
-	rtr_fileno_t fileno_;
 	va_list ap1;
 	int result;
 
-	real_vfscanf = RETRACE_GET_REAL(vfscanf);
-	fileno_ = RETRACE_GET_REAL(fileno);
-
 	__va_copy(ap1, ap);
 	result = real_vfscanf(stream, format, ap);
-	trace(__func__, true, fileno_(stream), result, NULL, format, ap1);
+	trace(__func__, true, real_fileno(stream), result, NULL, format, ap1);
 	va_end(ap1);
 
 	return result;
 }
 
-RETRACE_REPLACE(vfscanf)
+RETRACE_REPLACE(vfscanf, int, (FILE *stream, const char *format, va_list ap),
+	(stream, format, ap))

--- a/select.c
+++ b/select.c
@@ -60,7 +60,6 @@ int
 RETRACE_IMPLEMENTATION(select)(int nfds, fd_set *readfds, fd_set *writefds,
 			fd_set *exceptfds, struct timeval *timeout)
 {
-	rtr_select_t real_select;
 	fd_set inr, inw, inx;
 	int ret;
 
@@ -68,7 +67,6 @@ RETRACE_IMPLEMENTATION(select)(int nfds, fd_set *readfds, fd_set *writefds,
 	copy_fd_set(&inw, writefds);
 	copy_fd_set(&inx, exceptfds);
 
-	real_select = RETRACE_GET_REAL(select);
 	ret = real_select(nfds, readfds, writefds, exceptfds, timeout);
 
 	if (timeout != NULL)
@@ -85,4 +83,7 @@ RETRACE_IMPLEMENTATION(select)(int nfds, fd_set *readfds, fd_set *writefds,
 	return (ret);
 }
 
-RETRACE_REPLACE(select)
+RETRACE_REPLACE(select, int,
+	(int nfds, fd_set *readfds, fd_set *writefds, fd_set *exceptfds,
+	    struct timeval *timeout),
+	(nfds, readfds, writefds, exceptfds, timeout))

--- a/sock.h
+++ b/sock.h
@@ -7,9 +7,15 @@
 #include <arpa/inet.h>
 
 typedef int (*rtr_socket_t)(int domain, int type, int protocol);
-typedef int (*rtr_connect_t)(int sockfd, const struct sockaddr *addr, socklen_t addrlen);
+#ifdef __linux__
+typedef int (*rtr_connect_t)(int fd, __CONST_SOCKADDR_ARG address, socklen_t len);
+typedef int (*rtr_bind_t)(int fd, __CONST_SOCKADDR_ARG address, socklen_t len);
+typedef int (*rtr_accept_t)(int fd, __SOCKADDR_ARG address, socklen_t *len);
+#else
+typedef int (*rtr_connect_t)(int fd, const struct sockaddr *address, socklen_t len);
 typedef int (*rtr_bind_t)(int fd, const struct sockaddr *address, socklen_t len);
 typedef int (*rtr_accept_t)(int fd, struct sockaddr *address, socklen_t *len);
+#endif
 
 typedef int (*rtr_setsockopt_t)(int fd, int level, int optname, const void *optval, socklen_t optlen);
 

--- a/ssl.c
+++ b/ssl.c
@@ -105,10 +105,7 @@ print_ssl_keys(SSL *ssl)
 
 int RETRACE_IMPLEMENTATION(SSL_write)(SSL *ssl, const void *buf, int num)
 {
-	rtr_SSL_write_t real_SSL_write;
 	int r;
-
-	real_SSL_write = RETRACE_GET_REAL(SSL_write);
 
 	r = real_SSL_write(ssl, buf, num);
 
@@ -118,14 +115,13 @@ int RETRACE_IMPLEMENTATION(SSL_write)(SSL *ssl, const void *buf, int num)
 	return (r);
 }
 
-RETRACE_REPLACE(SSL_write)
+RETRACE_REPLACE(SSL_write, int, (SSL * ssl, const void *buf, int num),
+	(ssl, buf, num))
+
 
 int RETRACE_IMPLEMENTATION(SSL_read)(SSL *ssl, void *buf, int num)
 {
-	rtr_SSL_read_t real_SSL_read;
 	int r;
-
-	real_SSL_read = RETRACE_GET_REAL(SSL_read);
 
 	r = real_SSL_read(ssl, buf, num);
 
@@ -137,14 +133,13 @@ int RETRACE_IMPLEMENTATION(SSL_read)(SSL *ssl, void *buf, int num)
 	return (r);
 }
 
-RETRACE_REPLACE(SSL_read)
+RETRACE_REPLACE(SSL_read, int, (SSL * ssl, void *buf, int num),
+	(ssl, buf, num))
+
 
 int RETRACE_IMPLEMENTATION(SSL_connect)(SSL *ssl)
 {
-	rtr_SSL_connect_t real_SSL_connect;
 	int r;
-
-	real_SSL_connect = RETRACE_GET_REAL(SSL_connect);
 
 	r = real_SSL_connect(ssl);
 
@@ -154,15 +149,13 @@ int RETRACE_IMPLEMENTATION(SSL_connect)(SSL *ssl)
 	return (r);
 }
 
-RETRACE_REPLACE(SSL_connect)
+RETRACE_REPLACE(SSL_connect, int, (SSL * ssl), (ssl))
+
 
 
 int RETRACE_IMPLEMENTATION(SSL_accept)(SSL *ssl)
 {
-	rtr_SSL_accept_t real_SSL_accept;
 	int r;
-
-	real_SSL_accept = RETRACE_GET_REAL(SSL_accept);
 
 	r = real_SSL_accept(ssl);
 
@@ -172,16 +165,14 @@ int RETRACE_IMPLEMENTATION(SSL_accept)(SSL *ssl)
 	return (r);
 }
 
-RETRACE_REPLACE(SSL_accept)
+RETRACE_REPLACE(SSL_accept, int, (SSL * ssl), (ssl))
+
 
 long
 RETRACE_IMPLEMENTATION(SSL_get_verify_result)(const SSL *ssl)
 {
-	rtr_SSL_get_verify_result_t real_SSL_get_verify_result;
 	int r;
 	int redirect_id = 0;
-
-	real_SSL_get_verify_result = RETRACE_GET_REAL(SSL_get_verify_result);
 
 	if (rtr_get_config_single("SSL_get_verify_result", ARGUMENT_TYPE_INT, ARGUMENT_TYPE_END, &redirect_id)) {
 
@@ -199,18 +190,16 @@ RETRACE_IMPLEMENTATION(SSL_get_verify_result)(const SSL *ssl)
 	return r;
 }
 
-RETRACE_REPLACE(SSL_get_verify_result)
+RETRACE_REPLACE(SSL_get_verify_result, long, (const SSL * ssl), (ssl))
+
 
 #define DEFINE_TO_STR(def, str) case (def): str = #def; break;
 
 long RETRACE_IMPLEMENTATION(BIO_ctrl)(BIO *bp, int cmd, long larg, void *parg)
 {
-	rtr_BIO_ctrl_t real_BIO_ctrl;
 	long r;
 	SSL *ssl = NULL;
 	char *cmd_str;
-
-	real_BIO_ctrl = RETRACE_GET_REAL(BIO_ctrl);
 
 	r = real_BIO_ctrl(bp, cmd, larg, parg);
 
@@ -541,4 +530,5 @@ long RETRACE_IMPLEMENTATION(BIO_ctrl)(BIO *bp, int cmd, long larg, void *parg)
 	return (r);
 }
 
-RETRACE_REPLACE(BIO_ctrl)
+RETRACE_REPLACE(BIO_ctrl, long, (BIO * bp, int cmd, long larg, void *parg),
+	(bp, cmd, larg, parg))

--- a/str.c
+++ b/str.c
@@ -30,10 +30,6 @@
 
 char *RETRACE_IMPLEMENTATION(strstr)(const char *s1, const char *s2)
 {
-	rtr_strstr_t real_strstr;
-
-	real_strstr = RETRACE_GET_REAL(strstr);
-
 	trace_printf(1, "strstr(\"");
 	trace_printf_str(s1);
 	trace_printf(0, "\", \"");
@@ -43,14 +39,11 @@ char *RETRACE_IMPLEMENTATION(strstr)(const char *s1, const char *s2)
 	return real_strstr(s1, s2);
 }
 
-RETRACE_REPLACE(strstr)
+RETRACE_REPLACE(strstr, char *, (const char *s1, const char *s2), (s1, s2))
 
 size_t RETRACE_IMPLEMENTATION(strlen)(const char *s)
 {
 	size_t len;
-	rtr_strlen_t real_strlen;
-
-	real_strlen = RETRACE_GET_REAL(strlen);
 
 	len = real_strlen(s);
 
@@ -69,14 +62,10 @@ size_t RETRACE_IMPLEMENTATION(strlen)(const char *s)
 	return len;
 }
 
-RETRACE_REPLACE(strlen)
+RETRACE_REPLACE(strlen, size_t, (const char *s), (s))
 
 int RETRACE_IMPLEMENTATION(strncmp)(const char *s1, const char *s2, size_t n)
 {
-	rtr_strncmp_t real_strncmp;
-
-	real_strncmp = RETRACE_GET_REAL(strncmp);
-
 	trace_printf(1, "strncmp(\"");
 	trace_printf_str(s1);
 	trace_printf(0, "\", \"");
@@ -86,14 +75,10 @@ int RETRACE_IMPLEMENTATION(strncmp)(const char *s1, const char *s2, size_t n)
 	return real_strncmp(s1, s2, n);
 }
 
-RETRACE_REPLACE(strncmp)
+RETRACE_REPLACE(strncmp, int, (const char *s1, const char *s2, size_t n), (s1, s2, n))
 
 int RETRACE_IMPLEMENTATION(strcmp)(const char *s1, const char *s2)
 {
-	rtr_strcmp_t real_strcmp;
-
-	real_strcmp = RETRACE_GET_REAL(strcmp);
-
 	if (get_tracing_enabled()) {
 		int old_trace_state;
 
@@ -111,16 +96,11 @@ int RETRACE_IMPLEMENTATION(strcmp)(const char *s1, const char *s2)
 	return real_strcmp(s1, s2);
 }
 
-RETRACE_REPLACE(strcmp)
+RETRACE_REPLACE(strcmp, int, (const char *s1, const char *s2), (s1, s2))
 
 char *RETRACE_IMPLEMENTATION(strncpy)(char *s1, const char *s2, size_t n)
 {
 	size_t len = 0;
-	rtr_strncpy_t real_strncpy;
-	rtr_strlen_t real_strlen;
-
-	real_strncpy	= RETRACE_GET_REAL(strncpy);
-	real_strlen	= RETRACE_GET_REAL(strlen);
 
 	len = real_strlen(s2);
 
@@ -131,16 +111,11 @@ char *RETRACE_IMPLEMENTATION(strncpy)(char *s1, const char *s2, size_t n)
 	return real_strncpy(s1, s2, n);
 }
 
-RETRACE_REPLACE(strncpy)
+RETRACE_REPLACE(strncpy, char *, (char *s1, const char *s2, size_t n), (s1, s2, n))
 
 char *RETRACE_IMPLEMENTATION(strcat)(char *s1, const char *s2)
 {
 	size_t len;
-	rtr_strcat_t real_strcat;
-	rtr_strlen_t real_strlen;
-
-	real_strcat	= RETRACE_GET_REAL(strcat);
-	real_strlen	= RETRACE_GET_REAL(strlen);
 
 	len = real_strlen(s2);
 
@@ -151,16 +126,11 @@ char *RETRACE_IMPLEMENTATION(strcat)(char *s1, const char *s2)
 	return real_strcat(s1, s2);
 }
 
-RETRACE_REPLACE(strcat)
+RETRACE_REPLACE(strcat, char *, (char *s1, const char *s2), (s1, s2))
 
 char *RETRACE_IMPLEMENTATION(strncat)(char *s1, const char *s2, size_t n)
 {
 	size_t len;
-	rtr_strncat_t real_strncat;
-	rtr_strlen_t real_strlen;
-
-	real_strncat	= RETRACE_GET_REAL(strncat);
-	real_strlen	= RETRACE_GET_REAL(strlen);
 
 	len = real_strlen(s2) + 1;
 
@@ -171,16 +141,11 @@ char *RETRACE_IMPLEMENTATION(strncat)(char *s1, const char *s2, size_t n)
 	return real_strncat(s1, s2, n);
 }
 
-RETRACE_REPLACE(strncat)
+RETRACE_REPLACE(strncat, char *, (char *s1, const char *s2, size_t n), (s1, s2, n))
 
 char *RETRACE_IMPLEMENTATION(strcpy)(char *s1, const char *s2)
 {
 	size_t len;
-	rtr_strcpy_t real_strcpy;
-	rtr_strlen_t real_strlen;
-
-	real_strcpy = RETRACE_GET_REAL(strcpy);
-	real_strlen = RETRACE_GET_REAL(strlen);
 
 	len = real_strlen(s2);
 
@@ -191,15 +156,12 @@ char *RETRACE_IMPLEMENTATION(strcpy)(char *s1, const char *s2)
 	return real_strcpy(s1, s2);
 }
 
-RETRACE_REPLACE(strcpy)
+RETRACE_REPLACE(strcpy, char *, (char *s1, const char *s2), (s1, s2))
 
 char *RETRACE_IMPLEMENTATION(strchr)(const char *s, int c)
 {
 	static char specials[] = "\nn\rr\tt";
-	rtr_strchr_t real_strchr;
 	char *p, *result;
-
-	real_strchr = RETRACE_GET_REAL(strchr);
 
 	result = real_strchr(s, c);
 
@@ -215,4 +177,4 @@ char *RETRACE_IMPLEMENTATION(strchr)(const char *s, int c)
 	return (result);
 }
 
-RETRACE_REPLACE(strchr)
+RETRACE_REPLACE(strchr, char *, (const char *s, int c), (s, c))

--- a/time.c
+++ b/time.c
@@ -29,10 +29,6 @@
 char *RETRACE_IMPLEMENTATION(ctime_r)(const time_t *timep, char *buf)
 {
 	char *r;
-	rtr_ctime_r_t real_ctime_r;
-
-	real_ctime_r = RETRACE_GET_REAL(ctime_r);
-
 	r = real_ctime_r(timep, buf);
 
 	trace_printf(1, "ctime_r(\"%u\", \"%s\");\n", timep ? timep : 0, buf);
@@ -40,14 +36,11 @@ char *RETRACE_IMPLEMENTATION(ctime_r)(const time_t *timep, char *buf)
 	return r;
 }
 
-RETRACE_REPLACE(ctime_r)
+RETRACE_REPLACE(ctime_r, char *, (const time_t *timep, char *buf), (timep, buf))
 
 char *RETRACE_IMPLEMENTATION(ctime)(const time_t *timep)
 {
 	char *r;
-	rtr_ctime_t real_ctime;
-
-	real_ctime = RETRACE_GET_REAL(ctime);
 
 	r = real_ctime(timep);
 
@@ -56,7 +49,7 @@ char *RETRACE_IMPLEMENTATION(ctime)(const time_t *timep)
 	return r;
 }
 
-RETRACE_REPLACE(ctime)
+RETRACE_REPLACE(ctime, char *, (const time_t *timep), (timep))
 
 #if defined(__APPLE__) || defined(__NetBSD__)
 int RETRACE_IMPLEMENTATION(gettimeofday)(struct timeval *tv, void *tzp)
@@ -65,14 +58,11 @@ int RETRACE_IMPLEMENTATION(gettimeofday)(struct timeval *tv, struct timezone *tz
 #endif
 {
 	int ret;
-	rtr_gettimeofday_t real_gettimeofday;
 #if defined(__APPLE__) || defined(__NetBSD__)
 	struct timezone *tz;
 
 	tz = (struct timezone *)tzp;
 #endif
-
-	real_gettimeofday = RETRACE_GET_REAL(gettimeofday);
 
 	ret = real_gettimeofday(tv, tz);
 	if (ret == 0) {
@@ -97,4 +87,8 @@ int RETRACE_IMPLEMENTATION(gettimeofday)(struct timeval *tv, struct timezone *tz
 	return ret;
 }
 
-RETRACE_REPLACE(gettimeofday)
+#if defined(__APPLE__) || defined(__NetBSD__)
+RETRACE_REPLACE(gettimeofday, int, (struct timeval *tv, void *tzp), (tv, tsp))
+#else
+RETRACE_REPLACE(gettimeofday, int, (struct timeval *tv, struct timezone *tz), (tv, tz))
+#endif

--- a/trace.h
+++ b/trace.h
@@ -5,7 +5,15 @@
 #include <sys/types.h>
 #include <sys/ptrace.h>
 
+#ifdef __APPLE__
+typedef long int (*rtr_ptrace_t)(int request, ...);
+#elif defined(__FreeBSD__) || defined(__OpenBSD__)
 typedef int (*rtr_ptrace_t)(int request, pid_t pid, caddr_t addr, int data);
+#elif defined(__NetBSD__)
+typedef int (*rtr_ptrace_t)(int request, pid_t pid, void *addr, int data);
+#else
+typedef long int (*rtr_ptrace_t)(enum __ptrace_request request, ...);
+#endif
 
 RETRACE_DECL(ptrace);
 

--- a/write.c
+++ b/write.c
@@ -30,9 +30,6 @@ ssize_t RETRACE_IMPLEMENTATION(write)(int fd, const void *buf, size_t nbytes)
 {
 	ssize_t ret;
 	struct descriptor_info *di;
-	rtr_write_t real_write;
-
-	real_write = RETRACE_GET_REAL(write);
 
 	ret = real_write(fd, buf, nbytes);
 
@@ -48,4 +45,5 @@ ssize_t RETRACE_IMPLEMENTATION(write)(int fd, const void *buf, size_t nbytes)
 	return ret;
 }
 
-RETRACE_REPLACE(write)
+RETRACE_REPLACE(write, ssize_t, (int fd, const void *buf, size_t nbytes),
+	(fd, buf, nbytes))


### PR DESCRIPTION
I'm really sorry to do this - another system-wide change!

Inspired by ELF's GOT mechanism, I've reworked the real_ function fixup. At load time the real_ pointers point to a fixup function which when run replaces the real_ pointer from dlsym and then calls it (a little more complicated for the vararg functions).

So there is no longer a RETRACE_GET_REAL wrapper, you are free to use real_{func} whereever you need.

Tests pass I think, but only on linux so far ... I've updated the apple/bsd code but it's as yet untested.