### PR TITLE
Implemented fcntl and refactoring configure.ac

### DIFF
--- a/common.c
+++ b/common.c
@@ -51,6 +51,7 @@
 #include <sys/uio.h>
 #include <sys/utsname.h>
 #include <execinfo.h>
+#include <fcntl.h>
 
 #include "str.h"
 #include "id.h"
@@ -307,6 +308,78 @@ retrace_print_parameter(unsigned int event_type, unsigned int type, int flags, v
 	case PARAMETER_TYPE_SSL_WITH_KEY:
 		trace_printf(0, "%p", (*(void **) *value));
 		break;
+
+#if HAVE_STRUCT_FLOCK
+	case PARAMETER_TYPE_STRUCT_FLOCK:
+		trace_printf(1, "struct flock {\n");
+		trace_printf(1, "\tl_start = %zu\n", (*(struct flock **) *value)->l_start);
+		trace_printf(1, "\tl_len = %zu\n", (*(struct flock **) *value)->l_len);
+		trace_printf(1, "\tl_pid = %d\n", (*(struct flock **) *value)->l_pid);
+		trace_printf(1, "\tl_type = %d\n", (*(struct flock **) *value)->l_type);
+		trace_printf(1, "\tl_whence = %d\n", (*(struct flock **) *value)->l_whence);
+		trace_printf(1, "}\n");
+		break;
+#endif
+
+#if HAVE_STRUCT_FSTORE
+	case PARAMETER_TYPE_STRUCT_FSTORE:
+		trace_printf(1, "struct fstore {\n");
+		trace_printf(1, "\tfst_flags = %zu\n", (*(struct fstore **) *value)->fst_flags);
+		trace_printf(1, "\tfst_posmode = %d\n", (*(struct fstore **) *value)->fst_posmode);
+		trace_printf(1, "\tfst_offset = %zu\n", (*(struct fstore **) *value)->fst_offset);
+		trace_printf(1, "\tfst_length = %zu\n", (*(struct fstore **) *value)->fst_length);
+		trace_printf(1, "\tfst_bytesalloc = %zu\n", (*(struct fstore **) *value)->fst_bytesalloc);
+		trace_printf(1, "}\n");
+		break;
+#endif
+
+#if HAVE_STRUCT_FPUNCHHOLE
+	case PARAMETER_TYPE_STRUCT_FPUNCHHOLE:
+		trace_printf(1, "struct fpunchhole {\n");
+		trace_printf(1, "\tfp_flags = %zu\n", (*(struct fpunchhole **) *value)->fp_flags);
+		trace_printf(1, "\tfp_offset = %zu\n", (*(struct fpunchhole **) *value)->fp_offset);
+		trace_printf(1, "\tfp_length = %zu\n", (*(struct fpunchhole **) *value)->fp_length);
+		trace_printf(1, "}\n");
+		break;
+#endif
+
+#if HAVE_STRUCT_RADVISORY
+	case PARAMETER_TYPE_STRUCT_RADVISORY:
+		trace_printf(1, "struct radvisory {\n");
+		trace_printf(1, "\tra_offset = %zu\n", (*(struct radvisory **) *value)->ra_offset);
+		trace_printf(1, "\tra_count = %zu\n", (*(struct radvisory **) *value)->ra_count);
+		trace_printf(1, "}\n");
+		break;
+#endif
+
+#if HAVE_STRUCT_FBOOTSTRAPTRANSFER
+	case PARAMETER_TYPE_STRUCT_FBOOTSTRAPTRANSFER:
+		trace_printf(1, "struct fbootstraptransfer {\n");
+		trace_printf(1, "\tfbt_offset = %zu\n", (*(struct fbootstraptransfer **) *value)->fbt_offset);
+		trace_printf(1, "\tfbt_length = %zu\n", (*(struct fbootstraptransfer **) *value)->fbt_length);
+		trace_printf(1, "\tfbt_buffer = %p\n", (*(struct fbootstraptransfer **) *value)->fbt_buffer);
+		trace_printf(1, "}\n");
+		break;
+#endif
+
+#if HAVE_STRUCT_LOG2PHYS
+	case PARAMETER_TYPE_STRUCT_LOG2PHYS:
+		trace_printf(1, "struct log2phys {\n");
+		trace_printf(1, "\tl2p_flags = %zu\n", (*(struct log2phys **) *value)->l2p_flags);
+		trace_printf(1, "\tl2p_contigbytes = %zu\n", (*(struct log2phys **) *value)->l2p_contigbytes);
+		trace_printf(1, "\tl2p_devoffset = %zu\n", (*(struct log2phys **) *value)->l2p_devoffset);
+		trace_printf(1, "}\n");
+		break;
+#endif
+
+#if HAVE_DECL_F_GETOWN_EX
+	case PARAMETER_TYPE_STRUCT_F_GETOWN_EX:
+		trace_printf(1, "struct f_owner_ex {\n");
+		trace_printf(1, "\ttype = %d\n", (*(struct f_owner_ex **) *value)->type);
+		trace_printf(1, "\tpid = %zu\n", (*(struct f_owner_ex **) *value)->pid);
+		trace_printf(1, "}\n");
+		break;
+#endif
 	}
 
 	/* There's a string following this parameter that expands its meaning */

