### PR TITLE
Use RTR_CONFIG_START to signal start of the config

### DIFF
--- a/common.c
+++ b/common.c
@@ -1361,6 +1361,12 @@ int rtr_get_config_multiple(RTR_CONFIG_HANDLE *handle, const char *function, ...
 	if (!get_tracing_enabled())
 		return 0;
 
+	if (*config == NULL)
+		return 0;
+
+	if (*config  == RTR_CONFIG_START)
+		*config = NULL;
+
 	old_trace_state = trace_disable();
 
 	va_start(args, function);

--- a/common.h
+++ b/common.h
@@ -233,6 +233,7 @@ struct ts_info {
 };
 
 typedef const void *RTR_CONFIG_HANDLE;
+#define RTR_CONFIG_START ((void *) 0x1)
 
 int rtr_get_config_multiple(RTR_CONFIG_HANDLE *config, const char *function, ...);
 int rtr_get_config_single(const char *function, ...);

--- a/file.c
+++ b/file.c
@@ -255,7 +255,7 @@ FILE *RETRACE_IMPLEMENTATION(fopen)(const char *file, const char *mode)
 	retrace_log_and_redirect_before(&event_info);
 
 	if (get_tracing_enabled() && file) {
-		RTR_CONFIG_HANDLE config = NULL;
+		RTR_CONFIG_HANDLE config = RTR_CONFIG_START;
 
 		while (1) {
 			int r;

--- a/sock.c
+++ b/sock.c
@@ -99,7 +99,7 @@ int RETRACE_IMPLEMENTATION(connect)(int fd, const struct sockaddr *address, sock
 		struct sockaddr_in redirect_addr;
 		int enabled_redirect = 0;
 
-		RTR_CONFIG_HANDLE config = NULL;
+		RTR_CONFIG_HANDLE config = RTR_CONFIG_START;
 
 		/* get IP address and port number to connect */
 		const char *dst_ipaddr = inet_ntoa(dst_addr->sin_addr);


### PR DESCRIPTION
We were using NULL both to signal the end of the config and the start.

Now we need to initialize RTR_CONFIG_HANDLE to RTR_CONFIG_START