### PR TITLE
Fix deadlock from #198

### DIFF
--- a/common.c
+++ b/common.c
@@ -111,7 +111,6 @@ struct descriptor_info **g_descriptor_list;
 unsigned int g_descriptor_list_size;
 
 static pthread_mutex_t printing_lock = PTHREAD_MUTEX_INITIALIZER;
-static pthread_mutex_t logfile_lock = PTHREAD_MUTEX_INITIALIZER;
 
 static int output_file_flush;
 static FILE *output_file;
@@ -754,7 +753,9 @@ retrace_event(struct rtr_event_info *event_info)
 		return;
 
 	old_trace_state = trace_disable();
-	pthread_mutex_lock(&logfile_lock);
+	pthread_mutex_lock(&printing_lock);
+	olderrno = errno;
+
 	if (!loaded_config) {
 		loaded_config = 1;
 		if (rtr_get_config_single_internal("logtofile", ARGUMENT_TYPE_STRING, ARGUMENT_TYPE_INT, ARGUMENT_TYPE_END,
@@ -765,11 +766,6 @@ retrace_event(struct rtr_event_info *event_info)
 			output_file = out_file_tmp;
 		}
 	}
-	pthread_mutex_unlock(&logfile_lock);
-
-	olderrno = errno;
-
-	pthread_mutex_lock(&printing_lock);
 
 	if (event_info->event_type == EVENT_TYPE_AFTER_CALL || event_info->event_type == EVENT_TYPE_BEFORE_CALL) {
 		unsigned int *parameter_type;

--- a/common.c
+++ b/common.c
@@ -1582,10 +1582,10 @@ trace_printf_backtrace(void)
 
 	if (strs != NULL) {
 		trace_set_color(INF);
-		printf("======== begin callstack =========\n");
+		trace_printf(1, "======== begin callstack =========\n");
 		for (i = 2; i < frames; ++i)
-			printf("%s\n", strs[i]);
-		printf("======== end callstack =========\n");
+			trace_printf(1, "%s\n", strs[i]);
+		trace_printf(1, "======== end callstack =========\n");
 		trace_set_color(RST);
 
 		real_free(strs);

--- a/common.c
+++ b/common.c
@@ -441,7 +441,10 @@ retrace_print_parameter(unsigned int event_type, unsigned int type, int flags, v
 		char perm[10];
 
 		trace_mode(*((mode_t *) *value), perm);
-		trace_printf(0, "%o" INF " [%s]", *((int *) *value), perm);
+		trace_printf(0, "%o", *((int *) *value));
+		trace_set_color(INF);
+		trace_printf(0, " [%s]", perm);
+		trace_set_color(VAR);
 
 		break;
 	}
@@ -838,7 +841,7 @@ retrace_event(struct rtr_event_info *event_info)
 		}
 	}
 
-	if (event_info->print_backtrace) {
+	if (event_info->event_flags & EVENT_FLAGS_PRINT_BACKTRACE) {
 		trace_printf_backtrace();
 	}
 

--- a/common.h
+++ b/common.h
@@ -93,6 +93,13 @@ enum RTR_FUZZ_TYPE {
 #if HAVE_DECL_F_GETOWN_EX
 #define PARAMETER_TYPE_STRUCT_F_GETOWN_EX 31 /* fcntl's struct f_owner_ex */
 #endif
+#define PARAMETER_TYPE_PERM  32 /* write permission  */
+#define PARAMETER_TYPE_STRUCT_STAT 33 /* struct stat */
+#define PARAMETER_TYPE_STRUCT_SOCKADDR	35 /* struct sockaddr */
+#define PARAMETER_TYPE_FD_SET	36 /* fd_set: char **set, int *nfds, fd_set **in, fd_set **out */
+#define PARAMETER_TYPE_STRUCT_HOSTEN	37 /* struct hosten */
+#define PARAMETER_TYPE_IP_ADDR	38 /* ip addr: void **addr, int *type */
+#define PARAMETER_TYPE_STRUCT_ADDRINFO	39 /* struct addrinfo */
 
 #define PARAMETER_FLAG_OUTPUT_VARIABLE		0x40000000 /* This is an output variable, is uninitialized in EVENT_TYPE_BEFORE_CALL */
 #define PARAMETER_FLAG_STRING_NEXT		0x80000000 /* There's a string parameter that describes the string */
@@ -119,6 +126,8 @@ struct rtr_event_info {
 
 	unsigned int event_flags;
 	char *extra_info;
+
+    unsigned int print_backtrace;
 };
 
 #define RETRACE_INTERNAL __attribute__((visibility("hidden")))
@@ -217,12 +226,6 @@ struct ts_info {
 	int type;
 	const char *str;
 };
-
-void trace_printf(int hdr, const char *fmt, ...);
-void trace_printf_str(const char *string, int maxlength);
-void trace_dump_data(const unsigned char *buf, size_t nbytes);
-void trace_mode(mode_t mode, char *p);
-void trace_printf_backtrace(void);
 
 typedef const void *RTR_CONFIG_HANDLE;
 

--- a/common.h
+++ b/common.h
@@ -109,6 +109,7 @@ enum RTR_FUZZ_TYPE {
 #define EVENT_TYPE_AFTER_CALL		1
 
 #define EVENT_FLAGS_PRINT_RAND_SEED	0x00000001
+#define EVENT_FLAGS_PRINT_BACKTRACE	0x00000002
 
 #define GET_PARAMETER_TYPE(param) (param & ~PARAMETER_FLAGS_ALL)
 #define GET_PARAMETER_FLAGS(param) (param & PARAMETER_FLAGS_ALL)
@@ -126,8 +127,6 @@ struct rtr_event_info {
 
 	unsigned int event_flags;
 	char *extra_info;
-
-    unsigned int print_backtrace;
 };
 
 #define RETRACE_INTERNAL __attribute__((visibility("hidden")))

--- a/dlopen.c
+++ b/dlopen.c
@@ -126,8 +126,6 @@ int RETRACE_IMPLEMENTATION(dlclose)(void *handle)
 
 	retrace_log_and_redirect_after(&event_info);
 
-	trace_printf(1, "dlclose(%p); [return: %d]\n", handle, r);
-
 	return r;
 }
 

--- a/file.c
+++ b/file.c
@@ -38,35 +38,32 @@
 
 int RETRACE_IMPLEMENTATION(stat)(const char *path, struct stat *buf)
 {
-	char perm[10];
+	struct rtr_event_info event_info;
+	unsigned int parameter_types_short[] = {PARAMETER_TYPE_STRING, PARAMETER_TYPE_POINTER, PARAMETER_TYPE_END};
+	void const *parameter_values_short[] = {&path, &buf};
+
+	unsigned int parameter_types_full[] = {PARAMETER_TYPE_STRING, PARAMETER_TYPE_STRUCT_STAT, PARAMETER_TYPE_END};
+	void const *parameter_values_full[] = {&path, &buf};
+
 	int r;
 
-	trace_printf(1, "stat(\"%s\", buf);\n", path);
+	memset(&event_info, 0, sizeof(event_info));
+	event_info.function_name = "stat";
+	event_info.parameter_types = parameter_types_short;
+	event_info.parameter_values = (void **) parameter_values_short;
+	event_info.return_value_type = PARAMETER_TYPE_INT;
+	event_info.return_value = &r;
+
+	retrace_log_and_redirect_before(&event_info);
 
 	r = real_stat(path, buf);
 
 	if (r == 0) {
-		trace_printf(1, "struct stat {\n");
-		trace_printf(1, "\tst_dev = %lu\n", buf->st_dev);
-		trace_printf(1, "\tst_ino = %i\n", buf->st_ino);
-		trace_mode(buf->st_mode, perm);
-		trace_printf(1, "\tst_mode = %d [%s]\n", buf->st_mode, perm);
-		trace_printf(1, "\tst_nlink = %lu\n", buf->st_nlink);
-		trace_printf(1, "\tst_uid = %d\n", buf->st_uid);
-		trace_printf(1, "\tst_gid = %d\n", buf->st_gid);
-		trace_printf(1, "\tst_rdev = %r\n", buf->st_rdev);
-		trace_printf(1, "\tst_atime = %lu\n", buf->st_atime);
-		trace_printf(1, "\tst_mtime = %lu\n", buf->st_mtime);
-		trace_printf(1, "\tst_ctime = %lu\n", buf->st_ctime);
-		trace_printf(1, "\tst_size = %zu\n", buf->st_size);
-		trace_printf(1, "\tst_blocks = %lu\n", buf->st_blocks);
-		trace_printf(1, "\tst_blksize = %lu\n", buf->st_blksize);
-#if __APPLE__
-		trace_printf(1, "\tst_flags = %d\n", buf->st_flags);
-		trace_printf(1, "\tst_gen = %d\n", buf->st_gen);
-#endif
-		trace_printf(1, "}\n");
+		event_info.parameter_types = parameter_types_full;
+		event_info.parameter_values = (void **) parameter_values_full;
 	}
+
+	retrace_log_and_redirect_after(&event_info);
 
 	return r;
 }
@@ -75,15 +72,10 @@ RETRACE_REPLACE(stat, int, (const char *path, struct stat *buf), (path, buf))
 
 int RETRACE_IMPLEMENTATION(chmod)(const char *path, mode_t mode)
 {
-	char perm[10];
-	char *perm_p = &perm[0];
 	struct rtr_event_info event_info;
-	unsigned int parameter_types[] = {PARAMETER_TYPE_STRING, PARAMETER_TYPE_INT_OCTAL | PARAMETER_FLAG_STRING_NEXT, PARAMETER_TYPE_END};
-	void const *parameter_values[] = {&path, &mode, &perm_p};
+	unsigned int parameter_types[] = {PARAMETER_TYPE_STRING, PARAMETER_TYPE_PERM, PARAMETER_TYPE_END};
+	void const *parameter_values[] = {&path, &mode};
 	int r;
-
-	trace_mode(mode, perm);
-
 
 	memset(&event_info, 0, sizeof(event_info));
 	event_info.function_name = "chmod";
@@ -104,15 +96,10 @@ RETRACE_REPLACE(chmod, int, (const char *path, mode_t mode), (path, mode))
 
 int RETRACE_IMPLEMENTATION(fchmod)(int fd, mode_t mode)
 {
-	char perm[10];
-	char *perm_p = &perm[0];
 	struct rtr_event_info event_info;
-	unsigned int parameter_types[] = {PARAMETER_TYPE_FILE_DESCRIPTOR, PARAMETER_TYPE_INT_OCTAL | PARAMETER_FLAG_STRING_NEXT, PARAMETER_TYPE_END};
-	void const *parameter_values[] = {&fd, &mode, &perm_p};
+	unsigned int parameter_types[] = {PARAMETER_TYPE_FILE_DESCRIPTOR, PARAMETER_TYPE_PERM, PARAMETER_TYPE_END};
+	void const *parameter_values[] = {&fd, &mode};
 	int r;
-
-	trace_mode(mode, perm);
-
 
 	memset(&event_info, 0, sizeof(event_info));
 	event_info.function_name = "fchmod";
@@ -625,6 +612,8 @@ RETRACE_REPLACE(strmode, void, (int mode, char *bp), (mode, bp))
 static int
 fcntl_v(int fildes, int cmd, va_list ap)
 {
+	char extra_info_buf[128];
+
 	int r;
 	int int_parameter = 0;
 #if HAVE_STRUCT_FLOCK
@@ -879,10 +868,10 @@ fcntl_v(int fildes, int cmd, va_list ap)
 	default:
 		event_info.parameter_types = parameter_types_maybe;
 		event_info.parameter_values = (void **) parameter_values_maybe;
+		sprintf(extra_info_buf, "Unsupported fcntl command: %d", cmd);
+		event_info.extra_info = extra_info_buf;
 
 		maybe_parameter = va_arg(ap, void *);
-
-		trace_printf(1, "Unsupported fcntl command: %d", cmd);
 	}
 
 	retrace_log_and_redirect_before(&event_info);

--- a/id.c
+++ b/id.c
@@ -154,17 +154,12 @@ RETRACE_REPLACE(getegid, gid_t, (), ())
 
 uid_t RETRACE_IMPLEMENTATION(getuid)()
 {
+	char extra_info_buf[128];
+
 	struct rtr_event_info event_info;
 	unsigned int parameter_types[] = {PARAMETER_TYPE_END};
 	int redirect_id;
-	int uid;
-
-	if (rtr_get_config_single("getuid", ARGUMENT_TYPE_INT, ARGUMENT_TYPE_END, &redirect_id)) {
-		trace_printf(1, "getuid(); [redirection in effect: '%i']\n", redirect_id);
-
-		return redirect_id;
-	}
-
+	uid_t uid;
 
 	memset(&event_info, 0, sizeof(event_info));
 	event_info.function_name = "getuid";
@@ -174,10 +169,15 @@ uid_t RETRACE_IMPLEMENTATION(getuid)()
 
 	retrace_log_and_redirect_before(&event_info);
 
-	uid = real_getuid();
+	if (rtr_get_config_single("getuid", ARGUMENT_TYPE_INT, ARGUMENT_TYPE_END, &redirect_id)) {
+		sprintf(extra_info_buf, "redirection in effect: '%i'", redirect_id);
+		event_info.extra_info = extra_info_buf;
+		uid = (uid_t) redirect_id;
+	} else {
+		uid = real_getuid();
+	}
 
 	retrace_log_and_redirect_after(&event_info);
-
 
 	return uid;
 }
@@ -186,17 +186,12 @@ RETRACE_REPLACE(getuid, uid_t, (), ())
 
 uid_t RETRACE_IMPLEMENTATION(geteuid)()
 {
+	char extra_info_buf[128];
+
 	struct rtr_event_info event_info;
 	unsigned int parameter_types[] = {PARAMETER_TYPE_END};
-	int euid;
-	int redirect_id;
-
-	if (rtr_get_config_single("geteuid", ARGUMENT_TYPE_INT, ARGUMENT_TYPE_END, &redirect_id)) {
-		trace_printf(1, "geteuid(); [redirection in effect: '%i']\n", redirect_id);
-
-		return redirect_id;
-	}
-
+	uid_t euid;
+	uid_t redirect_id;
 
 	memset(&event_info, 0, sizeof(event_info));
 	event_info.function_name = "geteuid";
@@ -205,7 +200,13 @@ uid_t RETRACE_IMPLEMENTATION(geteuid)()
 	event_info.return_value = &euid;
 	retrace_log_and_redirect_before(&event_info);
 
-	euid = real_geteuid();
+	if (rtr_get_config_single("geteuid", ARGUMENT_TYPE_INT, ARGUMENT_TYPE_END, &redirect_id)) {
+		sprintf(extra_info_buf, "redirection in effect: '%i'", redirect_id);
+		event_info.extra_info = extra_info_buf;
+		euid = (uid_t) redirect_id;
+	} else {
+		euid = real_geteuid();
+	}
 
 	retrace_log_and_redirect_after(&event_info);
 

--- a/malloc.c
+++ b/malloc.c
@@ -65,7 +65,7 @@ void *RETRACE_IMPLEMENTATION(malloc)(size_t bytes)
 		p = real_malloc(bytes);
 
 	if (redirect) {
-		trace_printf_backtrace();
+		event_info.print_backtrace = 1;
 	}
 
 	retrace_log_and_redirect_after(&event_info);
@@ -130,7 +130,7 @@ void *RETRACE_IMPLEMENTATION(calloc)(size_t nmemb, size_t size)
 	retrace_log_and_redirect_after(&event_info);
 
 	if (redirect)
-		trace_printf_backtrace();
+		event_info.print_backtrace = 1;
 
 	return p;
 }
@@ -172,7 +172,7 @@ void *RETRACE_IMPLEMENTATION(realloc)(void *ptr, size_t size)
 	retrace_log_and_redirect_after(&event_info);
 
 	if (redirect)
-		trace_printf_backtrace();
+		event_info.print_backtrace = 1;
 
 	return p;
 }
@@ -209,7 +209,7 @@ void *RETRACE_IMPLEMENTATION(memcpy)(void *dest, const void *src, size_t n)
 	retrace_log_and_redirect_after(&event_info);
 
 	if (overlapped)
-		trace_printf_backtrace();
+		event_info.print_backtrace = 1;
 
 	return p;
 }
@@ -360,7 +360,7 @@ void *RETRACE_IMPLEMENTATION(mmap)(void *addr, size_t length, int prot, int flag
 	retrace_log_and_redirect_after(&event_info);
 
 	if (redirect)
-		trace_printf_backtrace();
+		event_info.print_backtrace = 1;
 
 	return p;
 }
@@ -431,7 +431,7 @@ int RETRACE_IMPLEMENTATION(brk)(void *addr)
 	retrace_log_and_redirect_after(&event_info);
 
 	if (redirect)
-		trace_printf_backtrace();
+		event_info.print_backtrace = 1;
 
 	return ret;
 }
@@ -474,7 +474,7 @@ void *RETRACE_IMPLEMENTATION(sbrk)(intptr_t increment)
 	retrace_log_and_redirect_after(&event_info);
 
 	if (redirect)
-		trace_printf_backtrace();
+		event_info.print_backtrace = 1;
 
 	return p;
 }

--- a/malloc.c
+++ b/malloc.c
@@ -58,15 +58,11 @@ void *RETRACE_IMPLEMENTATION(malloc)(size_t bytes)
 		errno = ENOMEM;
 		redirect = 1;
 		event_info.extra_info = "redirected : NULL";
-		event_info.event_flags = EVENT_FLAGS_PRINT_RAND_SEED;
+		event_info.event_flags = EVENT_FLAGS_PRINT_RAND_SEED | EVENT_FLAGS_PRINT_BACKTRACE;
 	}
 
 	if (!redirect)
 		p = real_malloc(bytes);
