### PR TITLE
An initial delivery of the cli framework.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -39,7 +39,8 @@ noinst_HEADERS= \
 	temp.h \
 	trace.h \
 	write.h \
-	ioctl.h
+	ioctl.h \
+	retrace_cli.h
 
 # include all C files here
 libretrace_la_SOURCES= \
@@ -74,4 +75,6 @@ libretrace_la_SOURCES= \
 	time.c \
 	trace.c \
 	write.c \
-	ioctl.c
+	ioctl.c \
+	retrace_cli.c \
+	retrace_main.c

--- a/src/retrace_cli.c
+++ b/src/retrace_cli.c
@@ -1,0 +1,274 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* because of _XOPEN_SOURCE, TODO: cross platform */
+#if __linux__
+
+#define  _DEFAULT_SOURCE
+#define _XOPEN_SOURCE 600
+
+#include <stdlib.h>
+#include <pthread.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <termios.h>
+#include <sys/select.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <string.h>
+
+#include "retrace_cli.h"
+
+#define CLI_MAX_MENU_ITEMS 20
+#define CLI_IN_BUFF_SIZE 128
+#define CLI_OUT_BUFF_SIZE CLI_IN_BUFF_SIZE
+
+typedef struct
+{
+	unsigned id;
+	cli_cmd_t cmd;
+} cli_menu_item_t;
+
+static int pts_fd = -1;
+static volatile cli_menu_item_t menu_items[CLI_MAX_MENU_ITEMS];
+static volatile unsigned menu_cnt;
+static pthread_mutex_t mutex;
+
+int cli_init(char *pts_path, size_t path_len)
+{
+	int res;
+	char *pts;
+	struct termios tios;
+
+	/* initialize mutex */
+	if ((res = pthread_mutex_init(&mutex, NULL)) < 0) return res;
+
+	/* open and unlock pts */
+	if ((pts_fd = posix_openpt(O_RDWR | O_NONBLOCK)) < 0) return -1;
+
+	if (grantpt(pts_fd) < 0) {
+		close(pts_fd);
+		return -1;
+	}
+
+	if (unlockpt(pts_fd) < 0) {
+		close(pts_fd);
+		return -1;
+	}
+
+	/* set raw mode */
+	if (tcgetattr(pts_fd, &tios)) {
+		close(pts_fd);
+		return -1;
+	}
+
+	cfmakeraw(&tios);
+
+	if (tcsetattr(pts_fd, TCSANOW, &tios)) {
+		close(pts_fd);
+		return -1;
+	}
+
+	/* return pts name */
+	if ((pts = ptsname(pts_fd)) == NULL) {
+		close(pts_fd);
+		return -1;
+	}
+
+	if (strlen(pts) + 1 > path_len) {
+		close(pts_fd);
+		return -1;
+	}
+
+	strcpy(pts_path, pts);
+
+	return 0;
+}
+
+int cli_printf(const char *format, ...)
+{
+	/* 1 for '\0' */
+	static char out_buff[CLI_OUT_BUFF_SIZE + 1];
+	va_list args;
+	int sz;
+
+	if (pts_fd == -1) return -1;
+
+	pthread_mutex_lock(&mutex);
+
+	va_start(args, format);
+    sz = vsnprintf(out_buff, sizeof(out_buff), format, args);
+    va_end(args);
+
+	write(pts_fd, out_buff, sz);
+
+	/* not sure if needed */
+	tcdrain(pts_fd);
+
+	pthread_mutex_unlock(&mutex);
+
+	return sz;
+}
+
+int cli_scanf(const char *format, ...)
+{
+	/* 1 for '\0' */
+	static char in_buff[CLI_IN_BUFF_SIZE + 1];
+
+	fd_set sel_set;
+	char in;
+	unsigned idx;
+	va_list args;
+	int res;
+
+	if (pts_fd == -1) return -1;
+
+	pthread_mutex_lock(&mutex);
+
+	tcflush(pts_fd, TCIFLUSH);
+
+	idx = 0;
+	in = 0;
+
+	/* read char by char till no more space or Main Enter key is pressed */
+	while ((idx != CLI_IN_BUFF_SIZE) && (in != '\n')) {
+
+		FD_ZERO(&sel_set);
+		FD_SET(pts_fd, &sel_set);
+
+	    if (select(pts_fd + 1, &sel_set, NULL, NULL, NULL) == -1) {
+	    	res = EOF;
+	    	goto unlock;
+	    }
+
+	    if (!FD_ISSET(pts_fd, &sel_set)) continue;
+
+	    /* read next character */
+		if (read(pts_fd, &in, 1) !=  1) {
+			res = EOF;
+			goto unlock;
+		}
+
+		/* echo back */
+		if (write(pts_fd, &in, 1) == -1) {
+			res = EOF;
+			goto unlock;
+		}
+
+		/* currently support only main Enter key as end of input */
+		if (in == '\r') {
+			in = '\n';
+			if (write(pts_fd, &in, 1) == -1) {
+				res = EOF;
+				goto unlock;
+			}
+		}
+		in_buff[idx++] = in;
+	}
+
+	/* indicate error in case no more space in buffer */
+	if (in != '\n') {
+		res = EOF;
+		goto unlock;
+	}
+
+	in_buff[idx] = '\0';
+	va_start(args, format);
+	res = vsscanf(in_buff, format, args);
+    va_end(args);
+
+unlock:
+	pthread_mutex_unlock(&mutex);
+	return res;
+}
+
+void cli_run(void)
+{
+	unsigned i;
+	unsigned cmd_id;
+	unsigned _menu_cmd;
+
+	if (pts_fd == -1) return;
+
+	while (1) {
+		cli_printf("Retrace command menu\r\n");
+		cli_printf("--------------------\r\n");
+
+		/* print command menu */
+		i = 0;
+
+		/* save menu_cnt since it can be updated by cli_register_command_blk */
+		_menu_cmd = menu_cnt;
+		while (i != _menu_cmd) {
+			cli_printf("[%u] %s\r\n", menu_items[i].id, menu_items[i].cmd.name);
+			i++;
+		}
+
+		/* read command id */
+		cli_printf("Enter command id>> ");
+		if (cli_scanf("%u", &cmd_id) != 1)
+		{
+			cli_printf("Failed to get command id, retry\r\n");
+			continue;
+		}
+
+		if (cmd_id >= _menu_cmd) {
+			cli_printf("Invalid command id: %u\r\n", cmd_id);
+		}
+		else {
+			/* Dispatch command */
+			cli_printf("command id %u START \r\n", cmd_id);
+			menu_items[cmd_id].cmd.func();
+			cli_printf("command id %u DONE \r\n", cmd_id);
+		}
+	}
+}
+
+int cli_register_command_blk(const cli_cmd_t *cmd_blk)
+{
+	const cli_cmd_t *p;
+
+	p = cmd_blk;
+
+	/* Add block to the end of menu_items */
+	while ((menu_cnt != CLI_MAX_MENU_ITEMS) && p->func) {
+		menu_items[menu_cnt].id = menu_cnt;
+		menu_items[menu_cnt].cmd = *p;
+
+		menu_cnt++;
+		p++;
+	}
+
+	if (p->func) {
+		return -1;
+	}
+
+	return 0;
+}
+
+#endif /* __linux__ */
+

