### PR TITLE
checkpatch: ignore autogenerated Makefile's from upcoming autotools patch

### DIFF
--- a/ci/main.sh
+++ b/ci/main.sh
@@ -29,7 +29,7 @@ CHECKPATCH_FLAGS+=" --ignore NAKED_SSCANF"
 CHECKPATCH_FLAGS+=" --ignore SSCANF_TO_KSTRTO"
 
 # checkpatch.pl will ignore the following paths
-CHECKPATCH_IGNORE+=" checkpatch.pl.patch"
+CHECKPATCH_IGNORE+=" checkpatch.pl.patch Makefile test/Makefile"
 CHECKPATCH_EXCLUDE=$(for p in $CHECKPATCH_IGNORE; do echo ":(exclude)$p" ; done)
 
 function _checkpatch() {


### PR DESCRIPTION
In preparation for https://github.com/riboseinc/retrace/pull/134 from @wizzard 
Signed-off-by: Ruslan Kuprieiev <kupruser@gmail.com>