-
-	if (redirect) {
-		event_info.print_backtrace = 1;
-	}
 
 	retrace_log_and_redirect_after(&event_info);
 
@@ -121,16 +117,13 @@ void *RETRACE_IMPLEMENTATION(calloc)(size_t nmemb, size_t size)
 		errno = ENOMEM;
 		redirect = 1;
 		event_info.extra_info = "redirected : NULL";
-		event_info.event_flags = EVENT_FLAGS_PRINT_RAND_SEED;
+		event_info.event_flags = EVENT_FLAGS_PRINT_RAND_SEED | EVENT_FLAGS_PRINT_BACKTRACE;
 	}
 
 	if (!redirect)
 		p = real_calloc(nmemb, size);
 
 	retrace_log_and_redirect_after(&event_info);
-
-	if (redirect)
-		event_info.print_backtrace = 1;
 
 	return p;
 }
@@ -163,16 +156,13 @@ void *RETRACE_IMPLEMENTATION(realloc)(void *ptr, size_t size)
 		errno = ENOMEM;
 		redirect = 1;
 		event_info.extra_info = "redirected : NULL";
-		event_info.event_flags = EVENT_FLAGS_PRINT_RAND_SEED;
+		event_info.event_flags = EVENT_FLAGS_PRINT_RAND_SEED | EVENT_FLAGS_PRINT_BACKTRACE;
 	}
 
 	if (!redirect)
 		p = real_realloc(ptr, size);
 
 	retrace_log_and_redirect_after(&event_info);