--- a/src/retrace_cli.c
+++ b/src/retrace_cli.c
@@ -224,7 +224,7 @@ void cli_run(void)
 		/*
 		 * print command menu
 		 * menu contents can be modified by cli_register_command_blk()
-		 * */
+		 */
 		pthread_mutex_lock(&data_mutex);
 
 		i = 0;

--- a/src/retrace_cli.c
+++ b/src/retrace_cli.c
@@ -49,14 +49,15 @@
 
 typedef struct
 {
-	unsigned id;
+	unsigned int id;
 	cli_cmd_t cmd;
 } cli_menu_item_t;
 
 static int pts_fd = -1;
-static volatile cli_menu_item_t menu_items[CLI_MAX_MENU_ITEMS];
-static volatile unsigned menu_cnt;
-static pthread_mutex_t mutex;
+static cli_menu_item_t menu_items[CLI_MAX_MENU_ITEMS];
+static unsigned int menu_cnt;
+static pthread_mutex_t api_mutex;
+static pthread_mutex_t data_mutex;
 
 int cli_init(char *pts_path, size_t path_len)
 {
@@ -64,11 +65,20 @@ int cli_init(char *pts_path, size_t path_len)
 	char *pts;
 	struct termios tios;
 
-	/* initialize mutex */
-	if ((res = pthread_mutex_init(&mutex, NULL)) < 0) return res;
+	/* initialize api mutex */
+	res = pthread_mutex_init(&api_mutex, NULL);
+	if (res < 0)
+		return res;
+
+	/* initialize data mutex */
+	res = pthread_mutex_init(&data_mutex, NULL);
+	if (res < 0)
+		return res;
 
 	/* open and unlock pts */
-	if ((pts_fd = posix_openpt(O_RDWR | O_NONBLOCK)) < 0) return -1;
+	pts_fd = posix_openpt(O_RDWR | O_NONBLOCK);
+	if (pts_fd < 0)
+		return -1;
 
 	if (grantpt(pts_fd) < 0) {
 		close(pts_fd);
@@ -94,12 +104,13 @@ int cli_init(char *pts_path, size_t path_len)
 	}
 
 	/* return pts name */
-	if ((pts = ptsname(pts_fd)) == NULL) {
+	pts = ptsname(pts_fd);
+	if (pts == NULL) {
 		close(pts_fd);
 		return -1;
 	}
 
-	if (strlen(pts) + 1 > path_len) {
+	if ((strlen(pts) + 1) > path_len) {
 		close(pts_fd);
 		return -1;
 	}
@@ -113,41 +124,41 @@ int cli_printf(const char *format, ...)
 {
 	/* 1 for '\0' */
 	static char out_buff[CLI_OUT_BUFF_SIZE + 1];
-	va_list args;
 	int sz;
+	va_list args;
 
-	if (pts_fd == -1) return -1;
+	if (pts_fd == -1)
+		return -1;
 
-	pthread_mutex_lock(&mutex);
+	pthread_mutex_lock(&api_mutex);
 
 	va_start(args, format);
-    sz = vsnprintf(out_buff, sizeof(out_buff), format, args);
-    va_end(args);
+	sz = vsnprintf(out_buff, sizeof(out_buff), format, args);
+	va_end(args);
 
-	write(pts_fd, out_buff, sz);
+	sz = write(pts_fd, out_buff, sz);
 
 	/* not sure if needed */
 	tcdrain(pts_fd);
 
-	pthread_mutex_unlock(&mutex);
+	pthread_mutex_unlock(&api_mutex);
 
 	return sz;
 }
 
 int cli_scanf(const char *format, ...)
 {
-	/* 1 for '\0' */
 	static char in_buff[CLI_IN_BUFF_SIZE + 1];
-
 	fd_set sel_set;
 	char in;
-	unsigned idx;
+	unsigned int idx;
 	va_list args;
 	int res;
 
-	if (pts_fd == -1) return -1;
+	if (pts_fd == -1)
+		return -1;
 
-	pthread_mutex_lock(&mutex);
+	pthread_mutex_lock(&api_mutex);
 
 	tcflush(pts_fd, TCIFLUSH);
 
@@ -160,86 +171,81 @@ int cli_scanf(const char *format, ...)
 		FD_ZERO(&sel_set);
 		FD_SET(pts_fd, &sel_set);
 
-	    if (select(pts_fd + 1, &sel_set, NULL, NULL, NULL) == -1) {
-	    	res = EOF;
-	    	goto unlock;
-	    }
+		if (select(pts_fd + 1, &sel_set, NULL, NULL, NULL) == -1)
+			return EOF;
 
-	    if (!FD_ISSET(pts_fd, &sel_set)) continue;
+		if (!FD_ISSET(pts_fd, &sel_set))
+			continue;
 
-	    /* read next character */
-		if (read(pts_fd, &in, 1) !=  1) {
-			res = EOF;
-			goto unlock;
-		}
+		/* read next character */
+		if (read(pts_fd, &in, 1) !=  1)
+			return EOF;
 
 		/* echo back */
-		if (write(pts_fd, &in, 1) == -1) {
-			res = EOF;
-			goto unlock;
-		}
+		if (write(pts_fd, &in, 1) == -1)
+			return EOF;
 
 		/* currently support only main Enter key as end of input */
 		if (in == '\r') {
 			in = '\n';
 			if (write(pts_fd, &in, 1) == -1) {
-				res = EOF;
-				goto unlock;
+				return EOF;
 			}
 		}
 		in_buff[idx++] = in;
 	}
 
 	/* indicate error in case no more space in buffer */
-	if (in != '\n') {
-		res = EOF;
-		goto unlock;
-	}
+	if (in != '\n')
+		return EOF;
 
 	in_buff[idx] = '\0';
 	va_start(args, format);
 	res = vsscanf(in_buff, format, args);
-    va_end(args);
+	va_end(args);
 
-unlock:
-	pthread_mutex_unlock(&mutex);
+	pthread_mutex_unlock(&api_mutex);
 	return res;
 }
 
 void cli_run(void)
 {
-	unsigned i;
-	unsigned cmd_id;
-	unsigned _menu_cmd;
+	unsigned int i;
+	unsigned int cmd_id;
 
-	if (pts_fd == -1) return;
+	if (pts_fd == -1)
+		return;
 
 	while (1) {
+
 		cli_printf("Retrace command menu\r\n");
 		cli_printf("--------------------\r\n");
 
-		/* print command menu */
-		i = 0;
+		/*
+		 * print command menu
+		 * menu contents can be modified by cli_register_command_blk()
+		 * */
+		pthread_mutex_lock(&data_mutex);
 
-		/* save menu_cnt since it can be updated by cli_register_command_blk */
-		_menu_cmd = menu_cnt;
-		while (i != _menu_cmd) {
+		i = 0;
+		while (i != menu_cnt) {
 			cli_printf("[%u] %s\r\n", menu_items[i].id, menu_items[i].cmd.name);
 			i++;
 		}
 
+		pthread_mutex_unlock(&data_mutex);
+
 		/* read command id */
 		cli_printf("Enter command id>> ");
-		if (cli_scanf("%u", &cmd_id) != 1)
-		{
+
+		if (cli_scanf("%u", &cmd_id) != 1) {
 			cli_printf("Failed to get command id, retry\r\n");
 			continue;
 		}
 
-		if (cmd_id >= _menu_cmd) {
+		if (cmd_id >= menu_cnt) {
 			cli_printf("Invalid command id: %u\r\n", cmd_id);
-		}
-		else {
+		} else {
 			/* Dispatch command */
 			cli_printf("command id %u START \r\n", cmd_id);
 			menu_items[cmd_id].cmd.func();
@@ -255,6 +261,8 @@ int cli_register_command_blk(const cli_cmd_t *cmd_blk)
 	p = cmd_blk;
 
 	/* Add block to the end of menu_items */
+	pthread_mutex_lock(&data_mutex);
+
 	while ((menu_cnt != CLI_MAX_MENU_ITEMS) && p->func) {
 		menu_items[menu_cnt].id = menu_cnt;
 		menu_items[menu_cnt].cmd = *p;
@@ -263,7 +271,10 @@ int cli_register_command_blk(const cli_cmd_t *cmd_blk)
 		p++;
 	}
 
+	pthread_mutex_unlock(&data_mutex);
+
 	if (p->func) {
+		/* no more space */
 		return -1;
 	}
 

--- a/src/retrace_cli.h
+++ b/src/retrace_cli.h
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SRC_RETRACE_CLI_H_
+#define SRC_RETRACE_CLI_H_
+
+#define CLI_MAX_CMD_NAME_LEN 20
+
+//#define cli_err(fmt, ...) cli_printf("[ERROR] %s:%u" #fmt, __FILE__, __LINE__, __VA_ARGS__)
+
+/**
+ * @brief Command information. Used during command registration
+ *
+ * @see cli_register_command_blk
+ */
+typedef struct
+{
+	/* name of command, as it will appear on cli */
+	char name[CLI_MAX_CMD_NAME_LEN];
+
+	/* command function, will be called when command is selected */
+	void (*func)(void);
+} cli_cmd_t;
+
+/**
+ * @brief Initialize cli
+ *
+ * Opens pseudo terminal for cli and return its file path,
+ * so a terminal emulator can be connected.
+ * Must be called before any other calls to cli functions can be made.
+ * Not threadsafe.
+ *
+ * @param[out] pts_path PTS file path
+ * @param[in] path_len size of pts_path in bytes
+ *
+ * @return 0 in case of success.
+ *
+ */
+int cli_init(char *pts_path, size_t path_len);
+
+
+/**
+ * @brief Main cli loop
+ *
+ * Implements command dispatching loop. Never returns.
+ * Not threadsafe - only one instance is intended to be run.
+ *
+ */
+void cli_run(void);
+
+/**
+ * @brief Register command block
+ *
+ * Registers a command block which will be presented on cli
+ * during cli_run(). Each command is assigned with an ID.
+ * User selects a command by entering its ID.
+ * Tested with minicom.
+ * Not threadsafe.
+ *
+ * @param[in] cmd_blk Array of command blocks,
+ * end of block must be marked by empty entry.
+ *
+ * @return 0 in case of success, -1 in case of error
+ */
+int cli_register_command_blk(const cli_cmd_t *cmd_blk);
+
+/**
+ * @brief Pseudo terminal version of printf
+ *
+ * Intended to be used only with raw terminal mode.
+ * Tested with minicom.
+ * Threadsafe.
+ *
+ * @param format as of printf
+ * @param ... as of printf
+ * @return as of printf
+ */
+int cli_printf(const char *format, ...);
+
+/**
+ * @brief Pseudo terminal version of scanf
+ *
+ * Intended to be used only with raw terminal mode.
+ * Tested only with single integer input.
+ * End of input is indicated by '\r' character. Tested with minicom.
+ * Threadsafe.
+ *
+ * @param format as of scanf
+ * @param ... as of scanf
+ * @return as of scanf
+ */
+int cli_scanf(const char *format, ...);
+
+#endif /* SRC_RETRACE_CLI_H_ */

--- a/src/retrace_cli.h
+++ b/src/retrace_cli.h
@@ -35,8 +35,7 @@
  *
  * @see cli_register_command_blk
  */
-typedef struct
-{
+typedef struct {
 	/* name of command, as it will appear on cli */
 	char name[CLI_MAX_CMD_NAME_LEN];
 

--- a/src/retrace_main.c
+++ b/src/retrace_main.c
@@ -31,13 +31,13 @@
 #include <stdarg.h>
 #include <stdio.h>
 #include <unistd.h>
-#include "retrace_cli.h"
 #include <pthread.h>
+
+#include "retrace_cli.h"
 
 #define RETRACE_VER "0.2"
 #define RETRACE_ENV_CLI_ENA "RETRACE_CLI"
 #define RETRACE_INFO_DELAY 3
-
 
 #define retrace_init_info(fmt, ...) printf("RETRACE-INIT [INFO]: " fmt, ## __VA_ARGS__)
 #define retrace_init_err(fmt, ...) printf("RETRACE-INIT [ERROR]: " fmt, ## __VA_ARGS__)
@@ -47,13 +47,11 @@
  *  @brief Initializes retrace upon loading into process address space
  */
 
-static void cmd_func_hello(void)
-{
+static void cmd_func_hello(void) {
 	cli_printf("Hello\r\n");
 }
 
-static void cmd_func_exit(void)
-{
+static void cmd_func_exit(void) {
 	exit(1);
 }
 
@@ -64,23 +62,20 @@ static cli_cmd_t cmd_blk[] = {
 };
 
 /* this function is run by the second thread */
-static void *cli_thread(void *x_void_ptr)
-{
+static void *cli_thread(void *x_void_ptr) {
 	cli_run();
 	return NULL;
 }
 
 __attribute__((constructor))
-static void retrace_main()
-{
+static void retrace_main(void) {
 	char *cli_env;
 	char pts_path[PATH_MAX];
 	int i;
 	pthread_t cli_t;
 
 	cli_env = getenv(RETRACE_ENV_CLI_ENA);
-	if ((cli_env != NULL) && (atoi(cli_env) == 1))
-	{
+	if ((cli_env != NULL) && (atoi(cli_env) == 1)) {
 		/* output only if not in silent mode */
 		retrace_init_info("version: %s\n", RETRACE_VER);
 
@@ -106,6 +101,7 @@ static void retrace_main()
 
 		for (i = RETRACE_INFO_DELAY; i; i--) {
 			retrace_init_info("continuing in %u sec...\n", i);
+
 			sleep(1);
 		}
 	}

--- a/src/retrace_main.c
+++ b/src/retrace_main.c
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifdef __linux__
+
+#include <linux/limits.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <unistd.h>
+#include "retrace_cli.h"
+#include <pthread.h>
+
+#define RETRACE_VER "0.2"
+#define RETRACE_ENV_CLI_ENA "RETRACE_CLI"
+#define RETRACE_INFO_DELAY 3
+
+
+#define retrace_init_info(fmt, ...) printf("RETRACE-INIT [INFO]: " fmt, ## __VA_ARGS__)
+#define retrace_init_err(fmt, ...) printf("RETRACE-INIT [ERROR]: " fmt, ## __VA_ARGS__)
+#define retrace_init_dbg(fmt, ...) printf("RETRACE-INIT [DBG]: " fmt, ## __VA_ARGS__)
+
+/**
+ *  @brief Initializes retrace upon loading into process address space
+ */
+
+static void cmd_func_hello(void)
+{
+	cli_printf("Hello\r\n");
+}
+
+static void cmd_func_exit(void)
+{
+	exit(1);
+}
+
+static cli_cmd_t cmd_blk[] = {
+		{"Say Hi", cmd_func_hello},
+		{"Terminate process", cmd_func_exit},
+		{"", NULL}
+};
+
+/* this function is run by the second thread */
+static void *cli_thread(void *x_void_ptr)
+{
+	cli_run();
+	return NULL;
+}
+
+__attribute__((constructor))
+static void retrace_main()
+{
+	char *cli_env;
+	char pts_path[PATH_MAX];
+	int i;
+	pthread_t cli_t;
+
+	cli_env = getenv(RETRACE_ENV_CLI_ENA);
+	if ((cli_env != NULL) && (atoi(cli_env) == 1))
+	{
+		/* output only if not in silent mode */
+		retrace_init_info("version: %s\n", RETRACE_VER);
+
+		/* init cli */
+		if (cli_init(pts_path, PATH_MAX)) {
+			retrace_init_err("failed to init cli!\n");
+			return;
+		}
+
+		retrace_init_info("cli pts is at: %s\n", pts_path);
+
+		/* register commands */
+		if (cli_register_command_blk(cmd_blk)) {
+			retrace_init_err("failed to register commands!\n");
+			return;
+		}
+
+		/* create cli thread */
+		if (pthread_create(&cli_t, NULL, cli_thread, NULL)) {
+			retrace_init_err("failed to create cli thread!\n");
+			return;
+		}
+
+		for (i = RETRACE_INFO_DELAY; i; i--) {
+			retrace_init_info("continuing in %u sec...\n", i);
+			sleep(1);
+		}
+	}
+}
+
+#endif /* __linux__ */
+

--- a/src/retrace_main.c
+++ b/src/retrace_main.c
@@ -47,11 +47,13 @@
  *  @brief Initializes retrace upon loading into process address space
  */
 
-static void cmd_func_hello(void) {
+static void cmd_func_hello(void)
+{
 	cli_printf("Hello\r\n");
 }
 
-static void cmd_func_exit(void) {
+static void cmd_func_exit(void)
+{
 	exit(1);
 }
 
@@ -62,13 +64,15 @@ static cli_cmd_t cmd_blk[] = {
 };
 
 /* this function is run by the second thread */
-static void *cli_thread(void *x_void_ptr) {
+static void *cli_thread(void *x_void_ptr)
+{
 	cli_run();
 	return NULL;
 }
 
 __attribute__((constructor))
-static void retrace_main(void) {
+static void retrace_main(void)
+{
 	char *cli_env;
 	char pts_path[PATH_MAX];
 	int i;


### PR DESCRIPTION
The framework allows an extendable menu to be created by retrace modules
and accessed by an user from a terminal emulator.
The framework interface is defined in retrace_cli.h,
it provides functionalities such as registering of commands and printf/scanf primitives.
In addition in order to facilitate initialization of modules and
specifically of the cli framework, a constructor function was added in retrace_main.c,
which will be called before the process main() function.
As an example, the constructor defines two menu commands: "Say Hi" and "Terminate"
Modules are expected to build upon that foundation.
Tested with minicom on Ubuntu Linux.