### PR TITLE
Fixes for GCC

### DIFF
--- a/common.h
+++ b/common.h
@@ -85,6 +85,8 @@ struct rtr_event_info {
 	void *return_value;
 };
 
+#define RETRACE_INTERNAL __attribute__((visibility("hidden")))
+
 #define RETRACE_DECL(func) extern rtr_##func##_t real_##func
 
 #ifdef __APPLE__
@@ -138,7 +140,7 @@ type rtr_fixup_##func defn {						\
 	RETRACE_FIXUP(func);						\
 	return real_##func args;					\
 }									\
-rtr_##func##_t real_##func = rtr_fixup_##func;
+RETRACE_INTERNAL rtr_##func##_t real_##func = rtr_fixup_##func;
 
 #define RETRACE_REPLACE_V(func, type, defn, last, vfunc, vargs)		\
 type rtr_fixup_##func defn {						\
@@ -169,7 +171,7 @@ struct ts_info {
 };
 
 void trace_printf(int hdr, const char *fmt, ...);
-void trace_printf_str(const char *string);
+void trace_printf_str(const char *string, int maxlength);
 void trace_dump_data(const unsigned char *buf, size_t nbytes);
 void trace_mode(mode_t mode, char *p);
 void trace_printf_backtrace(void);

--- a/str.c
+++ b/str.c
@@ -80,8 +80,8 @@ RETRACE_REPLACE(strlen, size_t, (const char *s), (s))
 int RETRACE_IMPLEMENTATION(strncmp)(const char *s1, const char *s2, size_t n)
 {
 	struct rtr_event_info event_info;
-	unsigned int parameter_types[] = {PARAMETER_TYPE_STRING, PARAMETER_TYPE_STRING, PARAMETER_TYPE_INT, PARAMETER_TYPE_END};
-	void const *parameter_values[] = {&s1, &s2, &n};
+	unsigned int parameter_types[] = {PARAMETER_TYPE_STRING_LEN, PARAMETER_TYPE_STRING_LEN, PARAMETER_TYPE_INT, PARAMETER_TYPE_END};
+	void const *parameter_values[] = {&n, &s1, &n, &s2, &n};
 	int result;
 
 
@@ -128,8 +128,8 @@ RETRACE_REPLACE(strcmp, int, (const char *s1, const char *s2), (s1, s2))
 char *RETRACE_IMPLEMENTATION(strncpy)(char *s1, const char *s2, size_t n)
 {
 	struct rtr_event_info event_info;
-	unsigned int parameter_types[] = {PARAMETER_TYPE_STRING, PARAMETER_TYPE_STRING, PARAMETER_TYPE_INT, PARAMETER_TYPE_END};
-	void const *parameter_values[] = {&s1, &s2, &n};
+	unsigned int parameter_types[] = {PARAMETER_TYPE_STRING_LEN, PARAMETER_TYPE_STRING_LEN, PARAMETER_TYPE_INT, PARAMETER_TYPE_END};
+	void const *parameter_values[] = {&n, &s1, &n, &s2, &n};
 	char *result = NULL;
 
 

--- a/test/cmockatest.c
+++ b/test/cmockatest.c
@@ -610,7 +610,7 @@ test_trace_printf(void **state)
 static void
 test_trace_printf_str(void **state)
 {
-	void (*trace_printf_str)(const char *);
+	void (*trace_printf_str)(const char *, int len);
 	FILE *oldstderr = stderr;
 	const char snip[] = "[SNIP]";
 	char buf[256];
@@ -626,7 +626,7 @@ test_trace_printf_str(void **state)
 
 	// special characters are handled correctly
 	stderr = fmemopen(buf, 256, "w");
-	trace_printf_str("abc\r\n\tdef");
+	trace_printf_str("abc\r\n\tdef", -1);
 	fclose(stderr);
 	stderr = oldstderr;
 	assert_string_equal(buf,
@@ -634,14 +634,14 @@ test_trace_printf_str(void **state)
 
 	// MAXLEN string is unmodified
 	stderr = fmemopen(buf, 256, "w");
-	trace_printf_str(s);
+	trace_printf_str(s, -1);
 	fclose(stderr);
 	stderr = oldstderr;
 	assert_string_equal(buf, s);
 
 	// MAXLEN+1 string is [SNIP]ped
 	stderr = fmemopen(buf, 256, "w");
-	trace_printf_str(s1);
+	trace_printf_str(s1, -1);
 	fclose(stderr);
 	stderr = oldstderr;
 


### PR DESCRIPTION
This makes GCC work if you use the disabledatadump option.

There's still something making the code loop in the data dump code that I couldn't figure out. I have the line isolated but couldn't for the life of me figure what was going on.