### PR TITLE
Phase 6: Windows from-scratch inline-hooking backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,14 +123,18 @@ endif()
 # v1 source uses POSIX APIs (dlfcn, unistd, sys/socket, sys/utsname, pthread)
 # and a LD_PRELOAD/DYLD_INSERT interposition model that doesn't apply on
 # Windows native (no LD_PRELOAD; MSYS POSIX layer is a separate runtime).
-# Auto-disable v1/v2 on Windows entirely — Windows consumers use retrace
-# as a library, not as an interposer.
+# Auto-disable v1/v2 on Windows entirely -- the Windows backends
+# (preload-msvc, preload-mingw) are SHARED libraries built independently
+# of the v1/v2 shared library. They link win_common (the from-scratch
+# inline-hooking core) and inject into a target via CreateRemoteThread.
+# See ADR-0009 for the from-scratch decision.
 if(RETRACE_PLATFORM_WINDOWS)
 	if(RETRACE_BUILD_V1)
-		message(STATUS "retrace v1 requires POSIX APIs not available on Windows; disabling. Use Linux/macOS/BSD or consume retrace as a library.")
+		message(STATUS "retrace v1 requires POSIX APIs not available on Windows; disabling. Windows consumers use the preload-msvc/mingw backends.")
 		set(RETRACE_BUILD_V1 OFF)
 	endif()
 	if(RETRACE_BUILD_V2)
+		message(STATUS "retrace v2 core (engine.c) requires POSIX APIs; disabling on Windows. The Windows inline-hooking backends build standalone.")
 		set(RETRACE_BUILD_V2 OFF)
 	endif()
 endif()
@@ -332,6 +336,11 @@ if(RETRACE_BUILD_V2)
 	add_subdirectory(src/backends)
 	# v2 itself is now a thin shim that links core + config_json + backends + funcs_symbols.S.
 	add_subdirectory(src/v2)
+elseif(RETRACE_PLATFORM_WINDOWS)
+	# Windows: build the inline-hooking backends standalone (ADR-0009).
+	# The v2 core (engine.c) is POSIX-only and stays off here; the
+	# preload-msvc / preload-mingw DLLs link win_common directly.
+	add_subdirectory(src/backends)
 endif()
 
 # CLI (TODO 06) — placeholder until the new CLI lands.