-
-	if (redirect)
-		event_info.print_backtrace = 1;
 
 	return p;
 }
@@ -202,14 +192,12 @@ void *RETRACE_IMPLEMENTATION(memcpy)(void *dest, const void *src, size_t n)
 	if (abs(dest - src) < n) {
 		overlapped = 1;
 		event_info.extra_info = "The memory areas must not overlap. It may arise bugs. Please refer the man page.";
+		event_info.event_flags = EVENT_FLAGS_PRINT_BACKTRACE;
 	}
 
 	p = real_memcpy(dest, src, n);
 
 	retrace_log_and_redirect_after(&event_info);
-
-	if (overlapped)
-		event_info.print_backtrace = 1;
 
 	return p;
 }
@@ -351,16 +339,13 @@ void *RETRACE_IMPLEMENTATION(mmap)(void *addr, size_t length, int prot, int flag
 		errno = ENOMEM;
 		redirect = 1;
 		event_info.extra_info = "redirected : (void *) -1";
-		event_info.event_flags = EVENT_FLAGS_PRINT_RAND_SEED;
+		event_info.event_flags = EVENT_FLAGS_PRINT_RAND_SEED | EVENT_FLAGS_PRINT_BACKTRACE;
 	}
 
 	if (!redirect)
 		p = real_mmap(addr, length, prot, flags, fd, offset);
 
 	retrace_log_and_redirect_after(&event_info);
