### PR TITLE
Change hint.ai_socktype for getaddrinfo() to SOCK_STREAM.

### DIFF
--- a/examples/net-fuzzing/test_client.c
+++ b/examples/net-fuzzing/test_client.c
@@ -31,7 +31,7 @@ static void test_inet(void)
 	/* obtain address(es) matching host/port */
 	memset(&hints, 0, sizeof(struct addrinfo));
 	hints.ai_family = AF_UNSPEC;
-	hints.ai_socktype = SOCK_DGRAM;
+	hints.ai_socktype = SOCK_STREAM;
 	hints.ai_flags = 0;
 	hints.ai_protocol = 0;
 


### PR DESCRIPTION
Retionale: 1. Compilation fails on Ubuntu as etc/services contains
only 80/tcp record. 2. Makes more sense as HTTP runs on TCP.