### PR TITLE
Fix some crashes

### DIFF
--- a/common.c
+++ b/common.c
@@ -524,7 +524,7 @@ trace_printf(int hdr, const char *fmt, ...)
 								  &output_file_path, &output_file_flush)) {
 			old_trace_state = trace_disable();
 			if (output_file_path) {
-				FILE *out_file_tmp = fopen(output_file_path, "a");
+				FILE *out_file_tmp = real_fopen(output_file_path, "a");
 
 				if (out_file_tmp)
 					output_file = out_file_tmp;

--- a/common.c
+++ b/common.c
@@ -920,6 +920,22 @@ int rtr_get_config_single(const char *function, ...)
 	return (ret);
 }
 
+static char *
+retrace_strdup(const char *s)
+{
+	size_t len;
+	char *ret;
+
+	len = real_strlen(s);
+
+	ret = (char *) real_malloc(len + 1);
+
+	if (ret)
+		memcpy(ret, s, len + 1);
+
+	return ret;
+}
+
 
 struct descriptor_info *
 descriptor_info_new(int fd, unsigned int type, const char *location, int port)
@@ -936,7 +952,7 @@ descriptor_info_new(int fd, unsigned int type, const char *location, int port)
 		di->type = type;
 
 		if (location)
-			di->location = strdup(location);
+			di->location = retrace_strdup(location);
 		else
 			di->location = NULL;
 
@@ -956,9 +972,9 @@ descriptor_info_free(struct descriptor_info *di)
 	old_trace_state = trace_disable();
 
 	if (di->location)
-		free(di->location);
+		real_free(di->location);
 
-	free(di);
+	real_free(di);
 
 	trace_restore(old_trace_state);
 }
@@ -1047,9 +1063,9 @@ file_descriptor_update(int fd, unsigned int type, const char *location, int port
 	if (di) {
 		di->type = type;
 		if (di->location) {
-			free(di->location);
+			real_free(di->location);
 		}
-		di->location = strdup (location);
+		di->location = retrace_strdup(location);
 
 		di->port = port;
 	} else {

--- a/dir.c
+++ b/dir.c
@@ -69,6 +69,7 @@ int RETRACE_IMPLEMENTATION(closedir)(DIR *dirp)
 	retrace_log_and_redirect_before(&event_info);
 
 	r = real_closedir(dirp);
+	dirp = NULL;
 
 	retrace_log_and_redirect_after(&event_info);
 


### PR DESCRIPTION
Bash does some weird stuff with the memory allocators.

This fixes some crashes when running

./retrace bash -c ls