-
-	if (redirect)
-		event_info.print_backtrace = 1;
 
 	return p;
 }
@@ -422,16 +407,13 @@ int RETRACE_IMPLEMENTATION(brk)(void *addr)
 		errno = ENOMEM;
 		redirect = 1;
 		event_info.extra_info = "redirected : -1";
-		event_info.event_flags = EVENT_FLAGS_PRINT_RAND_SEED;
+		event_info.event_flags = EVENT_FLAGS_PRINT_RAND_SEED | EVENT_FLAGS_PRINT_BACKTRACE;
 	}
 
 	if (!redirect)
 		ret = real_brk(addr);
 
 	retrace_log_and_redirect_after(&event_info);
-
-	if (redirect)
-		event_info.print_backtrace = 1;
 
 	return ret;
 }
@@ -465,16 +447,13 @@ void *RETRACE_IMPLEMENTATION(sbrk)(intptr_t increment)
 		errno = ENOMEM;
 		redirect = 1;
 		event_info.extra_info = "redirected : (void *) -1";
-		event_info.event_flags = EVENT_FLAGS_PRINT_RAND_SEED;
+		event_info.event_flags = EVENT_FLAGS_PRINT_RAND_SEED | EVENT_FLAGS_PRINT_BACKTRACE;
 	}
 
 	if (!redirect)
 		p = real_sbrk(increment);
 
 	retrace_log_and_redirect_after(&event_info);
