### PR TITLE
Fix OpenBSD build

### DIFF
--- a/common.c
+++ b/common.c
@@ -55,6 +55,7 @@
 #include <arpa/inet.h>
 #include <sys/un.h>
 #include <netdb.h>
+#include <sys/socket.h>
 
 #include "str.h"
 #include "id.h"
@@ -802,11 +803,7 @@ retrace_event(struct rtr_event_info *event_info)
 	}
 
 	old_trace_state = trace_disable();
-
-	old_trace_state = trace_disable();
 	pthread_mutex_lock(&printing_lock);
-	trace_restore(old_trace_state);
-
 	olderrno = errno;
 
 	if (!loaded_config) {
@@ -925,7 +922,6 @@ retrace_event(struct rtr_event_info *event_info)
 
 	errno = olderrno;
 
-	old_trace_state = trace_disable();
 	pthread_mutex_unlock(&printing_lock);
 	trace_restore(old_trace_state);
 }

--- a/exit.c
+++ b/exit.c
@@ -45,7 +45,7 @@ void RETRACE_IMPLEMENTATION(exit)(int status)
 
 RETRACE_REPLACE(exit, void, (int status), (status))
 
-#ifdef __linux
+#ifdef __linux__
 int RETRACE_IMPLEMENTATION(on_exit)(void (*function)(int, void *), void *arg)
 {
 	struct rtr_event_info event_info;

--- a/exit.c
+++ b/exit.c
@@ -45,7 +45,7 @@ void RETRACE_IMPLEMENTATION(exit)(int status)
 
 RETRACE_REPLACE(exit, void, (int status), (status))
 
-#ifndef __APPLE__
+#ifdef __linux
 int RETRACE_IMPLEMENTATION(on_exit)(void (*function)(int, void *), void *arg)
 {
 	struct rtr_event_info event_info;
@@ -95,6 +95,7 @@ int RETRACE_IMPLEMENTATION(__cxa_atexit)(void (*function)(void), void *p1, void 
 RETRACE_REPLACE(__cxa_atexit, int, (void (*function)(void), void *p1, void *p2), (function, p1, p2))
 #endif
 
+#ifndef __OpenBSD__
 int RETRACE_IMPLEMENTATION(atexit)(void (*function)(void))
 {
 	struct rtr_event_info event_info;
@@ -118,6 +119,7 @@ int RETRACE_IMPLEMENTATION(atexit)(void (*function)(void))
 }
 
 RETRACE_REPLACE(atexit, int, (void (*function)(void)), (function))
+#endif
 
 
 void RETRACE_IMPLEMENTATION(_exit)(int status)

--- a/log.c
+++ b/log.c
@@ -202,7 +202,8 @@ option_to_string(int option, char *buf)
 
 void RETRACE_IMPLEMENTATION(openlog)(const char *ident, int option, int facility)
 {
-	char option_str[OPTION_MAX_BUFFER + 1];
+	char option_buf[OPTION_MAX_BUFFER + 1];
+	char *option_str = option_buf;
 	const char *facility_str = NULL;
 	struct rtr_event_info event_info;
 	unsigned int parameter_types[] = {PARAMETER_TYPE_STRING,
@@ -315,7 +316,8 @@ RETRACE_REPLACE(vsyslog, void, (int priority, const char *format, va_list ap), (
 
 int RETRACE_IMPLEMENTATION(setlogmask)(int mask)
 {
-	char mask_str[OPTION_MAX_BUFFER + 1];
+	char mask_buf[OPTION_MAX_BUFFER + 1];
+	char *mask_str = mask_buf;
 	struct rtr_event_info event_info;
 	unsigned int parameter_types[] = {PARAMETER_TYPE_INT | PARAMETER_FLAG_STRING_NEXT,
 					  PARAMETER_TYPE_END};

--- a/malloc.c
+++ b/malloc.c
@@ -297,8 +297,10 @@ static const struct ts_info mmap_prot_ts[] = {
 	{PROT_READ, "PROT_READ"},
 	{PROT_WRITE, "PROT_WRITE"},
 	{PROT_EXEC, "PROT_EXEC"},
-#ifndef __APPLE__
+#ifdef PROT_GROWSDOWN
 	{PROT_GROWSDOWN, "PROT_GROWSDOWN"},
+#endif
+#ifdef PROT_GROWSUP
 	{PROT_GROWSUP, "PROT_GROWSUP"},
 #endif
 	{-1, NULL}
@@ -394,7 +396,6 @@ int RETRACE_IMPLEMENTATION(munmap)(void *addr, size_t length)
 RETRACE_REPLACE(munmap, int, (void *addr, size_t length), (addr, length))
 
 #ifndef __APPLE__
-
 int RETRACE_IMPLEMENTATION(brk)(void *addr)
 {
 	struct rtr_event_info event_info;
@@ -438,7 +439,11 @@ int RETRACE_IMPLEMENTATION(brk)(void *addr)
 
 RETRACE_REPLACE(brk, int, (void *addr), (addr))
 
+#if __OpenBSD__
+void *RETRACE_IMPLEMENTATION(sbrk)(int increment)
+#else
 void *RETRACE_IMPLEMENTATION(sbrk)(intptr_t increment)
+#endif
 {
 	struct rtr_event_info event_info;
 	unsigned int parameter_types[] = {PARAMETER_TYPE_INT, PARAMETER_TYPE_END};
@@ -479,6 +484,10 @@ void *RETRACE_IMPLEMENTATION(sbrk)(intptr_t increment)
 	return p;
 }
 
+#if __OpenBSD__
+RETRACE_REPLACE(sbrk, void *, (long int increment), (increment))
+#else
 RETRACE_REPLACE(sbrk, void *, (intptr_t increment), (increment))
+#endif
 
 #endif

--- a/malloc.c
+++ b/malloc.c
@@ -381,7 +381,12 @@ int RETRACE_IMPLEMENTATION(munmap)(void *addr, size_t length)
 RETRACE_REPLACE(munmap, int, (void *addr, size_t length), (addr, length))
 
 #ifndef __APPLE__
+
+#ifdef __FreeBSD__
 int RETRACE_IMPLEMENTATION(brk)(const void *addr)
+#else
+int RETRACE_IMPLEMENTATION(brk)(void *addr)
+#endif
 {
 	struct rtr_event_info event_info;
 	unsigned int parameter_types[] = {PARAMETER_TYPE_POINTER, PARAMETER_TYPE_END};

--- a/malloc.c
+++ b/malloc.c
@@ -381,7 +381,7 @@ int RETRACE_IMPLEMENTATION(munmap)(void *addr, size_t length)
 RETRACE_REPLACE(munmap, int, (void *addr, size_t length), (addr, length))
 
 #ifndef __APPLE__
-int RETRACE_IMPLEMENTATION(brk)(void *addr)
+int RETRACE_IMPLEMENTATION(brk)(const void *addr)
 {
 	struct rtr_event_info event_info;
 	unsigned int parameter_types[] = {PARAMETER_TYPE_POINTER, PARAMETER_TYPE_END};
@@ -412,7 +412,7 @@ int RETRACE_IMPLEMENTATION(brk)(void *addr)
 	}
 
 	if (!redirect)
-		ret = real_brk(addr);
+		ret = real_brk((void *) addr);
 
 	retrace_log_and_redirect_after(&event_info);
 

--- a/malloc.h
+++ b/malloc.h
@@ -19,7 +19,12 @@ typedef int (*rtr_munmap_t)(void *addr, size_t length);
 #ifndef __APPLE__
 
 typedef int (*rtr_brk_t)(void *addr);
+
+#ifdef __OpenBSD__
+typedef void *(*rtr_sbrk_t)(int long increment);
+#else
 typedef void *(*rtr_sbrk_t)(intptr_t increment);
+#endif
 
 #endif
 

--- a/ssl.c
+++ b/ssl.c
@@ -32,13 +32,6 @@
 
 #include "ssl.h"
 
-
-typedef size_t (*rtr_SSL_get_client_random_t)(const SSL *ssl, unsigned char *out, size_t outlen);
-typedef size_t (*rtr_SSL_get_server_random_t)(const SSL *ssl, unsigned char *out, size_t outlen);
-typedef size_t (*rtr_SSL_SESSION_get_master_key_t)(const SSL_SESSION *session, unsigned char *out, size_t outlen);
-typedef SSL_SESSION *(*rtr_SSL_get_session_t)(const SSL *ssl);
-
-
 int RETRACE_IMPLEMENTATION(SSL_write)(SSL *ssl, const void *buf, int num)
 {
 	int r;

--- a/ssl.h
+++ b/ssl.h
@@ -4,7 +4,6 @@
 #include "config.h"
 
 #ifdef HAVE_OPENSSL_SSL_H
-
 #include <unistd.h>
 #include <sys/types.h>
 #include <openssl/ssl.h>
@@ -17,6 +16,13 @@ typedef int (*rtr_SSL_accept_t)(SSL *ssl);
 typedef int (*rtr_SSL_connect_t)(SSL *ssl);
 typedef long (*rtr_SSL_get_verify_result_t)(const SSL *ssl);
 typedef long (*rtr_BIO_ctrl_t)(BIO *bp, int cmd, long larg, void *parg);
+
+/* No replacing these */
+typedef size_t (*rtr_SSL_get_client_random_t)(const SSL *ssl, unsigned char *out, size_t outlen);
+typedef size_t (*rtr_SSL_get_server_random_t)(const SSL *ssl, unsigned char *out, size_t outlen);
+typedef size_t (*rtr_SSL_SESSION_get_master_key_t)(const SSL_SESSION *session, unsigned char *out, size_t outlen);
+typedef SSL_SESSION *(*rtr_SSL_get_session_t)(const SSL *ssl);
+
 
 
 RETRACE_DECL(SSL_write);

--- a/test/exec.c
+++ b/test/exec.c
@@ -21,7 +21,7 @@ int main(void)
 
 	execvp("/bin/shouldntexitinanysystem", args);
 
-#ifndef __APPLE__
+#ifdef __linux__
 	execvpe("/bin/shouldntexitinanysystem", args, env);
 
 	fexecve(1, args, env);

--- a/test/exit.c
+++ b/test/exit.c
@@ -36,7 +36,7 @@ void test2(int status, void *p)
 int main(void)
 {
 	atexit(test1);
-#ifndef __APPLE__
+#ifdef __linux
 	on_exit(test2, (void *)0xdeadbeef);
 #endif
 	exit(42);

--- a/test/log.c
+++ b/test/log.c
@@ -18,10 +18,9 @@ int main(void)
 
 	syslog(LOG_INFO, "Test log %s %d", "string", 42);
 
-	closelog();
-
 	more_tests("vsyslog %d\n", 42);
 
+	closelog();
 
 	return 0;
 }

--- a/test/scanf.c
+++ b/test/scanf.c
@@ -30,17 +30,15 @@
 
 int scanf_test(void)
 {
-	FILE *oldstdin;
+	FILE *f;
 	char buf[1024];
 	int fd[2];
 
 	pipe(fd);
-	oldstdin = stdin;
-	stdin = fdopen(fd[0], "r");
+	f = fdopen(fd[0], "r");
 	write(fd[1], "string123 ", strlen("string123 "));
 	scanf("%s", buf);
-	fclose(stdin);
-	stdin = oldstdin;
+	fclose(f);
 	close(fd[1]);
 
 	printf("%s\n", buf);
@@ -94,17 +92,15 @@ void GetMatchesVscanf(const char *format, ...)
 
 int vscanf_test(void)
 {
-	FILE *oldstdin;
+	FILE *f;
 	char buf[1024];
 	int fd[2];
 
 	pipe(fd);
-	oldstdin = stdin;
-	stdin = fdopen(fd[0], "r");
+	f = fdopen(fd[0], "r");
 	write(fd[1], "string12 ", strlen("string12 "));
 	GetMatchesVscanf("%s", buf);
-	fclose(stdin);
-	stdin = oldstdin;
+	fclose(f);
 	close(fd[1]);
 
 	printf("%s\n", buf);

--- a/test/scanf.c
+++ b/test/scanf.c
@@ -30,15 +30,17 @@
 
 int scanf_test(void)
 {
-	FILE *f;
+	FILE oldstdin;
 	char buf[1024];
 	int fd[2];
 
 	pipe(fd);
-	f = fdopen(fd[0], "r");
+	oldstdin = *stdin;
+	*stdin = *fdopen(fd[0], "r");
 	write(fd[1], "string123 ", strlen("string123 "));
 	scanf("%s", buf);
-	fclose(f);
+	fclose(stdin);
+	*stdin = oldstdin;
 	close(fd[1]);
 
 	printf("%s\n", buf);
@@ -92,15 +94,17 @@ void GetMatchesVscanf(const char *format, ...)
 
 int vscanf_test(void)
 {
-	FILE *f;
+	FILE oldstdin;
 	char buf[1024];
 	int fd[2];
 
 	pipe(fd);
-	f = fdopen(fd[0], "r");
+	oldstdin = *stdin;
+	*stdin = *fdopen(fd[0], "r");
 	write(fd[1], "string12 ", strlen("string12 "));
 	GetMatchesVscanf("%s", buf);
-	fclose(f);
+	fclose(stdin);
+	*stdin = oldstdin;
 	close(fd[1]);
 
 	printf("%s\n", buf);

--- a/test/scanf.c
+++ b/test/scanf.c
@@ -39,7 +39,6 @@ int scanf_test(void)
 	*stdin = *fdopen(fd[0], "r");
 	write(fd[1], "string123 ", strlen("string123 "));
 	scanf("%s", buf);
-	fclose(stdin);
 	*stdin = oldstdin;
 	close(fd[1]);
 
@@ -103,7 +102,6 @@ int vscanf_test(void)
 	*stdin = *fdopen(fd[0], "r");
 	write(fd[1], "string12 ", strlen("string12 "));
 	GetMatchesVscanf("%s", buf);
-	fclose(stdin);
 	*stdin = oldstdin;
 	close(fd[1]);
 


### PR DESCRIPTION
This fixes the build in OpenBSD.

Still retrace won't run when build because it needs to link to pthread. If I manually link it to pthread it works fine. Hopefully @wizzard  can fix the pthread linking.