### PR TITLE
Time

### DIFF
--- a/common.c
+++ b/common.c
@@ -780,14 +780,14 @@ retrace_event(struct rtr_event_info *event_info)
 	if (!get_tracing_enabled())
 		return;
 
-	old_trace_state = trace_disable();
-	pthread_mutex_lock(&printing_lock);
-	olderrno = errno;
-
 	if (event_info->event_type == EVENT_TYPE_BEFORE_CALL) {
 		event_info->start_time = retrace_get_time();
 		return;
 	}
+
+	old_trace_state = trace_disable();
+	pthread_mutex_lock(&printing_lock);
+	olderrno = errno;
 
 	if (!loaded_config) {
 		loaded_config = 1;

--- a/common.h
+++ b/common.h
@@ -14,6 +14,7 @@
 #include <time.h>
 #include <unistd.h>
 #include <string.h>
+#include <time.h>
 
 #define MAXLEN		40
 
@@ -112,6 +113,8 @@ struct rtr_event_info {
 
 	unsigned int event_flags;
 	char *extra_info;
+
+	struct timespec start_time;
 };
 
 #define RETRACE_INTERNAL __attribute__((visibility("hidden")))

--- a/common.h
+++ b/common.h
@@ -114,7 +114,7 @@ struct rtr_event_info {
 	unsigned int event_flags;
 	char *extra_info;
 
-	struct timespec start_time;
+	double start_time;
 };
 
 #define RETRACE_INTERNAL __attribute__((visibility("hidden")))

--- a/retrace.conf.example
+++ b/retrace.conf.example
@@ -10,3 +10,5 @@ SSL_get_verify_result,10
 fuzzingseed,1498729252
 memoryfuzzing,0.05
 incompleteio
+showtimestamp
+showcalltime,0.0001


### PR DESCRIPTION
This is not yet finished, but shows the concept. The patch does two things:

1. Print a time stamp on each call. The first call would be 0 and then each subsequent call would show time elapsed since that first call.
2. Print how much time each call took. This can be used as a very crude poor man's profiler. Specially if I put in a config to only show calls that took more than X amount of time.

I still need to make all of this configurable and fix the printing I think the decimal part is wrong as displayed (its actually nano seconds rather than true decimal seconds).