-
-	if (redirect)
-		event_info.print_backtrace = 1;
 
 	return p;
 }

--- a/netdb.c
+++ b/netdb.c
@@ -32,22 +32,25 @@ struct hostent *RETRACE_IMPLEMENTATION(gethostbyname)(const char *name)
 {
 	struct hostent *hent;
 
+	struct rtr_event_info event_info;
+	unsigned int parameter_types[] = {PARAMETER_TYPE_STRING, PARAMETER_TYPE_END};
+	void const *parameter_values[] = {&name};
+
+	memset(&event_info, 0, sizeof(event_info));
+	event_info.function_name = "gethostbyname";
+	event_info.parameter_types = parameter_types;
+	event_info.parameter_values = (void **) parameter_values;
+	event_info.return_value_type = PARAMETER_TYPE_POINTER;
+	event_info.return_value = &hent;
+
+	retrace_log_and_redirect_before(&event_info);
+
 	hent = real_gethostbyname(name);
 	if (hent) {
-		int i;
+		event_info.return_value_type = PARAMETER_TYPE_STRUCT_HOSTEN;
+	}
 
-		trace_printf(1, "gethostbyname(\"%s\") = [", name);
-
-		for (i = 0; hent->h_addr_list[i] != NULL; i++) {
-			char ip_addr[INET6_ADDRSTRLEN];
-
-			inet_ntop(hent->h_addrtype, hent->h_addr_list[i], ip_addr, sizeof(ip_addr));
-			trace_printf(0, i > 0 ? ",%s" : "%s", ip_addr);
-		}
-
-		trace_printf(0, "]\n");
-	} else
-		trace_printf(1, "gethostbyname(\"%s\") = NULL [error:%s]\n", name, hstrerror(h_errno));
+	retrace_log_and_redirect_after(&event_info);
 
 	return hent;
 }