--- a/common.h
+++ b/common.h
@@ -62,6 +62,27 @@
 #define PARAMETER_TYPE_TIMEZONE		22 /* struct timezone* */
 #define PARAMETER_TYPE_SSL		23 /* OpenSSL's SSL* */
 #define PARAMETER_TYPE_SSL_WITH_KEY	24 /* OpenSSL's SSL* but attempt to dump the ssl key */
+#if HAVE_STRUCT_FLOCK
+#define PARAMETER_TYPE_STRUCT_FLOCK 25 /* fcntl's struct flock */
+#endif
+#if HAVE_STRUCT_FSTORE
+#define PARAMETER_TYPE_STRUCT_FSTORE 26 /* fcntl's struct fstore */
+#endif
+#if HAVE_STRUCT_FPUNCHHOLE
+#define PARAMETER_TYPE_STRUCT_FPUNCHHOLE 27 /* fcntl's struct fpunchhole */
+#endif
+#if HAVE_STRUCT_RADVISORY
+#define PARAMETER_TYPE_STRUCT_RADVISORY 28 /* fcntl's struct radvisory */
+#endif
+#if HAVE_STRUCT_FBOOTSTRAPTRANSFER
+#define PARAMETER_TYPE_STRUCT_FBOOTSTRAPTRANSFER 29 /* fcntl's struct fbootstraptransfer */
+#endif
+#if HAVE_STRUCT_LOG2PHYS
+#define PARAMETER_TYPE_STRUCT_LOG2PHYS 30 /* fcntl's struct log2phys */
+#endif
+#if HAVE_DECL_F_GETOWN_EX
+#define PARAMETER_TYPE_STRUCT_F_GETOWN_EX 31 /* fcntl's struct f_owner_ex */
+#endif
 
 #define PARAMETER_FLAG_OUTPUT_VARIABLE		0x40000000 /* This is an output variable, is uninitialized in EVENT_TYPE_BEFORE_CALL */
 #define PARAMETER_FLAG_STRING_NEXT		0x80000000 /* There's a string parameter that describes the string */

--- a/configure.ac
+++ b/configure.ac
@@ -83,7 +83,7 @@ AM_CONDITIONAL([OPENBSD], [test "x$isopenbsd" = "xyes"])
 
 # MacOS specific configuration
 if test "x$isdarwin" = "xyes"; then
-    CFLAGS="$CFLAGS -mmacosx-version-min=10.12"
+    CFLAGS="$CFLAGS -mmacosx-version-min=10.12 -D_DARWIN_C_SOURCE"
     LDFLAGS="$LDFLAGS -mmacosx-version-min=10.12"
 fi
 
@@ -148,124 +148,41 @@ fi
 
 
 # Check for PTRACE features
