### PR TITLE
Fix for OpenBSD

### DIFF
--- a/malloc.c
+++ b/malloc.c
@@ -54,7 +54,12 @@ static int map_bit(const void *p, int set)
 	struct map *map, *prev;
 	unsigned long int address;
 	unsigned int offset, bit;
-	int old, mask;
+	int old, mask, old_trace_state;
+
+	if (!get_tracing_enabled())
+		return 0;
+
+	old_trace_state = trace_disable();
 
 	address = p - NULL;
 	assert(address % ALIGNSZ == 0);
@@ -90,6 +95,8 @@ static int map_bit(const void *p, int set)
 		map->map[offset] &= ~mask;
 	else
 		map->map[offset] |= mask;
+
+	trace_restore(old_trace_state);
 
 	pthread_mutex_unlock(&maps_mutex);
 

--- a/pledge.c
+++ b/pledge.c
@@ -36,6 +36,8 @@ int RETRACE_IMPLEMENTATION(pledge)(const char *promises, const char *paths[])
 	unsigned int parameter_types[] = {PARAMETER_TYPE_STRING, PARAMETER_TYPE_END};
 	void const *parameter_values[] = {&promises};
 
+	/* Load our config file before we pledge() and give up our right to do so */
+	rtr_get_config_single("dummy");
 
 	memset(&event_info, 0, sizeof(event_info));
 	event_info.function_name = "pledge";


### PR DESCRIPTION
pthread_mutex_lock calls malloc in OpenBSD which gets into a loop
force load the config file before pledge()