@@ -59,20 +62,25 @@ struct hostent *RETRACE_IMPLEMENTATION(gethostbyaddr)(const void *addr, socklen_
 {
 	struct hostent *hent;
 
-	char ip_addr[INET6_ADDRSTRLEN];
+	struct rtr_event_info event_info;
+	unsigned int parameter_types[] = {PARAMETER_TYPE_STRING, PARAMETER_TYPE_END};
+	void const *parameter_values[] = {&addr};
 
-	/* get IP address */
-	inet_ntop(type, addr, ip_addr, sizeof(ip_addr));
+	memset(&event_info, 0, sizeof(event_info));
+	event_info.function_name = "gethostbyaddr";
+	event_info.parameter_types = parameter_types;
+	event_info.parameter_values = (void **) parameter_values;
+	event_info.return_value_type = PARAMETER_TYPE_POINTER;
+	event_info.return_value = &hent;
+
+	retrace_log_and_redirect_before(&event_info);
 
 	hent = real_gethostbyaddr(addr, len, type);
-	if (hent)
-		trace_printf(1, "gethostbyaddr(IP => %s, , type => %s) = [Hostname:%s]\n", ip_addr,
-			type == AF_INET ? "AF_INET" : "AF_INET6",
-			hent->h_name);
-	else
-		trace_printf(1, "gethostbyaddr(IP => %s, , type => %s) = [Error:%s]\n", ip_addr,
-			type == AF_INET ? "AF_INET" : "AF_INET6",
-			hstrerror(h_errno));
+	if (hent) {
+		event_info.return_value_type = PARAMETER_TYPE_STRUCT_HOSTEN;
+	}
+
+	retrace_log_and_redirect_after(&event_info);
 
 	return hent;
 }
@@ -83,9 +91,21 @@ RETRACE_REPLACE(gethostbyaddr, struct hostent *,
 
 void RETRACE_IMPLEMENTATION(sethostent)(int stayopen)
 {
-	trace_printf(1, "sethostent(%d)\n", stayopen);
+	struct rtr_event_info event_info;
+	unsigned int parameter_types[] = {PARAMETER_TYPE_INT, PARAMETER_TYPE_END};
+	void const *parameter_values[] = {&stayopen};
+
+	memset(&event_info, 0, sizeof(event_info));
+	event_info.function_name = "sethostent";
+	event_info.parameter_types = parameter_types;
+	event_info.parameter_values = (void **) parameter_values;
+
+	retrace_log_and_redirect_before(&event_info);
 
 	real_sethostent(stayopen);
+
+	retrace_log_and_redirect_after(&event_info);
+
 }
 
 RETRACE_REPLACE(sethostent, void, (int stayopen), (stayopen))
@@ -93,9 +113,21 @@ RETRACE_REPLACE(sethostent, void, (int stayopen), (stayopen))
 
 void RETRACE_IMPLEMENTATION(endhostent)(void)
 {
-	trace_printf(1, "endhostent()\n");
+	struct rtr_event_info event_info;
+	unsigned int parameter_types[] = {PARAMETER_TYPE_END};
+	void const *parameter_values[] = {};
+
+	memset(&event_info, 0, sizeof(event_info));
+	event_info.function_name = "endhostent";
+	event_info.parameter_types = parameter_types;
+	event_info.parameter_values = (void **) parameter_values;
+
+	retrace_log_and_redirect_before(&event_info);
 
 	real_endhostent();
+
+	retrace_log_and_redirect_after(&event_info);
+
 }
 
 RETRACE_REPLACE(endhostent, void, (void), ())
@@ -105,22 +137,25 @@ struct hostent *RETRACE_IMPLEMENTATION(gethostent)(void)
 {
 	struct hostent *hent;
 
+	struct rtr_event_info event_info;
+	unsigned int parameter_types[] = {PARAMETER_TYPE_END};
+	void const *parameter_values[] = {};
+
+	memset(&event_info, 0, sizeof(event_info));
+	event_info.function_name = "gethostent";
+	event_info.parameter_types = parameter_types;
+	event_info.parameter_values = (void **) parameter_values;
+	event_info.return_value_type = PARAMETER_TYPE_POINTER;
+	event_info.return_value = &hent;
+
+	retrace_log_and_redirect_before(&event_info);
+
 	hent = real_gethostent();
 	if (hent) {
-		int i;
+		event_info.return_value_type = PARAMETER_TYPE_STRUCT_HOSTEN;
+	}
 
-		trace_printf(1, "gethostent() = [");
-
-		for (i = 0; hent->h_addr_list[i] != NULL; i++) {
-			char ip_addr[INET6_ADDRSTRLEN];
-
-			inet_ntop(hent->h_addrtype, hent->h_addr_list[i], ip_addr, sizeof(ip_addr));
-			trace_printf(0, i > 0 ? ",%s" : "%s", ip_addr);
-		}
-
-		trace_printf(0, "]\n");
-	} else
-		trace_printf(1, "gethostent() = NULL [error:%s]\n", hstrerror(h_errno));
+	retrace_log_and_redirect_after(&event_info);
 
 	return hent;
 }
@@ -132,25 +167,25 @@ struct hostent *RETRACE_IMPLEMENTATION(gethostbyname2)(const char *name, int af)
 {
 	struct hostent *hent;
 
-	char ip_addr[INET6_ADDRSTRLEN];
-	int i;
+	struct rtr_event_info event_info;
+	unsigned int parameter_types[] = {PARAMETER_TYPE_STRING, PARAMETER_TYPE_INT, PARAMETER_TYPE_END};
+	void const *parameter_values[] = {&name, &af};
+
+	memset(&event_info, 0, sizeof(event_info));
+	event_info.function_name = "gethostbyname2";
+	event_info.parameter_types = parameter_types;
+	event_info.parameter_values = (void **) parameter_values;
+	event_info.return_value_type = PARAMETER_TYPE_POINTER;
+	event_info.return_value = &hent;
+
+	retrace_log_and_redirect_before(&event_info);
 
 	hent = real_gethostbyname2(name, af);
 	if (hent) {
-		int i;
+		event_info.return_value_type = PARAMETER_TYPE_STRUCT_HOSTEN;
+	}
 
-		trace_printf(1, "gethostbyname2(\"%s\", %s) = [", name, af == AF_INET ? "AF_INET" : "AF_INET6");
-
-		for (i = 0; hent->h_addr_list[i] != NULL; i++) {
-			char ip_addr[INET6_ADDRSTRLEN];
-
-			inet_ntop(hent->h_addrtype, hent->h_addr_list[i], ip_addr, sizeof(ip_addr));
-			trace_printf(0, i > 0 ? ",%s" : "%s", ip_addr);
-		}
-
-		trace_printf(0, "]\n");
-	} else
-		trace_printf(1, "gethostbyname2(%s, %d) = NULL [error:%s]\n", name, af, hstrerror(h_errno));
+	retrace_log_and_redirect_after(&event_info);
 
 	return hent;
 }
