### PR TITLE
Introduce EVENT_FLAGS_PRINT_BEFORE to log functions that might not return

### DIFF
--- a/common.c
+++ b/common.c
@@ -799,7 +799,10 @@ retrace_event(struct rtr_event_info *event_info)
 
 	if (event_info->event_type == EVENT_TYPE_BEFORE_CALL) {
 		event_info->start_time = retrace_get_time();
-		return;
+
+		/* Don't log any call on before unless explicitly asked too */
+		if (!(event_info->event_flags & EVENT_FLAGS_PRINT_BEFORE))
+			return;
 	}
 
 	old_trace_state = trace_disable();

--- a/common.h
+++ b/common.h
@@ -108,8 +108,9 @@ enum RTR_FUZZ_TYPE {
 #define EVENT_TYPE_BEFORE_CALL		0
 #define EVENT_TYPE_AFTER_CALL		1
 
-#define EVENT_FLAGS_PRINT_RAND_SEED	0x00000001
-#define EVENT_FLAGS_PRINT_BACKTRACE	0x00000002
+#define EVENT_FLAGS_PRINT_RAND_SEED	0x00000001  /* Print random seed */
+#define EVENT_FLAGS_PRINT_BACKTRACE	0x00000002  /* Print backtrace */
+#define EVENT_FLAGS_PRINT_BEFORE	0x00000004  /* Print this BEFORE the call, as the function might not return (i.e. exit) */
 
 #define GET_PARAMETER_TYPE(param) (param & ~PARAMETER_FLAGS_ALL)
 #define GET_PARAMETER_FLAGS(param) (param & PARAMETER_FLAGS_ALL)

--- a/exec.c
+++ b/exec.c
@@ -127,6 +127,7 @@ int RETRACE_IMPLEMENTATION(system)(const char *command)
 	event_info.parameter_values = (void **) parameter_values;
 	event_info.return_value_type = PARAMETER_TYPE_INT;
 	event_info.return_value = &r;
+	event_info.event_flags = EVENT_FLAGS_PRINT_BEFORE;
 	retrace_log_and_redirect_before(&event_info);
 
 	r = real_system(command);
@@ -169,6 +170,7 @@ execl_v(const char *path, const char *arg0, va_list ap)
 	event_info.parameter_values = (void **) parameter_values;
 	event_info.return_value_type = PARAMETER_TYPE_INT;
 	event_info.return_value = &r;
+	event_info.event_flags = EVENT_FLAGS_PRINT_BEFORE;
 	retrace_log_and_redirect_before(&event_info);
 
 	r = real_execv(path, args);
@@ -207,6 +209,7 @@ int RETRACE_IMPLEMENTATION(execv)(const char *path, char *const argv[])
 	event_info.parameter_values = (void **) parameter_values;
 	event_info.return_value_type = PARAMETER_TYPE_INT;
 	event_info.return_value = &r;
+	event_info.event_flags = EVENT_FLAGS_PRINT_BEFORE;
 	retrace_log_and_redirect_before(&event_info);
 
 	r = real_execv(path, argv);
@@ -262,6 +265,7 @@ execle_v(const char *path, const char *arg0, va_list ap)
 	event_info.parameter_values = (void **) parameter_values;
 	event_info.return_value_type = PARAMETER_TYPE_INT;
 	event_info.return_value = &r;
+	event_info.event_flags = EVENT_FLAGS_PRINT_BEFORE;
 	retrace_log_and_redirect_before(&event_info);
 
 	r = real_execve(path, args, envp);
@@ -310,6 +314,7 @@ int RETRACE_IMPLEMENTATION(execve)(const char *path, char *const argv[], char *c
 	event_info.parameter_values = (void **) parameter_values;
 	event_info.return_value_type = PARAMETER_TYPE_INT;
 	event_info.return_value = &r;
+	event_info.event_flags = EVENT_FLAGS_PRINT_BEFORE;
 	retrace_log_and_redirect_before(&event_info);
 
 	r = real_execve(path, argv, new_envp);
@@ -379,6 +384,7 @@ int RETRACE_IMPLEMENTATION(execvp)(const char *file, char *const argv[])
 	event_info.parameter_values = (void **) parameter_values;
 	event_info.return_value_type = PARAMETER_TYPE_INT;
 	event_info.return_value = &r;
+	event_info.event_flags = EVENT_FLAGS_PRINT_BEFORE;
 	retrace_log_and_redirect_before(&event_info);
 
 	r = real_execvp(file, argv);
@@ -410,6 +416,7 @@ int RETRACE_IMPLEMENTATION(execvpe)(const char *file, char *const argv[], char *
 	event_info.parameter_values = (void **) parameter_values;
 	event_info.return_value_type = PARAMETER_TYPE_INT;
 	event_info.return_value = &r;
+	event_info.event_flags = EVENT_FLAGS_PRINT_BEFORE;
 	retrace_log_and_redirect_before(&event_info);
 
 	r = real_execvpe(file, argv, envp);
@@ -450,6 +457,7 @@ int RETRACE_IMPLEMENTATION(execveat)(int dirfd, const char *pathname,
 	event_info.parameter_values = (void **) parameter_values;
 	event_info.return_value_type = PARAMETER_TYPE_INT;
 	event_info.return_value = &r;
+	event_info.event_flags = EVENT_FLAGS_PRINT_BEFORE;
 	retrace_log_and_redirect_before(&event_info);
 
 	r = real_execveat(dirfd, pathname, argv, envp, flags);
@@ -487,6 +495,7 @@ int RETRACE_IMPLEMENTATION(fexecve)(int fd, char *const argv[], char *const envp
 	event_info.parameter_values = (void **) parameter_values;
 	event_info.return_value_type = PARAMETER_TYPE_INT;
 	event_info.return_value = &r;
+	event_info.event_flags = EVENT_FLAGS_PRINT_BEFORE;
 	retrace_log_and_redirect_before(&event_info);
 
 	r = real_fexecve(fd, argv, envp);

--- a/exit.c
+++ b/exit.c
@@ -38,6 +38,7 @@ void RETRACE_IMPLEMENTATION(exit)(int status)
 	event_info.parameter_types = parameter_types;
 	event_info.parameter_values = parameter_values;
 	event_info.return_value_type = PARAMETER_TYPE_END;
+	event_info.event_flags = EVENT_FLAGS_PRINT_BEFORE;
 	retrace_log_and_redirect_before(&event_info);
 
 	real_exit(status);
@@ -133,6 +134,7 @@ void RETRACE_IMPLEMENTATION(_exit)(int status)
 	event_info.parameter_types = parameter_types;
 	event_info.parameter_values = parameter_values;
 	event_info.return_value_type = PARAMETER_TYPE_END;
+	event_info.event_flags = EVENT_FLAGS_PRINT_BEFORE;
 	retrace_log_and_redirect_before(&event_info);
 
 	real__exit(status);


### PR DESCRIPTION
Fixes https://github.com/riboseinc/retrace/issues/217