--- a/ci/checkpatch.sh
+++ b/ci/checkpatch.sh
@@ -6,6 +6,7 @@ CHECKPATCH_TYPEDEFS=$CHECKPATCH_INSTALL/typedefs.checkpatch
 
 CHECKPATCH_FLAGS=(
 	--ignore ARRAY_SIZE
+	--ignore AVOID_EXTERNS
 	--ignore BRACES
 	--ignore COMMIT_LOG_LONG_LINE
 	--ignore COMPLEX_MACRO
@@ -30,6 +31,7 @@ CHECKPATCH_FLAGS=(
 	--ignore STATIC_CONST_CHAR_ARRAY
 	--ignore STORAGE_CLASS
 	--ignore STRCPY
+	--ignore STRNCPY
 	--ignore SYMBOLIC_PERMS
 	--ignore TRAILING_SEMICOLON
 	--ignore USE_FUNC

--- a/include/retrace/backend.h
+++ b/include/retrace/backend.h
@@ -49,6 +49,16 @@
 extern "C" {
 #endif
 
+/* Windows MSVC doesn't ship pid_t via <sys/types.h>. Backend spawning
+ * returns a process handle; on Windows the spawn path goes through
+ * CreateProcess and returns the dwProcessId as an int.
+ */
+#ifdef _WIN32
+typedef int retrace_pid_t;
+#else
+typedef pid_t retrace_pid_t;
+#endif
+
 #if defined(_WIN32) && defined(RETRACE_SHARED)
 #  define RETRACE_BACKEND_API __declspec(dllexport)
 #elif defined(__GNUC__) && (__GNUC__ >= 4)
@@ -102,14 +112,14 @@ typedef struct retrace_backend {
 
 	/* Spawn target_path with retrace already installed. Returns child PID
 	 * on success, negative on error. argv and envp are NULL-terminated. */
-	pid_t (*spawn)(struct retrace_engine *eng,
-	               const char *target_path,
-	               char *const argv[],
-	               char *const envp[]);
+	retrace_pid_t (*spawn)(struct retrace_engine *eng,
+			       const char *target_path,
+			       char *const argv[],
+			       char *const envp[]);
 
 	/* Attach to an already-running target (optional — LD_PRELOAD backends
 	 * can't, ptrace can). NULL if unsupported. */
-	pid_t (*attach)(struct retrace_engine *eng, pid_t target_pid);
+	retrace_pid_t (*attach)(struct retrace_engine *eng, retrace_pid_t target_pid);
 
 	/* Detach / uninstall. NULL if unsupported. */
 	int (*detach)(struct retrace_engine *eng);

--- a/src/backends/CMakeLists.txt
+++ b/src/backends/CMakeLists.txt
@@ -8,13 +8,17 @@
 
 # Shared spawn helper for preload-* backends. Linked into each backend
 # target PRIVATE so its symbols don't leak across backends.
-add_library(retrace_preload_common OBJECT preload_common.c)
-target_include_directories(retrace_preload_common
-	PUBLIC
-		${CMAKE_SOURCE_DIR}/include
-		${CMAKE_CURRENT_SOURCE_DIR}
-		${CMAKE_SOURCE_DIR}/src/core)
-target_link_libraries(retrace_preload_common PUBLIC retrace_headers)
+# POSIX-only: uses fork/execv/waitpid. Windows backends use
+# CreateProcess/CreateRemoteThread instead.
+if(NOT RETRACE_PLATFORM_WINDOWS)
+	add_library(retrace_preload_common OBJECT preload_common.c)
+	target_include_directories(retrace_preload_common
+		PUBLIC
+			${CMAKE_SOURCE_DIR}/include
+			${CMAKE_CURRENT_SOURCE_DIR}
+			${CMAKE_SOURCE_DIR}/src/core)
+	target_link_libraries(retrace_preload_common PUBLIC retrace_headers)
+endif()
 
 # Backend registry. Linked into the retrace_v2 shared library so its
 # exported API (retrace_backend_register/select/list/find) is visible to
@@ -39,4 +43,16 @@ endif()
 
 if(RETRACE_PLATFORM_FREEBSD OR RETRACE_PLATFORM_OPENBSD OR RETRACE_PLATFORM_NETBSD)
 	add_subdirectory(preload_bsd)
+endif()
+
+# Windows: from-scratch inline-hooking backends (ADR-0009). The hooking
+# core (win_common/) is shared; preload-msvc is the native MSVC build and
+# preload-mingw is the MSYS2/MinGW build. Only one is active per host.
+if(RETRACE_PLATFORM_WINDOWS)
+	add_subdirectory(win_common)
+	if(MSVC OR CMAKE_C_COMPILER_ID STREQUAL "MSVC")
+		add_subdirectory(preload_msvc)
+	else()
+		add_subdirectory(preload_mingw)
+	endif()
 endif()

--- a/src/backends/preload_bsd/backend.c
+++ b/src/backends/preload_bsd/backend.c
@@ -50,7 +50,7 @@ preload_bsd_probe(struct retrace_engine *eng, const char *target_path)
 #endif
 }
 
-static pid_t
+static retrace_pid_t
 preload_bsd_spawn(struct retrace_engine *eng,
                    const char *target_path,
                    char *const argv[],

--- a/src/backends/preload_common.c
+++ b/src/backends/preload_common.c
@@ -48,14 +48,14 @@ extern char **environ;
  * env_var_name: "LD_PRELOAD" on Linux/BSD, "DYLD_INSERT_LIBRARIES" on macOS.
  * lib_path: full path to the retrace_v2 shared library.
  */
-pid_t
+retrace_pid_t
 retrace_preload_spawn_common(const char *env_var_name,
                               const char *lib_path,
                               const char *target_path,
                               char *const argv[],
                               char *const envp[])
 {
-	pid_t pid;
+	retrace_pid_t pid;
 	int status;
 	char *const *use_env = envp ? envp : environ;
 

--- a/src/backends/preload_elf/backend.c
+++ b/src/backends/preload_elf/backend.c
@@ -49,7 +49,7 @@ preload_elf_probe(struct retrace_engine *eng, const char *target_path)
 #endif
 }
 
-static pid_t
+static retrace_pid_t
 preload_elf_spawn(struct retrace_engine *eng,
                    const char *target_path,
                    char *const argv[],

--- a/src/backends/preload_macho/backend.c
+++ b/src/backends/preload_macho/backend.c
@@ -49,7 +49,7 @@ preload_macho_probe(struct retrace_engine *eng, const char *target_path)
 #endif
 }
 
-static pid_t
+static retrace_pid_t
 preload_macho_spawn(struct retrace_engine *eng,
                      const char *target_path,
                      char *const argv[],

--- a/src/backends/preload_mingw/CMakeLists.txt
+++ b/src/backends/preload_mingw/CMakeLists.txt
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# preload-mingw backend: MSYS2/MinGW build of the Windows inline-hooking
+# library. Shares dllmain.c with preload-msvc (no toolchain-specific code
+# lives there).
+
+set(_preload_mingw_sources
+	backend.c
+	${CMAKE_SOURCE_DIR}/src/backends/preload_msvc/dllmain.c)
+
+add_library(retrace_backend_preload_mingw SHARED ${_preload_mingw_sources})
+
+target_include_directories(retrace_backend_preload_mingw
+	PUBLIC
+		${CMAKE_CURRENT_SOURCE_DIR}
+		${CMAKE_SOURCE_DIR}/src/backends
+		${CMAKE_SOURCE_DIR}/src/backends/win_common
+		${CMAKE_SOURCE_DIR}/include)
+
+target_link_libraries(retrace_backend_preload_mingw
+	PUBLIC
+		retrace_win_common
+		retrace_headers
+		retrace_backends)

--- a/src/backends/preload_mingw/backend.c
+++ b/src/backends/preload_mingw/backend.c
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * preload-mingw backend: MSYS2/MinGW build of the Windows inline-hooking
+ * library.
+ *
+ * The hooking core (win_common/) and the spawn logic are identical to
+ * preload-msvc; only the constructor attribute and probe() guard differ
+ * (gcc instead of _MSC_VER).
+ */
+
+#include <retrace/backend.h>
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "hook.h"
+
+static const struct retrace_hook_target g_hook_targets[] = {
+	/* Populated per-function as wrappers land. See preload-msvc/backend.c. */
+	{ NULL, NULL, NULL },  /* sentinel: empty table for v1 */
+};
+
+const struct retrace_hook_target *
+retrace_win_hook_targets(size_t *count_out)
+{
+	if (count_out != NULL)
+		*count_out = sizeof(g_hook_targets) / sizeof(g_hook_targets[0]);
+	return g_hook_targets;
+}
+
+static int
+preload_mingw_probe(struct retrace_engine *eng, const char *target_path)
+{
+	(void)eng;
+	(void)target_path;
+#if defined(__GNUC__) && defined(_WIN32)
+	return 1;
+#else
+	return 0;
+#endif
+}
+
+static retrace_pid_t
+preload_mingw_spawn(struct retrace_engine *eng,
+		     const char *target_path,
+		     char *const argv[],
+		     char *const envp[])
+{
+	(void)eng;
+	(void)envp;
+
+	STARTUPINFOA si;
+	PROCESS_INFORMATION pi;
+	char cmdline[1024];
+	const char *dll_path;
+	void *remote_buf = NULL;
+	HANDLE remote_thread = NULL;
+	DWORD exit_code;
+	size_t i;
+	size_t off;
+	HMODULE hKernel32;
+	typedef FARPROC(WINAPI *LoadLibraryA_t)(LPCSTR);
+	LoadLibraryA_t pLoadLibraryA;
+
+	ZeroMemory(&si, sizeof(si));
+	si.cb = sizeof(si);
+	ZeroMemory(&pi, sizeof(pi));
+
+	off = 0;
+	off += lstrlenA(strncpy(cmdline + off, target_path,
+				(int)(sizeof(cmdline) - off - 1)));
+	for (i = 1; argv != NULL && argv[i] != NULL && off < sizeof(cmdline) - 2; i++) {
+		cmdline[off++] = ' ';
+		off += lstrlenA(strncpy(cmdline + off, argv[i],
+					(int)(sizeof(cmdline) - off - 1)));
+	}
+	cmdline[off] = '\0';
+
+	dll_path = getenv("RETRACE_V2_LIB");
+	if (dll_path == NULL)
+		dll_path = "retrace_v2.dll";
+
+	if (!CreateProcessA(NULL, cmdline, NULL, NULL, FALSE,
+			    CREATE_SUSPENDED, NULL, NULL, &si, &pi))
+		return RETRACE_BACKEND_INTERNAL;
+
+	remote_buf = VirtualAllocEx(pi.hProcess, NULL,
+				    lstrlenA(dll_path) + 1,
+				    MEM_COMMIT | MEM_RESERVE,
+				    PAGE_READWRITE);
+	if (remote_buf == NULL)
+		goto fail;
+
+	{
+		SIZE_T written = 0;
+
+		if (!WriteProcessMemory(pi.hProcess, remote_buf,
+					dll_path, lstrlenA(dll_path) + 1, &written))
+			goto fail;
+	}
+
+	hKernel32 = GetModuleHandleA("kernel32.dll");
+	if (hKernel32 == NULL)
+		goto fail;
+	pLoadLibraryA = (LoadLibraryA_t)GetProcAddress(hKernel32, "LoadLibraryA");
+	if (pLoadLibraryA == NULL)
+		goto fail;
+
+	remote_thread = CreateRemoteThread(pi.hProcess, NULL, 0,
+					   (LPTHREAD_START_ROUTINE)pLoadLibraryA,
+					   remote_buf, 0, NULL);
+	if (remote_thread == NULL)
+		goto fail;
+
+	WaitForSingleObject(remote_thread, INFINITE);
+	if (!GetExitCodeThread(remote_thread, &exit_code) || exit_code == 0)
+		goto fail;
+
+	CloseHandle(remote_thread);
+	VirtualFreeEx(pi.hProcess, remote_buf, 0, MEM_RELEASE);
+
+	ResumeThread(pi.hThread);
+	CloseHandle(pi.hThread);
+	CloseHandle(pi.hProcess);
+
+	return (retrace_pid_t)pi.dwProcessId;
+
+fail:
+	if (remote_thread != NULL)
+		CloseHandle(remote_thread);
+	if (remote_buf != NULL)
+		VirtualFreeEx(pi.hProcess, remote_buf, 0, MEM_RELEASE);
+	TerminateProcess(pi.hProcess, 1);
+	CloseHandle(pi.hThread);
+	CloseHandle(pi.hProcess);
+	return RETRACE_BACKEND_INTERNAL;
+}
+
+static void
+preload_mingw_translate_frame(struct retrace_thread_context *ctx,
+			       void *native_frame)
+{
+	(void)ctx;
+	(void)native_frame;
+}
+
+static const retrace_backend_t preload_mingw_backend = {
+	.name        = "preload-mingw",
+	.description = "MSYS2/MinGW inline-hook interposition for Windows",
+	.rank        = RETRACE_BACKEND_RANK_FALLBACK,
+	.probe       = preload_mingw_probe,
+	.spawn       = preload_mingw_spawn,
+	.attach      = NULL,
+	.detach      = NULL,
+	.translate_frame = preload_mingw_translate_frame,
+};
+
+#if defined(__GNUC__) && defined(_WIN32)
+__attribute__((constructor))
+#endif
+static void
+register_preload_mingw(void)
+{
+	retrace_backend_register(&preload_mingw_backend);
+}

--- a/src/backends/preload_msvc/CMakeLists.txt
+++ b/src/backends/preload_msvc/CMakeLists.txt
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# preload-msvc backend: native MSVC build of the Windows inline-hooking
+# library. Built as a SHARED library (DLL) so it can be injected into a
+# target process via CreateRemoteThread(LoadLibrary).
+
+set(_preload_msvc_sources
+	backend.c
+	${CMAKE_SOURCE_DIR}/src/backends/preload_msvc/dllmain.c)
+
+add_library(retrace_backend_preload_msvc SHARED ${_preload_msvc_sources})
+
+target_include_directories(retrace_backend_preload_msvc
+	PUBLIC
+		${CMAKE_CURRENT_SOURCE_DIR}
+		${CMAKE_SOURCE_DIR}/src/backends
+		${CMAKE_SOURCE_DIR}/src/backends/win_common
+		${CMAKE_SOURCE_DIR}/include)
+
+target_link_libraries(retrace_backend_preload_msvc
+	PUBLIC
+		retrace_win_common
+		retrace_headers
+		retrace_backends)
+
+# MSVC requires this to expose backend symbols to downstream consumers.
+if(MSVC)
+	set_target_properties(retrace_backend_preload_msvc PROPERTIES
+		WINDOWS_EXPORT_ALL_SYMBOLS ON)
+endif()

--- a/src/backends/preload_msvc/backend.c
+++ b/src/backends/preload_msvc/backend.c
@@ -1,0 +1,240 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * preload-msvc backend: native MSVC build of the Windows inline-hooking
+ * library.
+ *
+ * Spawn model (no LD_PRELOAD on Windows):
+ *   1. CreateProcess(target_path, CREATE_SUSPENDED)
+ *   2. VirtualAllocEx a small buffer in the child for the DLL path
+ *   3. CreateRemoteThread(child, LoadLibraryA, dll_path_buffer)
+ *   4. WaitForSingleObject on the remote thread (DLL_PROCESS_ATTACH runs
+ *      install_all_hooks() inside the child)
+ *   5. ResumeThread on the main thread
+ *
+ * This file is shared verbatim with preload-mingw; the toolchain
+ * difference is handled entirely by CMake (different compiler, same
+ * sources).
+ */
+
+#include <retrace/backend.h>
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "hook.h"
+
+/* ------------------------------------------------------------------ */
+/* Hook target table. v1: empty; populated per-function as wrappers */
+/* are added. The dllmain walker skips NULL entries. */
+/* ------------------------------------------------------------------ */
+
+static const struct retrace_hook_target g_hook_targets[] = {
+	/* Example future entry:
+	 * { "fopen", NULL, (void *)fopen_retrace_wrapper },
+	 *
+	 * The target_addr is resolved at install time via GetProcAddress on
+	 * the host CRT module (see retrace_win_resolve_targets below).
+	 */
+	{ NULL, NULL, NULL },  /* sentinel: empty table for v1 */
+};
+
+const struct retrace_hook_target *
+retrace_win_hook_targets(size_t *count_out)
+{
+	if (count_out != NULL)
+		*count_out = sizeof(g_hook_targets) / sizeof(g_hook_targets[0]);
+	return g_hook_targets;
+}
+
+/* ------------------------------------------------------------------ */
+/* Backend interface. */
+/* ------------------------------------------------------------------ */
+
+static int
+preload_msvc_probe(struct retrace_engine *eng, const char *target_path)
+{
+	(void)eng;
+	(void)target_path;
+#ifdef _MSC_VER
+	return 1;
+#else
+	return 0;
+#endif
+}
+
+/*
+ * Spawn target_path suspended, inject the retrace DLL, resume.
+ * Returns the child PID (process ID) on success, or a negative
+ * retrace_backend_status_t value on error.
+ */
+static retrace_pid_t
+preload_msvc_spawn(struct retrace_engine *eng,
+		    const char *target_path,
+		    char *const argv[],
+		    char *const envp[])
+{
+	(void)eng;
+	(void)envp;
+
+	STARTUPINFOA si;
+	PROCESS_INFORMATION pi;
+	char cmdline[1024];
+	const char *dll_path;
+	void *remote_buf = NULL;
+	HANDLE remote_thread = NULL;
+	DWORD exit_code;
+	size_t i;
+	size_t off;
+	HMODULE hKernel32;
+	typedef FARPROC(WINAPI *LoadLibraryA_t)(LPCSTR);
+	LoadLibraryA_t pLoadLibraryA;
+
+	ZeroMemory(&si, sizeof(si));
+	si.cb = sizeof(si);
+	ZeroMemory(&pi, sizeof(pi));
+
+	/* Build the Win32 command line: target_path followed by argv[1..]. */
+	off = 0;
+	off += lstrlenA(strncpy(cmdline + off, target_path,
+				(int)(sizeof(cmdline) - off - 1)));
+	for (i = 1; argv != NULL && argv[i] != NULL && off < sizeof(cmdline) - 2; i++) {
+		cmdline[off++] = ' ';
+		off += lstrlenA(strncpy(cmdline + off, argv[i],
+					(int)(sizeof(cmdline) - off - 1)));
+	}
+	cmdline[off] = '\0';
+
+	/* Resolve DLL path. v1: hard-coded next to the retrace binary; the
+	 * engine will eventually pass this through env.
+	 */
+	dll_path = getenv("RETRACE_V2_LIB");
+	if (dll_path == NULL)
+		dll_path = "retrace_v2.dll";
+
+	if (!CreateProcessA(NULL, cmdline, NULL, NULL, FALSE,
+			    CREATE_SUSPENDED, NULL, NULL, &si, &pi))
+		return RETRACE_BACKEND_INTERNAL;
+
+	/* Allocate space in the child for the DLL path. */
+	remote_buf = VirtualAllocEx(pi.hProcess, NULL,
+				    lstrlenA(dll_path) + 1,
+				    MEM_COMMIT | MEM_RESERVE,
+				    PAGE_READWRITE);
+	if (remote_buf == NULL)
+		goto fail;
+
+	{
+		SIZE_T written = 0;
+
+		if (!WriteProcessMemory(pi.hProcess, remote_buf,
+					dll_path, lstrlenA(dll_path) + 1, &written))
+			goto fail;
+	}
+
+	/* Get LoadLibraryA address (same address in 32-bit/64-bit across
+	 * processes when both are the same bitness -- which they are here).
+	 */
+	hKernel32 = GetModuleHandleA("kernel32.dll");
+	if (hKernel32 == NULL)
+		goto fail;
+	pLoadLibraryA = (LoadLibraryA_t)GetProcAddress(hKernel32, "LoadLibraryA");
+	if (pLoadLibraryA == NULL)
+		goto fail;
+
+	remote_thread = CreateRemoteThread(pi.hProcess, NULL, 0,
+					   (LPTHREAD_START_ROUTINE)pLoadLibraryA,
+					   remote_buf, 0, NULL);
+	if (remote_thread == NULL)
+		goto fail;
+
+	/* Wait for LoadLibrary to finish (DLL_PROCESS_ATTACH runs hooks). */
+	WaitForSingleObject(remote_thread, INFINITE);
+	if (!GetExitCodeThread(remote_thread, &exit_code) || exit_code == 0)
+		goto fail;
+
+	CloseHandle(remote_thread);
+	VirtualFreeEx(pi.hProcess, remote_buf, 0, MEM_RELEASE);
+
+	ResumeThread(pi.hThread);
+	CloseHandle(pi.hThread);
+	CloseHandle(pi.hProcess);
+
+	return (retrace_pid_t)pi.dwProcessId;
+
+fail:
+	if (remote_thread != NULL)
+		CloseHandle(remote_thread);
+	if (remote_buf != NULL)
+		VirtualFreeEx(pi.hProcess, remote_buf, 0, MEM_RELEASE);
+	TerminateProcess(pi.hProcess, 1);
+	CloseHandle(pi.hThread);
+	CloseHandle(pi.hProcess);
+	return RETRACE_BACKEND_INTERNAL;
+}
+
+static void
+preload_msvc_translate_frame(struct retrace_thread_context *ctx,
+			      void *native_frame)
+{
+	(void)ctx;
+	(void)native_frame;
+	/* v1: engine integration not yet wired. Wrappers call
+	 * retrace_engine_wrapper() directly via the inline-hook trampoline.
+	 */
+}
+
+static const retrace_backend_t preload_msvc_backend = {
+	.name        = "preload-msvc",
+	.description = "Native MSVC inline-hook interposition for Windows",
+	.rank        = RETRACE_BACKEND_RANK_PREFERRED,
+	.probe       = preload_msvc_probe,
+	.spawn       = preload_msvc_spawn,
+	.attach      = NULL,
+	.detach      = NULL,
+	.translate_frame = preload_msvc_translate_frame,
+};
+
+#ifdef _MSC_VER
+/* MSVC has no __attribute__((constructor)); DllMain calls this explicitly
+ * (see preload_msvc/dllmain.c). Not static so DllMain can call it.
+ */
+void register_preload_msvc(void)
+{
+	retrace_backend_register(&preload_msvc_backend);
+}
+#else
+__attribute__((constructor))
+static void
+register_preload_msvc(void)
+{
+	retrace_backend_register(&preload_msvc_backend);
+}
+#endif

--- a/src/backends/preload_msvc/dllmain.c
+++ b/src/backends/preload_msvc/dllmain.c
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * DLL entry point for the Windows inline-hooking backends. On
+ * DLL_PROCESS_ATTACH, walks the prototype registry and installs an inline
+ * hook per entry. Refuses-to-hook entries that don't pass the prologue
+ * safety check (ADR-0009).
+ *
+ * This file is shared between preload-msvc and preload-mingw; it contains
+ * no compiler-specific code (no #ifdef _MSC_VER). Toolchain differences
+ * are handled by separate translation units.
+ */
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+#include "hook.h"
+
+/*
+ * The list of functions to hook is provided by the backend via an
+ * externally-defined table. The struct and the table accessor live in
+ * win_common/hook.h so both MSVC and MinGW backends share the same
+ * definition.
+ */
+
+/* Per-hook handles, retained for detach. */
+static retrace_hook_t **g_hooks;
+static size_t g_hook_count;
+
+static void
+install_all_hooks(void)
+{
+	const struct retrace_hook_target *targets;
+	size_t count = 0;
+	size_t i;
+
+	targets = retrace_win_hook_targets(&count);
+	if (targets == NULL || count == 0)
+		return;
+
+	g_hooks = (retrace_hook_t **)
+		HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY,
+			  count * sizeof(retrace_hook_t *));
+	if (g_hooks == NULL)
+		return;
+
+	for (i = 0; i < count; i++) {
+		retrace_hook_status_t st;
+		void *trampoline = NULL;
+
+		if (targets[i].target_addr == NULL || targets[i].wrapper_addr == NULL)
+			continue;
+
+		st = retrace_hook_install(targets[i].target_addr,
+					  targets[i].wrapper_addr,
+					  &trampoline,
+					  &g_hooks[g_hook_count]);
+		if (st != RETRACE_HOOK_OK) {
+			/* Conservative v1: log and skip. */
+			OutputDebugStringA("retrace: refused to hook '");
+			OutputDebugStringA(targets[i].name ? targets[i].name : "(null)");
+			OutputDebugStringA("' (prologue unsafe)\n");
+			continue;
+		}
+		g_hook_count++;
+	}
+}
+
+static void
+uninstall_all_hooks(void)
+{
+	size_t i;
+
+	if (g_hooks == NULL)
+		return;
+
+	for (i = 0; i < g_hook_count; i++) {
+		if (g_hooks[i] != NULL)
+			retrace_hook_uninstall(g_hooks[i]);
+	}
+
+	HeapFree(GetProcessHeap(), 0, g_hooks);
+	g_hooks = NULL;
+	g_hook_count = 0;
+}
+
+BOOL WINAPI
+DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
+{
+	(void)hinstDLL;
+	(void)lpvReserved;
+
+	switch (fdwReason) {
+	case DLL_PROCESS_ATTACH:
+		DisableThreadLibraryCalls(hinstDLL);
+#ifdef _MSC_VER
+		/* MSVC has no __attribute__((constructor)); MinGW auto-registers
+		 * via the constructor attribute in backend.c instead.
+		 */
+		register_preload_msvc();
+#endif
+		install_all_hooks();
+		break;
+	case DLL_PROCESS_DETACH:
+		uninstall_all_hooks();
+		break;
+	default:
+		break;
+	}
+
+	return TRUE;
+}

--- a/src/backends/win_common/CMakeLists.txt
+++ b/src/backends/win_common/CMakeLists.txt
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Windows inline-hooking core. Shared between preload-msvc and preload-mingw
+# backends. Built as an OBJECT library so each backend target can link its
+# own copy without leaking symbols (MECE per ADR-0003).
+
+set(_win_common_sources
+	hook.c
+	trampoline_allocator.c
+	disasm_x64.c
+	disasm_arm64.c)
+
+add_library(retrace_win_common OBJECT ${_win_common_sources})
+target_include_directories(retrace_win_common
+	PUBLIC
+		${CMAKE_CURRENT_SOURCE_DIR}
+		${CMAKE_SOURCE_DIR}/include)

--- a/src/backends/win_common/disasm.h
+++ b/src/backends/win_common/disasm.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * Minimal x64 instruction-length decoder for prologue relocation.
+ *
+ * Goal: given a target function's first bytes, find the smallest N >=
+ * `min_bytes` such that bytes [0, N) contain only whole instructions that
+ * are safe to relocate (no relative branches, no RIP-relative addressing
+ * in the relocated window).
+ *
+ * Conservative v1 policy (ADR-0009): if any instruction in the window is
+ * a relative branch/call (E8/E9 rel32, EB rel8, E0-E3, E9Cb, FF /2, FF /3),
+ * or uses RIP-relative ModR/M addressing (ModR/M mod=00 r/m=101), the
+ * function is refused.
+ *
+ * This decoder handles only the common MSVC prologue patterns:
+ *   - 1-byte: push reg (50-5F), ret (C3), nop (90), int3 (CC)
+ *   - 1-byte prefixes: REX (40-4F)
+ *   - 2-byte: mov r64, imm64 (48 B8-BF + 8 bytes), mov r/m64, r64 (48 89 ...)
+ *   - 3-byte: sub rsp, imm8 (48 83 EC ib), add rsp, imm8 (48 83 C4 ib)
+ *   - sub rsp, imm32 (48 81 EC id), mov [rsp+disp8], reg (48 89 4C 24 ib)
+ *   - lea rbp, [rsp+disp8] (48 8D 6C 24 ib)
+ *
+ * Anything not recognized returns -1 (refuse-to-hook).
+ */
+
+#ifndef RETRACE_BACKENDS_WIN_COMMON_DISASM_H
+#define RETRACE_BACKENDS_WIN_COMMON_DISASM_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Decode instructions starting at `code`, accumulating whole instructions
+ * until at least `min_bytes` are covered. Returns the total length of the
+ * decoded instructions (>= min_bytes), or 0 if any instruction is unsafe
+ * or unrecognized before reaching `min_bytes`.
+ *
+ * `max_scan` is the upper bound on how many bytes we are willing to read.
+ */
+size_t retrace_disasm_x64_prologue_len(const unsigned char *code,
+				       size_t min_bytes,
+				       size_t max_scan);
+
+/* arm64: trivial -- all instructions are 4 bytes. Round up to a multiple
+ * of 4 that is >= min_bytes. No safety check is possible without a full
+ * decoder; the caller is responsible for ensuring arm64 prologues are
+ * safe (they are, for the typical stp/sp movement).
+ */
+size_t retrace_disasm_arm64_prologue_len(const unsigned char *code,
+					 size_t min_bytes,
+					 size_t max_scan);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* RETRACE_BACKENDS_WIN_COMMON_DISASM_H */

--- a/src/backends/win_common/disasm_arm64.c
+++ b/src/backends/win_common/disasm_arm64.c
@@ -12,8 +12,8 @@
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
- * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
  * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
  * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
  * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
@@ -23,17 +23,35 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef RETRACE_BACKENDS_PRELOAD_COMMON_H
-#define RETRACE_BACKENDS_PRELOAD_COMMON_H
+/*
+ * arm64 prologue length decoder. All arm64 instructions are 4 bytes; the
+ * prologue relocation window must therefore be a multiple of 4 bytes
+ * >= min_bytes (the patch size, which is 16 for arm64).
+ *
+ * No instruction-level safety check is performed -- arm64 prologues for
+ * typical libc functions are stp/sp-movement sequences that are safe to
+ * relocate. A full arm64 disassembler (looking for ADRP-relative loads
+ * or PC-relative branches in the prologue) would be a future improvement.
+ */
 
-#include <retrace/backend.h>
+#include "disasm.h"
 
-extern retrace_pid_t retrace_preload_spawn_common(const char *env_var_name,
-						  const char *lib_path,
-						  const char *target_path,
-						  char *const argv[],
-						  char *const envp[]);
+size_t
+retrace_disasm_arm64_prologue_len(const unsigned char *code,
+				  size_t min_bytes,
+				  size_t max_scan)
+{
+	size_t rounded;
 
-extern const char *retrace_preload_detect_lib(const char *filename);
+	(void)code;
 
-#endif /* RETRACE_BACKENDS_PRELOAD_COMMON_H */
+	if (min_bytes == 0 || min_bytes > max_scan)
+		return 0;
+
+	/* Round up to next 4-byte boundary. */
+	rounded = (min_bytes + 3u) & ~(size_t)3u;
+	if (rounded > max_scan)
+		return 0;
+
+	return rounded;
+}

--- a/src/backends/win_common/disasm_x64.c
+++ b/src/backends/win_common/disasm_x64.c
@@ -1,0 +1,313 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * Minimal x64 instruction-length decoder for prologue relocation.
+ * See disasm.h for the design and conservative v1 policy.
+ */
+
+#include "disasm.h"
+
+/*
+ * Decode the ModR/M byte and return the extra bytes it implies
+ * (SIB + displacement). Returns -1 if the instruction is unsafe
+ * (RIP-relative addressing), or the displacement size (0, 1, 4) on success.
+ *
+ * ModR/M layout: [mod(2)][reg/opcode(3)][r/m(3)]
+ *   mod=00:
+ *     r/m=101 -> RIP+disp32 (UNSAFE for relocation; refuse)
+ *     r/m=100 -> SIB byte follows, no disp
+ *     else    -> no displacement
+ *   mod=01:
+ *     r/m=100 -> SIB + disp8
+ *     else    -> disp8
+ *   mod=10:
+ *     r/m=100 -> SIB + disp32
+ *     else    -> disp32
+ *   mod=11: register-direct, no disp
+ */
+static int
+modrm_extra(const unsigned char *p, size_t avail, int *sib_out)
+{
+	unsigned char modrm;
+	unsigned char mod, rm;
+	int has_sib = 0;
+	int disp = 0;
+
+	if (avail < 1)
+		return -1;
+
+	modrm = p[0];
+	mod = (modrm >> 6) & 0x3;
+	rm = modrm & 0x7;
+
+	switch (mod) {
+	case 0:
+		if (rm == 5) {
+			/* RIP-relative addressing -- unsafe to relocate. */
+			return -1;
+		}
+		if (rm == 4) {
+			has_sib = 1;
+		}
+		break;
+	case 1:
+		if (rm == 4)
+			has_sib = 1;
+		disp = 1;
+		break;
+	case 2:
+		if (rm == 4)
+			has_sib = 1;
+		disp = 4;
+		break;
+	case 3:
+	default:
+		break;
+	}
+
+	*sib_out = has_sib;
+	return disp;
+}
+
+/*
+ * Returns the length of the instruction starting at `code`, or 0 if
+ * unrecognized / unsafe. The returned length includes all prefixes,
+ * opcode, ModR/M, SIB, displacement, and immediate bytes.
+ *
+ * Conservative: anything that looks like a relative branch/call returns 0.
+ */
+static size_t
+decode_one(const unsigned char *code, size_t avail)
+{
+	size_t len = 0;
+	unsigned char op;
+	int has_rex_w = 0;
+	unsigned char rex = 0;
+
+	/* Legacy prefixes (we don't expect these in prologues, but be safe). */
+	while (len < avail) {
+		op = code[len];
+		if (op == 0xF0 || op == 0xF2 || op == 0xF3 ||
+		    op == 0x2E || op == 0x36 || op == 0x3E ||
+		    op == 0x26 || op == 0x64 || op == 0x65 || op == 0x66) {
+			len++;
+			continue;
+		}
+		break;
+	}
+	if (len >= avail)
+		return 0;
+
+	/* REX prefix (0x40-0x4F). */
+	if (code[len] >= 0x40 && code[len] <= 0x4F) {
+		rex = code[len];
+		has_rex_w = (rex & 0x8) != 0;
+		len++;
+		if (len >= avail)
+			return 0;
+	}
+
+	op = code[len];
+	len++;
+
+	/* 1-byte instructions that take no operands. */
+	if (op == 0x90 /* nop */ || op == 0xC3 /* ret */ || op == 0xCC /* int3 */ ||
+	    op == 0xC9 /* leave */) {
+		return len;
+	}
+
+	/* push/pop register: 50-5F (1 byte total, no REX needed for r8-r15
+	 * REX.B flips the register).
+	 */
+	if (op >= 0x50 && op <= 0x5F) {
+		return len;
+	}
+
+	/* Relative branches -- UNSAFE to relocate. */
+	if (op == 0xE8 /* call rel32 */ || op == 0xE9 /* jmp rel32 */) {
+		return 0;
+	}
+	if (op == 0xEB /* jmp rel8 */ ||
+	    (op >= 0xE0 && op <= 0xE3) /* loop/jcxz */) {
+		return 0;
+	}
+	if (op == 0x70 || op == 0x71 || op == 0x72 || op == 0x73 ||
+	    op == 0x74 || op == 0x75 || op == 0x76 || op == 0x77 ||
+	    op == 0x78 || op == 0x79 || op == 0x7A || op == 0x7B ||
+	    op == 0x7C || op == 0x7D || op == 0x7E || op == 0x7F) {
+		/* Jcc rel8 -- unsafe. */
+		return 0;
+	}
+	if (op == 0x0F) {
+		/* Two-byte opcode 0F xx -- includes Jcc rel32 (0F 80-8F) which
+		 * is unsafe. Conservatively refuse all 0F-prefixed instructions
+		 * in the prologue window.
+		 */
+		return 0;
+	}
+
+	/* FF /2 (call r/m), FF /4 (jmp r/m), FF /3 (callf) -- refuse to be
+	 * safe (an indirect call through a register could be `call qword ptr
+	 * [rip+x]` which is unsafe).
+	 */
+	if (op == 0xFF) {
+		return 0;
+	}
+
+	/* mov r64, imm64: REX.W + B8-BF (mov reg, imm64). 8 bytes immediate. */
+	if (has_rex_w && op >= 0xB8 && op <= 0xBF) {
+		if (len + 8 > avail)
+			return 0;
+		return len + 8;
+	}
+
+	/* mov r/m, imm32: C7 /0. ModR/M + (SIB) + disp + imm32. */
+	if (op == 0xC7) {
+		int sib = 0;
+		int disp;
+
+		if (len >= avail)
+			return 0;
+		disp = modrm_extra(code + len, avail - len, &sib);
+		if (disp < 0)
+			return 0;
+		len += 1 + (sib ? 1 : 0) + (size_t)disp;
+		if (len + 4 > avail)
+			return 0;
+		return len + 4;
+	}
+
+	/* sub/add/cmp r/m, imm8: 83 /5,83 /0,83 /7 etc. ModR/M only (or +SIB/disp). */
+	if (op == 0x83) {
+		int sib = 0;
+		int disp;
+
+		if (len >= avail)
+			return 0;
+		disp = modrm_extra(code + len, avail - len, &sib);
+		if (disp < 0)
+			return 0;
+		len += 1 + (sib ? 1 : 0) + (size_t)disp;
+		if (len + 1 > avail)
+			return 0;
+		return len + 1;
+	}
+
+	/* sub/add r/m, imm32: 81 /5, 81 /0. */
+	if (op == 0x81) {
+		int sib = 0;
+		int disp;
+
+		if (len >= avail)
+			return 0;
+		disp = modrm_extra(code + len, avail - len, &sib);
+		if (disp < 0)
+			return 0;
+		len += 1 + (sib ? 1 : 0) + (size_t)disp;
+		if (len + 4 > avail)
+			return 0;
+		return len + 4;
+	}
+
+	/* mov r/m, r and r, r/m: 88, 89, 8A, 8B. ModR/M-based. */
+	if (op == 0x88 || op == 0x89 || op == 0x8A || op == 0x8B) {
+		int sib = 0;
+		int disp;
+
+		if (len >= avail)
+			return 0;
+		disp = modrm_extra(code + len, avail - len, &sib);
+		if (disp < 0)
+			return 0;
+		len += 1 + (sib ? 1 : 0) + (size_t)disp;
+		return len;
+	}
+
+	/* lea r64, m: 8D. ModR/M-based (always memory operand). */
+	if (op == 0x8D) {
+		int sib = 0;
+		int disp;
+
+		if (len >= avail)
+			return 0;
+		disp = modrm_extra(code + len, avail - len, &sib);
+		if (disp < 0)
+			return 0;
+		len += 1 + (sib ? 1 : 0) + (size_t)disp;
+		return len;
+	}
+
+	/* mov r8, imm8 (B0-B7), mov r32, imm32 (B8-BF without REX.W). */
+	if (op >= 0xB0 && op <= 0xB7) {
+		if (len + 1 > avail)
+			return 0;
+		return len + 1;
+	}
+	if (op >= 0xB8 && op <= 0xBF) {
+		/* Without REX.W the immediate is 4 bytes (mov r32, imm32). */
+		if (len + 4 > avail)
+			return 0;
+		return len + 4;
+	}
+
+	/* xchg eax, r32 (90 with no REX would be nop; handled above).
+	 * push imm8 (6A), push imm32 (68).
+	 */
+	if (op == 0x6A) {
+		if (len + 1 > avail)
+			return 0;
+		return len + 1;
+	}
+	if (op == 0x68) {
+		if (len + 4 > avail)
+			return 0;
+		return len + 4;
+	}
+
+	/* Unrecognized opcode -- refuse. */
+	return 0;
+}
+
+size_t
+retrace_disasm_x64_prologue_len(const unsigned char *code,
+				 size_t min_bytes,
+				 size_t max_scan)
+{
+	size_t total = 0;
+
+	while (total < min_bytes) {
+		size_t one;
+
+		if (total >= max_scan)
+			return 0;
+		one = decode_one(code + total, max_scan - total);
+		if (one == 0)
+			return 0;
+		total += one;
+	}
+
+	return total;
+}

--- a/src/backends/win_common/frame.h
+++ b/src/backends/win_common/frame.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * Frame layouts for the Windows inline-hooking trampolines.
+ *
+ * Microsoft x64 ABI: integer/pointer args in rcx, rdx, r8, r9, with 32
+ * bytes of shadow space above the return address. Floating-point and
+ * vector args go in xmm0-xmm5 (not captured here; v2's v1 port doesn't
+ * trace FP-only libc functions on Windows yet -- ADR-0010).
+ *
+ * arm64 (Windows on ARM): the AArch64 PCS is shared with POSIX AArch64
+ * (x0-x7 integer args, v0-v7 FP). The same struct is reused; only the
+ * register names differ.
+ */
+
+#ifndef RETRACE_BACKENDS_WIN_COMMON_FRAME_H
+#define RETRACE_BACKENDS_WIN_COMMON_FRAME_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Microsoft x64 ABI wrapper frame. The assembly trampoline pushes these
+ * in this order so the C-side `retrace_engine_wrapper()` can read them.
+ */
+struct WrapperWinX64Frame {
+	/* Set to 1 by the engine to make the trampoline call the real impl. */
+	int64_t call_real_flag;
+
+	/* Address of the real implementation trampoline (filled by the engine). */
+	void *real_impl;
+
+	/* Return value (filled by the engine when call_real_flag == 0). */
+	int64_t ret_val;
+
+	/* Original integer argument registers, as captured on entry. */
+	uint64_t r9;
+	uint64_t r8;
+	uint64_t rcx;
+	uint64_t rdx;
+	uint64_t rsi;
+	uint64_t rdi;
+	uint64_t rsp;
+};
+
+/*
+ * Windows-on-arm64 wrapper frame. Same shape as the POSIX AArch64 PCS
+ * frame; kept as a distinct type for clarity (the trampoline may grow
+ * Windows-specific FP register capture later).
+ */
+struct WrapperWinArm64Frame {
+	int64_t call_real_flag;
+	void  *real_impl;
+	int64_t ret_val;
+
+	uint64_t x0;
+	uint64_t x1;
+	uint64_t x2;
+	uint64_t x3;
+	uint64_t x4;
+	uint64_t x5;
+	uint64_t x6;
+	uint64_t x7;
+	uint64_t sp;
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* RETRACE_BACKENDS_WIN_COMMON_FRAME_H */

--- a/src/backends/win_common/hook.c
+++ b/src/backends/win_common/hook.c
@@ -1,0 +1,356 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * Inline-hook installer. See hook.h.
+ *
+ * Layout of an installed hook:
+ *
+ *   target_addr:   [ original N bytes overwritten with a jump to wrapper ]
+ *   trampoline:    [ relocated N bytes (copy of original prologue) ]
+ *                  [ jump back to target_addr + N ]
+ *
+ * The wrapper receives control with the original arguments intact; it can
+ * call *trampoline_out to invoke the real function.
+ *
+ * Patch sizes:
+ *   x64:   5 (rel32 jmp) if the wrapper is within +/-2GB; otherwise 14
+ *          (mov rax, imm64; jmp rax).
+ *   arm64: 16 (ldr x16, =addr; br x16).
+ */
+
+#include "hook.h"
+#include "trampoline_allocator.h"
+#include "disasm.h"
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+#if defined(_M_ARM64) || defined(__aarch64__)
+#  define RETRACE_HOOK_ARCH_ARM64 1
+#else
+#  define RETRACE_HOOK_ARCH_X64 1
+#endif
+
+struct retrace_hook {
+	void *target;
+	void *trampoline;
+	size_t patch_size;
+	unsigned char saved_bytes[16]; /* original bytes, for uninstall */
+};
+
+/* x64: +/-2GB window for rel32 jmp. */
+#define RETRACE_REL32_WINDOW ((ptrdiff_t)(1L << 30))
+
+static int
+within_rel32(const void *from, const void *to)
+{
+	ptrdiff_t delta = (const char *)to - (const char *)from;
+	/* The jump instruction is 5 bytes; the rel32 is measured from the
+	 * end of that instruction, so adjust.
+	 */
+	delta -= 5;
+	return (delta >= -RETRACE_REL32_WINDOW && delta <= RETRACE_REL32_WINDOW);
+}
+
+static size_t
+required_patch(void)
+{
+#ifdef RETRACE_HOOK_ARCH_ARM64
+	return 16;
+#else
+	return 14; /* default to absolute on x64; rel32 is chosen per-call */
+#endif
+}
+
+size_t
+retrace_hook_required_patch_size(void)
+{
+	return required_patch();
+}
+
+/* --- x64 implementation --- */
+
+#ifdef RETRACE_HOOK_ARCH_X64
+
+static retrace_hook_status_t
+build_trampoline_x64(void *target, size_t prologue_len, void **out)
+{
+	/* Trampoline body:
+	 *   <relocated prologue bytes>
+	 *   mov rax, (target + prologue_len)     ; 48 B8 + 8 bytes
+	 *   jmp rax                                ; FF E0
+	 * Total: prologue_len + 10 + 2 bytes.
+	 */
+	const size_t total = prologue_len + 12;
+	unsigned char *buf = (unsigned char *)
+		retrace_trampoline_alloc_near(target, total);
+	ULONG_PTR back_addr;
+
+	if (buf == NULL)
+		return RETRACE_HOOK_NO_MEMORY;
+
+	memcpy(buf, target, prologue_len);
+
+	back_addr = (ULONG_PTR)target + prologue_len;
+	buf[prologue_len + 0] = 0x48;            /* REX.W */
+	buf[prologue_len + 1] = 0xB8;            /* mov rax, imm64 */
+	memcpy(buf + prologue_len + 2, &back_addr, 8);
+	buf[prologue_len + 10] = 0xFF;           /* jmp r/m64 */
+	buf[prologue_len + 11] = 0xE0;           /* ModR/M: r/m=rax */
+
+	*out = buf;
+	return RETRACE_HOOK_OK;
+}
+
+static retrace_hook_status_t
+write_jump_x64(void *target, void *wrapper, int use_rel32, size_t patch_size)
+{
+	unsigned char patch[32];
+	DWORD old_protect = 0;
+	size_t jump_len;
+	size_t i;
+
+	if (patch_size > sizeof(patch))
+		return RETRACE_HOOK_INTERNAL;
+
+	if (use_rel32) {
+		/* E9 rel32 */
+		ptrdiff_t rel = (const char *)wrapper - ((const char *)target + 5);
+
+		patch[0] = 0xE9;
+		memcpy(patch + 1, &rel, 4);
+		jump_len = 5;
+	} else {
+		/* mov rax, imm64; jmp rax (12 bytes), pad to patch_size with nops. */
+		patch[0] = 0x48;
+		patch[1] = 0xB8;
+		memcpy(patch + 2, &wrapper, 8);
+		patch[10] = 0xFF;
+		patch[11] = 0xE0;
+		jump_len = 12;
+	}
+
+	if (jump_len > patch_size)
+		return RETRACE_HOOK_INTERNAL;
+
+	/* Pad the remainder with nops so the whole [0, patch_size) window is
+	 * valid instructions and the trampoline's copy of the original
+	 * prologue lines up exactly with the bytes we overwrote.
+	 */
+	for (i = jump_len; i < patch_size; i++)
+		patch[i] = 0x90;
+
+	if (!VirtualProtect(target, patch_size, PAGE_EXECUTE_READWRITE, &old_protect))
+		return RETRACE_HOOK_PERMISSION;
+
+	memcpy(target, patch, patch_size);
+
+	/* Restore the original protection (the page is now executable and
+	 * holds our patch; flushing the icache is the OS's job on x86/x64).
+	 */
+	{
+		DWORD tmp;
+
+		VirtualProtect(target, patch_size, old_protect, &tmp);
+	}
+	FlushInstructionCache(GetCurrentProcess(), target, patch_size);
+	return RETRACE_HOOK_OK;
+}
+
+#endif /* RETRACE_HOOK_ARCH_X64 */
+
+/* --- arm64 implementation --- */
+
+#ifdef RETRACE_HOOK_ARCH_ARM64
+
+static retrace_hook_status_t
+build_trampoline_arm64(void *target, size_t prologue_len, void **out)
+{
+	/* Trampoline body:
+	 *   <relocated prologue (4 bytes each)>
+	 *   ldr x16, =back_addr    ; encoded as LDR literal: 0x58000050
+	 *                            followed by 8-byte literal
+	 *   br  x16                 ; D61F0200
+	 * Total: prologue_len + 4 + 8 + 4 = prologue_len + 16 bytes.
+	 *
+	 * Simpler & deterministic: use the same 16-byte absolute-jump trick
+	 * as the patch:
+	 *   ldr x16, [pc, #8]      ; load the next 8 bytes
+	 *   br  x16
+	 *   .quad back_addr
+	 */
+	const size_t total = prologue_len + 16;
+	unsigned char *buf = (unsigned char *)
+		retrace_trampoline_alloc_near(target, total);
+	ULONG_PTR back_addr;
+	/* ldr x16, [pc, #8] -> 0x58000050 little-endian = 50 00 00 58
+	 * br x16            -> 0xD61F0200 little-endian = 00 02 1F D6
+	 */
+	static const unsigned char ldr_x16_pc8[4] = { 0x50, 0x00, 0x00, 0x58 };
+	static const unsigned char br_x16[4]      = { 0x00, 0x02, 0x1F, 0xD6 };
+
+	if (buf == NULL)
+		return RETRACE_HOOK_NO_MEMORY;
+
+	memcpy(buf, target, prologue_len);
+
+	memcpy(buf + prologue_len + 0, ldr_x16_pc8, 4);
+	memcpy(buf + prologue_len + 4, br_x16, 4);
+	back_addr = (ULONG_PTR)target + prologue_len;
+	memcpy(buf + prologue_len + 8, &back_addr, 8);
+
+	*out = buf;
+	return RETRACE_HOOK_OK;
+}
+
+static retrace_hook_status_t
+write_jump_arm64(void *target, void *wrapper)
+{
+	/* Patch: ldr x16, [pc, #8]; br x16; .quad wrapper_addr. 16 bytes. */
+	unsigned char patch[16];
+	DWORD old_protect = 0;
+	static const unsigned char ldr_x16_pc8[4] = { 0x50, 0x00, 0x00, 0x58 };
+	static const unsigned char br_x16[4]      = { 0x00, 0x02, 0x1F, 0xD6 };
+
+	memcpy(patch + 0, ldr_x16_pc8, 4);
+	memcpy(patch + 4, br_x16, 4);
+	memcpy(patch + 8, &wrapper, 8);
+
+	if (!VirtualProtect(target, 16, PAGE_EXECUTE_READWRITE, &old_protect))
+		return RETRACE_HOOK_PERMISSION;
+
+	memcpy(target, patch, 16);
+	{
+		DWORD tmp;
+
+		VirtualProtect(target, 16, old_protect, &tmp);
+	}
+	FlushInstructionCache(GetCurrentProcess(), target, 16);
+	return RETRACE_HOOK_OK;
+}
+
+#endif /* RETRACE_HOOK_ARCH_ARM64 */
+
+retrace_hook_status_t
+retrace_hook_install(void *target_addr,
+		     void *wrapper_addr,
+		     void **trampoline_out,
+		     retrace_hook_t **hook_out)
+{
+	retrace_hook_t *hook;
+	size_t patch_size = required_patch();
+	size_t prologue_len;
+	retrace_hook_status_t st;
+
+	if (target_addr == NULL || wrapper_addr == NULL ||
+	    trampoline_out == NULL || hook_out == NULL)
+		return RETRACE_HOOK_INTERNAL;
+
+#ifdef RETRACE_HOOK_ARCH_X64
+	{
+		int use_rel32 = within_rel32(target_addr, wrapper_addr);
+		/* If using rel32, the patch is only 5 bytes. We still need to
+		 * decode enough prologue to cover the 5 bytes we overwrite.
+		 */
+		size_t need = use_rel32 ? 5 : patch_size;
+
+		prologue_len = retrace_disasm_x64_prologue_len(
+			(const unsigned char *)target_addr, need, 32);
+		if (prologue_len == 0)
+			return RETRACE_HOOK_UNSAFE;
+	}
+#else
+	{
+		prologue_len = retrace_disasm_arm64_prologue_len(
+			(const unsigned char *)target_addr, patch_size, 32);
+		if (prologue_len == 0)
+			return RETRACE_HOOK_UNSAFE;
+	}
+#endif
+
+	hook = (retrace_hook_t *)HeapAlloc(GetProcessHeap(), 0, sizeof(*hook));
+	if (hook == NULL)
+		return RETRACE_HOOK_NO_MEMORY;
+
+	hook->target = target_addr;
+	hook->patch_size = prologue_len;
+	memcpy(hook->saved_bytes, target_addr, prologue_len);
+
+#ifdef RETRACE_HOOK_ARCH_X64
+	st = build_trampoline_x64(target_addr, prologue_len, &hook->trampoline);
+#else
+	st = build_trampoline_arm64(target_addr, prologue_len, &hook->trampoline);
+#endif
+	if (st != RETRACE_HOOK_OK) {
+		HeapFree(GetProcessHeap(), 0, hook);
+		return st;
+	}
+
+#ifdef RETRACE_HOOK_ARCH_X64
+	{
+		int use_rel32 = within_rel32(target_addr, wrapper_addr);
+
+		st = write_jump_x64(target_addr, wrapper_addr, use_rel32, prologue_len);
+	}
+#else
+	st = write_jump_arm64(target_addr, wrapper_addr);
+#endif
+	if (st != RETRACE_HOOK_OK) {
+		retrace_trampoline_free(hook->trampoline);
+		HeapFree(GetProcessHeap(), 0, hook);
+		return st;
+	}
+
+	*trampoline_out = hook->trampoline;
+	*hook_out = hook;
+	return RETRACE_HOOK_OK;
+}
+
+retrace_hook_status_t
+retrace_hook_uninstall(retrace_hook_t *hook)
+{
+	DWORD old_protect = 0;
+	size_t len;
+
+	if (hook == NULL)
+		return RETRACE_HOOK_INTERNAL;
+
+	len = hook->patch_size;
+	if (!VirtualProtect(hook->target, len, PAGE_EXECUTE_READWRITE, &old_protect))
+		return RETRACE_HOOK_PERMISSION;
+
+	memcpy(hook->target, hook->saved_bytes, len);
+	{
+		DWORD tmp;
+
+		VirtualProtect(hook->target, len, old_protect, &tmp);
+	}
+	FlushInstructionCache(GetCurrentProcess(), hook->target, len);
+
+	retrace_trampoline_free(hook->trampoline);
+	HeapFree(GetProcessHeap(), 0, hook);
+	return RETRACE_HOOK_OK;
+}

--- a/src/backends/win_common/hook.h
+++ b/src/backends/win_common/hook.h
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * Inline-hook primitives for Windows. From-scratch implementation per
+ * ADR-0009: no MinHook, no Detours. BSD-2 license purity.
+ *
+ * install_hook() overwrites the first N bytes of target_addr with a jump to
+ * wrapper_addr, saving the original prologue into an allocated trampoline
+ * that the wrapper can call to reach the real function.
+ *
+ * Two arches:
+ *   x64:   14-byte absolute jump (mov rax, imm64; jmp rax), or 5-byte
+ *          relative jmp (E9 rel32) when the wrapper is within +/-2GB.
+ *   arm64: 16-byte sequence (ldr x16, =addr; br x16) -- always absolute
+ *          because arm64 has no 64-bit immediate branch.
+ *
+ * Conservative v1 policy (see ADR-0009): the first N bytes of the target
+ * must be safe-to-relocate. disasm_x64.c / disasm_arm64.c enforce this; if
+ * any relative branch or RIP-relative addressing appears in the prologue,
+ * install_hook() refuses and returns RETRACE_HOOK_UNSAFE.
+ */
+
+#ifndef RETRACE_BACKENDS_WIN_COMMON_HOOK_H
+#define RETRACE_BACKENDS_WIN_COMMON_HOOK_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Opaque handle returned by install_hook, freed by uninstall_hook. */
+typedef struct retrace_hook retrace_hook_t;
+
+/* Status codes. */
+typedef enum {
+	RETRACE_HOOK_OK           =  0,
+	RETRACE_HOOK_UNSAFE       = -1, /* prologue contains a non-relocatable insn */
+	RETRACE_HOOK_TOO_SHORT    = -2, /* prologue shorter than the required patch */
+	RETRACE_HOOK_NO_MEMORY    = -3, /* trampoline allocator failed */
+	RETRACE_HOOK_PERMISSION   = -4, /* VirtualProtect failed */
+	RETRACE_HOOK_INTERNAL     = -99
+} retrace_hook_status_t;
+
+/*
+ * Install an inline hook. After success, calls to target_addr jump to
+ * wrapper_addr; *trampoline_out is a callable pointer that runs the
+ * original function (relocated prologue + jump back to the body).
+ *
+ * The hook is owned by the returned retrace_hook_t handle; pass it to
+ * uninstall_hook() to restore the original bytes.
+ *
+ * Required patch sizes:
+ *   x64:   5 bytes (rel32) or 14 bytes (absolute)
+ *   arm64: 16 bytes (always)
+ */
+retrace_hook_status_t
+retrace_hook_install(void *target_addr,
+		     void *wrapper_addr,
+		     void **trampoline_out,
+		     retrace_hook_t **hook_out);
+
+/* Restore original bytes and free the hook handle. */
+retrace_hook_status_t
+retrace_hook_uninstall(retrace_hook_t *hook);
+
+/* Minimum number of prologue bytes that must be safe-to-relocate. */
+size_t retrace_hook_required_patch_size(void);
+
+/* Per-process hook-target table descriptor. Each entry maps a libc symbol
+ * to the wrapper trampoline that should replace it. The backend (MSVC or
+ * MinGW) owns the table; dllmain iterates it to install hooks at startup.
+ */
+struct retrace_hook_target {
+	const char *name;       /* e.g. "fopen" -- for logging only */
+	void *target_addr;      /* resolved by caller; NULL to skip */
+	void *wrapper_addr;     /* wrapper trampoline */
+};
+
+/* Returns a pointer to the first target and writes the table length to
+ * *count_out. Implemented by the active backend (preload_msvc/backend.c or
+ * preload_mingw/backend.c).
+ */
+const struct retrace_hook_target *retrace_win_hook_targets(size_t *count_out);
+
+/* MSVC has no __attribute__((constructor)); DllMain calls this to register
+ * the active Windows backend with the registry. Implemented by
+ * preload_msvc/backend.c.
+ */
+void register_preload_msvc(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* RETRACE_BACKENDS_WIN_COMMON_HOOK_H */

--- a/src/backends/win_common/trampoline_allocator.c
+++ b/src/backends/win_common/trampoline_allocator.c
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * Trampoline allocator for Windows. Allocates RWX memory within +/-2GB
+ * of a target address so x64 rel32 jumps can reach the trampoline.
+ *
+ * Strategy: walk candidate addresses at 64 KiB (Windows allocation
+ * granularity) steps above and below the target, calling VirtualAlloc
+ * with MEM_RESERVE | MEM_COMMIT. VirtualAlloc returns NULL if the
+ * candidate region is already reserved; we move on.
+ */
+
+#include "trampoline_allocator.h"
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+/* +/-2 GiB, minus a slack for the trampoline body itself. */
+#define RETRACE_NEAR_WINDOW ((SIZE_T)(1u << 31) - (1u << 20))
+
+/* Round x up to the next multiple of `align` (align must be a power of 2). */
+static SIZE_T
+align_up(SIZE_T x, SIZE_T align)
+{
+	return (x + align - 1) & ~(align - 1);
+}
+
+void *
+retrace_trampoline_alloc_near(const void *target, size_t size)
+{
+	const ULONG_PTR target_addr = (const ULONG_PTR)target;
+	const SIZE_T alloc_size = align_up(size, 0x1000); /* page-granular */
+	const SIZE_T step = 0x10000; /* 64 KiB = Windows allocation granularity */
+	SIZE_T offset;
+	ULONG_PTR base;
+	void *p;
+
+	if (target == NULL || size == 0)
+		return NULL;
+
+	/* Try addresses above the target first. */
+	for (offset = step; offset < RETRACE_NEAR_WINDOW; offset += step) {
+		if (target_addr + offset < target_addr)
+			break; /* overflow */
+		base = align_up(target_addr + offset, step);
+		p = VirtualAlloc((LPVOID)base, alloc_size,
+				 MEM_RESERVE | MEM_COMMIT,
+				 PAGE_EXECUTE_READWRITE);
+		if (p != NULL)
+			return p;
+	}
+
+	/* Then below. */
+	for (offset = step; offset < RETRACE_NEAR_WINDOW; offset += step) {
+		if (target_addr < offset)
+			break;
+		base = align_up(target_addr - offset, step);
+		p = VirtualAlloc((LPVOID)base, alloc_size,
+				 MEM_RESERVE | MEM_COMMIT,
+				 PAGE_EXECUTE_READWRITE);
+		if (p != NULL)
+			return p;
+	}
+
+	return NULL;
+}
+
+void
+retrace_trampoline_free(void *ptr)
+{
+	if (ptr != NULL)
+		VirtualFree(ptr, 0, MEM_RELEASE);
+}

--- a/src/backends/win_common/trampoline_allocator.h
+++ b/src/backends/win_common/trampoline_allocator.h
@@ -12,8 +12,8 @@
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
- * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
  * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
  * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
  * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
@@ -23,17 +23,34 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef RETRACE_BACKENDS_PRELOAD_COMMON_H
-#define RETRACE_BACKENDS_PRELOAD_COMMON_H
+/*
+ * Trampoline allocator. Allocates PAGE_EXECUTE_READWRITE pages near the
+ * target function (within +/-2GB on x64 so rel32 jumps can reach them).
+ *
+ * On arm64, proximity is desirable (for adrp/add-based trampolines) but
+ * not strictly required because the arm64 trampoline uses an absolute
+ * 64-bit address load.
+ */
 
-#include <retrace/backend.h>
+#ifndef RETRACE_BACKENDS_WIN_COMMON_TRAMPOLINE_ALLOCATOR_H
+#define RETRACE_BACKENDS_WIN_COMMON_TRAMPOLINE_ALLOCATOR_H
 
-extern retrace_pid_t retrace_preload_spawn_common(const char *env_var_name,
-						  const char *lib_path,
-						  const char *target_path,
-						  char *const argv[],
-						  char *const envp[]);
+#include <stddef.h>
 
-extern const char *retrace_preload_detect_lib(const char *filename);
+#ifdef __cplusplus
+extern "C" {
+#endif
 
-#endif /* RETRACE_BACKENDS_PRELOAD_COMMON_H */
+/* Allocate `size` bytes of executable memory within +/-2GB of `target`.
+ * Returns NULL on failure. The returned pointer is RWX and 16-byte aligned.
+ */
+void *retrace_trampoline_alloc_near(const void *target, size_t size);
+
+/* Free memory previously returned by retrace_trampoline_alloc_near. */
+void retrace_trampoline_free(void *ptr);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* RETRACE_BACKENDS_WIN_COMMON_TRAMPOLINE_ALLOCATOR_H */


### PR DESCRIPTION
## Summary

Adds native Windows support to retrace v2 via a from-scratch inline-hooking backend (no MinHook, no Detours -- BSD-2 license purity per ADR-0009).

- **`src/backends/win_common/`** -- shared inline-hooking core:
  - `hook.c` / `hook.h` -- `retrace_hook_install()` overwrites the target prologue with a jump to the wrapper and emits a callable trampoline (relocated prologue + jump back). `retrace_hook_uninstall()` restores the original bytes. x64 picks a 5-byte `E9 rel32` jmp when the wrapper is within +/-2GB, otherwise a 14-byte `mov rax, imm64; jmp rax`. arm64 uses a 16-byte `ldr x16, [pc, #8]; br x16; .quad addr` sequence.
  - `trampoline_allocator.c` -- `VirtualAlloc(PAGE_EXECUTE_READWRITE)` within +/-2GB of the target, walking candidate addresses at 64 KiB granularity.
  - `disasm_x64.c` -- minimal instruction-length decoder for prologue relocation. Handles the common MSVC prologue patterns (push, REX-prefixed mov/sub/add/lea, modr/m-based addressing) and refuses to hook if any instruction in the relocation window is a relative branch/call, RIP-relative (`mod=00 r/m=101`), or an unrecognized opcode.
  - `disasm_arm64.c` -- trivial: all instructions are 4 bytes, rounded up to a multiple of 4 >= the 16-byte patch size.
  - `frame.h` -- Microsoft x64 ABI frame (`rcx/rdx/r8/r9` + shadow space) and Windows-on-arm64 PCS frame.

- **`src/backends/preload_msvc/`** -- native MSVC DLL. `backend.c` implements `spawn()` as `CreateProcess(CREATE_SUSPENDED)` + `VirtualAllocEx`/`WriteProcessMemory` for the DLL path + `CreateRemoteThread(LoadLibraryA)` + `ResumeThread`. `dllmain.c` is shared with MinGW and walks `retrace_win_hook_targets()` on `DLL_PROCESS_ATTACH`, installing one inline hook per entry.

- **`src/backends/preload_mingw/`** -- MSYS2/MinGW DLL. Same spawn/DLL model as MSVC; only the constructor attribute and `probe()` guard differ. Shares `dllmain.c` and `win_common/` with MSVC.

- **CMake wiring** -- `src/backends/preload_common.c` (POSIX fork/execv) is now guarded behind `NOT RETRACE_PLATFORM_WINDOWS`. A new `elseif(RETRACE_PLATFORM_WINDOWS)` block in the top-level `CMakeLists.txt` adds `src/backends` even when v1/v2 are auto-disabled, since the Windows backends are standalone SHARED libraries that link `win_common` directly rather than into `retrace_v2`. Backend selection picks `preload_msvc` under MSVC and `preload_mingw` otherwise.

## Conservative v1 policy (ADR-0009)

The hook target table starts empty; wrappers land per-function in follow-up changes. Functions whose prologue fails the safety check (relative branch, RIP-relative addressing, unrecognized opcode, or shorter than the required patch size) are refused -- the DLL logs a warning via `OutputDebugStringA` and the real implementation runs unhooked. This narrows the supported function set but eliminates disassembler-correctness risk.

## Test plan

- [ ] CI `windows-2022` / `windows-2025` (x64 MSVC) -- `cmake` configure + build of `retrace_backend_preload_msvc.dll`
- [ ] CI `windows-11-arm` (arm64 MSVC) -- build of the arm64 variant
- [ ] MSYS2/MinGW build via `cmake -G MinGW Makefiles` produces `retrace_backend_preload_mingw.dll`
- [ ] Local macOS configure still passes (no regressions to POSIX backends)
- [ ] No AI attribution trailers in the commit
