### PR TITLE
getenv format string fuzzing: reorder 's%' -> '%s'

### DIFF
--- a/common.c
+++ b/common.c
@@ -1802,7 +1802,7 @@ void *rtr_get_fuzzing_value(enum RTR_FUZZ_TYPE fuzz_type, void *param)
 
 		ret = real_malloc(len + 1);
 		for (i = 0; i < len; i++) {
-			char c = (i % 2) ? '%' : 's';
+			char c = (i % 2) ? 's' : '%';
 
 			ret[i] = c;
 		}


### PR DESCRIPTION
The format string worked only if fuzzing rate > 1 because the format string is was incorrectly ordered (s%). E.g.: (6739) getenv("FOOBAR", ) = "s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%<SNIP>

After the patch we now have expected behaviour (%s):
(74584) getenv("FOOBAR", ) = "%s%s%s%s%s<SNIP>
