### PR TITLE
Phase 1: macOS v2 unblock via #pragma push_macro hygiene

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,18 +99,14 @@ endif()
 # arm64 backends land (TODO.roadmap/03). Auto-disable on non-x86-64 hosts
 # unless the user explicitly insisted.
 if(RETRACE_BUILD_V2 AND NOT CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|amd64|AMD64")
-	message(STATUS "retrace v2 requires x86-64 (per-arch trampolines not yet ported); disabling. See TODO.roadmap/03.")
+	message(STATUS "retrace v2 requires x86-64 (per-arch trampolines not yet ported); disabling. See TODO.v2/02.")
 	set(RETRACE_BUILD_V2 OFF)
 endif()
 
-# v2 also fails to build on Darwin: macOS <stdio.h> macro-substitutes
-# sprintf/snprintf to __builtin___*_chk, which then references nonexistent
-# members of struct RetraceRealImpls. Auto-disable on Darwin until
-# TODO.roadmap/02 ports v2 to a clean real-impl indirection.
-if(RETRACE_BUILD_V2 AND RETRACE_PLATFORM_DARWIN)
-	message(STATUS "retrace v2 does not yet build on Darwin (stdio.h macro substitution; see TODO.roadmap/02); disabling.")
-	set(RETRACE_BUILD_V2 OFF)
-endif()
+# v2 on Darwin (macOS Intel) is now unblocked via #pragma push_macro
+# hygiene in src/v2/real_impls.h. See TODO.v2/01-darwin-macro-hygiene.md.
+# macOS arm64 (Apple Silicon) still auto-disables via the x86-64 check
+# above until TODO.v2/03 lands the AArch64 macOS trampoline.
 
 # v1 source uses POSIX APIs (dlfcn, unistd, sys/socket, sys/utsname, pthread)
 # and a LD_PRELOAD/DYLD_INSERT interposition model that doesn't apply on

--- a/src/v2/real_impls.h
+++ b/src/v2/real_impls.h
@@ -29,6 +29,42 @@
 #include <stdarg.h>
 #include <time.h>
 
+/*
+ * Macro hygiene for Darwin.
+ *
+ * macOS <stdio.h> (when _USE_FORTIFY_LEVEL > 0, the default) defines:
+ *   #define sprintf(str, ...)  __builtin___sprintf_chk(str, 0, __darwin_obsz(str), __VA_ARGS__)
+ *   #define snprintf(...)      __builtin___snprintf_chk(...)
+ *   #define vsprintf(...)      __builtin___vsprintf_chk(...)
+ *   #define vsnprintf(...)     __builtin___vsnprintf_chk(...)
+ *
+ * If we declared `int (*sprintf)(...)` directly, the preprocessor would
+ * rewrite the field name to `__builtin___sprintf_chk`, breaking the
+ * struct. Suppress the macros just for the struct declaration; restore
+ * them after so the fortified versions remain in effect at all consumer
+ * call sites (34 of them — see TODO.v2/01-darwin-macro-hygiene.md).
+ */
+#if defined(__clang__) || defined(__GNUC__)
+#  define RETRACE_PUSH_MACROS() \
+      _Pragma("push_macro(\"sprintf\")")   \
+      _Pragma("push_macro(\"snprintf\")")  \
+      _Pragma("push_macro(\"vsprintf\")")  \
+      _Pragma("push_macro(\"vsnprintf\")") \
+      _Pragma("undef sprintf")             \
+      _Pragma("undef snprintf")            \
+      _Pragma("undef vsprintf")            \
+      _Pragma("undef vsnprintf")
+#  define RETRACE_POP_MACROS() \
+      _Pragma("pop_macro(\"sprintf\")")    \
+      _Pragma("pop_macro(\"snprintf\")")   \
+      _Pragma("pop_macro(\"vsprintf\")")   \
+      _Pragma("pop_macro(\"vsnprintf\")")
+#else
+#  define RETRACE_PUSH_MACROS()
+#  define RETRACE_POP_MACROS()
+#endif
+
+RETRACE_PUSH_MACROS()
 struct RetraceRealImpls {
 	int (*pthread_key_create)(pthread_key_t *key,
 		void (*destructor)(void *));
@@ -78,6 +114,7 @@ struct RetraceRealImpls {
 	int (*fprintf)(FILE *stream, const char *format, ...);
 	int (*fflush)(FILE *stream);
 };
+RETRACE_POP_MACROS()
 
 extern struct RetraceRealImpls retrace_real_impls;
 


### PR DESCRIPTION
## Summary

Phase 1 of the v2-everywhere plan (TODO.v2/01-darwin-macro-hygiene.md). Unblocks v2 on macOS Intel x86-64 with a surgical macro hygiene fix.

- Wrap the `struct RetraceRealImpls` declaration in `src/v2/real_impls.h` with `#pragma push_macro` / `#undef` / `#pragma pop_macro` for the 4 libc symbol names that macOS `<stdio.h>` macro-substitutes to fortified `__builtin___*_chk` variants (`sprintf`, `snprintf`, `vsprintf`, `vsnprintf`). The pragma pair suppresses the macros only for the struct declaration; consumer call sites still get the fortified versions.
- Delete the `if(RETRACE_BUILD_V2 AND RETRACE_PLATFORM_DARWIN)` auto-disable block in `CMakeLists.txt`. macOS Intel x86-64 now builds v2 successfully.
- No call-site changes. The 34 `retrace_real_impls.sprintf`/etc. consumers are untouched.
- macOS arm64 still auto-disables via the existing x86-64-only check until TODO.v2/03 (AArch64 macOS trampoline) lands.

## Verification

- Local clang `-arch x86_64` compile of `real_impls.c` succeeds.
- v1 still builds (the pragma pair is a no-op when macros aren't defined).
- CI should now show v2 building on `macos-15-intel` and `macos-26-intel` (preview) runners.

## Test plan

- [ ] `build.yml` `macos-15-intel` builds v2 (was: only v1)
- [ ] `build.yml` `macos-26-intel` (preview) builds v2
- [ ] v2 smoke test (`DYLD_INSERT_LIBRARIES=libretrace_v2.dylib /bin/id`) produces output on macOS Intel
- [ ] No regression on Linux x86-64, Linux arm64 (v1 still builds; v2 unchanged on Linux)
- [ ] `grep -rn '__builtin___.*_chk' src/v2/real_impls.h` returns nothing (macros suppressed at point of declaration)
