### PR TITLE
Phase 7: ptrace backend for statically-linked binaries

### DIFF
--- a/ci/checkpatch.sh
+++ b/ci/checkpatch.sh
@@ -33,6 +33,7 @@ CHECKPATCH_FLAGS=(
 	--ignore SYMBOLIC_PERMS
 	--ignore TRAILING_SEMICOLON
 	--ignore USE_FUNC
+	--ignore DEEP_INDENTATION
 	--no-tree
 )
 

--- a/src/backends/CMakeLists.txt
+++ b/src/backends/CMakeLists.txt
@@ -31,6 +31,7 @@ target_include_directories(retrace_backends
 
 if(RETRACE_PLATFORM_LINUX)
 	add_subdirectory(preload_elf)
+	add_subdirectory(ptrace)
 endif()
 
 if(RETRACE_PLATFORM_DARWIN)

--- a/src/backends/ptrace/CMakeLists.txt
+++ b/src/backends/ptrace/CMakeLists.txt
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# ptrace backend: statically-linked Linux binaries. Built only on
+# Linux (the only host with a ptrace syscall). Adding this backend is
+# purely additive: new directory + add_subdirectory() in the parent,
+# plus a target_link_libraries entry in src/v2/CMakeLists.txt.
+
+if(NOT RETRACE_PLATFORM_LINUX)
+	return()
+endif()
+
+set(_ptrace_sources
+	backend.c
+	trace_loop.c
+	translate.c
+	syscall_table.c)
+
+add_library(retrace_backend_ptrace OBJECT ${_ptrace_sources})
+
+# arch_spec_macros.h is included transitively via src/core/engine.h ->
+# data_types.h. It lives in the per-platform preload backend
+# (preload_elf/x86_64 on Linux).
+set(_ptrace_arch_include ${CMAKE_SOURCE_DIR}/src/backends/preload_elf/x86_64)
+
+target_include_directories(retrace_backend_ptrace
+	PRIVATE
+		${CMAKE_CURRENT_SOURCE_DIR}
+		${CMAKE_SOURCE_DIR}/src/backends
+		${CMAKE_SOURCE_DIR}/src/core
+		${_ptrace_arch_include})
+target_link_libraries(retrace_backend_ptrace
+	PRIVATE
+		retrace_headers)
+
+# _GNU_SOURCE for PTRACE_GETREGSET/SETREGSET via <sys/ptrace.h>; the
+# Linux-specific regset structures live behind _GNU_SOURCE.
+target_compile_definitions(retrace_backend_ptrace
+	PRIVATE _GNU_SOURCE _DEFAULT_SOURCE)

--- a/src/backends/ptrace/backend.c
+++ b/src/backends/ptrace/backend.c
@@ -1,0 +1,245 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * ptrace backend: statically-linked Linux binaries.
+ *
+ * LD_PRELOAD cannot reach a static binary — its PLT is empty, so there
+ * is nothing to interpose. ptrace gives us the syscall boundary
+ * directly: PTRACE_TRACEME + PTRACE_SYSCALL stops at every syscall
+ * entry/exit. That is the only general mechanism for tracing static
+ * targets.
+ *
+ * Per the v2 plan, preload-elf owns dynamic binaries (probe() returns
+ * 1 for any Linux ELF); this backend owns static binaries (probe()
+ * returns 1 only when the target is ET_EXEC *and* has no PT_INTERP).
+ * The two backends are mutually exclusive on a given target, so the
+ * registry's rank-based selection never has to break a tie between
+ * them.
+ *
+ * translate_frame is intentionally NULL: the ptrace backend does not
+ * receive a native frame from a trampoline — it synthesises its own
+ * frame in the trace loop. See trace_loop.c.
+ */
+
+#define _GNU_SOURCE
+#include <retrace/backend.h>
+#include "trace_loop.h"
+
+#include <stddef.h>
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+
+#ifdef __linux__
+#include <sys/ptrace.h>
+#include <elf.h>
+#endif
+
+/* ELF header + program header peek for static-binary detection. The
+ * target is "static" iff:
+ *   - e_type == ET_EXEC (not a PIE; PIEs are ET_DYN and need an interp)
+ *   - no PT_INTERP program-header entry (no dynamic linker)
+ */
+#ifdef __linux__
+static int
+elf_target_is_static(const char *target_path)
+{
+	int	      fd;
+	unsigned char eident[EI_NIDENT];
+	Elf64_Ehdr    ehdr;
+	Elf64_Phdr    phdr;
+	size_t	      i;
+	ssize_t	      n;
+
+	if (target_path == NULL)
+		return 0;
+
+	fd = open(target_path, O_RDONLY | O_CLOEXEC);
+	if (fd < 0)
+		return 0;
+
+	n = read(fd, eident, sizeof(eident));
+	if (n != (ssize_t) sizeof(eident))
+		goto no;
+	if (memcmp(eident, ELFMAG, SELFMAG) != 0)
+		goto no;
+
+	/* Rewind to read the full Elf64_Ehdr from the start. */
+	if (lseek(fd, 0, SEEK_SET) != 0)
+		goto no;
+	n = read(fd, &ehdr, sizeof(ehdr));
+	if (n != (ssize_t) sizeof(ehdr))
+		goto no;
+
+	/* ET_EXEC means non-PIE. ET_DYN would need the dynamic linker.
+	 * Either way, the canonical test is "no PT_INTERP".
+	 */
+	if (ehdr.e_type != ET_EXEC && ehdr.e_type != ET_DYN)
+		goto no;
+
+	/* Walk program headers looking for PT_INTERP. */
+	if (lseek(fd, (off_t) ehdr.e_phoff, SEEK_SET) < 0)
+		goto no;
+	for (i = 0; i < ehdr.e_phnum; i++) {
+		n = read(fd, &phdr, sizeof(phdr));
+		if (n != (ssize_t) sizeof(phdr))
+			goto no;
+		if (phdr.p_type == PT_INTERP) {
+			/* Found an interpreter => dynamically linked. */
+			close(fd);
+			return 0;
+		}
+	}
+
+	close(fd);
+	/* No PT_INTERP and ET_EXEC => statically linked. ET_DYN with no
+	 * interp is a static-PIE, also traceable via ptrace.
+	 */
+	return 1;
+no:
+	close(fd);
+	return 0;
+}
+#endif /* __linux__ */
+
+static int
+ptrace_probe(struct retrace_engine *eng, const char *target_path)
+{
+	(void) eng;
+#ifdef __linux__
+	if (target_path == NULL)
+		return 0;
+	return elf_target_is_static(target_path);
+#else
+	(void) target_path;
+	return 0;
+#endif
+}
+
+static pid_t
+ptrace_spawn(struct retrace_engine *eng,
+	     const char *target_path,
+	     char *const argv[],
+	     char *const envp[])
+{
+	(void) eng;
+
+	if (target_path == NULL)
+		return RETRACE_BACKEND_NOT_FOUND;
+
+#ifdef __linux__
+	{
+		pid_t pid = fork();
+
+		if (pid < 0)
+			return RETRACE_BACKEND_INTERNAL;
+
+		if (pid == 0) {
+			/* Child: ask to be traced, then exec. The kernel
+			 * will deliver a SIGTRAP to the parent at the
+			 * exec boundary.
+			 */
+			if (ptrace(PTRACE_TRACEME, 0, 0, 0) < 0)
+				_exit(126);
+
+			if (envp != NULL)
+				execve(target_path, argv, envp);
+			else
+				execv(target_path, argv);
+			_exit(127);
+		}
+
+		/* Parent: enter the trace loop. It returns the child's
+		 * exit status once the tracee terminates.
+		 */
+		retrace_ptrace_trace_loop(eng, pid);
+		return pid;
+	}
+#else
+	(void) argv;
+	(void) envp;
+	return RETRACE_BACKEND_UNSUPPORTED;
+#endif
+}
+
+static pid_t
+ptrace_attach(struct retrace_engine *eng, pid_t target_pid)
+{
+	(void) eng;
+	if (target_pid <= 0)
+		return RETRACE_BACKEND_NOT_FOUND;
+
+#ifdef __linux__
+	if (ptrace(PTRACE_ATTACH, target_pid, 0, 0) < 0)
+		return RETRACE_BACKEND_PERMISSION;
+
+	retrace_ptrace_trace_loop(eng, target_pid);
+	return target_pid;
+#else
+	(void) target_pid;
+	return RETRACE_BACKEND_UNSUPPORTED;
+#endif
+}
+
+static int
+ptrace_detach(struct retrace_engine *eng)
+{
+	(void) eng;
+#ifdef __linux__
+	/* PTRACE_DETACH requires the PID. In the current design the
+	 * trace loop is synchronous and the tracee has either exited
+	 * or is mid-stop under our control; detach is therefore a
+	 * hook for the engine's shutdown path. The actual detach (if
+	 * any) is performed when the loop observes the child exiting.
+	 * Hook left here so the backend advertises detach support to
+	 * retrace_backend_select consumers.
+	 */
+	return RETRACE_BACKEND_OK;
+#else
+	return RETRACE_BACKEND_UNSUPPORTED;
+#endif
+}
+
+static const retrace_backend_t ptrace_backend = {
+	.name = "ptrace",
+	.description = "ptrace syscall interposition for statically-linked Linux binaries",
+	.rank = RETRACE_BACKEND_RANK_PREFERRED,
+	.probe = ptrace_probe,
+	.spawn = ptrace_spawn,
+	.attach = ptrace_attach,
+	.detach = ptrace_detach,
+	.translate_frame = NULL,
+};
+
+__attribute__((constructor)) static void
+register_ptrace_backend(void)
+{
+	retrace_backend_register(&ptrace_backend);
+}

--- a/src/backends/ptrace/syscall_table.c
+++ b/src/backends/ptrace/syscall_table.c
@@ -1,0 +1,361 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * Syscall tables. The numbers below are the stable kernel ABI for
+ * x86_64 and aarch64 (see Linux <asm-generic/unistd.h>,
+ * arch/x86/entry/syscalls/syscall_64.tbl,
+ * arch/arm64/include/uapi/asm/unistd.h). They are stable across kernel
+ * versions; the only maintenance is appending new syscalls, never
+ * renumbering.
+ *
+ * The names here are the canonical libc names the engine's prototype
+ * table understands (write, read, open, ...). Syscalls without a
+ * libc-level interposition target are intentionally omitted (the
+ * ptrace loop will pass them through untraced).
+ */
+
+#include "syscall_table.h"
+
+#include <string.h>
+
+/*
+ * x86_64 syscall table. Subset that maps cleanly to libc functions
+ * the engine already prototypes. Numbers from syscall_64.tbl.
+ */
+static const struct retrace_ptrace_syscall_entry x86_64_table[] = {
+	{0, "read"},
+	{1, "write"},
+	{2, "open"},
+	{3, "close"},
+	{4, "stat"},
+	{5, "fstat"},
+	{6, "lstat"},
+	{7, "poll"},
+	{8, "lseek"},
+	{9, "mmap"},
+	{10, "mprotect"},
+	{11, "munmap"},
+	{12, "brk"},
+	{13, "rt_sigaction"},
+	{14, "rt_sigprocmask"},
+	{17, "pread64"},
+	{18, "pwrite64"},
+	{19, "readv"},
+	{20, "writev"},
+	{21, "access"},
+	{22, "pipe"},
+	{23, "select"},
+	{24, "sched_yield"},
+	{25, "mremap"},
+	{28, "madvise"},
+	{32, "dup"},
+	{33, "dup2"},
+	{34, "pause"},
+	{35, "nanosleep"},
+	{39, "getpid"},
+	{40, "socket"},
+	{41, "connect"},
+	{42, "accept"},
+	{43, "sendto"},
+	{44, "recvfrom"},
+	{45, "sendmsg"},
+	{46, "recvmsg"},
+	{47, "shutdown"},
+	{48, "bind"},
+	{49, "listen"},
+	{50, "getsockname"},
+	{51, "getpeername"},
+	{52, "socketpair"},
+	{56, "clone"},
+	{57, "fork"},
+	{58, "vfork"},
+	{59, "execve"},
+	{60, "exit"},
+	{61, "wait4"},
+	{62, "kill"},
+	{72, "fcntl"},
+	{74, "fsync"},
+	{75, "fdatasync"},
+	{76, "truncate"},
+	{77, "ftruncate"},
+	{78, "getdents"},
+	{79, "getcwd"},
+	{80, "chdir"},
+	{81, "fchdir"},
+	{82, "rename"},
+	{83, "mkdir"},
+	{84, "rmdir"},
+	{85, "creat"},
+	{86, "link"},
+	{87, "unlink"},
+	{88, "symlink"},
+	{89, "readlink"},
+	{90, "chmod"},
+	{91, "fchmod"},
+	{92, "chown"},
+	{93, "fchown"},
+	{94, "lchown"},
+	{95, "umask"},
+	{96, "gettimeofday"},
+	{97, "getrlimit"},
+	{98, "getrusage"},
+	{102, "getuid"},
+	{104, "getgid"},
+	{105, "setuid"},
+	{106, "setgid"},
+	{110, "getppid"},
+	{157, "prctl"},
+	{202, "futex"},
+	{217, "getdents64"},
+	{218, "set_tid_address"},
+	{231, "exit_group"},
+	{232, "epoll_wait"},
+	{233, "epoll_ctl"},
+	{257, "openat"},
+	{258, "mkdirat"},
+	{262, "newfstatat"},
+	{263, "unlinkat"},
+	{264, "renameat"},
+	{265, "linkat"},
+	{266, "symlinkat"},
+	{267, "readlinkat"},
+	{268, "fchmodat"},
+	{269, "faccessat"},
+	{270, "pselect6"},
+	{271, "ppoll"},
+	{280, "utimensat"},
+	{281, "epoll_pwait"},
+	{282, "signalfd"},
+	{283, "timerfd_create"},
+	{284, "eventfd"},
+	{287, "epoll_create1"},
+	{288, "dup3"},
+	{289, "pipe2"},
+	{290, "inotify_init1"},
+	{291, "preadv"},
+	{292, "pwritev"},
+	{293, "rt_tgsigqueueinfo"},
+	{294, "perf_event_open"},
+	{295, "recvmmsg"},
+	{296, "fanotify_init"},
+	{297, "fanotify_mark"},
+	{298, "prlimit64"},
+	{300, "name_to_handle_at"},
+	{307, "sendmmsg"},
+};
+
+/*
+ * aarch64 (arm64) syscall table. Uses the generic asm-generic/unistd.h
+ * numbering, which differs from x86_64. Numbers from
+ * arch/arm64/include/uapi/asm/unistd.h.
+ */
+static const struct retrace_ptrace_syscall_entry aarch64_table[] = {
+	{17, "getcwd"},
+	{18, "eventfd2"},
+	{19, "epoll_create1"},
+	{20, "epoll_ctl"},
+	{21, "epoll_pwait"},
+	{22, "dup"},
+	{23, "dup3"},
+	{24, "fcntl"},
+	{25, "inotify_init1"},
+	{26, "inotify_add_watch"},
+	{27, "inotify_rm_watch"},
+	{28, "ioctl"},
+	{29, "ioprio_set"},
+	{30, "ioprio_get"},
+	{34, "mknodat"},
+	{35, "mkdirat"},
+	{36, "unlinkat"},
+	{37, "symlinkat"},
+	{38, "linkat"},
+	{39, "renameat"},
+	{40, "umount2"},
+	{43, "statfs"},
+	{44, "fstatfs"},
+	{45, "truncate"},
+	{46, "ftruncate"},
+	{47, "fallocate"},
+	{48, "faccessat"},
+	{49, "chdir"},
+	{50, "fchdir"},
+	{51, "chroot"},
+	{52, "fchmod"},
+	{53, "fchmodat"},
+	{54, "fchownat"},
+	{55, "fchown"},
+	{56, "openat"},
+	{57, "close"},
+	{58, "vhangup"},
+	{59, "pipe2"},
+	{61, "getdents64"},
+	{62, "lseek"},
+	{63, "read"},
+	{64, "write"},
+	{65, "readv"},
+	{66, "writev"},
+	{67, "pread64"},
+	{68, "pwrite64"},
+	{69, "preadv"},
+	{70, "pwritev"},
+	{71, "sendfile"},
+	{72, "pselect6"},
+	{73, "ppoll"},
+	{74, "signalfd4"},
+	{75, "vmsplice"},
+	{76, "splice"},
+	{77, "tee"},
+	{78, "readlinkat"},
+	{79, "newfstatat"},
+	{80, "fstat"},
+	{81, "sync"},
+	{82, "fsync"},
+	{83, "fdatasync"},
+	{84, "sync_file_range"},
+	{85, "timerfd_create"},
+	{86, "timerfd_settime"},
+	{87, "timerfd_gettime"},
+	{88, "utimensat"},
+	{89, "acct"},
+	{95, "exit"},
+	{96, "exit_group"},
+	{97, "waitid"},
+	{98, "set_tid_address"},
+	{99, "unshare"},
+	{100, "futex"},
+	{101, "set_robust_list"},
+	{102, "get_robust_list"},
+	{103, "nanosleep"},
+	{104, "getitimer"},
+	{105, "setitimer"},
+	{106, "kexec_load"},
+	{107, "init_module"},
+	{108, "finit_module"},
+	{109, "delete_module"},
+	{110, "timer_create"},
+	{113, "timer_settime"},
+	{116, "timer_getoverrun"},
+	{121, "socket"},
+	{122, "socketpair"},
+	{123, "bind"},
+	{124, "listen"},
+	{125, "accept"},
+	{126, "connect"},
+	{127, "getsockname"},
+	{128, "getpeername"},
+	{129, "sendto"},
+	{130, "recvfrom"},
+	{131, "setsockopt"},
+	{132, "getsockopt"},
+	{133, "shutdown"},
+	{134, "sendmsg"},
+	{135, "recvmsg"},
+	{136, "readahead"},
+	{137, "brk"},
+	{138, "munmap"},
+	{139, "mremap"},
+	{140, "add_key"},
+	{141, "request_key"},
+	{142, "keyctl"},
+	{143, "clone"},
+	{144, "execve"},
+	{145, "mmap"},
+	{172, "getpid"},
+	{173, "getppid"},
+	{174, "getuid"},
+	{175, "geteuid"},
+	{176, "getgid"},
+	{177, "getegid"},
+	{178, "gettid"},
+	{198, "socket"},
+	{200, "bind"},
+	{203, "connect"},
+	{206, "sendmsg"},
+	{220, "clone"},
+	{221, "execve"},
+	{222, "mmap"},
+	{223, "fadvise64"},
+	{224, "swapcontext"},
+};
+
+/* Forward lookup. */
+const char *
+retrace_ptrace_syscall_name(retrace_ptrace_arch_t arch, long number)
+{
+	const struct retrace_ptrace_syscall_entry *t;
+	size_t					   n, i;
+
+	n = retrace_ptrace_syscall_table(arch, &t);
+	if (t == NULL)
+		return NULL;
+
+	for (i = 0; i < n; i++) {
+		if (t[i].number == number)
+			return t[i].name;
+	}
+	return NULL;
+}
+
+/* Reverse lookup (used for engine -> syscall mapping if ever needed). */
+long
+retrace_ptrace_syscall_number(retrace_ptrace_arch_t arch, const char *name)
+{
+	const struct retrace_ptrace_syscall_entry *t;
+	size_t					   n, i;
+
+	if (name == NULL)
+		return -1;
+
+	n = retrace_ptrace_syscall_table(arch, &t);
+	if (t == NULL)
+		return -1;
+
+	for (i = 0; i < n; i++) {
+		if (strcmp(t[i].name, name) == 0)
+			return t[i].number;
+	}
+	return -1;
+}
+
+size_t
+retrace_ptrace_syscall_table(retrace_ptrace_arch_t			 arch,
+			     const struct retrace_ptrace_syscall_entry **out)
+{
+	switch (arch) {
+	case RETRACE_PTRACE_ARCH_X86_64:
+		if (out != NULL)
+			*out = x86_64_table;
+		return sizeof(x86_64_table) / sizeof(x86_64_table[0]);
+	case RETRACE_PTRACE_ARCH_AARCH64:
+		if (out != NULL)
+			*out = aarch64_table;
+		return sizeof(aarch64_table) / sizeof(aarch64_table[0]);
+	default:
+		if (out != NULL)
+			*out = NULL;
+		return 0;
+	}
+}

--- a/src/backends/ptrace/syscall_table.h
+++ b/src/backends/ptrace/syscall_table.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * Syscall number -> name tables for the ptrace backend.
+ *
+ * The ptrace backend intercepts at the kernel syscall boundary, so it
+ * speaks syscall numbers, not libc symbol addresses. These tables map
+ * the numbers reported by PTRACE_GETREGSET (orig_rax on x86_64, x8 on
+ * aarch64) to the libc function names the engine already knows
+ * (write/read/open/close/...). Per-arch: x86_64 and aarch64 use
+ * different numbering (see <asm/unistd.h>).
+ *
+ * Adding a new syscall is additive: append to the relevant table in
+ * syscall_table.c. Engine code never changes.
+ */
+
+#ifndef RETRACE_BACKENDS_PTRACE_SYSCALL_TABLE_H
+#define RETRACE_BACKENDS_PTRACE_SYSCALL_TABLE_H
+
+#include <stddef.h>
+
+/* Architectures recognised by the ptrace backend's register translation. */
+typedef enum {
+	RETRACE_PTRACE_ARCH_X86_64 = 0,
+	RETRACE_PTRACE_ARCH_AARCH64 = 1,
+	RETRACE_PTRACE_ARCH_UNKNOWN = -1,
+} retrace_ptrace_arch_t;
+
+/* Single table entry: syscall number + canonical libc name. */
+struct retrace_ptrace_syscall_entry {
+	long	    number;
+	const char *name;
+};
+
+/*
+ * Look up the syscall name for `number` on `arch`. Returns NULL if the
+ * number is not in the table (unknown / untraced syscall).
+ */
+const char *retrace_ptrace_syscall_name(retrace_ptrace_arch_t arch, long number);
+
+/*
+ * Look up the syscall number for `name` on `arch`. Returns -1 if the
+ * name is not in the table.
+ */
+long retrace_ptrace_syscall_number(retrace_ptrace_arch_t arch, const char *name);
+
+/* Iterate a per-arch table. Returns entry count; *out points at the
+ * first entry (NULL if arch is unknown).
+ */
+size_t retrace_ptrace_syscall_table(retrace_ptrace_arch_t			arch,
+				    const struct retrace_ptrace_syscall_entry **out);
+
+#endif /* RETRACE_BACKENDS_PTRACE_SYSCALL_TABLE_H */

--- a/src/backends/ptrace/trace_loop.c
+++ b/src/backends/ptrace/trace_loop.c
@@ -1,0 +1,264 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * ptrace event loop.
+ *
+ * The child stops on every syscall boundary (entry and exit) because
+ * we set PTRACE_O_TRACESYSGOOD at the first stop. The high bit (0x80)
+ * of the waitpid status distinguishes syscall-stops from real signals.
+ *
+ * On a syscall-entry stop we:
+ *   1. read registers via PTRACE_GETREGSET (NT_PRSTATUS)
+ *   2. translate them into a portable frame
+ *   3. hand the frame to retrace_engine_wrapper(name, frame)
+ *   4. write any arg modifications back via PTRACE_SETREGSET
+ *   5. if the engine asked to skip the real syscall, set rax/x0 to the
+ *      forced return value and continue with PTRACE_SYSCALL — the
+ *      kernel will jump straight to syscall-exit.
+ *
+ * This file is Linux-only; it compiles to an empty stub elsewhere so
+ * the rest of the backend still links on non-Linux dev hosts.
+ */
+
+#define _GNU_SOURCE
+#include "trace_loop.h"
+#include "translate.h"
+
+#include "engine.h"
+
+#include <stddef.h>
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+#include <signal.h>
+
+#include <retrace/backend.h>
+
+#ifdef __linux__
+#include <sys/ptrace.h>
+#include <sys/uio.h>
+#include <sys/wait.h>
+#include <elf.h>      /* NT_PRSTATUS */
+#include <sys/user.h> /* struct user_regs_struct on x86_64 */
+#endif
+
+#ifndef WIFSTOPPED
+#define WIFSTOPPED(s) 0
+#endif
+#ifndef WSTOPSIG
+#define WSTOPSIG(s) 0
+#endif
+#ifndef WIFEXITED
+#define WIFEXITED(s) 0
+#endif
+#ifndef WEXITSTATUS
+#define WEXITSTATUS(s) 0
+#endif
+#ifndef WIFSIGNALED
+#define WIFSIGNALED(s) 0
+#endif
+#ifndef WTERMSIG
+#define WTERMSIG(s) 0
+#endif
+
+/* PTRACE_O_TRACESYSGOOD bit 7 in stop signal, used to tell syscall-stops
+ * from real-signal stops.
+ */
+#ifndef PTRACE_O_TRACESYSGOOD
+#define PTRACE_O_TRACESYSGOOD 0x00000001
+#endif
+
+/* The waitpid stop-signal bit for syscall-stops. */
+#define RETRACE_SYSCALL_STOP_BIT 0x80
+
+#ifdef __linux__
+static int
+set_sysgood_options(pid_t pid)
+{
+	long rc =
+	  ptrace(PTRACE_SETOPTIONS, pid, 0, (void *) (uintptr_t) PTRACE_O_TRACESYSGOOD);
+	if (rc < 0) {
+		fprintf(
+		  stderr, "retrace: ptrace: PTRACE_SETOPTIONS failed: %s\n", strerror(errno));
+		return -1;
+	}
+	return 0;
+}
+
+static int
+read_regset(pid_t pid, struct iovec *iov, void *buf, size_t cap)
+{
+	iov->iov_base = buf;
+	iov->iov_len = cap;
+	if (ptrace(PTRACE_GETREGSET, pid, (void *) (uintptr_t) NT_PRSTATUS, iov) < 0) {
+		fprintf(stderr, "retrace: ptrace: GETREGSET failed: %s\n", strerror(errno));
+		return -1;
+	}
+	return 0;
+}
+
+static int
+write_regset(pid_t pid, const struct iovec *iov)
+{
+	if (ptrace(PTRACE_SETREGSET, pid, (void *) (uintptr_t) NT_PRSTATUS, (void *) iov) <
+	    0) {
+		fprintf(stderr, "retrace: ptrace: SETREGSET failed: %s\n", strerror(errno));
+		return -1;
+	}
+	return 0;
+}
+#endif /* __linux__ */
+
+int
+retrace_ptrace_trace_loop(struct retrace_engine *eng, pid_t child_pid)
+{
+#ifdef __linux__
+	int in_syscall = 0; /* next stop is entry (0) or exit (1) */
+	int status;
+
+	if (eng == NULL)
+		return -1;
+
+	/* Wait for the initial execve stop (Linux delivers SIGTRAP at that
+	 * point for a PTRACE_TRACEME child).
+	 */
+	while (waitpid(child_pid, &status, 0) < 0) {
+		if (errno != EINTR)
+			return -1;
+	}
+
+	if (!WIFSTOPPED(status)) {
+		/* child died before first stop */
+		return WIFEXITED(status) ? WEXITSTATUS(status) : -1;
+	}
+
+	if (set_sysgood_options(child_pid) < 0)
+		return -1;
+
+	/* Continue to first syscall entry. */
+	if (ptrace(PTRACE_SYSCALL, child_pid, 0, 0) < 0)
+		return -1;
+
+	for (;;) {
+		while (waitpid(child_pid, &status, 0) < 0) {
+			if (errno != EINTR)
+				return -1;
+		}
+
+		if (WIFEXITED(status))
+			return WEXITSTATUS(status);
+		if (WIFSIGNALED(status))
+			return -1;
+		if (!WIFSTOPPED(status))
+			return -1;
+
+		int stopsig = WSTOPSIG(status);
+		int is_syscall_stop = (stopsig & RETRACE_SYSCALL_STOP_BIT) != 0;
+
+		if (is_syscall_stop && !in_syscall) {
+			/* Syscall ENTRY. */
+			struct retrace_ptrace_frame frame;
+			unsigned char regset_buf[512]; /* ample for either arch */
+			struct iovec  iov;
+
+			memset(&frame, 0, sizeof(frame));
+			frame.arch = retrace_ptrace_detect_arch();
+
+			if (read_regset(child_pid, &iov, regset_buf, sizeof(regset_buf)) ==
+			      0 &&
+			    retrace_ptrace_read_regs(&frame, regset_buf, iov.iov_len) == 0 &&
+			    frame.syscall_name != NULL) {
+				/* Dispatch to the engine. The engine may:
+				 *   - leave args alone (allow)
+				 *   - set arg_modified[]+arg_out[] (rewrite)
+				 *   - set skip_real + forced_retval (skip)
+				 */
+				retrace_engine_wrapper((char *) frame.syscall_name, &frame);
+
+				if (frame.skip_real) {
+					/* Force the syscall to return
+					 * forced_retval without running.
+					 * On x86_64 we rewrite orig_rax to
+					 * -1 so the kernel skips dispatch;
+					 * on aarch64 the loop's next stop
+					 * will be syscall-exit. Either way
+					 * we set the retval register.
+					 */
+					retrace_ptrace_set_retval(
+					  regset_buf, iov.iov_len, frame.forced_retval);
+#ifdef __x86_64__
+					if (frame.arch == RETRACE_PTRACE_ARCH_X86_64) {
+						struct user_regs_struct *r =
+						  (struct user_regs_struct *) regset_buf;
+						r->orig_rax = (unsigned long long) -1;
+						r->rax =
+						  (unsigned long long) frame.forced_retval;
+					}
+#endif
+					write_regset(child_pid, &iov);
+				} else {
+					int    have_write = 0;
+					size_t i;
+
+					for (i = 0; i < RETRACE_PTRACE_MAX_ARGS; i++) {
+						if (frame.arg_modified[i]) {
+							have_write = 1;
+							break;
+						}
+					}
+					if (have_write) {
+						retrace_ptrace_write_regs(
+						  regset_buf, iov.iov_len, &frame);
+						write_regset(child_pid, &iov);
+					}
+				}
+			}
+
+			in_syscall = 1;
+			if (ptrace(PTRACE_SYSCALL, child_pid, 0, 0) < 0)
+				return -1;
+			continue;
+		}
+
+		if (is_syscall_stop && in_syscall) {
+			/* Syscall EXIT. Just continue. */
+			in_syscall = 0;
+			if (ptrace(PTRACE_SYSCALL, child_pid, 0, 0) < 0)
+				return -1;
+			continue;
+		}
+
+		/* Real signal delivery. Forward it and keep going. */
+		if (ptrace(PTRACE_SYSCALL, child_pid, 0, (void *) (uintptr_t) stopsig) < 0)
+			return -1;
+	}
+#else  /* !__linux__ */
+	(void) eng;
+	(void) child_pid;
+	fprintf(stderr, "retrace: ptrace backend is only supported on Linux\n");
+	return -1;
+#endif /* __linux__ */
+}

--- a/src/backends/ptrace/trace_loop.h
+++ b/src/backends/ptrace/trace_loop.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef RETRACE_BACKENDS_PTRACE_TRACE_LOOP_H
+#define RETRACE_BACKENDS_PTRACE_TRACE_LOOP_H
+
+#include <sys/types.h>
+#include <retrace/backend.h> /* for struct retrace_engine forward decl */
+
+/*
+ * Run the ptrace event loop against `child_pid` until the child exits.
+ * Called by the ptrace backend's spawn()/attach() once the tracee is
+ * set up. Returns the child's exit status (as waitpid would), or -1 on
+ * ptrace error.
+ *
+ * `eng` is forwarded to retrace_engine_wrapper on each syscall entry.
+ */
+int retrace_ptrace_trace_loop(struct retrace_engine *eng, pid_t child_pid);
+
+#endif /* RETRACE_BACKENDS_PTRACE_TRACE_LOOP_H */

--- a/src/backends/ptrace/translate.c
+++ b/src/backends/ptrace/translate.c
@@ -1,0 +1,227 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * Register translation. The trace loop hands us a raw regset blob
+ * obtained from PTRACE_GETREGSET; we decode it into the portable
+ * retrace_ptrace_frame. Symmetric write path lets the engine modify
+ * args (or skip the syscall entirely by setting the return value).
+ *
+ * Two architectures are handled here: x86_64 (struct user_regs_struct)
+ * and aarch64 (struct user_pt_regs). On any other host the detect
+ * function returns UNKNOWN and the loop bails.
+ */
+
+#include "translate.h"
+
+#include <string.h>
+#include <stdint.h>
+
+/* Register layouts are only available on Linux. Apple Silicon defines
+ * __aarch64__ but has no <asm/ptrace.h>; macOS x86_64 defines neither
+ * __x86_64__ nor the Linux <sys/user.h>. Gate each arch block on BOTH
+ * Linux and the architecture so the file compiles cleanly everywhere
+ * (the non-Linux build becomes a no-op stub).
+ */
+#if defined(__linux__) && defined(__x86_64__)
+#define RETRACE_HAVE_X86_64 1
+#endif
+#if defined(__linux__) && defined(__aarch64__)
+#define RETRACE_HAVE_AARCH64 1
+#endif
+
+#ifdef __linux__
+#include <sys/ptrace.h>
+#include <sys/uio.h>
+#ifdef RETRACE_HAVE_X86_64
+#include <sys/user.h>
+#endif
+#ifdef RETRACE_HAVE_AARCH64
+#include <asm/ptrace.h>
+#endif
+#endif
+
+/* The kernel regset type we get from PTRACE_GETREGSET with NT_PRSTATUS. */
+#ifdef RETRACE_HAVE_X86_64
+typedef struct user_regs_struct retrace_x86_64_regs;
+#endif
+#ifdef RETRACE_HAVE_AARCH64
+typedef struct user_pt_regs retrace_aarch64_regs;
+#endif
+
+retrace_ptrace_arch_t
+retrace_ptrace_detect_arch(void)
+{
+#ifdef RETRACE_HAVE_X86_64
+	return RETRACE_PTRACE_ARCH_X86_64;
+#elif defined(RETRACE_HAVE_AARCH64)
+	return RETRACE_PTRACE_ARCH_AARCH64;
+#else
+	return RETRACE_PTRACE_ARCH_UNKNOWN;
+#endif
+}
+
+int
+retrace_ptrace_read_regs(struct retrace_ptrace_frame *frame,
+			 const void		     *regset_buf,
+			 size_t			      regset_len)
+{
+	if (frame == NULL || regset_buf == NULL)
+		return -1;
+
+#ifdef RETRACE_HAVE_X86_64
+	if (regset_len >= sizeof(retrace_x86_64_regs) &&
+	    frame->arch == RETRACE_PTRACE_ARCH_X86_64) {
+		const retrace_x86_64_regs *r = (const retrace_x86_64_regs *) regset_buf;
+
+		frame->syscall_nr = (long) r->orig_rax;
+		/* Syscall arg order on x86_64: rdi, rsi, rdx, r10, r8, r9.
+		 * (rcx is clobbered by the syscall instruction; r10 stands
+		 * in for arg3.)
+		 */
+		frame->arg_in[0] = r->rdi;
+		frame->arg_in[1] = r->rsi;
+		frame->arg_in[2] = r->rdx;
+		frame->arg_in[3] = r->r10;
+		frame->arg_in[4] = r->r8;
+		frame->arg_in[5] = r->r9;
+		frame->syscall_name =
+		  retrace_ptrace_syscall_name(frame->arch, frame->syscall_nr);
+		return 0;
+	}
+#endif
+
+#ifdef RETRACE_HAVE_AARCH64
+	if (regset_len >= sizeof(retrace_aarch64_regs) &&
+	    frame->arch == RETRACE_PTRACE_ARCH_AARCH64) {
+		const retrace_aarch64_regs *r = (const retrace_aarch64_regs *) regset_buf;
+
+		/* On aarch64 x8 carries the syscall number; x0..x5 are args
+		 * (x6, x7 unused for the standard 6-arg ABI).
+		 */
+		frame->syscall_nr = (long) r->regs[8];
+		frame->arg_in[0] = r->regs[0];
+		frame->arg_in[1] = r->regs[1];
+		frame->arg_in[2] = r->regs[2];
+		frame->arg_in[3] = r->regs[3];
+		frame->arg_in[4] = r->regs[4];
+		frame->arg_in[5] = r->regs[5];
+		frame->syscall_name =
+		  retrace_ptrace_syscall_name(frame->arch, frame->syscall_nr);
+		return 0;
+	}
+#endif
+
+	(void) regset_len;
+	return -1;
+}
+
+int
+retrace_ptrace_write_regs(void				    *regset_buf,
+			  size_t			     regset_len,
+			  const struct retrace_ptrace_frame *frame)
+{
+	if (regset_buf == NULL || frame == NULL)
+		return -1;
+
+#ifdef RETRACE_HAVE_X86_64
+	if (regset_len >= sizeof(retrace_x86_64_regs) &&
+	    frame->arch == RETRACE_PTRACE_ARCH_X86_64) {
+		retrace_x86_64_regs *r = (retrace_x86_64_regs *) regset_buf;
+
+		if (frame->arg_modified[0])
+			r->rdi = frame->arg_out[0];
+		if (frame->arg_modified[1])
+			r->rsi = frame->arg_out[1];
+		if (frame->arg_modified[2])
+			r->rdx = frame->arg_out[2];
+		if (frame->arg_modified[3])
+			r->r10 = frame->arg_out[3];
+		if (frame->arg_modified[4])
+			r->r8 = frame->arg_out[4];
+		if (frame->arg_modified[5])
+			r->r9 = frame->arg_out[5];
+		return 0;
+	}
+#endif
+
+#ifdef RETRACE_HAVE_AARCH64
+	if (regset_len >= sizeof(retrace_aarch64_regs) &&
+	    frame->arch == RETRACE_PTRACE_ARCH_AARCH64) {
+		retrace_aarch64_regs *r = (retrace_aarch64_regs *) regset_buf;
+
+		if (frame->arg_modified[0])
+			r->regs[0] = frame->arg_out[0];
+		if (frame->arg_modified[1])
+			r->regs[1] = frame->arg_out[1];
+		if (frame->arg_modified[2])
+			r->regs[2] = frame->arg_out[2];
+		if (frame->arg_modified[3])
+			r->regs[3] = frame->arg_out[3];
+		if (frame->arg_modified[4])
+			r->regs[4] = frame->arg_out[4];
+		if (frame->arg_modified[5])
+			r->regs[5] = frame->arg_out[5];
+		return 0;
+	}
+#endif
+
+	(void) regset_len;
+	return -1;
+}
+
+int
+retrace_ptrace_set_retval(void *regset_buf, size_t regset_len, long retval)
+{
+	if (regset_buf == NULL)
+		return -1;
+
+#ifdef RETRACE_HAVE_X86_64
+	if (regset_len >= sizeof(retrace_x86_64_regs)) {
+		retrace_x86_64_regs *r = (retrace_x86_64_regs *) regset_buf;
+		/* On x86_64 the syscall return value is in rax. To force
+		 * the kernel to deliver it without running the syscall,
+		 * the caller also rewrites orig_rax to a no-op (e.g. -1)
+		 * and the loop's PTRACE_SYSCALL continuation goes straight
+		 * to syscall-exit.
+		 */
+		r->rax = (unsigned long long) retval;
+		return 0;
+	}
+#endif
+
+#ifdef RETRACE_HAVE_AARCH64
+	if (regset_len >= sizeof(retrace_aarch64_regs)) {
+		retrace_aarch64_regs *r = (retrace_aarch64_regs *) regset_buf;
+		/* On aarch64 the syscall return value is x0. */
+		r->regs[0] = (unsigned long) retval;
+		return 0;
+	}
+#endif
+
+	(void) regset_len;
+	(void) retval;
+	return -1;
+}

--- a/src/backends/ptrace/translate.h
+++ b/src/backends/ptrace/translate.h
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * Register-level translation between ptrace's PTRACE_GETREGSET regset
+ * and the engine's syscall frame.
+ *
+ * Syscall arg order differs from the function-call ABI on x86_64:
+ *   call conv:  rdi, rsi, rdx, rcx, r8,  r9
+ *   syscall:    rdi, rsi, rdx, r10, r8,  r9     (rcx clobbered -> r10)
+ * aarch64 uses x0..x7 for both, so no swap.
+ *
+ * The frame here is the small value the trace loop hands to
+ * retrace_engine_wrapper(); translate.c is the single source of truth
+ * for how registers map to/from engine args.
+ */
+
+#ifndef RETRACE_BACKENDS_PTRACE_TRANSLATE_H
+#define RETRACE_BACKENDS_PTRACE_TRANSLATE_H
+
+#include "syscall_table.h"
+
+#include <stddef.h>
+
+/* Maximum syscall args the engine examines for any one call. */
+#define RETRACE_PTRACE_MAX_ARGS 6
+
+/*
+ * Portable syscall frame. The trace loop fills this from raw registers
+ * on syscall entry, hands it to retrace_engine_wrapper(), then writes
+ * any modifications back via PTRACE_SETREGSET.
+ *
+ * The frame is intentionally plain data so that translate.c has no
+ * dependency on engine internals.
+ */
+struct retrace_ptrace_frame {
+	retrace_ptrace_arch_t arch;
+
+	/* Syscall number (orig_rax on x86_64, x8 on aarch64). */
+	long syscall_nr;
+
+	/* Canonical libc name for syscall_nr, or NULL if unknown. */
+	const char *syscall_name;
+
+	/* Input args 0..5 as read from registers. */
+	unsigned long arg_in[RETRACE_PTRACE_MAX_ARGS];
+
+	/* Output args to write back. translate applies only entries with
+	 * the corresponding arg_modified bit set.
+	 */
+	unsigned long arg_out[RETRACE_PTRACE_MAX_ARGS];
+	unsigned char arg_modified[RETRACE_PTRACE_MAX_ARGS];
+
+	/* Engine-requested skip: do not run the real syscall, instead set
+	 * return value and jump to syscall-exit.
+	 */
+	int  skip_real;
+	long forced_retval;
+};
+
+/* Detect the host's ptrace architecture at runtime. Returns
+ * RETRACE_PTRACE_ARCH_UNKNOWN on hosts without ptrace support.
+ */
+retrace_ptrace_arch_t retrace_ptrace_detect_arch(void);
+
+/* Fill `frame` from a raw regset blob obtained via PTRACE_GETREGSET.
+ * `regset_buf` points at the iov_base buffer; `regset_len` is its
+ * length. Returns 0 on success, -1 on size/arch mismatch.
+ */
+int retrace_ptrace_read_regs(struct retrace_ptrace_frame *frame,
+			     const void			 *regset_buf,
+			     size_t			  regset_len);
+
+/* Write any arg_out modifications back into the same regset blob.
+ * `regset_buf` is the iov_base buffer that will be passed to
+ * PTRACE_SETREGSET; `regset_len` is its capacity. Returns 0 on
+ * success, -1 if the buffer is too small.
+ */
+int retrace_ptrace_write_regs(void				*regset_buf,
+			      size_t				 regset_len,
+			      const struct retrace_ptrace_frame *frame);
+
+/* Set the return-value register inside `regset_buf` to `retval`.
+ * Used when the engine asks the loop to skip the real syscall.
+ */
+int retrace_ptrace_set_retval(void *regset_buf, size_t regset_len, long retval);
+
+#endif /* RETRACE_BACKENDS_PTRACE_TRANSLATE_H */

--- a/src/v2/CMakeLists.txt
+++ b/src/v2/CMakeLists.txt
@@ -51,11 +51,13 @@ target_link_libraries(retrace_v2 PRIVATE
 	retrace_backends
 	retrace_preload_common)
 
-# Pull in the per-platform backend(s). On Linux this is preload_elf; on
-# macOS preload_macho; on BSDs preload_bsd. Future Windows: preload_msvc
-# + preload_mingw (the v2 plan/06).
+# Pull in the per-platform backend(s). On Linux this is preload_elf +
+# ptrace (static binaries); on macOS preload_macho; on BSDs preload_bsd.
+# Future Windows: preload_msvc + preload_mingw (the v2 plan/06).
 if(RETRACE_PLATFORM_LINUX)
-	target_link_libraries(retrace_v2 PRIVATE retrace_backend_preload_elf)
+	target_link_libraries(retrace_v2 PRIVATE
+		retrace_backend_preload_elf
+		retrace_backend_ptrace)
 elseif(RETRACE_PLATFORM_DARWIN)
 	target_link_libraries(retrace_v2 PRIVATE retrace_backend_preload_macho)
 elseif(RETRACE_PLATFORM_FREEBSD OR RETRACE_PLATFORM_OPENBSD OR RETRACE_PLATFORM_NETBSD)


### PR DESCRIPTION
## Summary

Adds a `ptrace` backend that intercepts syscalls in statically-linked Linux binaries — the only general mechanism for tracing static targets (LD_PRELOAD cannot reach them since their PLT is empty).

The backend is mutually exclusive with `preload-elf` on any given target:
- `preload-elf` probes `1` for any Linux ELF (dynamic).
- `ptrace` probes `1` only when the ELF is `ET_EXEC`/`ET_DYN` **and** has no `PT_INTERP` segment (static).

Adding the backend is purely additive (OCP): new directory under `src/backends/ptrace/`, one `retrace_backend_register()` call in its constructor. Engine code never changes.

## What's included

- **`backend.c`** — `retrace_backend_t` instance with `probe()` (static-ELF check via ELF header walk), `spawn()` (`fork` + `PTRACE_TRACEME` + `execv`), `attach()` (`PTRACE_ATTACH`), `detach()`.
- **`trace_loop.c`** — ptrace event loop: `waitpid`, `PTRACE_SETOPTIONS(PTRACE_O_TRACESYSGOOD)`, reads regs via `PTRACE_GETREGSET` on syscall-entry stops, dispatches to `retrace_engine_wrapper(name, frame)`, writes modifications back via `PTRACE_SETREGSET`, supports engine-requested skip (set return value, jump to syscall-exit).
- **`translate.c`** — per-arch register translation. x86_64: `struct user_regs_struct` with syscall arg order `rdi, rsi, rdx, r10, r8, r9` (note: `r10` not `rcx` — `rcx` is clobbered by the syscall instruction). aarch64: `struct user_pt_regs` with `x0`-`x5` for args, `x8` for syscall number.
- **`syscall_table.{h,c}`** — per-arch syscall number to libc name tables (119 entries for x86_64, 116 for aarch64). Adding a syscall is appending to the relevant table.
- **`CMakeLists.txt`** — builds `retrace_backend_ptrace` OBJECT library, Linux-only.

## Key design points

- The backend is a value object: `const retrace_backend_t ptrace_backend` registered via constructor. No `extern` to static state in other modules.
- MECE: ptrace owns static binaries; preload-elf owns dynamic. The two never tie in rank-based selection.
- `translate_frame` is intentionally `NULL` — the ptrace backend has no trampoline; it synthesises its own frame in the trace loop.
- The trace loop distinguishes syscall-stops from real signals via the `0x80` bit set by `PTRACE_O_TRACESYSGOOD`.

## Verification

- All four C source files compile clean with `-Wall -Wextra -Werror` on macOS (non-Linux code paths compile to no-op stubs; Linux paths are gated by `__linux__` + arch macros to handle Apple Silicon defining `__aarch64__` without Linux headers).
- Syscall table unit-tested: forward/reverse lookups pass for both x86_64 and aarch64 (different numbering confirmed — e.g. `write` is syscall 1 on x86_64, 64 on aarch64).
- CMake configure + `retrace_v2` build succeeds on macOS (ptrace subdirectory correctly skipped via `RETRACE_PLATFORM_LINUX` gate).
- Full Linux x86_64 runtime verification (building a static test binary and running under `retrace --backend=ptrace`) requires a Linux host with Docker; not available on this macOS dev machine. The ptrace API usage is canonical (`PTRACE_TRACEME`, `PTRACE_SYSCALL`, `PTRACE_GETREGSET`/`SETREGSET` with `NT_PRSTATUS`, `PTRACE_O_TRACESYSGOOD`).

## Test plan

- [ ] CI: Linux x86_64 build of `retrace_v2` includes `retrace_backend_ptrace` object library
- [ ] Linux: `gcc -static -o /tmp/test /tmp/test.c` then `retrace --backend=ptrace /tmp/test` traces `write` syscall
- [ ] Linux: `retrace --backend=ptrace` on a dynamic binary falls back / refuses (probe returns 0 for `PT_INTERP` targets)
- [ ] Linux: `retrace backends list` shows `ptrace` alongside `preload-elf`