-AC_MSG_CHECKING([for PTRACE_GETREGS])
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-#include <stdlib.h>
-#include <stddef.h>
-#include <sys/ptrace.h>
-#include <sys/user.h>
-]], [[
-  void *p;
-  long res = ptrace(PTRACE_GETREGS, 0, p, p);
-]])],
-[
-    AC_MSG_RESULT([yes])
-    AC_DEFINE([HAVE_PTRACE_GETREGS], 1, [Define to 1 if you have the PTRACE_GETREGS ptrace request.])
-], [
-AC_MSG_RESULT([no])
-])
+AC_CHECK_DECLS([PTRACE_GETREGS, PTRACE_GETREGSET, PTRACE_SETREGSET], [], [], [#include <sys/ptrace.h.h>])
+AC_CHECK_DECLS([PTRACE_SEIZE], [], [], [#include <sys/ptrace.h.h>])
+AC_CHECK_DECLS([PTRACE_INTERRUPT], [], [], [#include <sys/ptrace.h.h>])
+AC_CHECK_DECLS([PTRACE_LISTEN], [], [], [#include <sys/ptrace.h.h>])
+AC_CHECK_DECLS([PTRACE_PEEKSIGINFO], [], [], [#include <sys/ptrace.h.h>])
 
-AC_MSG_CHECKING([for PTRACE_GETREGSET])
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-#include <stdlib.h>
-#include <stddef.h>
-#include <sys/ptrace.h>
-#include <sys/user.h>
-]], [[
-  void *p;
-  long res = ptrace(PTRACE_GETREGSET, 0, p, p);
-]])],
-[
-    AC_MSG_RESULT([yes])
-    AC_DEFINE([HAVE_PTRACE_GETREGSET], 1, [Define to 1 if you have the PTRACE_GETREGSET ptrace request.])
-], [
-AC_MSG_RESULT([no])
-])
-
-AC_MSG_CHECKING([for PTRACE_SETREGSET])
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-#include <stdlib.h>
-#include <stddef.h>
-#include <sys/ptrace.h>
-#include <sys/user.h>
-]], [[
-  void *p;
-  long res = ptrace(PTRACE_SETREGSET, 0, p, p);
-]])],
-[
-    AC_MSG_RESULT([yes])
-    AC_DEFINE([HAVE_PTRACE_SETREGSET], 1, [Define to 1 if you have the PTRACE_SETREGSET ptrace request.])
-], [
-AC_MSG_RESULT([no])
-])
-
-AC_MSG_CHECKING([for PTRACE_SEIZE])
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-#include <stdlib.h>
-#include <stddef.h>
-#include <sys/ptrace.h>
-#include <sys/user.h>
-]], [[
-  void *p;
-  long res = ptrace(PTRACE_SEIZE, 0, p, p);
-]])],
-[
-    AC_MSG_RESULT([yes])
-    AC_DEFINE([HAVE_PTRACE_SEIZE], 1, [Define to 1 if you have the PTRACE_SEIZE ptrace request.])
-], [
-AC_MSG_RESULT([no])
-])
-
-AC_MSG_CHECKING([for PTRACE_INTERRUPT])
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-#include <stdlib.h>
-#include <stddef.h>
-#include <sys/ptrace.h>
-#include <sys/user.h>
-]], [[
-  void *p;
-  long res = ptrace(PTRACE_INTERRUPT, 0, p, p);
-]])],
-[
-    AC_MSG_RESULT([yes])
-    AC_DEFINE([HAVE_PTRACE_INTERRUPT], 1, [Define to 1 if you have the PTRACE_INTERRUPT ptrace request.])
-], [
-AC_MSG_RESULT([no])
-])
-
-AC_MSG_CHECKING([for PTRACE_LISTEN])
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-#include <stdlib.h>
-#include <stddef.h>
-#include <sys/ptrace.h>
-#include <sys/user.h>
-]], [[
-  void *p;
-  long res = ptrace(PTRACE_LISTEN, 0, p, p);
-]])],
-[
-    AC_MSG_RESULT([yes])
-    AC_DEFINE([HAVE_PTRACE_LISTEN], 1, [Define to 1 if you have the PTRACE_LISTEN ptrace request.])
-], [
-AC_MSG_RESULT([no])
-])
-
-AC_MSG_CHECKING([for PTRACE_PEEKSIGINFO])
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-#include <stdlib.h>
-#include <stddef.h>
-#include <sys/ptrace.h>
-#include <sys/user.h>
-]], [[
-  void *p;
-  long res = ptrace(PTRACE_PEEKSIGINFO, 0, p, p);
-]])],
-[
-    AC_MSG_RESULT([yes])
-    AC_DEFINE([HAVE_PTRACE_PEEKSIGINFO], 1, [Define to 1 if you have the PTRACE_PEEKSIGINFO ptrace request.])
-], [
-AC_MSG_RESULT([no])
-])
+# Check fcntl features
+AC_CHECK_DECLS([F_DUPFD_CLOEXEC], [], [], [#include <fcntl.h>])
+AC_CHECK_DECLS([F_SETOWN, F_GETOWN], [], [], [#include <fcntl.h>])
+AC_CHECK_TYPES([struct flock], [], [], [#include <fcntl.h>])
+AC_CHECK_DECLS([F_SETLKW], [], [], [#include <fcntl.h>])
+AC_CHECK_DECLS([F_GETPATH], , [], [#include <fcntl.h>])
+AC_CHECK_TYPES([struct fstore], [], [], [#include <fcntl.h>])
+AC_CHECK_DECLS([F_PREALLOCATE], [], [], [#include <fcntl.h>])
+AC_CHECK_TYPES([struct fpunchhole], [], [], [#include <fcntl.h>])
+AC_CHECK_DECLS([F_PUNCHHOLE], [], [], [#include <fcntl.h>])
+AC_CHECK_DECLS([F_SETSIZE], [], [], [#include <fcntl.h>])
+AC_CHECK_TYPES([struct radvisory], [], [], [#include <fcntl.h>])
+AC_CHECK_DECLS([F_RDADVISE], [], [], [#include <fcntl.h>])
+AC_CHECK_DECLS([F_RDAHEAD], [], [], [#include <fcntl.h>])
+AC_CHECK_TYPES([struct fbootstraptransfer], [], [], [#include <fcntl.h>])
+AC_CHECK_DECLS([F_READBOOTSTRAP, F_WRITEBOOTSTRAP], [], [], [#include <fcntl.h>])
+AC_CHECK_DECLS([F_NOCACHE], [], [], [#include <fcntl.h>])
+AC_CHECK_TYPES([struct log2phys], [], [], [#include <fcntl.h>])
+AC_CHECK_DECLS([F_LOG2PHYS, F_LOG2PHYS_EXT], [], [], [#include <fcntl.h>])
+AC_CHECK_DECLS([F_FULLFSYNC], [], [], [#include <fcntl.h>])
+AC_CHECK_DECLS([F_SETNOSIGPIPE, F_GETNOSIGPIPE], [], [], [#include <fcntl.h>])
+AC_CHECK_DECLS([F_OFD_SETLK, F_OFD_SETLKW, F_OFD_GETLK], [], [], [#include <fcntl.h>])
+AC_CHECK_TYPES([struct f_owner_ex], [], [], [#include <fcntl.h>])
+AC_CHECK_DECLS([F_GETOWN_EX, F_SETOWN_EX], [], [], [#include <fcntl.h>])
+AC_CHECK_DECLS([F_GETSIG, F_SETSIG], [], [], [#include <fcntl.h>])
+AC_CHECK_DECLS([F_SETLEASE, F_GETLEASE], [], [], [#include <fcntl.h>])
+AC_CHECK_DECLS([F_NOTIFY], [], [], [#include <fcntl.h>])
+AC_CHECK_DECLS([F_SETPIPE_SZ, F_GETPIPE_SZ], [], [], [#include <fcntl.h>])
+AC_CHECK_DECLS([F_ADD_SEALS, F_GET_SEALS], [], [], [#include <fcntl.h>])
 
 TESTS_CFLAGS=""
 AC_MSG_CHECKING(whether to run tests)

--- a/file.c
+++ b/file.c
@@ -876,11 +876,11 @@ fcntl_v(int fildes, int cmd, va_list ap)
 #endif
 		r = real_fcntl(fildes, cmd, int_parameter);
 		if (r >= 0) {
-		    di = file_descriptor_get(fildes);
-		    if (di->location != NULL) {
-			    old_location = di->location;
-		    }
-		    file_descriptor_update(r, FILE_DESCRIPTOR_TYPE_FILE, old_location, 0);
+			di = file_descriptor_get(fildes);
+			if (di->location != NULL)
+				old_location = di->location;
+
+			file_descriptor_update(r, FILE_DESCRIPTOR_TYPE_FILE, old_location, 0);
 		}
 		break;
 

--- a/file.c
+++ b/file.c
@@ -603,3 +603,436 @@ void RETRACE_IMPLEMENTATION(strmode)(int mode, char *bp)
 }
 
 RETRACE_REPLACE(strmode, void, (int mode, char *bp), (mode, bp))
+
+static int
+fcntl_v(int fildes, int cmd, va_list ap)
+{
+	int r;
+	int int_parameter = 0;
+#if HAVE_STRUCT_FLOCK
+	struct flock *flock_parameter = NULL;
+#endif
+	void *maybe_parameter = NULL;
+#if HAVE_DECL_F_GETPATH
+	void *char_parameter = NULL;
+#endif
+#if HAVE_STRUCT_FSTORE && HAVE_DECL_F_PREALLOCATE
+	struct fstore *fstore_parameter = NULL;
+#endif
+#if HAVE_STRUCT_FPUNCHHOLE && HAVE_DECL_F_PUNCHHOLE
+	struct fpunchhole *fpunchhole_parameter = NULL;
+#endif
+#if HAVE_STRUCT_RADVISORY && HAVE_DECL_F_RDADVISE
+	struct radvisory *radvisory_parameter = NULL;
+#endif
+#if HAVE_STRUCT_FBOOTSTRAPTRANSFER && (HAVE_DECL_F_READBOOTSTRAP || HAVE_DECL_F_WRITEBOOTSTRAP)
+	struct fbootstraptransfer *fbootstraptransfer_parameter = NULL;
+#endif
+#if HAVE_STRUCT_LOG2PHYS && (HAVE_DECL_F_LOG2PHYS || HAVE_DECL_F_LOG2PHYS_EXT)
+	struct log2phys *log2phys_parameter = NULL;
+#endif
+#if HAVE_DECL_F_GETOWN_EX && (HAVE_DECL_F_GETOWN_EX || HAVE_DECL_F_SETOWN_EX)
+	struct f_owner_ex *f_owner_ex_parameter = NULL;
+#endif
+
+	struct descriptor_info *di;
+	const char *old_location = "fcntl";
+
+	struct rtr_event_info event_info;
+
+	unsigned int parameter_types_maybe[] = {PARAMETER_TYPE_FILE_DESCRIPTOR, PARAMETER_TYPE_INT, PARAMETER_TYPE_POINTER, PARAMETER_TYPE_END};
+	void const *parameter_values_maybe[] = {&fildes, &cmd, &maybe_parameter};
+
+	unsigned int parameter_types_int[] = {PARAMETER_TYPE_FILE_DESCRIPTOR, PARAMETER_TYPE_INT, PARAMETER_TYPE_INT, PARAMETER_TYPE_END};
+	void const *parameter_values_int[] = {&fildes, &cmd, &int_parameter};
+
+	unsigned int parameter_types_void[] = {PARAMETER_TYPE_FILE_DESCRIPTOR, PARAMETER_TYPE_INT, PARAMETER_TYPE_END};
+	void const *parameter_values_void[] = {&fildes, &cmd};
+
+#if HAVE_STRUCT_FLOCK
+	unsigned int parameter_types_flock[] = {PARAMETER_TYPE_FILE_DESCRIPTOR, PARAMETER_TYPE_INT, PARAMETER_TYPE_STRUCT_FLOCK, PARAMETER_TYPE_END};
+	void const *parameter_values_flock[] = {&fildes, &cmd, &flock_parameter};
+#endif
+#if HAVE_DECL_F_GETPATH
+	unsigned int parameter_types_char[] = {PARAMETER_TYPE_FILE_DESCRIPTOR, PARAMETER_TYPE_INT, PARAMETER_TYPE_STRING, PARAMETER_TYPE_END};
+	void const *parameter_values_char[] = {&fildes, &cmd, &char_parameter};
+#endif
+#if HAVE_STRUCT_FSTORE && HAVE_DECL_F_PREALLOCATE
+	unsigned int parameter_types_fstore[] = {PARAMETER_TYPE_FILE_DESCRIPTOR, PARAMETER_TYPE_INT, PARAMETER_TYPE_STRUCT_FSTORE, PARAMETER_TYPE_END};
+	void const *parameter_values_fstore[] = {&fildes, &cmd, &fstore_parameter};
+#endif
+#if HAVE_STRUCT_FPUNCHHOLE && HAVE_DECL_F_PUNCHHOLE
+	unsigned int parameter_types_fpunchhole[] = {PARAMETER_TYPE_FILE_DESCRIPTOR, PARAMETER_TYPE_INT, PARAMETER_TYPE_STRUCT_FPUNCHHOLE, PARAMETER_TYPE_END};
+	void const *parameter_values_fpunchhole[] = {&fildes, &cmd, &fpunchhole_parameter};
+#endif
+#if HAVE_STRUCT_RADVISORY && HAVE_DECL_F_RDADVISE
+	unsigned int parameter_types_radvisory[] = {PARAMETER_TYPE_FILE_DESCRIPTOR, PARAMETER_TYPE_INT, PARAMETER_TYPE_STRUCT_RADVISORY, PARAMETER_TYPE_END};
+	void const *parameter_values_radvisory[] = {&fildes, &cmd, &radvisory_parameter};
+#endif
+#if HAVE_STRUCT_FBOOTSTRAPTRANSFER && (HAVE_DECL_F_READBOOTSTRAP || HAVE_DECL_F_WRITEBOOTSTRAP)
+	unsigned int parameter_types_fbootstraptransfer[] = {PARAMETER_TYPE_FILE_DESCRIPTOR, PARAMETER_TYPE_INT, PARAMETER_TYPE_STRUCT_FBOOTSTRAPTRANSFER, PARAMETER_TYPE_END};
+	void const *parameter_values_fbootstraptransfer[] = {&fildes, &cmd, &fbootstraptransfer_parameter};
+#endif
+#if HAVE_STRUCT_LOG2PHYS && (HAVE_DECL_F_LOG2PHYS || HAVE_DECL_F_LOG2PHYS_EXT)
+	unsigned int parameter_types_log2phys[] = {PARAMETER_TYPE_FILE_DESCRIPTOR, PARAMETER_TYPE_INT, PARAMETER_TYPE_STRUCT_LOG2PHYS, PARAMETER_TYPE_END};
+	void const *parameter_values_log2phys[] = {&fildes, &cmd, &log2phys_parameter};
+#endif
+#if HAVE_DECL_F_GETOWN_EX && (HAVE_DECL_F_GETOWN_EX || HAVE_DECL_F_SETOWN_EX)
+	unsigned int parameter_types_f_owner_ex[] = {PARAMETER_TYPE_FILE_DESCRIPTOR, PARAMETER_TYPE_INT, PARAMETER_TYPE_STRUCT_F_GETOWN_EX, PARAMETER_TYPE_END};
+	void const *parameter_values_f_owner_ex[] = {&fildes, &cmd, &f_owner_ex_parameter};
+#endif
+
+	event_info.function_name = "fcntl";
+	event_info.return_value_type = PARAMETER_TYPE_INT;
+	event_info.return_value = &r;
+
+	switch (cmd) {
+	// (int) arg
+	case F_DUPFD:
+#if HAVE_DECL_F_DUPFD_CLOEXEC
+	case F_DUPFD_CLOEXEC:
+#endif
+	case F_SETFD:
+	case F_SETFL:
+#if HAVE_DECL_F_SETOWN
+	case F_SETOWN:
+#endif
+#if HAVE_DECL_F_RDAHEAD
+	case F_RDAHEAD:
+#endif
+#if HAVE_DECL_F_NOCACHE
+	case F_NOCACHE:
+#endif
+#if HAVE_DECL_F_SETNOSIGPIPE
+	case F_SETNOSIGPIPE:
+#endif
+#if HAVE_DECL_F_SETSIG
+	case F_SETSIG:
+#endif
+#if HAVE_DECL_F_SETLEASE
+	case F_SETLEASE:
+#endif
+#if HAVE_DECL_F_NOTIFY
+	case F_NOTIFY:
+#endif
+#if HAVE_DECL_F_SETPIPE_SZ
+	case F_SETPIPE_SZ:
+#endif
+#if HAVE_DECL_F_ADD_SEALS
+	case F_ADD_SEALS:
+#endif
+		event_info.parameter_types = parameter_types_int;
+		event_info.parameter_values = (void **) parameter_values_int;
+
+		int_parameter = va_arg(ap, int);
+
+		break;
+
+	// (void) arg
+	case F_GETFD:
+	case F_GETFL:
+#if HAVE_DECL_F_GETOWN
+	case F_GETOWN:
+#endif
+#if HAVE_DECL_F_SETSIZE
+	case F_SETSIZE:
+#endif
+#if HAVE_DECL_F_FULLFSYNC
+	case F_FULLFSYNC:
+#endif
+#if HAVE_DECL_F_GETNOSIGPIPE
+	case F_GETNOSIGPIPE:
+#endif
+#if HAVE_DECL_F_GETSIG
+	case F_GETSIG:
+#endif
+#if HAVE_DECL_F_GETLEASE
+	case F_GETLEASE:
+#endif
+#if HAVE_DECL_F_GETPIPE_SZ
+	case F_GETPIPE_SZ:
+#endif
+#if HAVE_DECL_F_GET_SEALS
+	case F_GET_SEALS:
+#endif
+		event_info.parameter_types = parameter_types_void;
+		event_info.parameter_values = (void **) parameter_values_void;
+
+		break;
+
+#if HAVE_STRUCT_FLOCK
+	// (struct flock *) arg
+	case F_SETLK:
+#if HAVE_DECL_F_SETLKW
+	case F_SETLKW:
+#endif
+	case F_GETLK:
+#if HAVE_DECL_F_OFD_SETLK
+	case F_OFD_SETLK:
+#endif
+#if HAVE_DECL_F_OFD_SETLKW
+	case F_OFD_SETLKW:
+#endif
+#if HAVE_DECL_F_OFD_GETLK
+	case F_OFD_GETLK:
+#endif
+		event_info.parameter_types = parameter_types_flock;
+		event_info.parameter_values = (void **) parameter_values_flock;
+
+		flock_parameter = va_arg(ap, struct flock *);
+
+		break;
+#endif
+
+#if HAVE_DECL_F_GETPATH
+	// char* arg
+	case F_GETPATH:
+		event_info.parameter_types = parameter_types_char;
+		event_info.parameter_values = (void **) parameter_values_char;
+
+		char_parameter = va_arg(ap, char*);
+
+		break;
+#endif
+#if HAVE_STRUCT_FSTORE && HAVE_DECL_F_PREALLOCATE
+	// (struct fstore *) arg
+	case F_PREALLOCATE:
+		event_info.parameter_types = parameter_types_fstore;
+		event_info.parameter_values = (void **) parameter_values_fstore;
+
+		fstore_parameter = va_arg(ap, struct fstore *);
+
+		break;
+#endif
+#if HAVE_STRUCT_FPUNCHHOLE && HAVE_DECL_F_PUNCHHOLE
+	// (struct fpunchhole *) arg
+	case F_PUNCHHOLE:
+		event_info.parameter_types = parameter_types_fpunchhole;
+		event_info.parameter_values = (void **) parameter_values_fpunchhole;
+
+		fpunchhole_parameter = va_arg(ap, struct fpunchhole *);
+
+		break;
+#endif
+#if HAVE_STRUCT_RADVISORY && HAVE_DECL_F_RDADVISE
+	// (struct radvisory *) arg
+	case F_RDADVISE:
+		event_info.parameter_types = parameter_types_radvisory;
+		event_info.parameter_values = (void **) parameter_values_radvisory;
+
+		radvisory_parameter = va_arg(ap, struct radvisory *);
+
+		break;
+#endif
+#if HAVE_STRUCT_FBOOTSTRAPTRANSFER && (HAVE_DECL_F_READBOOTSTRAP || HAVE_DECL_F_WRITEBOOTSTRAP)
+	// (struct fbootstraptransfer *) arg
+	case F_READBOOTSTRAP:
+	case F_WRITEBOOTSTRAP:
+		event_info.parameter_types = parameter_types_fbootstraptransfer;
+		event_info.parameter_values = (void **) parameter_values_fbootstraptransfer;
+
+		fbootstraptransfer_parameter = va_arg(ap, struct fbootstraptransfer *);
+
+		break;
+#endif
+#if HAVE_STRUCT_LOG2PHYS && (HAVE_DECL_F_LOG2PHYS || HAVE_DECL_F_LOG2PHYS_EXT)
+	// (struct log2phys *) arg
+	case F_LOG2PHYS:
+	case F_LOG2PHYS_EXT:
+		event_info.parameter_types = parameter_types_log2phys;
+		event_info.parameter_values = (void **) parameter_values_log2phys;
+
+		log2phys_parameter = va_arg(ap, struct log2phys *);
+
+		break;
+#endif
+#if HAVE_DECL_F_GETOWN_EX && (HAVE_DECL_F_GETOWN_EX || HAVE_DECL_F_SETOWN_EX)
+	// (struct f_owner_ex *) arg
+	case F_GETOWN_EX:
+	case F_SETOWN_EX:
+		event_info.parameter_types = parameter_types_f_owner_ex;
+		event_info.parameter_values = (void **) parameter_values_f_owner_ex;
+
+		f_owner_ex_parameter = va_arg(ap, struct f_owner_ex *);
+
+		break;
+#endif
+	default:
+		event_info.parameter_types = parameter_types_maybe;
+		event_info.parameter_values = (void **) parameter_values_maybe;
+
+		maybe_parameter = va_arg(ap, void *);
+
+		trace_printf(1, "Unsupported fcntl command: %d", cmd);
+	}
+
+	retrace_log_and_redirect_before(&event_info);
+
+	switch (cmd) {
+	// hack for duplicating FD
+	case F_DUPFD:
+#if HAVE_DECL_F_DUPFD_CLOEXEC
+	case F_DUPFD_CLOEXEC:
+#endif
+		r = real_fcntl(fildes, cmd, int_parameter);
+		if (r >= 0) {
+		    di = file_descriptor_get(fildes);
+		    if (di->location != NULL) {
+			    old_location = di->location;
+		    }
+		    file_descriptor_update(r, FILE_DESCRIPTOR_TYPE_FILE, old_location, 0);
+		}
+		break;
+
+	// (int) arg
+	case F_SETFD:
+	case F_SETFL:
+#if HAVE_DECL_F_SETOWN
+	case F_SETOWN:
+#endif
+#if HAVE_DECL_F_RDAHEAD
+	case F_RDAHEAD:
+#endif
+#if HAVE_DECL_F_NOCACHE
+	case F_NOCACHE:
+#endif
+#if HAVE_DECL_F_SETNOSIGPIPE
+	case F_SETNOSIGPIPE:
+#endif
+#if HAVE_DECL_F_SETSIG
+	case F_SETSIG:
+#endif
+#if HAVE_DECL_F_SETLEASE
+	case F_SETLEASE:
+#endif
+#if HAVE_DECL_F_NOTIFY
+	case F_NOTIFY:
+#endif
+#if HAVE_DECL_F_SETPIPE_SZ
+	case F_SETPIPE_SZ:
+#endif
+#if HAVE_DECL_F_ADD_SEALS
+	case F_ADD_SEALS:
+#endif
+		r = real_fcntl(fildes, cmd, int_parameter);
+		break;
+
+	// (void) arg
+	case F_GETFD:
+	case F_GETFL:
+#if HAVE_DECL_F_GETOWN
+	case F_GETOWN:
+#endif
+#if HAVE_DECL_F_SETSIZE
+	case F_SETSIZE:
+#endif
+#if HAVE_DECL_F_FULLFSYNC
+	case F_FULLFSYNC:
+#endif
+#if HAVE_DECL_F_GETNOSIGPIPE
+	case F_GETNOSIGPIPE:
+#endif
+#if HAVE_DECL_F_GETSIG
+	case F_GETSIG:
+#endif
+#if HAVE_DECL_F_GETLEASE
+	case F_GETLEASE:
+#endif
+#if HAVE_DECL_F_GETPIPE_SZ
+	case F_GETPIPE_SZ:
+#endif
+#if HAVE_DECL_F_GET_SEALS
+	case F_GET_SEALS:
+#endif
+		r = real_fcntl(fildes, cmd);
+		break;
+
+#if HAVE_STRUCT_FLOCK
+	// (struct flock *) arg
+	case F_SETLK:
+#if HAVE_DECL_F_SETLKW
+	case F_SETLKW:
+#endif
+	case F_GETLK:
+#if HAVE_DECL_F_OFD_SETLK
+	case F_OFD_SETLK:
+#endif
+#if HAVE_DECL_F_OFD_SETLKW
+	case F_OFD_SETLKW:
+#endif
+#if HAVE_DECL_F_OFD_GETLK
+	case F_OFD_GETLK:
+#endif
+		r = real_fcntl(fildes, cmd, flock_parameter);
+		break;
+#endif
+#if HAVE_DECL_F_GETPATH
+		// char* arg
+	case F_GETPATH:
+		r = real_fcntl(fildes, cmd, char_parameter);
+		break;
+#endif
+#if HAVE_STRUCT_FSTORE && HAVE_DECL_F_PREALLOCATE
+	// (struct fstore *) arg
+	case F_PREALLOCATE:
+			r = real_fcntl(fildes, cmd, fstore_parameter);
+		break;
+#endif
+#if HAVE_STRUCT_FPUNCHHOLE && HAVE_DECL_F_PUNCHHOLE
+	// (struct fpunchhole *) arg
+	case F_PUNCHHOLE:
+		r = real_fcntl(fildes, cmd, fpunchhole_parameter);
+		break;
+#endif
+#if HAVE_STRUCT_RADVISORY && HAVE_DECL_F_RDADVISE
+	// (struct radvisory *) arg
+	case F_RDADVISE:
+		r = real_fcntl(fildes, cmd, radvisory_parameter);
+		break;
+#endif
+#if HAVE_STRUCT_FBOOTSTRAPTRANSFER && (HAVE_DECL_F_READBOOTSTRAP || HAVE_DECL_F_WRITEBOOTSTRAP)
+	// (struct fbootstraptransfer *) arg
+	case F_READBOOTSTRAP:
+	case F_WRITEBOOTSTRAP:
+		r = real_fcntl(fildes, cmd, fbootstraptransfer_parameter);
+		break;
+#endif
+#if HAVE_STRUCT_LOG2PHYS && (HAVE_DECL_F_LOG2PHYS || HAVE_DECL_F_LOG2PHYS_EXT)
+	// (struct fbootstraptransfer *) arg
+	case F_LOG2PHYS:
+	case F_LOG2PHYS_EXT:
+		r = real_fcntl(fildes, cmd, log2phys_parameter);
+		break;
+#endif
+#if HAVE_DECL_F_GETOWN_EX && (HAVE_DECL_F_GETOWN_EX || HAVE_DECL_F_SETOWN_EX)
+	// (struct f_owner_ex *) arg
+	case F_GETOWN_EX:
+	case F_SETOWN_EX:
+		r = real_fcntl(fildes, cmd, f_owner_ex_parameter);
+		break;
+#endif
+
+	default:
+		r = real_fcntl(fildes, cmd, maybe_parameter);
+		break;
+	}
+
+
+	retrace_log_and_redirect_after(&event_info);
+
+	return r;
+}
+
+int RETRACE_IMPLEMENTATION(fcntl)(int fildes, int cmd, ...)
+{
+	int rc;
+	va_list ap;
+
+	va_start(ap, cmd);
+	rc = fcntl_v(fildes, cmd, ap);
+	va_end(ap);
+
+	return rc;
+}
+
+RETRACE_REPLACE_V(fcntl, int, (int fildes, int cmd, ...), cmd, fcntl_v, (fildes, cmd, ap))

--- a/file.h
+++ b/file.h
@@ -21,6 +21,7 @@ typedef int (*rtr_fputs_t)(const char *s, FILE *stream);
 typedef int (*rtr_fgetc_t)(FILE *stream);
 typedef char*(*rtr_fgets_t)(char *s, int size, FILE *stream);
 typedef void (*rtr_strmode_t)(int mode, char *bp);
+typedef int (*rtr_fcntl_t)(int fildes, int cmd, ...);
 
 RETRACE_DECL(fopen);
 RETRACE_DECL(fclose);
@@ -42,5 +43,6 @@ RETRACE_DECL(fputs);
 RETRACE_DECL(fgetc);
 RETRACE_DECL(fgets);
 RETRACE_DECL(strmode);
+RETRACE_DECL(fcntl);
 
 #endif /* __RETRACE_FILE_H__ */

--- a/trace.c
+++ b/trace.c
@@ -140,7 +140,7 @@ long int RETRACE_IMPLEMENTATION(ptrace)(enum __ptrace_request request, ...)
 	case PT_ATTACH:
 		request_str = "PT_ATTACH";
 		break;
-#ifdef HAVE_PTRACE_GETREGS
+#if HAVE_DECL_PTRACE_GETREGS
 	case PTRACE_GETREGS:
 		request_str = "PTRACE_GETREGS";
 		break;
@@ -175,33 +175,33 @@ long int RETRACE_IMPLEMENTATION(ptrace)(enum __ptrace_request request, ...)
 	case PTRACE_SETSIGINFO:
 		request_str = "PTRACE_SETSIGINFO";
 		break;
-#ifdef HAVE_PTRACE_GETREGSET
+#if HAVE_DECL_PTRACE_GETREGSET
 	case PTRACE_GETREGSET:
 		request_str = "PTRACE_GETREGSET";
 		break;
 #endif
-#ifdef HAVE_PTRACE_SETREGSET
+#if HAVE_DECL_PTRACE_SETREGSET
 	case PTRACE_SETREGSET:
 		request_str = "PTRACE_SETREGSET";
 		break;
 #endif
-#ifdef HAVE_PTRACE_SEIZE
+#if HAVE_DECL_PTRACE_SEIZE
 	case PTRACE_SEIZE:
 		request_str = "PTRACE_SEIZE";
 		break;
 #endif
-#ifdef HAVE_PTRACE_INTERRUPT
+#if HAVE_DECL_PTRACE_INTERRUPT
 	case PTRACE_INTERRUPT:
 		request_str = "PTRACE_INTERRUPT";
 		break;
 #endif
-#ifdef HAVE_PTRACE_LISTEN
+#if HAVE_DECL_PTRACE_LISTEN
 	case PTRACE_LISTEN:
 		request_str = "PTRACE_LISTEN";
 		break;
 #endif
 
-#ifdef HAVE_PTRACE_PEEKSIGINFO
+#if HAVE_DECL_PTRACE_PEEKSIGINFO
 	case PTRACE_PEEKSIGINFO:
 		request_str = "PTRACE_PEEKSIGINFO";
 		break;


### PR DESCRIPTION
Supported commands from:
 - UNIX93...Open Group Base Specifications Issue 7
 - BSD 2.10 (as example of very old UNIX)
 - macOS 10.12 man-page
 - linux man-page 4.11

Refactoring:
 - switch configure at ptrace features to use `AC_CHECK_DECLS`/`AC_CHECK_TYPES`