### PR TITLE
Changes to RPC version

### DIFF
--- a/ci/before_install.sh
+++ b/ci/before_install.sh
@@ -11,16 +11,21 @@ get_os() {
 }
 
 macos_install() {
-	brew upgrade
-	brew install openssl
-	brew install make
-	brew install cmake
-	brew install autoconf
-	brew install automake
-	brew install libtool
-	brew install cmocka
-	brew install pkg-config
-	brew install ruby
+	brew update
+	packages="
+		openssl
+		make
+		cmake
+		autoconf
+		automake
+		libtool
+		cmocka
+		pkg-config
+		ruby
+	"
+	for p in ${packages}; do
+		brew install ${p} || brew upgrade ${p}
+	done
 	mkdir -p ${CMOCKA_INSTALL}
 	gem install mustache
 }

--- a/configure.ac
+++ b/configure.ac
@@ -159,6 +159,7 @@ else
     AC_DEFINE(USE_OPENSSL, [0], [Define to use OpenSSL])
 fi
 
+AC_CHECK_DECLS([O_TMPFILE], [], [], [#include <fcntl.h>])
 
 # Check for PTRACE features
 AC_CHECK_DECLS([PTRACE_GETREGS, PTRACE_GETREGSET, PTRACE_SETREGSET], [], [], [#include <sys/ptrace.h.h>])
@@ -207,7 +208,7 @@ AC_MSG_RESULT($enable_test)
 AM_CONDITIONAL([ENABLE_TESTS], [test "x$enable_tests" = "xyes"])
 if test "x$enable_tests" = "xyes" ; then
 AC_MSG_NOTICE([yes])
-TESTS_CFLAGS="$TESTS_CFLAGS -fno-builtin -Wno-unused-result"
+TESTS_CFLAGS="$TESTS_CFLAGS -fno-builtin"
 else
 AC_MSG_NOTICE([no])
 fi

--- a/rpc/Makefile.am
+++ b/rpc/Makefile.am
@@ -1,30 +1,19 @@
-AM_CFLAGS = -Wall -Wno-sizeof-array-argument
+AM_CFLAGS = -Wall
 noinst_PROGRAMS = functions2yaml
 functions2yaml_SOURCES = functions2yaml.c
 
 lib_LTLIBRARIES = libretracerpc.la
 libretracerpc_la_LDFLAGS = -no-undefined -avoid-version
 libretracerpc_la_CFLAGS = $(AM_CFLAGS) $(LIBSSL_FLAGS)
-noinst_HEADERS = rpc.h shim.h frontend.h backend.h functions.h
+noinst_HEADERS = rpc.h shim.h frontend.h backend.h functions.h tracefd.h backtrace.h
 libretracerpc_la_SOURCES = shim.c version.c backend.c
 bin_PROGRAMS = retrace
-retrace_SOURCES = retrace.c version.c handlers.c frontend.c functions.c display.c
+retrace_SOURCES = retrace.c version.c handlers.c frontend.c functions.c display.c tracefd.c backtrace.c
 
 if LINUX
-MD5SUM=/usr/bin/md5sum
-endif
-if DARWIN
-MD5SUM=/sbin/md5
-endif
-if OPENBSD
-MD5SUM=/bin/md5
-endif
-
-if !OPENBSD
-MUSTACHE=mustache
-endif
-if OPENBSD
-MUSTACHE=mustache22
+MD5SUM=md5sum
+else
+MD5SUM=md5
 endif
 
 FUNCTIONS_DEPS= shim.c shim.h handlers.c functions.c functions.h
@@ -41,7 +30,7 @@ handlers.c : handlers.c.template
 $(FUNCTIONS_DEPS): functions.yaml
 
 $(FUNCTIONS_DEPS):
-	$(MUSTACHE) - $@.template <functions.yaml >$@
+	mustache - $@.template <functions.yaml >$@
 
 version.c : $(FUNCTION_DEPS)
 	echo const char *retrace_version = \"$$(cat $(FUNCTIONS_DEPS) | $(MD5SUM) | cut -c1-32)\"\; >$@

--- a/rpc/backend.h
+++ b/rpc/backend.h
@@ -4,13 +4,15 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 
-#if defined(__OpenBSD__)
+#if defined __OpenBSD__ || defined __FreeBSD__
 int rpc_get_sockfd(enum retrace_function_id fid);
 #else
 int rpc_get_sockfd(void);
 #endif
 void rpc_set_sockfd(long int fd);
-int rpc_send_message(int fd, enum rpc_msg_type msg_type, const void *buf, size_t len);
+int rpc_send_message(int fd, enum rpc_msg_type msg_type, const void *buf, size_t length);
+int rpc_send_init(int fd, enum retrace_function_id fid, void *params, size_t length);
+int rpc_send_result(int fd, const void *result, size_t length);
 int rpc_recv_message(int fd, enum rpc_msg_type *msg_type, void *buf);
 int rpc_handle_message(int fd, enum rpc_msg_type msg_type, void *buf);
 

--- a/rpc/backtrace.c
+++ b/rpc/backtrace.c
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "../config.h"
+
+#include "frontend.h"
+#include "handlers.h"
+
+#if BACKTRACE
+static void
+backtrace_handler(struct retrace_endpoint *ep,
+	struct retrace_call_context *context)
+{
+	char buf[4096];
+	struct handler_info *hi = ep->handle->user_data;
+
+	if (retrace_fetch_backtrace(ep->fd, hi->backtrace_depth, buf,
+	    sizeof(buf)))
+		printf("%s", buf);
+}
+
+void init_backtrace_handlers(struct retrace_handle *handle,
+	int *backtrace_funcs)
+{
+	int i;
+
+	for (i = 0; i < RPC_FUNCTION_COUNT; i++)
+		if (backtrace_funcs[i] != 0)
+			retrace_add_postcall_handler(handle, i,
+			    backtrace_handler);
+}
+#endif

--- a/rpc/backtrace.h
+++ b/rpc/backtrace.h
@@ -1,0 +1,6 @@
+#ifndef __BACKTRACE_H__
+#define __BACKTRACE_H__
+
+void init_backtrace_handlers(struct retrace_handle *handle, int *backtrace_flags);
+
+#endif

--- a/rpc/display.c
+++ b/rpc/display.c
@@ -25,21 +25,39 @@
 
 #include "../config.h"
 
+#include <assert.h>
 #include <ctype.h>
+#include <stdlib.h>
+#include <string.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <sys/un.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
 
 #include "frontend.h"
 #include "display.h"
+#include "tracefd.h"
+#include "handlers.h"
+
+struct flag_name {
+	int flag;
+	const char *name;
+};
 
 static char *
 format_char(char *buf, int c)
 {
 	static const char hex[] = "0123456789ABCDEF";
 
-	if (isprint(c))
+	if (isprint(c) && c != '\\')
 		*(buf++) = c;
 	else {
 		*(buf++) = '\\';
 		switch (c) {
+		case '\\':
+			*(buf++) = '\\';
+			break;
 		case '\0':
 			*(buf++) = '0';
 			break;
@@ -97,20 +115,607 @@ print_string(const char *s)
 void
 display_string(struct retrace_endpoint *ep, const char *s)
 {
-	struct display_info *di = ep->handle->user_data;
-	char buf[di->expand_strings + 1];
+	struct handler_info *hi = ep->handle->user_data;
+	char buf[hi->expand_strings + 1];
 	int snipped;
 
-	if (s && di->expand_strings) {
-		buf[di->expand_strings] = '\0';
-		retrace_fetch_string(ep->fd, s, buf,
-		    di->expand_strings + 1);
-		snipped = buf[di->expand_strings] != '\0';
-		buf[di->expand_strings] = '\0';
+	if (s && hi->expand_strings) {
+		buf[hi->expand_strings] = '\0';
+		retrace_fetch_string(ep->fd, s, buf, sizeof(buf));
+		snipped = buf[hi->expand_strings] != '\0';
+		buf[hi->expand_strings] = '\0';
 		printf("\"");
 		print_string(buf);
 		printf(snipped ? "\"+" : "\"");
 	} else {
 		printf("%p", s);
 	}
+}
+
+void
+display_char(int c)
+{
+	char buf[16], *e;
+
+	e = format_char(buf, c);
+	*e = '\0';
+	printf("'%s'", buf);
+}
+
+void
+display_fd(struct retrace_endpoint *ep, int fd)
+{
+	struct handler_info *hi = ep->handle->user_data;
+	const struct fdinfo *fi = NULL;
+
+	if (hi->tracefds)
+		fi = get_fdinfo(&hi->fdinfos, ep->pid, fd);
+
+	if (fi != NULL)
+		printf("%d:%s", fd, fi->info);
+	else
+		printf("%d", fd);
+}
+
+void
+display_stream(struct retrace_endpoint *ep, FILE *stream)
+{
+	struct handler_info *hi = ep->handle->user_data;
+	const struct fdinfo *fi = NULL;
+
+	if (hi->tracefds)
+		fi = get_streaminfo(&hi->fdinfos, ep->pid, stream);
+
+	if (fi != NULL)
+		printf("%p:%s", stream, fi->info);
+	else
+		printf("%p", stream);
+}
+
+void
+display_dir(struct retrace_endpoint *ep, DIR *dir)
+{
+	struct handler_info *hi = ep->handle->user_data;
+	const struct fdinfo *fi = NULL;
+
+	if (hi->tracefds)
+		fi = get_dirinfo(&hi->fdinfos, ep->pid, dir);
+
+	if (fi != NULL)
+		printf("%p:%s", dir, fi->info);
+	else
+		printf("%p", dir);
+}
+
+void
+display_fflags(struct retrace_endpoint *ep, int flags)
+{
+	static struct flag_name flag_names[] = {
+		{O_APPEND,	"O_APPEND"},
+		{O_ASYNC,	"O_ASYNC"},
+		{O_CLOEXEC,	"O_CLOEXEC"},
+		{O_CREAT,	"O_CREAT"},
+		{O_DIRECTORY,	"O_DIRECTORY"},
+		{O_EXCL,	"O_EXCL"},
+		{O_NOCTTY,	"O_NOCTTY"},
+		{O_NOFOLLOW,	"O_NOFOLLOW"},
+		{O_NONBLOCK,	"O_NONBLOCK"},
+		{O_NDELAY,	"O_NDELAY"},
+		{O_SYNC,	"O_SYNC"},
+		{O_TRUNC,	"O_TRUNC"},
+#if defined __APPLE__ || defined __OpenBSD__ || defined __linux__
+		{O_DSYNC,	"O_DSYNC"},
+#endif
+#ifdef __linux__
+		{O_LARGEFILE,	"O_LARGEFILE"},
+		{O_NOATIME,	"O_NOATIME"},
+		{O_PATH,	"O_PATH"},
+		{O_TMPFILE,	"O_TMPFILE"},
+#endif
+#if defined __linux__ || defined __FreeBSD__
+		{O_DIRECT,	"O_DIRECT"},
+#endif
+#ifdef __APPLE__
+		{O_EVTONLY,	"O_EVTONLY"},
+		{O_SYMLINK,	"O_SYMLINK"},
+#endif
+#ifdef __FreeBSD__
+		{O_EXEC,	"O_EXEC"},
+		{O_FSYNC,	"O_FSYNC"},
+		{O_TTY_INIT,	"O_TTY_INIT"},
+		{O_VERIFY,	"O_VERIFY"},
+#endif
+#if defined __APPLE__ || defined __OpenBSD__ || defined __FreeBSD__
+		{O_EXLOCK,	"O_EXLOCK"},
+		{O_SHLOCK,	"O_SHLOCK"},
+#endif
+		{0,	NULL} };
+	struct flag_name *f;
+
+	switch (flags & O_ACCMODE) {
+	case O_RDONLY:
+		printf("O_RDONLY");
+		break;
+	case O_WRONLY:
+		printf("O_WRONLY");
+		break;
+	case O_RDWR:
+		printf("O_RDWR");
+		break;
+	}
+
+	flags &= ~O_ACCMODE;
+
+	for (f = flag_names; f->name != NULL; ++f) {
+		if ((flags & f->flag) != 0)
+			printf(" | %s", f->name);
+		flags &= ~f->flag;
+	}
+
+	if (flags != 0)
+		printf(" | UNKNOWN(%x)", flags);
+}
+
+void
+display_msgflags(struct retrace_endpoint *ep, int flags)
+{
+	static struct flag_name flag_names[] = {
+		{MSG_DONTROUTE,	"MSG_DONTROUTE"},
+		{MSG_OOB,	"MSG_OOB"},
+		{MSG_PEEK,	"MSG_PEEK"},
+		{MSG_WAITALL,	"MSG_WAITALL"},
+#ifdef __linux__
+		{MSG_CMSG_CLOEXEC,	"MSG_CMSG_CLOEXEC"},
+		{MSG_CONFIRM,	"MSG_CONFIRM"},
+		{MSG_ERRQUEUE,	"MSG_ERRQUEUE"},
+		{MSG_MORE,	"MSG_MORE"},
+		{MSG_TRUNC,	"MSG_TRUNC"},
+#endif
+#if defined __linux__ || defined __OpenBSD__
+		{MSG_DONTWAIT,	"MSG_DONTWAIT"},
+		{MSG_NOSIGNAL,	"MSG_NOSIGNAL"},
+		{MSG_EOR,	"MSG_EOR"},
+#endif
+		{0,	NULL} };
+	struct flag_name *f;
+	const char *fmt = "%s";
+
+	if (flags == 0)
+		printf("0");
+	else {
+		for (f = flag_names; f->name != NULL; ++f) {
+			if ((flags & f->flag) != 0) {
+				printf(fmt, f->name);
+				fmt = " | %s";
+			}
+		}
+	}
+
+	if (flags != 0) {
+		printf(fmt, "UNKNOWN");
+		printf("(%x)", flags);
+	}
+}
+
+void
+display_errno(int _errno)
+{
+	static struct flag_name flag_names[] = {
+		{E2BIG,	"E2BIG"},
+		{EACCES,	"EACCES"},
+		{EADDRINUSE,	"EADDRINUSE"},
+		{EADDRNOTAVAIL,	"EADDRNOTAVAIL"},
+		{EAFNOSUPPORT,	"EAFNOSUPPORT"},
+		{EAGAIN,	"EAGAIN"},
+		{EALREADY,	"EALREADY"},
+		{EBADF,	"EBADF"},
+		{EBUSY,	"EBUSY"},
+		{ECANCELED,	"ECANCELED"},
+		{ECHILD,	"ECHILD"},
+		{ECONNABORTED,	"ECONNABORTED"},
+		{ECONNREFUSED,	"ECONNREFUSED"},
+		{ECONNRESET,	"ECONNRESET"},
+		{EDEADLK,	"EDEADLK"},
+		{EDESTADDRREQ,	"EDESTADDRREQ"},
+		{EDOM,	"EDOM"},
+		{EDQUOT,	"EDQUOT"},
+		{EEXIST,	"EEXIST"},
+		{EFAULT,	"EFAULT"},
+		{EFBIG,	"EFBIG"},
+		{EHOSTDOWN,	"EHOSTDOWN"},
+		{EHOSTUNREACH,	"EHOSTUNREACH"},
+		{EIDRM,	"EIDRM"},
+		{EILSEQ,	"EILSEQ"},
+		{EINPROGRESS,	"EINPROGRESS"},
+		{EINTR,	"EINTR"},
+		{EINVAL,	"EINVAL"},
+		{EIO,	"EIO"},
+		{EISCONN,	"EISCONN"},
+		{EISDIR,	"EISDIR"},
+		{ELOOP,	"ELOOP"},
+		{EMFILE,	"EMFILE"},
+		{EMLINK,	"EMLINK"},
+		{EMSGSIZE,	"EMSGSIZE"},
+		{ENAMETOOLONG,	"ENAMETOOLONG"},
+		{ENETDOWN,	"ENETDOWN"},
+		{ENETRESET,	"ENETRESET"},
+		{ENETUNREACH,	"ENETUNREACH"},
+		{ENFILE,	"ENFILE"},
+		{ENOBUFS,	"ENOBUFS"},
+		{ENODEV,	"ENODEV"},
+		{ENOENT,	"ENOENT"},
+		{ENOEXEC,	"ENOEXEC"},
+		{ENOLCK,	"ENOLCK"},
+		{ENOMEM,	"ENOMEM"},
+		{ENOMSG,	"ENOMSG"},
+		{ENOPROTOOPT,	"ENOPROTOOPT"},
+		{ENOSPC,	"ENOSPC"},
+		{ENOTBLK,	"ENOTBLK"},
+		{ENOTCONN,	"ENOTCONN"},
+		{ENOTDIR,	"ENOTDIR"},
+		{ENOTEMPTY,	"ENOTEMPTY"},
+		{ENOTSOCK,	"ENOTSOCK"},
+		{ENOTSUP,	"ENOTSUP"},
+		{ENOTTY,	"ENOTTY"},
+		{ENXIO,	"ENXIO"},
+		{EOPNOTSUPP,	"EOPNOTSUPP"},
+		{EOVERFLOW,	"EOVERFLOW"},
+		{EPERM,	"EPERM"},
+		{EPFNOSUPPORT,	"EPFNOSUPPORT"},
+		{EPIPE,	"EPIPE"},
+		{EPROTONOSUPPORT,	"EPROTONOSUPPORT"},
+		{EPROTOTYPE,	"EPROTOTYPE"},
+		{ERANGE,	"ERANGE"},
+		{EREMOTE,	"EREMOTE"},
+		{EROFS,	"EROFS"},
+		{ESHUTDOWN,	"ESHUTDOWN"},
+		{ESOCKTNOSUPPORT,	"ESOCKTNOSUPPORT"},
+		{ESPIPE,	"ESPIPE"},
+		{ESRCH,	"ESRCH"},
+		{ESTALE,	"ESTALE"},
+		{ETIMEDOUT,	"ETIMEDOUT"},
+		{ETXTBSY,	"ETXTBSY"},
+		{EUSERS,	"EUSERS"},
+		{EWOULDBLOCK,	"EWOULDBLOCK"},
+		{EXDEV,	"EXDEV"},
+#if defined __APPLE__ || defined __OpenBSD__
+		{EAUTH,	"EAUTH"},
+		{EBADRPC,	"EBADRPC"},
+		{EFTYPE,	"EFTYPE"},
+		{ENEEDAUTH,	"ENEEDAUTH"},
+		{ENOATTR,	"ENOATTR"},
+		{EPROCLIM,	"EPROCLIM"},
+		{EPROCUNAVAIL,	"EPROCUNAVAIL"},
+		{EPROGMISMATCH,	"EPROGMISMATCH"},
+		{EPROGUNAVAIL,	"EPROGUNAVAIL"},
+		{ERPCMISMATCH,	"ERPCMISMATCH"},
+#endif
+#if defined __APPLE__ || defined __linux__
+		{EBADMSG,	"EBADMSG"},
+		{EMULTIHOP,	"EMULTIHOP"},
+		{ENODATA,	"ENODATA"},
+		{ENOLINK,	"ENOLINK"},
+		{ENOSR,	"ENOSR"},
+		{ENOSTR,	"ENOSTR"},
+		{EPROTO,	"EPROTO"},
+		{ETIME,	"ETIME"},
+#endif
+#if defined __OpenBSD__ || defined __linux__
+		{EMEDIUMTYPE,	"EMEDIUMTYPE"},
+		{ENOMEDIUM,	"ENOMEDIUM"},
+#endif
+#ifdef __OpenBSD__
+		{EIPSEC,	"EIPSEC"},
+#endif
+#ifdef __linux__
+		{EBADE,	"EBADE"},
+		{EBADFD,	"EBADFD"},
+		{EBADR,	"EBADR"},
+		{EBADRQC,	"EBADRQC"},
+		{EBADSLT,	"EBADSLT"},
+		{ECHRNG,	"ECHRNG"},
+		{ECOMM,	"ECOMM"},
+		{EDEADLOCK,	"EDEADLOCK"},
+		{EISNAM,	"EISNAM"},
+		{EKEYEXPIRED,	"EKEYEXPIRED"},
+		{EKEYREJECTED,	"EKEYREJECTED"},
+		{EKEYREVOKED,	"EKEYREVOKED"},
+		{EL2HLT,	"EL2HLT"},
+		{EL2NSYNC,	"EL2NSYNC"},
+		{EL3HLT,	"EL3HLT"},
+		{EL3RST,	"EL3RST"},
+		{ELIBACC,	"ELIBACC"},
+		{ELIBBAD,	"ELIBBAD"},
+		{ELIBMAX,	"ELIBMAX"},
+		{ELIBSCN,	"ELIBSCN"},
+		{ELIBEXEC,	"ELIBEXEC"},
+		{ENOKEY,	"ENOKEY"},
+		{ENONET,	"ENONET"},
+		{ENOPKG,	"ENOPKG"},
+		{ENOTUNIQ,	"ENOTUNIQ"},
+		{EREMCHG,	"EREMCHG"},
+		{EREMOTEIO,	"EREMOTEIO"},
+		{ERESTART,	"ERESTART"},
+		{ESTRPIPE,	"ESTRPIPE"},
+		{EUCLEAN,	"EUCLEAN"},
+		{EUNATCH,	"EUNATCH"},
+		{EXFULL,	"EXFULL"},
+#endif
+#ifdef __APPLE__
+		{EBADARCH,	"EBADARCH"},
+		{EBADEXEC,	"EBADEXEC"},
+		{EBADMACHO,	"EBADMACHO"},
+		{EDEVERR,	"EDEVERR"},
+		{ENOPOLICY,	"ENOPOLICY"},
+		{ENOTRECOVERABLE,	"ENOTRECOVERABLE"},
+		{EOWNERDEAD,	"EOWNERDEAD"},
+		{EPWROFF,	"EPWROFF"},
+		{EQFULL,	"EQFULL"},
+		{ESHLIBVERS,	"ESHLIBVERS"},
+		{ETOOMANYREFS,	"ETOOMANYREFS"},
+#endif
+		{0,	NULL} };
+	struct flag_name *f;
+
+	for (f = flag_names; f->name; ++f) {
+		if (f->flag == _errno) {
+			printf(" [%s:%d])", f->name, _errno);
+			return;
+		}
+	}
+	printf(" [errno:%d]", _errno);
+}
+
+void
+display_domain(int domain)
+{
+	static struct flag_name flag_names[] = {
+#ifdef __linux__
+		{AF_NETLINK,	"AF_NETLINK"},
+		{AF_X25,	"AF_X25"},
+		{AF_AX25,	"AF_AX25"},
+		{AF_ATMPVC,	"AF_ATMPVC"},
+		{AF_PACKET,	"AF_PACKET"},
+		{AF_ALG,	"AF_ALG"},
+#endif
+#if defined __linux__ || defined __OpenBSD__
+		{AF_UNIX,	"AF_UNIX"},
+		{AF_LOCAL,	"AF_LOCAL"},
+		{AF_INET,	"AF_INET"},
+		{AF_INET6,	"AF_INET6"},
+		{AF_IPX,	"AF_IPX"},
+		{AF_APPLETALK,	"AF_APPLETALK"},
+#endif
+#ifdef __APPLE__
+		{PF_LOCAL,	"PF_LOCAL"},
+		{PF_UNIX,	"PF_UNIX"},
+		{PF_INET,	"PF_INET"},
+		{PF_ROUTE,	"PF_ROUTE"},
+		{PF_KEY,	"PF_KEY"},
+		{PF_INET6,	"PF_INET6"},
+		{PF_SYSTEM,	"PF_SYSTEM"},
+		{PF_NDRV,	"PF_NDRV"},
+#endif
+		{0,	NULL} };
+	struct flag_name *f;
+
+	for (f = flag_names; f->name; ++f) {
+		if (f->flag == domain) {
+			printf("%s", f->name);
+			return;
+		}
+	}
+	printf("unknown:%d", domain);
+}
+
+void
+display_protocol(int protocol)
+{
+	/* from /etc/protocols */
+	/* TODO: read from file at startup */
+	static struct flag_name flag_names[] = {
+		{0,	"IP"},
+		{0,	"HOPOPT"},
+		{1,	"ICMP"},
+		{2,	"IGMP"},
+		{3,	"GGP"},
+		{4,	"IP-ENCAP"},
+		{5,	"ST"},
+		{6,	"TCP"},
+		{8,	"EGP"},
+		{9,	"IGP"},
+		{12,	"PUP"},
+		{17,	"UDP"},
+		{20,	"HMP"},
+		{22,	"XNS-IDP"},
+		{27,	"RDP"},
+		{29,	"ISO-TP4"},
+		{33,	"DCCP"},
+		{36,	"XTP"},
+		{37,	"DDP"},
+		{38,	"IDPR-CMTP"},
+		{41,	"IPv6"},
+		{43,	"IPv6-Route"},
+		{44,	"IPv6-Frag"},
+		{45,	"IDRP"},
+		{46,	"RSVP"},
+		{47,	"GRE"},
+		{0,	NULL} };
+	struct flag_name *f;
+
+	for (f = flag_names; f->name; ++f) {
+		if (f->flag == protocol) {
+			printf("%s", f->name);
+			return;
+		}
+	}
+	printf("unknown:%d", protocol);
+}
+
+void
+display_socktype(int socktype)
+{
+	static struct flag_name flag_names[] = {
+		{SOCK_STREAM,	"SOCK_STREAM"},
+		{SOCK_DGRAM,	"SOCK_DGRAM"},
+		{SOCK_SEQPACKET,	"SOCK_SEQPACKET"},
+		{SOCK_RAW,	"SOCK_RAW"},
+		{SOCK_RDM,	"SOCK_RDM"},
+#ifdef __linux__
+		{SOCK_PACKET,	"SOCK_PACKET"},
+#endif
+#if defined __linix__ || defined __OpenBSD__
+		{SOCK_NONBLOCK,	"SOCK_NONBLOCK"},
+		{SOCK_CLOEXEC,	"SOCK_CLOEXEC"},
+#endif
+		{0,	NULL} };
+	struct flag_name *f;
+
+	for (f = flag_names; f->name; ++f) {
+		if (f->flag == socktype) {
+			printf("%s", f->name);
+			return;
+		}
+	}
+	printf("unknown:%d", socktype);
+}
+
+void
+display_sockaddr(struct retrace_endpoint *ep, const struct sockaddr *addr, socklen_t len)
+{
+	struct handler_info *hi = ep->handle->user_data;
+	struct sockaddr_storage raddr;
+	int x;
+	char buf[256];
+
+	assert(sizeof(struct sockaddr_un) <= sizeof(raddr));
+
+	if (!hi->expand_structs || addr == NULL) {
+		DISPLAY_pvoid(ep, addr);
+		return;
+	}
+
+	if (len > sizeof(raddr))
+		len = sizeof(raddr);
+
+	x = retrace_fetch_memory(ep->fd, addr, &raddr, len);
+	if (x == 0) {
+		DISPLAY_pvoid(ep, addr);
+		return;
+	}
+
+	if (raddr.ss_family == AF_UNIX) {
+		struct sockaddr_un *sa = (struct sockaddr_un *)&raddr;
+
+		printf("{AF_UNIX, %*s}", (int)sizeof(sa->sun_path),
+		    sa->sun_path);
+	} else if (raddr.ss_family == AF_INET) {
+		struct sockaddr_in *sa = (struct sockaddr_in *)&raddr;
+
+		printf("{AF_INET, %d, %s}", ntohs(sa->sin_port),
+		    inet_ntop(AF_INET, &sa->sin_addr, buf, sizeof(buf)));
+	} else if (raddr.ss_family == AF_INET6) {
+		struct sockaddr_in6 *sa = (struct sockaddr_in6 *)&raddr;
+
+		printf("{AF_INET6, %d, %s}", ntohs(sa->sin6_port),
+		    inet_ntop(AF_INET6, &sa->sin6_addr, buf, sizeof(buf)));
+	}
+}
+
+void
+display_msg(struct retrace_endpoint *ep, const struct msghdr *msg, size_t msglen)
+{
+	struct handler_info *hi = ep->handle->user_data;
+	struct msghdr rmsg;
+	int x;
+
+	if (!hi->expand_structs || msg == NULL) {
+		DISPLAY_pvoid(ep, msg);
+		return;
+	}
+
+	x = retrace_fetch_memory(ep->fd, msg, &rmsg, sizeof(rmsg));
+	if (x == 0) {
+		DISPLAY_pvoid(ep, msg);
+		return;
+	}
+
+	printf("{");
+	if (rmsg.msg_name != NULL)
+		display_sockaddr(ep, rmsg.msg_name, rmsg.msg_namelen);
+	else
+		printf("NULL");
+	printf(", %d", rmsg.msg_namelen);
+
+	printf(", ");
+	display_iovec(ep, rmsg.msg_iov, rmsg.msg_iovlen, msglen);
+#ifdef __linux__
+	printf(", %lu}", rmsg.msg_iovlen);
+#else
+	printf(", %d}", rmsg.msg_iovlen);
+#endif
+}
+
+void
+display_iovec(struct retrace_endpoint *ep, const struct iovec *iov, size_t iovlen, size_t msglen)
+{
+	struct handler_info *hi = ep->handle->user_data;
+	struct iovec riov[iovlen];
+	int i, x;
+	size_t len;
+
+	if (!hi->expand_structs || iov == NULL) {
+		DISPLAY_pvoid(ep, iov);
+		return;
+	}
+
+	x = retrace_fetch_memory(ep->fd, iov, riov, sizeof(riov));
+	if (x == 0) {
+		DISPLAY_pvoid(ep, iov);
+		return;
+	}
+
+	printf("{");
+	for (i = 0; i < iovlen; i++) {
+		printf("{");
+		len = riov[i].iov_len;
+		if (len > msglen)
+			len = msglen;
+		msglen -= len;
+		display_buffer(ep, riov[i].iov_base, len);
+		printf(", %lu}", riov[i].iov_len);
+	}
+}
+
+void
+display_buffer(struct retrace_endpoint *ep, const void *addr, size_t len)
+{
+	static const char hex[] = "0123456789abcdef";
+	struct handler_info *hi = ep->handle->user_data;
+	char buf[hi->expand_buffers];
+	int x, i, truncated = 0;
+	const char *mask;
+
+	if (!hi->expand_buffers || addr == NULL) {
+		DISPLAY_pvoid(ep, addr);
+		return;
+	}
+
+	if (len > hi->expand_buffers) {
+		len = hi->expand_buffers;
+		truncated = 1;
+	}
+
+	x = retrace_fetch_memory(ep->fd, addr, buf, len);
+	if (x == 0) {
+		DISPLAY_pvoid(ep, addr);
+		return;
+	}
+
+	mask = "[%c%c";
+	for (i = 0; i < len; i++) {
+		printf(mask, hex[buf[i] >> 4 & 0x0f], hex[buf[i] & 0x0f]);
+		mask = " %c%c";
+	}
+	printf(truncated ? "]+" : "]");
 }

--- a/rpc/display.h
+++ b/rpc/display.h
@@ -1,37 +1,55 @@
 #ifndef __RETRACE_DISPLAY_H__
 #define __RETRACE_DISPLAY_H__
 
-#define DISPLAY_char(ep, c)	if (c) printf("'%c'", c); else printf("'\\0'");
-#define DISPLAY_cmsghdr(ep, p)	DISPLAY_pvoid(ep, p)
+#include <sys/queue.h>
+
+#define DISPLAY_char(ep, c)	display_char(c);
 #define DISPLAY_cstring(ep, p)	display_string(ep, p)
-#define DISPLAY_dir(ep, p)	DISPLAY_pvoid(ep, p)
-#define DISPLAY_dirent(ep, p)	DISPLAY_pvoid(ep, p)
-#define DISPLAY_file(ep, p)	DISPLAY_pvoid(ep, p)
-#define DISPLAY_fd(ep, i)	DISPLAY_int(ep, i)
+#define DISPLAY_dir(ep, p)	display_dir(ep, p)
+#define DISPLAY_dirent(ep, i)	DISPLAY_pvoid(ep, i)
+#define DISPLAY_domain(ep, p)	display_domain(p)
+#define DISPLAY_file(ep, p)	display_stream(ep, p)
+#define DISPLAY_fileflags(ep, i)	display_fflags(ep, i)
+#define DISPLAY_fd(ep, i)	display_fd(ep, i)
 #define DISPLAY_int(ep, i)	printf("%d", (i))
 #define DISPLAY_long(ep, i)	printf("%ld", (i))
-#define DISPLAY_msghdr(ep, p)	DISPLAY_pvoid(ep, p)
+#define DISPLAY_mode_t(ep, m)	printf("0%.3o", m)
+#define DISPLAY_msgflags(ep, i)	display_msgflags(ep, i)
 #define DISPLAY_pid_t(ep, i)	DISPLAY_int(ep, i)
 #define DISPLAY_pcvoid(ep, p)	DISPLAY_pvoid(ep, p)
 #define DISPLAY_pdirent(ep, p)	DISPLAY_pvoid(ep, p)
 #define DISPLAY_pint(ep, p)	DISPLAY_pvoid(ep, p)
+#define DISPLAY_protocol(ep, i)	display_protocol(i)
 #define DISPLAY_psize_t(ep, p)	DISPLAY_pvoid(ep, p)
 #define DISPLAY_pstring(ep, p)	DISPLAY_pvoid(ep, p)
 #define DISPLAY_pvoid(ep, p)	printf("%p", (p))
 #define DISPLAY_size_t(ep, i)	DISPLAY_ulong(ep, i)
+#define DISPLAY_socklen_t(ep, i)	DISPLAY_uint(ep, i)
+#define DISPLAY_socktype(ep, i)	display_socktype(i)
 #define DISPLAY_ssize_t(ep, i)	DISPLAY_long(ep, i)
 #define DISPLAY_string(ep, p)	display_string(ep, p)
+#define DISPLAY_uint(ep, i)	printf("%u", (i))
 #define DISPLAY_ulong(ep, i)	printf("%lu", (i))
 #define DISPLAY_va_list(ep, ap)	printf("ap")
 
-struct display_info {
-#if BACKTRACE
-	int backtrace_functions[RPC_FUNCTION_COUNT];
-	int backtrace_depth;
-#endif
-	int expand_strings;
-};
-
-void *display_buffer(void *buffer, size_t length);
+void display_buffer(struct retrace_endpoint *ep, const void *buffer,
+	size_t length);
+void display_char(int c);
+void display_dir(struct retrace_endpoint *ep, DIR *dir);
+void display_domain(int domain);
+void display_errno(int _errno);
+void display_fd(struct retrace_endpoint *ep, int fd);
+void display_fflags(struct retrace_endpoint *ep, int flags);
+void display_iovec(struct retrace_endpoint *ep, const struct iovec *iov,
+	size_t iovlen, size_t msglen);
+void display_msg(struct retrace_endpoint *ep, const struct msghdr *msg,
+	size_t msglen);
+void display_msgflags(struct retrace_endpoint *ep, int flags);
+void display_protocol(int protocol);
+void display_sockaddr(struct retrace_endpoint *ep,
+	const struct sockaddr *addr, socklen_t len);
+void display_socktype(int socktype);
+void display_stream(struct retrace_endpoint *ep, FILE *s);
 void display_string(struct retrace_endpoint *ep, const char *s);
+
 #endif

--- a/rpc/frontend.h
+++ b/rpc/frontend.h
@@ -9,13 +9,16 @@
 
 #define RETRACE_TRACE 0x01
 
-struct rpc_call_context {
-	SLIST_ENTRY(rpc_call_context) next;
+struct retrace_call_context {
+	SLIST_ENTRY(retrace_call_context) next;
 	enum retrace_function_id function_id;
-	void *context;
+	char params[128];
+	char result[16];
+	int _errno;
+	void *user_data;
 };
 
-SLIST_HEAD(rpc_call_stack, rpc_call_context);
+SLIST_HEAD(retrace_call_stack, retrace_call_context);
 
 struct retrace_endpoint {
 	SLIST_ENTRY(retrace_endpoint) next;
@@ -24,7 +27,7 @@ struct retrace_endpoint {
 	int thread_num;
 	unsigned int call_num;
 	unsigned int call_depth;
-	struct rpc_call_stack call_stack;
+	struct retrace_call_stack call_stack;
 	struct retrace_handle *handle;
 };
 
@@ -38,15 +41,29 @@ struct retrace_process_info {
 
 SLIST_HEAD(process_list, retrace_process_info);
 
-typedef int (*retrace_precall_handler_t)(struct retrace_endpoint *ep, void *buf, void **context);
-typedef int (*retrace_postcall_handler_t)(struct retrace_endpoint *ep, void *buf, void *context);
+typedef int (*retrace_precall_handler_t)(struct retrace_endpoint *ep, struct retrace_call_context *context);
+typedef void (*retrace_postcall_handler_t)(struct retrace_endpoint *ep, struct retrace_call_context *context);
+
+struct retrace_precall_handler {
+	SLIST_ENTRY(retrace_precall_handler) next;
+	retrace_precall_handler_t fn;
+};
+
+SLIST_HEAD(retrace_precall_handlers, retrace_precall_handler);
+
+struct retrace_postcall_handler {
+	SLIST_ENTRY(retrace_postcall_handler) next;
+	retrace_postcall_handler_t fn;
+};
+
+SLIST_HEAD(retrace_postcall_handlers, retrace_postcall_handler);
 
 struct retrace_handle {
 	struct retrace_endpoints endpoints;
 	struct process_list processes;
 	int control_fd;
-	retrace_precall_handler_t precall_handlers[RPC_FUNCTION_COUNT];
-	retrace_postcall_handler_t postcall_handlers[RPC_FUNCTION_COUNT];
+	struct retrace_precall_handlers precall_handlers[RPC_FUNCTION_COUNT];
+	struct retrace_postcall_handlers postcall_handlers[RPC_FUNCTION_COUNT];
 	void *user_data;
 };
 
@@ -54,17 +71,21 @@ struct retrace_handle *retrace_start(char *const argv[], const int *trace_flags)
 void retrace_close(struct retrace_handle *handle);
 void retrace_trace(struct retrace_handle *handle);
 void retrace_handle_call(const struct retrace_endpoint *ep);
-void retrace_set_handlers(struct retrace_handle *handle,
-	retrace_precall_handler_t *pre, retrace_postcall_handler_t *post);
+void retrace_add_precall_handler(struct retrace_handle *handle,
+	enum retrace_function_id fid, retrace_precall_handler_t fn);
+void retrace_add_postcall_handler(struct retrace_handle *handle,
+	enum retrace_function_id fid, retrace_postcall_handler_t fn);
 void retrace_set_user_data(struct retrace_handle *handle, void *data);
 int retrace_fetch_backtrace(int fd, int depth, char *buf, size_t len);
+int retrace_fetch_memory(int fd, const void *address, void *buffer, size_t len);
 int retrace_fetch_string(int fd, const char *address, char *buffer, size_t len);
+int retrace_fetch_fileno(int fd, FILE *s, int *result);
 enum retrace_function_id retrace_function_id(const char *name);
 const char *retrace_function_name(enum retrace_function_id id);
 
 int rpc_send_message(int fd, enum rpc_msg_type msg_type, const void *buf, size_t len);
 int rpc_send(int fd, const void *buf, size_t len);
-int rpc_recv_message(int fd, enum rpc_msg_type *msg_type, void *buf);
+ssize_t rpc_recv_message(int fd, enum rpc_msg_type *msg_type, void *buf);
 int rpc_recv(int fd, void *buf, size_t len);
 int rpc_recv_string(int fd, char *buffer, size_t len);
 

--- a/rpc/functions.h.template
+++ b/rpc/functions.h.template
@@ -7,6 +7,7 @@
 #include <dirent.h>
 #include <stdio.h>
 #include <sys/types.h>
+#include <sys/socket.h>
 
 enum retrace_function_id {
 	[[#functions]]
@@ -16,13 +17,13 @@ enum retrace_function_id {
 };
 
 [[#functions]]
+[[#has_parameters]]
 struct retrace_[[name]]_params {
-	enum retrace_function_id function_id;
 	[[#params]]
 	[[rpctype]][[name]];
 	[[/params]]
 };
-
+[[/has_parameters]]
 [[/functions]]
 
 enum retrace_function_id retrace_function_id(const char *name);

--- a/rpc/functions.txt
+++ b/rpc/functions.txt
@@ -1,78 +1,206 @@
-function getenv string
-parameter name cstring
+function bind int
+parameter sockfd fd
+parameter addr csockaddr
+parameter addrlen socklen_t
+errno -1
+
+function close int
+parameter fd fd
+errno -1
 
 function closedir int
 parameter dirp dir
+errno -1
+
+function connect int
+parameter sockfd fd
+parameter addr csockaddr
+parameter addrlen socklen_t
+errno -1
+
+function creat int
+parameter pathname cstring
+parameter mode mode_t
+errno -1
 
 function dirfd fd
 parameter dirp dir
+errno -1
 
 function fclose int
 parameter stream file
+errno EOF
 
 function fdopendir dir
 parameter fd fd
+errno NULL
 
 function fileno fd
 parameter stream file
+errno -1
 
 function fopen file
 parameter path cstring
 parameter mode cstring
+errno NULL
 
 function fprintf int
 parameter stream file
 parameter format cstring
 variadic real_vfprintf
 
+function fputs int
+parameter s cstring
+parameter stream file
+errno EOF
+
 function free void
 parameter ptr pvoid
 
+function getenv string
+parameter name cstring
+
+function getline ssize_t
+parameter lineptr pstring
+parameter n psize_t
+parameter stream file
+errno -1
+
 function getpid pid_t
+
+function getppid pid_t
 
 function _IO_putc char
 parameter c char
 parameter stream file
+errno EOF
 guard #ifndef __APPLE__
 
 function malloc pvoid
 parameter size size_t
+errno NULL
 
-function realloc pvoid
-parameter ptr pvoid
-parameter size size_t
+function memcpy pvoid
+parameter dest pvoid
+parameter src pcvoid
+parameter n size_t
+
+function memmove pvoid
+parameter dest pvoid
+parameter src pcvoid
+parameter n size_t
+
+function memset pvoid
+parameter s pvoid
+parameter c char
+parameter n size_t
+
+function open int
+parameter pathname cstring
+parameter flags fileflags
+parameter mode mode_t
+errno -1
+
+function openat int
+parameter dirfd fd
+parameter pathname cstring
+parameter flags fileflags
+parameter mode mode_t
+errno -1
 
 function opendir dir
 parameter name cstring
+errno NULL
 
 function putc char
 parameter c char
 parameter stream file
+errno EOF
 
 function readdir_r int
 parameter dirp dir
 parameter entry dirent
 parameter result pdirent
+errno (result > 0 ? result : 0)
 
 function read ssize_t
 parameter fd fd
 parameter buf pvoid
 parameter count size_t
+errno -1
+
+function realloc pvoid
+parameter ptr pvoid
+parameter size size_t
+errno NULL
+
+function recv ssize_t
+parameter sockfd fd
+parameter buf pvoid
+parameter len size_t
+parameter flags msgflags
+errno -1
+
+function recvfrom ssize_t
+parameter sockfd fd
+parameter buf pvoid
+parameter len size_t
+parameter flags msgflags
+parameter src_addr sockaddr
+parameter addrlen psocklen_t
+errno -1
+
+function recvmsg ssize_t
+parameter sockfd fd
+parameter msg msghdr
+parameter flags msgflags
+errno -1
+
+function send ssize_t
+parameter sockfd fd
+parameter buf pcvoid
+parameter len size_t
+parameter flags msgflags
+errno -1
+
+function sendmsg ssize_t
+parameter sockfd fd
+parameter msg cmsghdr
+parameter flags msgflags
+errno -1
+
+function sendto ssize_t
+parameter sockfd fd
+parameter buf pcvoid
+parameter len size_t
+parameter flags msgflags
+parameter dest_addr csockaddr
+parameter addrlen socklen_t
+errno -1
+
+function socket int
+parameter domain domain
+parameter type socktype
+parameter protocol protocol
+errno -1
+
+function socketpair int
+parameter domain domain
+parameter type socktype
+parameter protocol protocol
+parameter sv pint
+errno -1
 
 function sprintf int
 parameter str string
 parameter format cstring
 variadic real_vsprintf
 
-function vsprintf int
-parameter str string
-parameter format cstring
-parameter ap va_list
-
 function sscanf int
 parameter str cstring
 parameter format cstring
 variadic real_vsscanf
+errno EOF
 
 function strcat string
 parameter dest string
@@ -119,57 +247,19 @@ parameter size size_t
 parameter format cstring
 parameter ap va_list
 
+function vsprintf int
+parameter str string
+parameter format cstring
+parameter ap va_list
+
 function vsscanf int
 parameter str cstring
 parameter format cstring
 parameter ap va_list
+errno EOF
 
 function write ssize_t
 parameter fd fd
 parameter buf pcvoid
 parameter count size_t
-
-function memmove pvoid
-parameter dest pvoid
-parameter src pcvoid
-parameter n size_t
-
-function memcpy pvoid
-parameter dest pvoid
-parameter src pcvoid
-parameter n size_t
-
-function memset pvoid
-parameter s pvoid
-parameter c char
-parameter n size_t
-
-function getline ssize_t
-parameter lineptr pstring
-parameter n psize_t
-parameter stream file
-
-function close int
-parameter fd fd
-
-function socketpair int
-parameter domain int
-parameter type int
-parameter protocol int
-parameter sv pint
-
-function send ssize_t
-parameter sockfd int
-parameter buf pcvoid
-parameter len size_t
-parameter flags int
-
-function sendmsg ssize_t
-parameter sockfd int
-parameter msg cmsghdr
-parameter flags int
-
-function recvmsg ssize_t
-parameter sockfd int
-parameter msg msghdr
-parameter flags int
+errno -1

--- a/rpc/functions2yaml.c
+++ b/rpc/functions2yaml.c
@@ -50,21 +50,31 @@ struct type {
 } types[] = {
 	{"char",	"int ",			NULL		},
 	{"cmsghdr",	"const struct msghdr *",	NULL	},
+	{"csockaddr",	"const struct sockaddr *",	NULL	},
 	{"cstring",	"const char *",		NULL		},
 	{"dir",		"DIR *",		NULL		},
 	{"dirent",	"struct dirent *",	NULL		},
+	{"domain",	"int ",			NULL		},
 	{"fd",		"int ",			NULL		},
 	{"file",	"FILE *",		NULL		},
+	{"fileflags",	"int ",			NULL		},
 	{"int",		"int ",			NULL		},
+	{"mode_t",	"mode_t ",		NULL		},
 	{"msghdr",	"struct msghdr *",	NULL		},
+	{"msgflags",	"int ",			NULL		},
 	{"pcvoid",	"const void *",		NULL		},
 	{"pdirent",	"struct dirent **",	NULL		},
 	{"pid_t",	"pid_t ",		NULL		},
 	{"pint",	"int *",		NULL		},
+	{"protocol",	"int ",			NULL		},
 	{"psize_t",	"size_t *",		NULL		},
+	{"psocklen_t",	"socklen_t *",		NULL		},
 	{"pstring",	"char **",		NULL		},
 	{"pvoid",	"void *",		NULL		},
 	{"size_t",	"size_t ",		NULL		},
+	{"sockaddr",	"struct sockaddr *",	NULL		},
+	{"socklen_t",	"socklen_t ",		NULL		},
+	{"socktype",	"int ",			NULL		},
 	{"ssize_t",	"ssize_t ",		NULL		},
 	{"string",	"char *",		NULL		},
 	{"va_list",	"va_list ",		"void *"	},
@@ -91,6 +101,7 @@ struct function {
 	struct param_list params;
 	const char *va_fn;
 	const char *guard;
+	const char *errno;
 };
 
 STAILQ_HEAD(function_list, function);
@@ -139,6 +150,8 @@ void yaml(struct function_list *fns)
 			printf("  result: true\n");
 		if (fn->guard != NULL)
 			printf("  guard: \"%s\"\n", fn->guard);
+		if (fn->errno != NULL)
+			printf("  errno: \"%s\"\n", fn->errno);
 
 		if (!TAILQ_EMPTY(&(fn->params))) {
 			printf("  has_parameters: true\n");
@@ -282,8 +295,11 @@ int main(void)
 			fn->va_fn = _strdup(strtok(NULL, " "));
 			if (fn->va_fn == NULL)
 				errexit(1, "Keyword 'variadic' must be followed the name of a fixed param version at line %d.", line);
-		} else if (strcmp(tok, "guard") == 0)
+		} else if (strcmp(tok, "guard") == 0) {
 			fn->guard = _strdup(strtok(NULL, "\n"));
+		} else if (strcmp(tok, "errno") == 0) {
+			fn->errno = _strdup(strtok(NULL, "\n"));
+		}
 	}
 
 	if (fn)

--- a/rpc/handlers.c.template
+++ b/rpc/handlers.c.template
@@ -1,70 +1,193 @@
 {{=[[ ]]=}}
-#include <stdlib.h>
+#include "../config.h"
 #include <string.h>
-#include "rpc.h"
+#include <fcntl.h>
+
 #include "frontend.h"
-#include "handlers.h"
 #include "display.h"
-[[#functions]]
 
-int
-default_[[name]]_precall_handler(struct retrace_endpoint *ep, void *buf, void **context)
+#if HAVE_DECL_O_TMPFILE
+#define OPEN_CREATE_FLAGS (O_CREAT | O_TMPFILE)
+#else
+#define OPEN_CREATE_FLAGS O_CREAT
+#endif
+
+#define LOG_PARAMS_bind
+static void
+log_params_bind(struct retrace_endpoint *ep, struct retrace_bind_params *params, int result)
 {
-[[#has_parameters]]
-	struct retrace_[[name]]_params *params;
-
-	params = malloc(sizeof(struct retrace_[[name]]_params));
-	*params = *(struct retrace_[[name]]_params *)buf;
-	*context = params;
-[[/has_parameters]]
-
-	return 1;
+	DISPLAY_fd(ep, params->sockfd);
+	printf(", ");
+	display_sockaddr(ep, params->addr, params->addrlen);
+	printf(", ");
+	DISPLAY_socklen_t(ep, params->addrlen);
 }
 
-int
-default_[[name]]_postcall_handler(struct retrace_endpoint *ep, void *buf, void *context)
+#define LOG_PARAMS_connect
+static void
+log_params_connect(struct retrace_endpoint *ep, struct retrace_connect_params *params, int result)
 {
-#if BACKTRACE
-	struct display_info *display_info = ep->handle->user_data;
-	char btbuffer[4096];
-#endif
+	DISPLAY_fd(ep, params->sockfd);
+	printf(", ");
+	display_sockaddr(ep, params->addr, params->addrlen);
+	printf(", ");
+	DISPLAY_socklen_t(ep, params->addrlen);
+}
+
+#define LOG_PARAMS_open
+static void
+log_params_open(struct retrace_endpoint *ep, struct retrace_open_params *params, int result)
+{
+	DISPLAY_cstring(ep, params->pathname);
+	printf(", ");
+	DISPLAY_fileflags(ep, params->flags);
+	if (params->flags & OPEN_CREATE_FLAGS) {
+		printf(", ");
+		DISPLAY_mode_t(ep, params->mode);
+	}
+}
+
+#define LOG_PARAMS_openat
+static void
+log_params_openat(struct retrace_endpoint *ep, struct retrace_openat_params *params, int result)
+{
+	DISPLAY_fd(ep, params->dirfd);
+	printf(", ");
+	DISPLAY_cstring(ep, params->pathname);
+	printf(", ");
+	DISPLAY_fileflags(ep, params->flags);
+	if (params->flags & OPEN_CREATE_FLAGS) {
+		printf(", ");
+		DISPLAY_mode_t(ep, params->mode);
+	}
+}
+
+#define LOG_PARAMS_recvfrom
+static void
+log_params_recvfrom(struct retrace_endpoint *ep, struct retrace_recvfrom_params *params, int result)
+{
+	socklen_t addrlen = 0;
+
+	DISPLAY_fd(ep, params->sockfd);
+	printf(", ");
+
+	if (result != -1)
+		display_buffer(ep, params->buf, result);
+	else
+		DISPLAY_pvoid(ep, params->buf);
+
+	printf(", ");
+	DISPLAY_size_t(ep, params->len);
+	printf(", ");
+	DISPLAY_msgflags(ep, params->flags);
+	printf(", ");
+
+	if (result != -1 && params->addrlen != NULL)
+		retrace_fetch_memory(ep->fd, params->addrlen, &addrlen,
+		    sizeof(addrlen));
+
+	if (addrlen != 0) {
+		display_sockaddr(ep, params->src_addr, addrlen);
+		printf(", ");
+		DISPLAY_pint(ep, params->addrlen);
+	} else {
+		DISPLAY_pvoid(ep, params->src_addr);
+		printf(", ");
+		DISPLAY_pvoid(ep, params->addrlen);
+	}
+}
+
+#define LOG_PARAMS_recvmsg
+static void
+log_params_recvmsg(struct retrace_endpoint *ep, struct retrace_recvmsg_params *params, int result)
+{
+	DISPLAY_fd(ep, params->sockfd);
+	printf(", ");
+	if (result != -1)
+		display_msg(ep, params->msg, result);
+	else
+		DISPLAY_pvoid(ep, params->msg);
+	printf(", ");
+	DISPLAY_msgflags(ep, params->flags);
+}
+
+#define LOG_PARAMS_sendmsg
+static void
+log_params_sendmsg(struct retrace_endpoint *ep, struct retrace_sendmsg_params *params, int result)
+{
+	DISPLAY_fd(ep, params->sockfd);
+	printf(", ");
+	if (result != -1)
+		display_msg(ep, params->msg, result);
+	else
+		display_msg(ep, params->msg, 0);
+	printf(", ");
+	DISPLAY_msgflags(ep, params->flags);
+}
+
+#define LOG_PARAMS_sendto
+static void
+log_params_sendto(struct retrace_endpoint *ep, struct retrace_sendto_params *params, int result)
+{
+	DISPLAY_fd(ep, params->sockfd);
+	printf(", ");
+	if (result != -1)
+		DISPLAY_pvoid(ep, params->buf);
+	else
+		DISPLAY_pvoid(ep, params->buf);
+	printf(", ");
+	DISPLAY_size_t(ep, params->len);
+	printf(", ");
+	DISPLAY_msgflags(ep, params->flags);
+	printf(", ");
+	if (result != -1)
+		display_sockaddr(ep, params->dest_addr, params->addrlen);
+	else
+		DISPLAY_pvoid(ep, params->dest_addr);
+
+	printf(", ");
+	DISPLAY_int(ep, params->addrlen);
+}
+
+[[#functions]]
+static void
+log_[[name]](struct retrace_endpoint *ep, struct retrace_call_context *context)
+{
 [[#has_parameters]]
-	struct retrace_[[name]]_params *params = (struct retrace_[[name]]_params *)context;
+	struct retrace_[[name]]_params *params = (struct retrace_[[name]]_params *)&context->params;
 [[/has_parameters]]
 [[#result]]
-	[[rpctype]]result = *([[rpctype]]*)buf;
+	[[rpctype]]result = *([[rpctype]]*)context->result;
 [[/result]]
 
 	printf("(%d:%d %d)%.*s[[name]](", ep->pid, ep->thread_num, ep->call_num, ep->call_depth, "\t\t\t\t\t");
+#ifndef LOG_PARAMS_[[name]]
 [[#params]]
 	DISPLAY_[[type]](ep, params->[[name]]);
 [[^last]]
 	printf(", ");
 [[/last]]
 [[/params]]
+#else
+	log_params_[[name]](ep, params, result);
+#endif
 	printf(")");
 [[#result]]
 	printf(" = ");
 	DISPLAY_[[type]](ep, result);
+[[#errno]]
+	if (result == [[& errno]])
+		display_errno(context->_errno);
+[[/errno]]
 [[/result]]
 	printf("\n");
-
-#if BACKTRACE
-	if (display_info->backtrace_functions[RPC_[[name]]]) {
-		if (retrace_fetch_backtrace(ep->fd, display_info->backtrace_depth, btbuffer, sizeof(btbuffer)))
-			printf("%s", btbuffer);
-	}
-#endif
-
-	free(context);
-	return 0;
 }
-[[/functions]]
 
-void get_handlers(retrace_precall_handler_t *pre, retrace_postcall_handler_t *post)
+[[/functions]]
+void
+set_log_handlers(struct retrace_handle *handle)
 {
 	[[#functions]]
-	pre[RPC_[[name]]] = default_[[name]]_precall_handler;
-	post[RPC_[[name]]] = default_[[name]]_postcall_handler;
+	retrace_add_postcall_handler(handle, RPC_[[name]], log_[[name]]);
 	[[/functions]]
 };

--- a/rpc/handlers.h
+++ b/rpc/handlers.h
@@ -1,6 +1,19 @@
 #ifndef __RETRACE_HANDLERS_H__
 #define __RETRACE_HANDLERS_H__
 
-void get_handlers(retrace_precall_handler_t *pre, retrace_postcall_handler_t *post);
+#include "tracefd.h"
+
+void set_log_handlers(struct retrace_handle *handle);
+
+struct handler_info {
+#if BACKTRACE
+	int backtrace_depth;
+#endif
+	int expand_buffers;
+	int expand_strings;
+	int expand_structs;
+	int tracefds;
+	struct fdinfo_h fdinfos;
+};
 
 #endif

--- a/rpc/rpc.h
+++ b/rpc/rpc.h
@@ -19,6 +19,7 @@ enum rpc_msg_type {
 	RPC_MSG_SET_ERRNO,
 	RPC_MSG_SET_PARAMETERS,
 	RPC_MSG_GET_STRING,
+	RPC_MSG_GET_FILENO,
 #if BACKTRACE
 	RPC_MSG_BACKTRACE,
 #endif
@@ -48,5 +49,9 @@ struct rpc_backtrace_params {
 
 struct rpc_errno_params {
 	int e;
+};
+
+struct rpc_fileno_params {
+	FILE *fd;
 };
 #endif

--- a/rpc/shim.c.template
+++ b/rpc/shim.c.template
@@ -32,8 +32,8 @@ int trace_functions[RPC_FUNCTION_COUNT];
 	enum rpc_msg_type _msg_type;
 	int _postcall = 0, _fd, _errno;
 	char _buf[RPC_MSG_LEN_MAX];
-	struct retrace_[[name]]_params _params = {RPC_[[name]][[#params]], [[name]][[/params]]};
 [[#has_parameters]]
+	struct retrace_[[name]]_params _params = {[[#params]][[name]][[^last]], [[/last]][[/params]]};
 	struct retrace_[[name]]_params *_buf_params = (struct retrace_[[name]]_params *)_buf;
 [[/has_parameters]]
 [[#variadic]]
@@ -46,7 +46,7 @@ int trace_functions[RPC_FUNCTION_COUNT];
 
 	_errno = errno;
 
-#if defined(__OpenBSD__)
+#if defined __OpenBSD__ || defined __FreeBSD__
 	_fd = rpc_get_sockfd(RPC_[[name]]);
 #else
 	_fd = rpc_get_sockfd();
@@ -64,7 +64,12 @@ int trace_functions[RPC_FUNCTION_COUNT];
 		return[[#result]] _result[[/result]];
 	}
 
-	if (!rpc_send_message(_fd, RPC_MSG_CALL_INIT, &_params, sizeof(_params)))
+[[#has_parameters]]
+	if (!rpc_send_init(_fd, RPC_[[name]], &_params, sizeof(_params)))
+[[/has_parameters]]
+[[^has_parameters]]
+	if (!rpc_send_init(_fd, RPC_[[name]], NULL, 0))
+[[/has_parameters]]
 		goto rpc_fail;
 
 	while (rpc_recv_message(_fd, &_msg_type, _buf)) {
@@ -92,15 +97,15 @@ int trace_functions[RPC_FUNCTION_COUNT];
 [[/variadic]]
 			_postcall = 1;
 			_errno = errno;
-			if (!rpc_send_message(_fd, RPC_MSG_CALL_RESULT, [[#result]]&_result, sizeof(_result)[[/result]][[^result]]NULL, 0[[/result]]))
+			if (!rpc_send_result(_fd, [[#result]]&_result, sizeof(_result)[[/result]][[^result]]NULL, 0[[/result]]))
 				goto rpc_fail;
 		} else if (!rpc_handle_message(_fd, _msg_type, _buf))
 			goto rpc_fail;
 	}
 
 rpc_fail:
-	real_close(_fd);
 	rpc_set_sockfd(-1);
+	real_close(_fd);
 
 	if (!_postcall) {
 [[#variadic]]

--- a/rpc/tracefd.c
+++ b/rpc/tracefd.c
@@ -1,0 +1,378 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "../config.h"
+
+#include <stdlib.h>
+#include <string.h>
+#include <fcntl.h>
+
+#include "frontend.h"
+#include "tracefd.h"
+#include "handlers.h"
+
+#if HAVE_DECL_O_TMPFILE
+#define OPEN_CREATE_FLAGS (O_CREAT | O_TMPFILE)
+#else
+#define OPEN_CREATE_FLAGS O_CREAT
+#endif
+
+static const struct fdinfo *
+_get_fdinfo(struct fdinfo_h *infos, enum tracefd_keytype type, pid_t pid,
+	void *key)
+{
+	const struct fdinfo *fi;
+
+	SLIST_FOREACH(fi, infos, next)
+		if (fi->pid == pid && fi->type == type && fi->key == key)
+			return fi;
+
+	return NULL;
+}
+
+static void
+_set_fdinfo(struct fdinfo_h *infos, enum tracefd_keytype type, pid_t pid,
+	void *key, const char *info)
+{
+	struct fdinfo *fi;
+	size_t infolen;
+
+	fi = (struct fdinfo *)_get_fdinfo(infos, type, pid, key);
+	if (fi != NULL) {
+		SLIST_REMOVE(infos, fi, fdinfo, next);
+		free(fi);
+	}
+
+	if (info == NULL)
+		return;
+
+	infolen = strlen(info) + 1;
+	fi = malloc(sizeof(struct fdinfo) + infolen);
+	if (fi != NULL) {
+		fi->type = type;
+		fi->key = key;
+		fi->pid = pid;
+		fi->info = (char *)&fi[1];
+		strncpy(fi->info, info, infolen);
+		SLIST_INSERT_HEAD(infos, fi, next);
+	}
+}
+
+void
+set_dirinfo(struct fdinfo_h *infos, pid_t pid, DIR *dir, const char *info)
+{
+	_set_fdinfo(infos, tracefd_keytype_dirp, pid, dir, info);
+}
+
+const struct fdinfo *
+get_dirinfo(struct fdinfo_h *infos, pid_t pid, DIR *dir)
+{
+	return _get_fdinfo(infos, tracefd_keytype_dirp, pid, dir);
+}
+
+void
+set_streaminfo(struct fdinfo_h *infos, pid_t pid, FILE *stream,
+	const char *info)
+{
+	_set_fdinfo(infos, tracefd_keytype_stream, pid, stream, info);
+}
+
+const struct fdinfo *
+get_streaminfo(struct fdinfo_h *infos, pid_t pid, FILE *stream)
+{
+	return _get_fdinfo(infos, tracefd_keytype_stream, pid, stream);
+}
+
+void
+set_fdinfo(struct fdinfo_h *infos, pid_t pid, int fd, const char *info)
+{
+	_set_fdinfo(infos, tracefd_keytype_fd, pid, (void *)(long)fd, info);
+}
+
+const struct fdinfo *
+get_fdinfo(struct fdinfo_h *infos, pid_t pid, int fd)
+{
+	return _get_fdinfo(infos, tracefd_keytype_fd, pid, (void *)(long)fd);
+}
+
+static void
+opendir_postcall(struct retrace_endpoint *ep,
+	struct retrace_call_context *context)
+{
+	struct retrace_opendir_params *params =
+	    (struct retrace_opendir_params *)&context->params;
+	struct handler_info *hi = ep->handle->user_data;
+	struct fdinfo_h *fdinfos = &hi->fdinfos;
+	DIR *dir = *(DIR **)context->result;
+	int x;
+	char name[1024], info[1024];
+
+	if (dir == NULL)
+		return;
+
+	x = retrace_fetch_string(ep->fd, params->name, name, sizeof(name));
+	if (x == 0)
+		return;
+
+	snprintf(info, sizeof(info), "opendir(\"%s\")", name);
+	set_dirinfo(fdinfos, ep->pid, dir, info);
+}
+
+static void
+fdopendir_postcall(struct retrace_endpoint *ep,
+	struct retrace_call_context *context)
+{
+	struct retrace_fdopendir_params *params =
+	    (struct retrace_fdopendir_params *)&context->params;
+	struct handler_info *hi = ep->handle->user_data;
+	struct fdinfo_h *fdinfos = &hi->fdinfos;
+	DIR *dir = *(DIR **)context->result;
+	char info[1024];
+	const struct fdinfo *oldinfo;
+
+	if (dir == NULL)
+		return;
+
+	oldinfo = get_fdinfo(fdinfos, ep->pid, params->fd);
+	if (oldinfo != NULL)
+		snprintf(info, sizeof(info), "fdopendir(%d:%s)",
+		    params->fd, oldinfo->info);
+	else
+		snprintf(info, sizeof(info), "fdopendir(%d)",
+		    params->fd);
+	set_dirinfo(fdinfos, ep->pid, dir, info);
+}
+
+static void
+fopen_postcall(struct retrace_endpoint *ep,
+	struct retrace_call_context *context)
+{
+	struct retrace_fopen_params *params =
+	    (struct retrace_fopen_params *)&context->params;
+	struct handler_info *hi = ep->handle->user_data;
+	struct fdinfo_h *fdinfos = &hi->fdinfos;
+	FILE *s = *(FILE **)context->result;
+	int x;
+	char path[1024], mode[16], info[1024];
+
+	if (s == NULL)
+		return;
+
+	x = retrace_fetch_string(ep->fd, params->path, path, sizeof(path));
+	if (x == 0)
+		return;
+
+	x = retrace_fetch_string(ep->fd, params->mode, mode, sizeof(mode));
+	if (x == 0)
+		return;
+
+	snprintf(info, sizeof(info), "fopen(\"%s\", \"%s\")", path, mode);
+	set_streaminfo(fdinfos, ep->pid, s, info);
+}
+
+static void
+creat_postcall(struct retrace_endpoint *ep,
+	struct retrace_call_context *context)
+{
+	struct retrace_creat_params *params =
+	    (struct retrace_creat_params *)&context->params;
+	struct handler_info *hi = ep->handle->user_data;
+	struct fdinfo_h *fdinfos = &hi->fdinfos;
+	int fd = *(int *)context->result;
+	int x;
+	char path[1024], info[1024];
+
+	if (fd == -1)
+		return;
+
+	x = retrace_fetch_string(ep->fd, params->pathname, path,
+	    sizeof(path));
+	if (x == 0)
+		return;
+
+	snprintf(info, sizeof(info), "creat(\"%s\")", path);
+	set_fdinfo(fdinfos, ep->pid, fd, info);
+}
+
+static void
+open_postcall(struct retrace_endpoint *ep,
+	struct retrace_call_context *context)
+{
+	struct retrace_open_params *params =
+	    (struct retrace_open_params *)&context->params;
+	struct handler_info *hi = ep->handle->user_data;
+	struct fdinfo_h *fdinfos = &hi->fdinfos;
+	int fd = *(int *)context->result;
+	int x;
+	char path[1024], info[1024];
+
+	if (fd == -1)
+		return;
+
+	x = retrace_fetch_string(ep->fd, params->pathname, path,
+	    sizeof(path));
+	if (x == 0)
+		return;
+
+	if (params->flags & OPEN_CREATE_FLAGS)
+		snprintf(info, sizeof(info), "open(\"%s\", 0x%x, 0%.3o)",
+		    path, params->flags, params->mode);
+	else
+		snprintf(info, sizeof(info), "open(\"%s\", 0x%x)",
+		    path, params->flags);
+	set_fdinfo(fdinfos, ep->pid, fd, info);
+}
+
+static void
+openat_postcall(struct retrace_endpoint *ep,
+	struct retrace_call_context *context)
+{
+	struct retrace_openat_params *params =
+	    (struct retrace_openat_params *)&context->params;
+	struct handler_info *hi = ep->handle->user_data;
+	struct fdinfo_h *fdinfos = &hi->fdinfos;
+	int fd = *(int *)context->result;
+	int x;
+	char path[1024], info[1024];
+
+	if (fd == -1)
+		return;
+
+	x = retrace_fetch_string(ep->fd, params->pathname, path,
+	    sizeof(path));
+	if (x == 0)
+		return;
+
+	if (params->flags & OPEN_CREATE_FLAGS)
+		snprintf(info, sizeof(info),
+		    "openat(%d, \"%s\", 0x%x, 0%.3o)",
+		    params->dirfd, path, params->flags, params->mode);
+	else
+		snprintf(info, sizeof(info), "openat(%d, \"%s\", 0x%x)",
+		    params->dirfd, path, params->flags);
+
+	set_fdinfo(fdinfos, ep->pid, fd, info);
+}
+
+static void
+socket_postcall(struct retrace_endpoint *ep,
+	struct retrace_call_context *context)
+{
+	struct retrace_socket_params *params =
+	    (struct retrace_socket_params *)&context->params;
+	struct handler_info *hi = ep->handle->user_data;
+	struct fdinfo_h *fdinfos = &hi->fdinfos;
+	int fd = *(int *)context->result;
+	char info[1024];
+
+	if (fd == -1)
+		return;
+
+	snprintf(info, sizeof(info), "socket(%d, %d, %d)", params->domain,
+	    params->type, params->protocol);
+	set_fdinfo(fdinfos, ep->pid, fd, info);
+}
+
+static void
+socketpair_postcall(struct retrace_endpoint *ep,
+	struct retrace_call_context *context)
+{
+	struct retrace_socketpair_params *params =
+	    (struct retrace_socketpair_params *)&context->params;
+	struct handler_info *hi = ep->handle->user_data;
+	struct fdinfo_h *fdinfos = &hi->fdinfos;
+	int result = *(int *)context->result;
+	char info[1024];
+
+	if (result == -1)
+		return;
+
+	snprintf(info, sizeof(info), "socketpair(%d, %d, %d, %d<->%d)",
+	    params->domain, params->type, params->protocol,
+	    *params->sv, *(params->sv + 1));
+	set_fdinfo(fdinfos, ep->pid, params->sv[0], info);
+	set_fdinfo(fdinfos, ep->pid, params->sv[1], info);
+}
+
+static void
+fclose_postcall(struct retrace_endpoint *ep,
+	struct retrace_call_context *context)
+{
+	struct retrace_fclose_params *params =
+	    (struct retrace_fclose_params *)&context->params;
+	struct handler_info *hi = ep->handle->user_data;
+	struct fdinfo_h *fdinfos = &hi->fdinfos;
+
+	set_streaminfo(fdinfos, ep->pid, params->stream, NULL);
+}
+
+static void
+close_postcall(struct retrace_endpoint *ep,
+	struct retrace_call_context *context)
+{
+	struct retrace_close_params *params =
+	    (struct retrace_close_params *)&context->params;
+	struct handler_info *hi = ep->handle->user_data;
+	struct fdinfo_h *fdinfos = &hi->fdinfos;
+
+	set_fdinfo(fdinfos, ep->pid, params->fd, NULL);
+}
+
+static void
+closedir_postcall(struct retrace_endpoint *ep,
+	struct retrace_call_context *context)
+{
+	struct retrace_closedir_params *params =
+	    (struct retrace_closedir_params *)&context->params;
+	struct handler_info *hi = ep->handle->user_data;
+	struct fdinfo_h *fdinfos = &hi->fdinfos;
+
+	set_dirinfo(fdinfos, ep->pid, params->dirp, NULL);
+}
+
+void
+init_tracefd_handlers(struct retrace_handle *handle)
+{
+	struct handler_info *handler_info;
+
+	handler_info = handle->user_data;
+
+	SLIST_INIT(&handler_info->fdinfos);
+
+	retrace_add_postcall_handler(handle, RPC_opendir, opendir_postcall);
+	retrace_add_postcall_handler(handle, RPC_fdopendir,
+	    fdopendir_postcall);
+	retrace_add_postcall_handler(handle, RPC_fopen, fopen_postcall);
+	retrace_add_postcall_handler(handle, RPC_creat, creat_postcall);
+	retrace_add_postcall_handler(handle, RPC_open, open_postcall);
+	retrace_add_postcall_handler(handle, RPC_openat, openat_postcall);
+	retrace_add_postcall_handler(handle, RPC_socket, socket_postcall);
+	retrace_add_postcall_handler(handle, RPC_socketpair, socketpair_postcall);
+	retrace_add_postcall_handler(handle, RPC_close, close_postcall);
+	retrace_add_postcall_handler(handle, RPC_fclose, fclose_postcall);
+	retrace_add_postcall_handler(handle, RPC_closedir, closedir_postcall);
+
+	handler_info->tracefds = 1;
+}

--- a/rpc/tracefd.h
+++ b/rpc/tracefd.h
@@ -1,0 +1,34 @@
+#ifndef __RETRACE_TRACEFD_H__
+#define __RETRACE_TRACEFD_H__
+
+enum tracefd_keytype {
+	tracefd_keytype_fd,
+	tracefd_keytype_dirp,
+	tracefd_keytype_stream
+};
+
+void init_tracefd_handlers(struct retrace_handle *handle);
+
+struct fdinfo {
+	SLIST_ENTRY(fdinfo) next;
+	enum tracefd_keytype type;
+	pid_t pid;
+	void *key;
+	char *info;
+};
+
+SLIST_HEAD(fdinfo_h, fdinfo);
+
+void set_fdinfo(struct fdinfo_h *infos, pid_t pid, int fd, const char *info);
+const struct fdinfo *get_fdinfo(struct fdinfo_h *infos, pid_t pid, int fd);
+
+void set_dirinfo(struct fdinfo_h *infos, pid_t pid, DIR *dir,
+	const char *info);
+const struct fdinfo *get_dirinfo(struct fdinfo_h *infos, pid_t pid,
+	DIR *dir);
+
+void set_streaminfo(struct fdinfo_h *infos, pid_t pid, FILE *stream,
+	const char *info);
+const struct fdinfo *get_streaminfo(struct fdinfo_h *infos, pid_t pid,
+	FILE *stream);
+#endif


### PR DESCRIPTION
Adds --help and --version
Adds stream, dir and fd tracing
Adds socket, open, openat, creat, sendto, recv and recvfrom
Change from single handlers to handler lists
Converts backtrace into postcall handler
Rework log handler overrides
Adds logging for errno, msghdr, sockaddr and iovec
Use real_sendto instead of real_send
FreeBSD compatibility
Fix thread termination loop in OpenBSD