### PR TITLE
Implements http redirect functionality

### DIFF
--- a/ci/main.sh
+++ b/ci/main.sh
@@ -32,7 +32,7 @@ CHECKPATCH_FLAGS+=" --ignore MULTISTATEMENT_MACRO_USE_DO_WHILE"
 CHECKPATCH_FLAGS+=" --ignore STORAGE_CLASS"
 
 # checkpatch.pl will ignore the following paths
-CHECKPATCH_IGNORE+=" checkpatch.pl.patch Makefile test/Makefile"
+CHECKPATCH_IGNORE+=" checkpatch.pl.patch Makefile test/Makefile test/http.redirect/hello.txt"
 CHECKPATCH_EXCLUDE=$(for p in $CHECKPATCH_IGNORE; do echo ":(exclude)$p" ; done)
 
 function _checkpatch() {

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -16,8 +16,11 @@ noinst_HEADERS= \
 	exit.h \
 	file.h \
 	fork.h \
+	httpredirect.h \
 	id.h \
+	log.h \
 	malloc.h \
+	netfuzz.h \
 	rtr-netdb.h \
 	perror.h \
 	pipe.h \
@@ -30,12 +33,10 @@ noinst_HEADERS= \
 	select.h \
 	sock.h \
 	str.h \
-	trace.h \
-	write.h \
-	log.h \
-	netfuzz.h \
 	strinject.h \
-	temp.h
+	temp.h \
+	trace.h \
+	write.h
 
 if OPENSSL
 noinst_HEADERS+= ssl.h
@@ -52,9 +53,12 @@ libretrace_la_SOURCES= \
 	exit.c \
 	file.c \
 	fork.c \
+	httpredirect.c \
 	id.c \
+	log.c \
 	malloc.c \
 	netdb.c \
+	netfuzz.c \
 	perror.c \
 	pipe.c \
 	pledge.c \
@@ -65,13 +69,11 @@ libretrace_la_SOURCES= \
 	select.c \
 	sock.c \
 	str.c \
+	strinject.c \
+	temp.c \
 	time.c \
 	trace.c \
-	write.c \
-	log.c \
-	netfuzz.c \
-	strinject.c \
-	temp.c
+	write.c
 
 if OPENSSL
 libretrace_la_SOURCES+= ssl.c

--- a/src/common.h
+++ b/src/common.h
@@ -17,6 +17,8 @@
 #include <string.h>
 #include <errno.h>
 
+#include "httpredirect.h"
+
 #define MAXLEN		40
 
 #define VAR "\033[33m"  /* ANSI yellow for variable values */
@@ -217,6 +219,7 @@ struct descriptor_info {
 	int fd;
 	unsigned int type;
 	char *location; /* File name or address */
+	struct rtr_http_redirect_info *http_redirect;
 };
 
 void retrace_log_and_redirect_before(struct rtr_event_info *event_info);
@@ -234,7 +237,8 @@ int trace_disable();
 void trace_restore(int oldstate);
 
 /* Descriptor tracking */
-void file_descriptor_update(int fd, unsigned int type, const char *location);
+struct descriptor_info *file_descriptor_update(int fd, unsigned int type,
+	const char *location);
 struct descriptor_info *file_descriptor_get(int fd);
 void file_descriptor_remove(int fd);
 

--- a/src/httpredirect.c
+++ b/src/httpredirect.c
@@ -1,0 +1,341 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <stdlib.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <fcntl.h>
+#include <sys/select.h>
+
+#include "common.h"
+#include "sock.h"
+#include "scanf.h"
+#include "printf.h"
+#include "malloc.h"
+#include "file.h"
+#include "read.h"
+#include "str.h"
+#include "select.h"
+
+struct rtr_http_redirect_info *
+rtr_setup_http_redirect(const struct sockaddr *addr)
+{
+	const char *match_ip, *dir;
+	int port, match_port;
+	RTR_CONFIG_HANDLE config = RTR_CONFIG_START;
+	struct rtr_http_redirect_info *pinfo = NULL;
+	char ip[128];
+
+	if (addr->sa_family == AF_INET) {
+		port = ntohs(((struct sockaddr_in *)addr)->sin_port);
+		inet_ntop(AF_INET, &(((struct sockaddr_in *)addr)->sin_addr),
+		    ip, sizeof(ip));
+	} else {
+		port = ntohs(((struct sockaddr_in6 *)addr)->sin6_port);
+		inet_ntop(AF_INET6,
+		    &(((struct sockaddr_in6 *)addr)->sin6_addr), ip,
+		    sizeof(ip));
+	}
+
+	for (;;) {
+		if (rtr_get_config_multiple(&config, "httpredirect",
+		    ARGUMENT_TYPE_STRING, ARGUMENT_TYPE_INT,
+		    ARGUMENT_TYPE_STRING, ARGUMENT_TYPE_END,
+		    &match_ip, &match_port, &dir) == 0)
+			break;
+
+		if (match_port == port && real_strcmp(match_ip, ip) == 0) {
+			pinfo = real_malloc(
+			    sizeof(struct rtr_http_redirect_info));
+			if (pinfo) {
+				memset(pinfo, 0,
+				    sizeof(struct rtr_http_redirect_info));
+				pinfo->filefd = -1;
+				pinfo->dir = dir;
+				pinfo->sniffing = 1;
+			}
+			break;
+		}
+	}
+
+	return pinfo;
+}
+
+static struct rtr_http_redirect_info *lookup_redirect_info(int fd)
+{
+	struct descriptor_info *pinfo;
+
+	pinfo = file_descriptor_get(fd);
+
+	return (pinfo ? pinfo->http_redirect : NULL);
+}
+
+static ssize_t select_and_read(int fd, void *buf, size_t len)
+{
+	fd_set fds;
+	ssize_t readlen;
+
+	for (;;) {
+		FD_ZERO(&fds);
+		FD_SET(fd, &fds);
+		if (real_select(fd + 1, &fds, NULL, NULL, NULL) == -1) {
+			if (errno == EINTR)
+				continue;
+			return -1;
+		}
+		readlen = real_recv(fd, buf, len, MSG_DONTWAIT);
+		if (readlen == 0)
+			readlen = -1;
+		break;
+	}
+	return readlen;
+}
+
+static void discard_response(int fd)
+{
+	const size_t READ_MAX = 1024;
+	size_t readlen, contentlen = 0;
+	char buf[READ_MAX + 1], *p, *end;
+	unsigned int bufoff = 0;
+	int chunked = 0, inheaders = 1;
+
+	/*
+	 * parse headers taking transfer encoding and/or content length
+	 */
+	while (inheaders) {
+		readlen = select_and_read(fd, buf + bufoff,
+		    READ_MAX - bufoff);
+
+		if (readlen == -1)
+			return;
+
+		bufoff += readlen;
+		buf[bufoff] = '\0';
+		for (p = buf; inheaders; p = end + 2) {
+			end = real_strstr(p, "\r\n");
+			if (end == p)
+				inheaders = 0;
+
+			if (end == NULL)
+				/* not a full line */
+				break;
+
+			*end = '\0';
+			if (strcasestr(p, "Content-Length: ") == p)
+				contentlen = atol(p + 16);
+
+			if (strcasestr(p, "Transfer-Encoding: ") == p)
+				if (strcasestr(p, "chunked"))
+					chunked = 1;
+		}
+
+		bufoff -= p - buf;
+		real_memmove(buf, p, bufoff);
+		buf[bufoff] = '\0';
+	}
+
+	if (chunked) {
+		while (real_strstr(buf, "\r\n0\r\n") == NULL) {
+
+			if (bufoff > 4) {
+				real_memmove(buf, buf + bufoff - 4, 4);
+				bufoff = 4;
+				buf[bufoff] = '\0';
+			}
+
+			readlen = select_and_read(fd, buf + bufoff,
+			    READ_MAX - bufoff);
+
+			if (readlen == -1)
+				return;
+
+			bufoff += readlen;
+			buf[bufoff] = '\0';
+		}
+	} else {
+		contentlen -= bufoff;
+		while (contentlen) {
+
+			readlen = contentlen;
+			if (readlen > READ_MAX)
+				readlen = READ_MAX;
+
+			readlen = select_and_read(fd, buf, readlen);
+
+			if (readlen == -1)
+				break;
+
+			contentlen -= readlen;
+		}
+	}
+}
+
+const char *locate_url(char *buf)
+{
+	char *url, *end;
+
+	if (real_strstr(buf, "GET /") != buf)
+		return 0;
+
+	url = buf + 5;
+	end = real_strchr(url, ' ');
+
+	if (end == NULL || end == url ||
+	    (real_strcmp(end, " HTTP/1.0") && real_strcmp(end, " HTTP/1.1")))
+		return 0;
+
+	*end = '\0';
+
+	return url;
+}
+
+static int open_redirect_file(const char *dir, const char *url)
+{
+	char *path;
+	int retval;
+
+	path = real_malloc(strlen(dir) + real_strlen(url) + 2);
+	if (path == NULL)
+		return -1;
+
+	real_sprintf(path, "%s/%s", dir, url);
+
+	retval = real_open(path, O_RDONLY);
+
+	real_free(path);
+
+	return retval;
+}
+
+static size_t size_redirect_file(int fd)
+{
+	off_t retval;
+
+	retval = lseek(fd, 0, SEEK_END);
+	if (retval == -1)
+		return 0;
+
+	lseek(fd, 0, SEEK_SET);
+
+	return retval;
+}
+
+/*
+ * rtr_http_sniff_request sniffs the first line of a request for
+ * "GET %s HTTP/1.n". If it matches it then opens any corresponding redirect
+ * file in preparation for rtr_http_redirect_response.
+ */
+void
+rtr_http_sniff_request(int fd, const void *buf, size_t len)
+{
+	struct rtr_http_redirect_info *info;
+	const char *url;
+	size_t snifflen;
+	char *p;
+
+	info = lookup_redirect_info(fd);
+
+	if (info == NULL || info->sniffing == 0)
+		return;
+
+	snifflen = len;
+	if (snifflen > RTR_HTTP_SNIFFLEN - info->sniffoff)
+		snifflen = RTR_HTTP_SNIFFLEN - info->sniffoff;
+
+	real_memcpy(info->sniffbuf + info->sniffoff, buf, snifflen);
+
+	info->sniffoff += snifflen;
+	info->sniffbuf[info->sniffoff] = '\0';
+
+	p = real_strstr(info->sniffbuf, "\r\n");
+	if (p != NULL) {
+		*p = '\0';
+		url = locate_url(info->sniffbuf);
+		if (url)
+			info->filefd = open_redirect_file(info->dir, url);
+		if (info->filefd != -1) {
+			info->remainder = size_redirect_file(info->filefd);
+			if (info->remainder == 0) {
+				real_close(info->filefd);
+				info->filefd = -1;
+			}
+		}
+		info->sniffing = 0;
+	}
+
+	if (info->sniffoff == RTR_HTTP_SNIFFLEN)
+		info->sniffing = 0;
+}
+
+/*
+ * rtr_http_redirect_response checks to see if we're redirecting (ie.
+ * rtr_http_sniff_request set up a file descriptor for redirected response.) If
+ * so it copies the content of the file into the buffer. After file contents
+ * are exhauseted, it reads and discards the server's own response before
+ * returning.
+ */
+size_t
+rtr_http_redirect_response(int fd, void *buf, size_t len, int flags)
+{
+	struct rtr_http_redirect_info *info;
+	ssize_t readlen;
+
+	info = lookup_redirect_info(fd);
+
+	if (info == NULL || info->filefd == -1 || info->remainder == 0)
+		return 0;
+
+	info->sniffing = 1;
+
+	readlen = info->remainder;
+	if (readlen > len)
+		readlen = len;
+
+	readlen = real_read(info->filefd, buf, readlen);
+	if (readlen <= 0)
+		/* TODO: error handling */
+		return 0;
+
+	if (flags & MSG_PEEK)
+		lseek(info->filefd, -readlen, SEEK_CUR);
+	else
+		info->remainder -= readlen;
+
+	if (info->remainder == 0) {
+		real_close(info->filefd);
+		info->sniffoff = 0;
+		info->sniffing = 1;
+		info->filefd = -1;
+
+		discard_response(fd);
+	}
+
+	errno = 0;
+	return readlen;
+}

--- a/src/httpredirect.h
+++ b/src/httpredirect.h
@@ -1,0 +1,20 @@
+#ifndef __RETRACE_HTTP_REDIRECT_H__
+#define __RETRACE_HTTP_REDIRECT_H__
+
+#include <sys/socket.h>
+
+#define RTR_HTTP_SNIFFLEN 1024
+
+struct rtr_http_redirect_info {
+	char sniffbuf[RTR_HTTP_SNIFFLEN + 1];
+	off_t sniffoff;
+	const char *dir;
+	int filefd, sniffing;
+	size_t remainder;
+};
+
+struct rtr_http_redirect_info *rtr_setup_http_redirect(const struct sockaddr *addr);
+void rtr_http_sniff_request(int fd, const void *buf, size_t len);
+size_t rtr_http_redirect_response(int fd, void *buf, size_t len, int flags);
+
+#endif

--- a/src/read.c
+++ b/src/read.c
@@ -63,7 +63,13 @@ ssize_t RETRACE_IMPLEMENTATION(read)(int fd, void *buf, size_t nbytes)
 		event_info.logging_level |= RTR_LOG_LEVEL_FUZZ;
 	}
 