@@ -164,36 +199,26 @@ int RETRACE_IMPLEMENTATION(getaddrinfo)(const char *node, const char *service,
 {
 	int ret;
 
+	struct rtr_event_info event_info;
+	unsigned int parameter_types[] = {PARAMETER_TYPE_STRING, PARAMETER_TYPE_STRING, PARAMETER_TYPE_STRUCT_ADDRINFO, PARAMETER_TYPE_POINTER, PARAMETER_TYPE_END};
+	void const *parameter_values[] = {&node, &service, &hints, res};
+
+	memset(&event_info, 0, sizeof(event_info));
+	event_info.function_name = "getaddrinfo";
+	event_info.parameter_types = parameter_types;
+	event_info.parameter_values = (void **) parameter_values;
+	event_info.return_value_type = PARAMETER_TYPE_INT;
+	event_info.return_value = &ret;
+
+	retrace_log_and_redirect_before(&event_info);
+
 	ret = real_getaddrinfo(node, service, hints, res);
 	if (ret == 0) {
-		struct addrinfo *rp, *result = *res;
+		event_info.return_value_type = PARAMETER_TYPE_STRUCT_ADDRINFO;
+		event_info.return_value = res;
+	}
 
-		trace_printf(1, "getaddrinfo(\"%s\", \"%s\", hints=>[AF_FAMILY:%d, SOCK_TYPE:%d], ) = [%p=",
-			node ? node : "NULL", service ? service : "NULL",
-			hints->ai_family, hints->ai_socktype, *res);
-
-		for (rp = result; rp != NULL; rp = rp->ai_next) {
-			char addr[INET6_ADDRSTRLEN];
-
-			if (rp->ai_family == AF_INET) {
-				struct sockaddr_in *in_addr = (struct sockaddr_in *)rp->ai_addr;
-
-				inet_ntop(rp->ai_family, &(in_addr->sin_addr), addr, sizeof(addr));
-			} else if (rp->ai_family == AF_INET6) {
-				struct sockaddr_in6 *in_addr = (struct sockaddr_in6 *)rp->ai_addr;
-
-				inet_ntop(rp->ai_family, &(in_addr->sin6_addr), addr, sizeof(addr));
-			}
-
-			trace_printf(0, (rp != result) ? ",%s" : "%s", addr);
-		}
-
-		trace_printf(0, "]\n");
-	} else
-		trace_printf(1, "getaddrinfo(\"%s\", \"%s\", [AF_FAMILY:%d, SOCK_TYPE:%d]) = [Error:%s]\n",
-			node ? node : "NULL", service ? service : "NULL",
-			hints ? hints->ai_family : -1, hints ? hints->ai_socktype : -1,
-			gai_strerror(ret));
+	retrace_log_and_redirect_after(&event_info);
 
 	return ret;
 }
@@ -206,8 +231,20 @@ RETRACE_REPLACE(getaddrinfo, int,
 
 void RETRACE_IMPLEMENTATION(freeaddrinfo)(struct addrinfo *res)
 {
-	trace_printf(1, "freeaddrinfo(%p)\n", res);
+	struct rtr_event_info event_info;
+	unsigned int parameter_types[] = {PARAMETER_TYPE_POINTER, PARAMETER_TYPE_END};
+	void const *parameter_values[] = {&res};
+
+	memset(&event_info, 0, sizeof(event_info));
+	event_info.function_name = "freeaddrinfo";
+	event_info.parameter_types = parameter_types;
+	event_info.parameter_values = (void **) parameter_values;
+
+	retrace_log_and_redirect_before(&event_info);
+
 	real_freeaddrinfo(res);
+
+	retrace_log_and_redirect_after(&event_info);
 }
 
 RETRACE_REPLACE(freeaddrinfo, void, (struct addrinfo *res), (res))

--- a/read.c
+++ b/read.c
@@ -55,14 +55,11 @@ ssize_t RETRACE_IMPLEMENTATION(read)(int fd, void *buf, size_t nbytes)
 			real_nbytes = nbytes;
 		}
 		event_info.extra_info = "[redirected]";
-		event_info.event_flags = EVENT_FLAGS_PRINT_RAND_SEED;
+		event_info.event_flags = EVENT_FLAGS_PRINT_RAND_SEED | EVENT_FLAGS_PRINT_BACKTRACE;
 	}
 
 
 	ret = real_read(fd, buf, real_nbytes);
-
-	if (incompleteio)
-		event_info.print_backtrace = 1;
 
 	retrace_log_and_redirect_after(&event_info);
 

--- a/read.c
+++ b/read.c
@@ -62,7 +62,7 @@ ssize_t RETRACE_IMPLEMENTATION(read)(int fd, void *buf, size_t nbytes)
 	ret = real_read(fd, buf, real_nbytes);
 
 	if (incompleteio)
-		trace_printf_backtrace();
+		event_info.print_backtrace = 1;
 
 	retrace_log_and_redirect_after(&event_info);
 

--- a/ssl.h
+++ b/ssl.h
@@ -26,8 +26,6 @@ RETRACE_DECL(SSL_connect);
 RETRACE_DECL(SSL_get_verify_result);
 RETRACE_DECL(BIO_ctrl);
 
-void print_ssl_keys(void *ssl);
-
 #endif /* HAVE_OPENSSL_SSL_H */
 
 #endif /* __RETRACE_SSL_H__ */

--- a/write.c
+++ b/write.c
@@ -57,15 +57,12 @@ ssize_t RETRACE_IMPLEMENTATION(write)(int fd, const void *buf, size_t nbytes)
 			real_nbytes = nbytes;
 		}
 		event_info.extra_info = "[redirected]";
-		event_info.event_flags = EVENT_FLAGS_PRINT_RAND_SEED;
+		event_info.event_flags = EVENT_FLAGS_PRINT_RAND_SEED | EVENT_FLAGS_PRINT_BACKTRACE;
 	}
 
 	retrace_log_and_redirect_before(&event_info);
 
 	ret = real_write(fd, buf, real_nbytes);
-
-	if (incompleteio)
-		event_info.print_backtrace = 1;
 
 	retrace_log_and_redirect_after(&event_info);
 

