### PR TITLE
Incompleteio fix

### DIFF
--- a/common.c
+++ b/common.c
@@ -1163,6 +1163,9 @@ void trace_printf_backtrace(void)
 	if (!get_tracing_enabled())
 		return;
 
+	if (!rtr_get_config_single("backtrace", ARGUMENT_TYPE_END))
+		return;
+
 	old_trace_state = trace_disable();
 
 	int i, frames = backtrace(callstack, 128);

--- a/read.c
+++ b/read.c
@@ -56,9 +56,8 @@ ssize_t RETRACE_IMPLEMENTATION(read)(int fd, void *buf, size_t nbytes)
 
 	ret = real_read(fd, buf, nbytes);
 
-	if (incompleteio) {
+	if (incompleteio)
 		trace_printf_backtrace();
-	}
 
 	retrace_log_and_redirect_after(&event_info);
 

--- a/read.c
+++ b/read.c
@@ -29,6 +29,8 @@
 ssize_t RETRACE_IMPLEMENTATION(read)(int fd, void *buf, size_t nbytes)
 {
 	ssize_t ret = 0;
+	int incompleteio = 0;
+
 	struct rtr_event_info event_info;
 	unsigned int parameter_types[] = {PARAMETER_TYPE_FILE_DESCRIPTOR, PARAMETER_TYPE_MEMORY_BUFFER, PARAMETER_TYPE_INT, PARAMETER_TYPE_END};
 	void const *parameter_values[] = {&fd, &ret, &buf, &nbytes};
@@ -42,6 +44,7 @@ ssize_t RETRACE_IMPLEMENTATION(read)(int fd, void *buf, size_t nbytes)
 	retrace_log_and_redirect_before(&event_info);
 
 	if (rtr_get_config_single("incompleteio", ARGUMENT_TYPE_END)) {
+		incompleteio = 1;
 		nbytes = rtr_get_fuzzing_random() % nbytes;
 		if (nbytes <= 0) {
 			nbytes = 1;
@@ -52,6 +55,10 @@ ssize_t RETRACE_IMPLEMENTATION(read)(int fd, void *buf, size_t nbytes)
 
 
 	ret = real_read(fd, buf, nbytes);
+
+	if (incompleteio) {
+		trace_printf_backtrace();
+	}
 
 	retrace_log_and_redirect_after(&event_info);
 

--- a/read.c
+++ b/read.c
@@ -43,6 +43,9 @@ ssize_t RETRACE_IMPLEMENTATION(read)(int fd, void *buf, size_t nbytes)
 
 	if (rtr_get_config_single("incompleteio", ARGUMENT_TYPE_END)) {
 		nbytes = rtr_get_fuzzing_random() % nbytes;
+		if (nbytes <= 0) {
+			nbytes = 1;
+		}
 		event_info.extra_info = "[redirected]";
 		event_info.event_flags = EVENT_FLAGS_PRINT_RAND_SEED;
 	}

--- a/write.c
+++ b/write.c
@@ -45,6 +45,9 @@ ssize_t RETRACE_IMPLEMENTATION(write)(int fd, const void *buf, size_t nbytes)
 
 	if (rtr_get_config_single("incompleteio", ARGUMENT_TYPE_END)) {
 		nbytes = rtr_get_fuzzing_random() % nbytes;
+		if (nbytes <= 0) {
+			nbytes = 1;
+		}
 		event_info.extra_info = "[redirected]";
 		event_info.event_flags = EVENT_FLAGS_PRINT_RAND_SEED;
 	}

--- a/write.c
+++ b/write.c
@@ -59,9 +59,8 @@ ssize_t RETRACE_IMPLEMENTATION(write)(int fd, const void *buf, size_t nbytes)
 
 	ret = real_write(fd, buf, nbytes);
 
-	if (incompleteio) {
+	if (incompleteio)
 		trace_printf_backtrace();
-	}
 
 	retrace_log_and_redirect_after(&event_info);
 


### PR DESCRIPTION
I've introduced very small fix for incompleteio — never returns negative or zero value because it isn't an incomplete :) Zero means EOF and negative means an error.

Also I introduced one more option to enable/disable printing stacktrace and by default it's disabled because it's provides huge output.