### PR TITLE
Fix more crashes in macOS by only reporting a timestamp rathern than …

### DIFF
--- a/src/v2/logger.c
+++ b/src/v2/logger.c
@@ -278,12 +278,9 @@ void retrace_logger_log_json(int module, int sev, JSON_Value *msg_value)
 	root_value = json_value_init_object();
 	root_object = json_value_get_object(root_value);
 
-	char buff[26];
-
 	retrace_real_impls.time(&rawtime);
-	retrace_real_impls.ctime_r(&rawtime, buff);
 
-	json_object_set_string(root_object, "time", buff);
+	json_object_set_number(root_object, "time", rawtime);
 	json_object_set_string(root_object, "module",
 		g_retrace_module_pref[module]);
 	json_object_set_string(root_object, "severity",

--- a/src/v2/main.c
+++ b/src/v2/main.c
@@ -102,16 +102,6 @@ static void retrace_main(void)
 
 	log_dbg("retrace init success");
 
-#ifdef __APPLE__
-	// Call this here so that the timezone structures can be initialized before
-	// retrace gets in the way, otherwise we crash
-	time_t clock;
-	char *buff;
-
-	clock = time(NULL);
-	buff = ctime(&clock);
-#endif
-
 	retrace_inited = 1;
 }
 


### PR DESCRIPTION
…local time