### PR TITLE
fix pledge.c to compile on OpenBSD, remove 'local' from retrace.in because OpenBSD /bin/sh does not like that

### DIFF
--- a/pledge.c
+++ b/pledge.c
@@ -42,7 +42,7 @@ int RETRACE_IMPLEMENTATION(pledge)(const char *promises, const char *paths[])
 	event_info.parameter_types = parameter_types;
 	event_info.parameter_values = (void **) parameter_values;
 	event_info.return_value_type = PARAMETER_TYPE_INT;
-	event_info.return_value = &ret;
+	event_info.return_value = &r;
 	retrace_log_and_redirect_before(&event_info);
 
 	r = real_pledge(promises, paths);
@@ -52,6 +52,6 @@ int RETRACE_IMPLEMENTATION(pledge)(const char *promises, const char *paths[])
 	return r;
 }
 
-RETRACE_REPLACE(pledge)
+RETRACE_REPLACE(pledge, int, (const char *promises, const char *paths[]), (promises, paths))
 
 #endif /* __OpenBSD */

--- a/retrace.in
+++ b/retrace.in
@@ -13,7 +13,7 @@ usage() {
 }
 
 get_lib_file() {
-	readonly local fname="$1"
+	readonly fname="$1"
 
 	for path in "${fname}" \
 	    ".libs/${fname}" \
@@ -37,7 +37,7 @@ main() {
 		usage
 
 	if [ $# -ge 3 -a "$1" = "-f" ]; then
-		local RETRACE_CONFIG="$2"
+		RETRACE_CONFIG="$2"
 
 		shift 2
 	fi
@@ -47,22 +47,22 @@ main() {
 			errx "cannot open '${RETRACE_CONFIG}'"
 	fi
 
-	readonly local libname="libretrace"
+	readonly libname="libretrace"
 
 	if $(uname | grep -q ^Darwin); then
-		readonly local lib="${libname}.dylib"
-		readonly local output=$(get_lib_file "${lib}")
-		readonly local envload="RETRACE_CONFIG=${RETRACE_CONFIG} DYLD_FORCE_FLAT_NAMESPACE=1 DYLD_INSERT_LIBRARIES=${output}"
+		readonly lib="${libname}.dylib"
+		readonly output=$(get_lib_file "${lib}")
+		readonly envload="RETRACE_CONFIG=${RETRACE_CONFIG} DYLD_FORCE_FLAT_NAMESPACE=1 DYLD_INSERT_LIBRARIES=${output}"
 	else
-		readonly local lib="${libname}.so"
-		readonly local output=$(get_lib_file "${lib}")
-		readonly local envload="RETRACE_CONFIG=${RETRACE_CONFIG} LD_PRELOAD=${output}"
+		readonly lib="${libname}.so"
+		readonly output=$(get_lib_file "${lib}")
+		readonly envload="RETRACE_CONFIG=${RETRACE_CONFIG} LD_PRELOAD=${output}"
 	fi
 
 	[ ! "${output}" ] && \
 		errx "cannot find '${lib}'"
 
-	[ ! -x "$1" ] && \
+	which "$1" >/dev/null 2>&1 || \
 		errx "cannot execute '$1'"
 
 	eval "${envload}" "$@"


### PR DESCRIPTION
. pledge.c had incorrect return_value, and insufficient RETRACE_REPLACE
. retrace.in used local which OpenBSD /bin/sh does not like
. retrace.in used '[ -x ]' to assess executability of '$1' but this does not work when '$1' is not absolute but in PATH