--- a/write.c
+++ b/write.c
@@ -65,7 +65,7 @@ ssize_t RETRACE_IMPLEMENTATION(write)(int fd, const void *buf, size_t nbytes)
 	ret = real_write(fd, buf, real_nbytes);
 
 	if (incompleteio)
-		trace_printf_backtrace();
+		event_info.print_backtrace = 1;
 
 	retrace_log_and_redirect_after(&event_info);
 


### PR DESCRIPTION
I've found and fixed a deadlock inside retrace that easy reproduced by gperftools, but it may happen at any signal handler or something like this that interrup the program when retrace is printing output.

Example stack-trace of deadlock that I fixed:
```
warning: could not execute support code to read Objective-C class data in the process. This may reduce the quality of type information available.
* thread #1, queue = 'com.apple.main-thread', stop reason = signal SIGSTOP
  * frame #0: 0x00007fffaea4fc22 libsystem_kernel.dylib`__psynch_mutexwait + 10
    frame #1: 0x00007fffaeb3adfa libsystem_pthread.dylib`_pthread_mutex_lock_wait + 100
    frame #2: 0x000000010010b69b libretrace.dylib`retrace_event(event_info=0x00007fff5fbfa488) at common.c:481
    frame #3: 0x000000010010ca7f libretrace.dylib`retrace_log_and_redirect_after(event_info=0x00007fff5fbfa488) at common.c:568
    frame #4: 0x0000000100114e19 libretrace.dylib`retrace_impl_memmove(dest=0x0000000101510358, src=0x0000000101430bd0, n=168) at malloc.c:238
    frame #5: 0x00000001000fd78a libprofiler.0.dylib`ProfileData::Evict(ProfileData::Entry const&) + 114
    frame #6: 0x00000001000fddd9 libprofiler.0.dylib`ProfileData::Add(int, void const* const*) + 239
    frame #7: 0x00000001000fc7a1 libprofiler.0.dylib`CpuProfiler::prof_handler(int, __siginfo*, void*, void*) + 145
    frame #8: 0x00000001000fcc46 libprofiler.0.dylib`ProfileHandler::SignalHandler(int, __siginfo*, void*) + 130
    frame #9: 0x00007fffaeb30b3a libsystem_platform.dylib`_sigtramp + 26
    frame #10: 0x000000010010bd53 libretrace.dylib`retrace_print_parameter(event_type=1, type=1, flags=0, value=0x00007fff5fbfb3a0) at common.c:120
    frame #11: 0x000000010010b78e libretrace.dylib`retrace_event(event_info=0x00007fff5fbfb338) at common.c:508
    frame #12: 0x000000010010ca7f libretrace.dylib`retrace_log_and_redirect_after(event_info=0x00007fff5fbfb338) at common.c:568
    frame #13: 0x0000000100114e19 libretrace.dylib`retrace_impl_memmove(dest=0x000000010100db88, src=0x000000010100dac0, n=72) at malloc.c:238
    frame #14: 0x00000001001c331c libbotan-2.2.dylib`Botan::bigint_monty_redc(unsigned long long*, unsigned long long const*, unsigned long, unsigned long long, unsigned long long*) + 719
    frame #15: 0x00000001001c7e81 libbotan-2.2.dylib`Botan::Montgomery_Exponentiator::execute() const + 183
    frame #16: 0x00000001001c6f56 libbotan-2.2.dylib`Botan::Power_Mod::execute() const + 34
    frame #17: 0x00000001001c672f libbotan-2.2.dylib`Botan::is_prime(Botan::BigInt const&, Botan::RandomNumberGenerator&, unsigned long, bool) + 763
    frame #18: 0x00000001001c45d3 libbotan-2.2.dylib`Botan::random_prime(Botan::RandomNumberGenerator&, unsigned long, Botan::BigInt const&, unsigned long, unsigned long) + 947
    frame #19: 0x00000001002415cc libbotan-2.2.dylib`Botan::RSA_PrivateKey::RSA_PrivateKey(Botan::RandomNumberGenerator&, unsigned long, unsigned long) + 566
    frame #20: 0x000000010017bf44 libbotan-2.2.dylib`botan_privkey_create_rsa + 103
    frame #21: 0x00000001000cb65c librnp.0.dylib`pgp_genkey_rsa(seckey=0x0000000101100728, numbits=1024) at rsa.c:319
    frame #22: 0x000000010009fdf7 librnp.0.dylib`pgp_generate_keypair(key_desc=0x00007fff5fbfcf3c, userid="sigtest_SHA224") at crypto.c:255
    frame #23: 0x00000001000c68d6 librnp.0.dylib`rnp_generate_key(rnp=0x00007fff5fbfced8, id="sigtest_SHA224") at rnp.c:1350
    frame #24: 0x00000001000033dc rnp_tests`rnpkeys_generatekey_testSignature(state=0x0000000101200710) at rnp_tests_generatekey.c:78
    frame #25: 0x000000010048bbb2 libcmocka.0.dylib`cmocka_run_one_test_or_fixture + 425
    frame #26: 0x0000000100489f11 libcmocka.0.dylib`_cmocka_run_group_tests + 1042
    frame #27: 0x0000000100007dc7 rnp_tests`main at rnp_tests.c:120
    frame #28: 0x00007fffae921235 libdyld.dylib`start + 1
```

How you can see, the process received signal SIGPROF when it was inside `retrace_print_parameter` and at this signal handler it used `memmove`... and it go down to `retrace_event` and blocking for forever :)