-	ret = real_read(fd, buf, real_nbytes);
+	ret = rtr_http_redirect_response(fd, buf, real_nbytes, 0);
+
+	if (ret == 0)
+		ret = real_read(fd, buf, real_nbytes);
+	else
+		event_info.extra_info = "[redirected]";
+
 	if (errno)
 		event_info.logging_level |= RTR_LOG_LEVEL_ERR;
 	else {

--- a/src/write.c
+++ b/src/write.c
@@ -26,6 +26,7 @@
 #include "common.h"
 #include "strinject.h"
 #include "write.h"
+#include "httpredirect.h"
 
 ssize_t RETRACE_IMPLEMENTATION(write)(int fd, const void *buf, size_t nbytes)
 {
@@ -72,6 +73,8 @@ ssize_t RETRACE_IMPLEMENTATION(write)(int fd, const void *buf, size_t nbytes)
 	}
 
 	retrace_log_and_redirect_before(&event_info);
+
+	rtr_http_sniff_request(fd, buf, real_nbytes);
 
 	ret = real_write(fd, buf, real_nbytes);
 	if (errno)

--- a/test/http.redirect/hello.txt
+++ b/test/http.redirect/hello.txt
@@ -1,0 +1,8 @@
+HTTP/1.0 200 OK
+Server: SimpleHTTP/0.6 Python/2.7.13
+Date: Tue, 15 Aug 2017 22:35:28 GMT
+Content-type: text/plain
+Content-Length: 16
+Last-Modified: Tue, 15 Aug 2017 22:31:35 GMT
+
+Hello, retrace!

--- a/test/http.site/hello.txt
+++ b/test/http.site/hello.txt
@@ -1,0 +1,1 @@
+Hello, world!

--- a/test/http.site/index.txt
+++ b/test/http.site/index.txt
@@ -1,0 +1,1 @@
+Hello, world!

--- a/test/httpredirect.config
+++ b/test/httpredirect.config
@@ -1,0 +1,1 @@
+httpredirect,127.0.0.1,8000,/home/john/upwork/riboseinc/retrace/test/http.redirect

--- a/test/httpredirect.sh
+++ b/test/httpredirect.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+
+set -e
+
+PYTHON=/usr/bin/python
+CURL=/usr/bin/curl
+RETRACE=../retrace
+CONFIG=httpredirect.config
+URL1=http://127.0.0.1:8000/hello.txt
+URL2=http://127.0.0.1:8000/index.txt
+
+[ -x "$PYTHON" -a -x "$CURL" ] || (echo Python or curl not found; exit 1)
+SCRIPTNAME=$(basename $0)
+
+cd $(dirname $0)
+
+(cd http.site && $PYTHON -m SimpleHTTPServer >/dev/null 2>&1) &
+PYTHONPID=$!
+
+# RESPONSE1 redirected url without http redirection
+RESPONSE1=$($RETRACE $CURL $URL1 2>/dev/null)
+
+# RESPONSE2 redirected url with http redirection
+RESPONSE2=$($RETRACE -f $CONFIG $CURL $URL1 2>/dev/null)
+
+# RESPONSE3 non-redirected url with http redirection
+RESPONSE3=$($RETRACE -f $CONFIG $CURL $URL2 2>/dev/null)
+
+kill $PYTHONPID
+
+if [ "$RESPONSE1" != "Hello, world!" ]; then
+	echo $SCRIPTNAME: Failed to fetch $URL1
+	exit 1
+fi
+
+if [ "$RESPONSE2" != "Hello, retrace!" ]; then
+	echo $SCRIPTNAME: Failed to redirect $URL1
+	exit 1
+fi
+
+if [ "$RESPONSE3" != "Hello, world!" ]; then
+	echo $SCRIPTNAME: Failed to fetch $URL2
+	exit 1
+fi

--- a/test/runtests.sh
+++ b/test/runtests.sh
@@ -6,6 +6,7 @@
 ../retrace ./file
 ../retrace ./fork
 ../retrace ./getaddrinfo
+./httpredirect.sh
 ../retrace ./id
 ../retrace ./malloc
 ../retrace ./pipe


### PR DESCRIPTION
The way I'm testing is to create static files in `/somedir/http.site/`, `(cd /somedir/http.site && python -m SimpleHTTPServer >/dev/null &)` Then use `curl -i localhost:8000/test.txt >/somedir/http.redirect/test.txt` to get a redirected file complete with headers. Edit the file making sure to keep the `Content-length:` header sane. Put  `httpredirect,127.0.0.1,8000,/somedir/http.redirect` into your `retrace` config file and cross your fingers ...

Tests, documentation and bugfixes to follow next week.