### PR TITLE
Fix v2 build

### DIFF
--- a/src/v2/actions/basic.c
+++ b/src/v2/actions/basic.c
@@ -29,16 +29,16 @@
 #include "data_types.h"
 
 #define log_err(fmt, ...) \
-	retrace_logger_log(ACTIONS, ERROR, fmt, ##__VA_ARGS__)
+	retrace_logger_log(ACTIONS, SEVERITY_ERROR, fmt, ##__VA_ARGS__)
 
 #define log_info(fmt, ...) \
-	retrace_logger_log(ACTIONS, INFO, fmt, ##__VA_ARGS__)
+	retrace_logger_log(ACTIONS, SEVERITY_INFO, fmt, ##__VA_ARGS__)
 
 #define log_warn(fmt, ...) \
-	retrace_logger_log(ACTIONS, WARN, fmt, ##__VA_ARGS__)
+	retrace_logger_log(ACTIONS, SEVERITY_WARN, fmt, ##__VA_ARGS__)
 
 #define log_dbg(fmt, ...) \
-	retrace_logger_log(ACTIONS, DEBUG, fmt, ##__VA_ARGS__)
+	retrace_logger_log(ACTIONS, SEVERITY_DEBUG, fmt, ##__VA_ARGS__)
 
 #define ARR_MAX_COUNT 64
 
@@ -251,7 +251,7 @@ next_param:;
 
 	/* finally */
 	//log_info("%s", serialized_string);
-	retrace_logger_log_json(ACTIONS, INFO, root_value);
+	retrace_logger_log_json(ACTIONS, SEVERITY_INFO, root_value);
 
 	//json_free_serialized_string(serialized_string);
 	//json_value_free(root_value);

--- a/src/v2/arch/x86-64/linux/arch_spec_bottom.c
+++ b/src/v2/arch/x86-64/linux/arch_spec_bottom.c
@@ -31,16 +31,16 @@
 #include "printf.h"
 
 #define log_err(fmt, ...) \
-	retrace_logger_log(ARCH, ERROR, fmt, ##__VA_ARGS__)
+	retrace_logger_log(ARCH, SEVERITY_ERROR, fmt, ##__VA_ARGS__)
 
 #define log_info(fmt, ...) \
-	retrace_logger_log(ARCH, INFO, fmt, ##__VA_ARGS__)
+	retrace_logger_log(ARCH, SEVERITY_INFO, fmt, ##__VA_ARGS__)
 
 #define log_warn(fmt, ...) \
-	retrace_logger_log(ARCH, WARN, fmt, ##__VA_ARGS__)
+	retrace_logger_log(ARCH, SEVERITY_WARN, fmt, ##__VA_ARGS__)
 
 #define log_dbg(fmt, ...) \
-	retrace_logger_log(ARCH, DEBUG, fmt, ##__VA_ARGS__)
+	retrace_logger_log(ARCH, SEVERITY_DEBUG, fmt, ##__VA_ARGS__)
 
 struct WrapperSystemVFrame {
 	/* this flag will cause the assembly portion to call the real impl */

--- a/src/v2/conf.c
+++ b/src/v2/conf.c
@@ -29,16 +29,16 @@
 #include "logger.h"
 
 #define log_err(fmt, ...) \
-	retrace_logger_log(CONF, ERROR, fmt, ##__VA_ARGS__)
+	retrace_logger_log(CONF, SEVERITY_ERROR, fmt, ##__VA_ARGS__)
 
 #define log_info(fmt, ...) \
-	retrace_logger_log(CONF, INFO, fmt, ##__VA_ARGS__)
+	retrace_logger_log(CONF, SEVERITY_INFO, fmt, ##__VA_ARGS__)
 
 #define log_warn(fmt, ...) \
-	retrace_logger_log(CONF, WARN, fmt, ##__VA_ARGS__)
+	retrace_logger_log(CONF, SEVERITY_WARN, fmt, ##__VA_ARGS__)
 
 #define log_dbg(fmt, ...) \
-	retrace_logger_log(CONF, DEBUG, fmt, ##__VA_ARGS__)
+	retrace_logger_log(CONF, SEVERITY_DEBUG, fmt, ##__VA_ARGS__)
 
 #define ENVAR_JSON_CONFIG_FN "RETRACE_JSON_CONFIG"
 

--- a/src/v2/data_types.c
+++ b/src/v2/data_types.c
@@ -37,16 +37,16 @@
 #include "real_impls.h"
 
 #define log_err(fmt, ...) \
-	retrace_logger_log(DATA_TYPES, ERROR, fmt, ##__VA_ARGS__)
+	retrace_logger_log(DATA_TYPES, SEVERITY_ERROR, fmt, ##__VA_ARGS__)
 
 #define log_info(fmt, ...) \
-	retrace_logger_log(DATA_TYPES, INFO, fmt, ##__VA_ARGS__)
+	retrace_logger_log(DATA_TYPES, SEVERITY_INFO, fmt, ##__VA_ARGS__)
 
 #define log_warn(fmt, ...) \
-	retrace_logger_log(DATA_TYPES, WARN, fmt, ##__VA_ARGS__)
+	retrace_logger_log(DATA_TYPES, SEVERITY_WARN, fmt, ##__VA_ARGS__)
 
 #define log_dbg(fmt, ...) \
-	retrace_logger_log(DATA_TYPES, DEBUG, fmt, ##__VA_ARGS__)
+	retrace_logger_log(DATA_TYPES, SEVERITY_DEBUG, fmt, ##__VA_ARGS__)
 
 #define MAXCOUNT_DT_HASH_ENTRIES 16
 

--- a/src/v2/datatypes/basic.c
+++ b/src/v2/datatypes/basic.c
@@ -34,16 +34,16 @@
 #include "logger.h"
 
 #define log_err(fmt, ...) \
-	retrace_logger_log(DATA_TYPES, ERROR, fmt, ##__VA_ARGS__)
+	retrace_logger_log(DATA_TYPES, SEVERITY_ERROR, fmt, ##__VA_ARGS__)
 
 #define log_info(fmt, ...) \
-	retrace_logger_log(DATA_TYPES, INFO, fmt, ##__VA_ARGS__)
+	retrace_logger_log(DATA_TYPES, SEVERITY_INFO, fmt, ##__VA_ARGS__)
 
 #define log_warn(fmt, ...) \
-	retrace_logger_log(DATA_TYPES, WARN, fmt, ##__VA_ARGS__)
+	retrace_logger_log(DATA_TYPES, SEVERITY_WARN, fmt, ##__VA_ARGS__)
 
 #define log_dbg(fmt, ...) \
-	retrace_logger_log(DATA_TYPES, DEBUG, fmt, ##__VA_ARGS__)
+	retrace_logger_log(DATA_TYPES, SEVERITY_DEBUG, fmt, ##__VA_ARGS__)
 
 static int get_member(const struct DataType *struct_type,
 		const void *struct_data,

--- a/src/v2/engine.c
+++ b/src/v2/engine.c
@@ -41,16 +41,16 @@
 #include "logger.h"
 
 #define log_err(fmt, ...) \
-	retrace_logger_log(ENGINE, ERROR, fmt, ##__VA_ARGS__)
+	retrace_logger_log(ENGINE, SEVERITY_ERROR, fmt, ##__VA_ARGS__)
 
 #define log_info(fmt, ...) \
-	retrace_logger_log(ENGINE, INFO, fmt, ##__VA_ARGS__)
+	retrace_logger_log(ENGINE, SEVERITY_INFO, fmt, ##__VA_ARGS__)
 
 #define log_warn(fmt, ...) \
-	retrace_logger_log(ENGINE, WARN, fmt, ##__VA_ARGS__)
+	retrace_logger_log(ENGINE, SEVERITY_WARN, fmt, ##__VA_ARGS__)
 
 #define log_dbg(fmt, ...) \
-	retrace_logger_log(ENGINE, DEBUG, fmt, ##__VA_ARGS__)
+	retrace_logger_log(ENGINE, SEVERITY_DEBUG, fmt, ##__VA_ARGS__)
 
 static pthread_key_t thread_ctx_key;
 

--- a/src/v2/logger.c
+++ b/src/v2/logger.c
@@ -47,10 +47,10 @@ static struct LoggerConfig
 
 } g_logger_config = {
 	.severities_ena = {
-		[DEBUG] = 0,
-		[INFO] = 1,
-		[WARN] = 1,
-		[ERROR] = 1
+		[SEVERITY_DEBUG] = 0,
+		[SEVERITY_INFO] = 1,
+		[SEVERITY_WARN] = 1,
+		[SEVERITY_ERROR] = 1
 	},
 	.modules_ena = {
 		[ACTIONS] = 1,

--- a/src/v2/logger.h
+++ b/src/v2/logger.h
@@ -36,10 +36,10 @@ enum Modules {
 };
 
 enum Severity {
-	DEBUG,
-	INFO,
-	WARN,
-	ERROR,
+	SEVERITY_DEBUG,
+	SEVERITY_INFO,
+	SEVERITY_WARN,
+	SEVERITY_ERROR,
 	SEVERITY_CNT
 };
 

--- a/src/v2/main.c
+++ b/src/v2/main.c
@@ -38,16 +38,16 @@
 #include "data_types.h"
 
 #define log_err(fmt, ...) \
-	retrace_logger_log(MAIN, ERROR, fmt, ##__VA_ARGS__)
+	retrace_logger_log(MAIN, SEVERITY_ERROR, fmt, ##__VA_ARGS__)
 
 #define log_info(fmt, ...) \
-	retrace_logger_log(MAIN, INFO, fmt, ##__VA_ARGS__)
+	retrace_logger_log(MAIN, SEVERITY_INFO, fmt, ##__VA_ARGS__)
 
 #define log_warn(fmt, ...) \
-	retrace_logger_log(MAIN, WARN, fmt, ##__VA_ARGS__)
+	retrace_logger_log(MAIN, SEVERITY_WARN, fmt, ##__VA_ARGS__)
 
 #define log_dbg(fmt, ...) \
-	retrace_logger_log(MAIN, DEBUG, fmt, ##__VA_ARGS__)
+	retrace_logger_log(MAIN, SEVERITY_DEBUG, fmt, ##__VA_ARGS__)
 
 int retrace_inited;
 


### PR DESCRIPTION
v2 build was failing to me because I enabled debug mode and that passed -DDEBUG, but we where also using the DEBUG keyword inside an enum.

I noticed there's a bunch of repeated macros (log_) I will tackle those as I get back up to speed with v2.