### PR TITLE
Fix include paths: add src/config/json and src/backends globally

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -274,8 +274,14 @@ configure_file(
 	ESCAPE_QUOTES)
 
 # Make config.h discoverable by every target.
+# Also add src/config/json (parson.h, conf.h) and src/backends (arch_spec.h)
+# globally — OBJECT libraries don't always propagate target_include_directories
+# to their own sources across all CMake versions.
 add_compile_definitions(HAVE_CONFIG_H)
-include_directories(BEFORE "${CMAKE_BINARY_DIR}")
+include_directories(BEFORE
+	"${CMAKE_BINARY_DIR}"
+	"${CMAKE_CURRENT_SOURCE_DIR}/src/config/json"
+	"${CMAKE_CURRENT_SOURCE_DIR}/src/backends")
 
 # ---------------------------------------------------------------
 # Sanitizers and coverage (see cmake/Sanitizers.cmake)


### PR DESCRIPTION
## Summary

Fixes the `parson.h: No such file or directory` build failure on Linux CI introduced by the Phase 5 backend abstraction. Phase 5's OBJECT library include paths (`$<BUILD_INTERFACE:...>` on `retrace_core`) don't propagate to the OBJECT library's own source files across all CMake versions (confirmed broken on CMake 3.22/ubuntu-22.04; works on macOS with newer CMake).

Fix: add `src/config/json` and `src/backends` to the global `include_directories` alongside the existing `config.h` path. Mirrors how the Autotools build worked (include paths were global via CPPFLAGS).

This unblocks the 3 pending agent PRs (#439 Windows, #440 ptrace, #441 AArch64) which all inherit this bug from main.

## Test plan

- [ ] `build-and-test (ubuntu-22.04, linux-x64)` passes
- [ ] `build-and-test (ubuntu-24.04, linux-x64)` passes
- [ ] `build-and-test (macos-15-intel, macos-x64)` passes
- [ ] No regression on macOS arm64
