### PR TITLE
v2: stop intercepting dlsym (issue #445 root cause)

### DIFF
--- a/src/core/real_impls.c
+++ b/src/core/real_impls.c
@@ -43,15 +43,21 @@ int retrace_real_impls_init(void)
 		return -1;
 
 #ifdef __linux__
-	/* load all libs that are used in safe mode,
-	 *  since the linker won't link them
+	/* On glibc < 2.34, pthreads lived in a separate libpthread.so.0 that
+	 * the dynamic linker wouldn't load unless explicitly requested.
+	 * Loading it made pthread_key_create etc. resolvable via RTLD_NEXT.
+	 *
+	 * On glibc >= 2.34, libpthread is integrated into libc -- there's no
+	 * separate libpthread.so.0 to dlopen. The dlopen call returns NULL,
+	 * and that's fine: the symbols are already in libc. Don't fail init
+	 * in that case.
 	 */
 	void *handle;
 
 	handle = retrace_real_impls.dlopen(
 			"libpthread.so.0", RTLD_NOW | RTLD_GLOBAL);
-	if (handle == NULL)
-		return -2;
+	/* handle may be NULL on glibc >= 2.34 -- not an error. */
+	(void)handle;
 #endif
 
 	retrace_real_impls.pthread_key_create =

--- a/src/v2/funcs_symbols.S
+++ b/src/v2/funcs_symbols.S
@@ -224,12 +224,11 @@ WRAPPER_ENTRY_SYSTEM_V readv
 #dlfcn
 WRAPPER_ENTRY_SYSTEM_V dlopen
 WRAPPER_ENTRY_SYSTEM_V dlerror
-#if !defined(__OpenBSD__)\
- && !defined(__FreeBSD__)\
- && !defined(__NetBSD__)
-#No suitable method besides dlsym, thus cannot shim it
-WRAPPER_ENTRY_SYSTEM_V dlsym
-#endif
+/* dlsym is intentionally NOT intercepted. The engine's real-impl
+ * resolver (retrace_as_get_real_safe) uses dlsym(RTLD_NEXT, ...) as
+ * the fallback when _dl_sym (GLIBC_PRIVATE) is unavailable on
+ * glibc >= 2.34. Intercepting dlsym would cause infinite recursion
+ * inside the constructor before retrace_inited is set. */
 WRAPPER_ENTRY_SYSTEM_V dlclose
 #pthreads
 WRAPPER_ENTRY_SYSTEM_V pthread_attr_destroy

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -58,9 +58,18 @@ endforeach()
 set(RETRACE_CONF_EXAMPLE "${CMAKE_SOURCE_DIR}/examples/getenv-fuzzing/retrace.conf.example")
 set(TEST_DIR "${CMAKE_BINARY_DIR}/test")
 
+# 1. configure_file(@ONLY) substitutes @TEST_DIR@ and @RETRACE_CONF_EXAMPLE@
+#    at configure time.
+# 2. file(GENERATE) then evaluates $<TARGET_FILE:retrace_v2> at build time
+#    (generator expressions aren't allowed in configure_file).
+configure_file(
+	"${CMAKE_CURRENT_SOURCE_DIR}/runtests.sh.in"
+	"${CMAKE_CURRENT_BINARY_DIR}/runtests.sh.in.configured"
+	@ONLY)
+
 file(GENERATE
 	OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/runtests.sh"
-	INPUT  "${CMAKE_CURRENT_SOURCE_DIR}/runtests.sh.in")
+	INPUT  "${CMAKE_CURRENT_BINARY_DIR}/runtests.sh.in.configured")
 
 # ----------------------------------------------------------------
 # CTest registration with labels.
@@ -71,8 +80,9 @@ add_test(NAME integration-runtests
 	WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
 set_tests_properties(integration-runtests PROPERTIES
 	LABELS "integration;v2")
-# v2's _dl_sym resolution on glibc >= 2.34 is being fixed (issue #445,
-# PR feat/phase8-test-pyramid). Skip v2 tests until verified working
-# on Linux CI.
+# v2 still segfaults mid-execution after logger_init (issue #445 has
+# findings). The dlsym-recursion fix in this PR gets v2 past the
+# constructor; the next segfault is in the engine/action handler.
+# Skip v2 tests until that's tracked down via gdb on Linux.
 set_tests_properties(integration-runtests PROPERTIES
 	ENVIRONMENT "RETRACE_SKIP_V2=1")

--- a/test/runtests.sh.in
+++ b/test/runtests.sh.in
@@ -10,7 +10,7 @@
 set -eu
 
 RETRACE_V2_LIB=$<TARGET_FILE:retrace_v2>
-TEST_DIR=$<TARGET_FILE_DIR:retrace_v2>
+TEST_DIR=@TEST_DIR@
 RETRACE_CONF_EXAMPLE=@RETRACE_CONF_EXAMPLE@
 
 # v2 interposition mechanism differs by OS.
@@ -79,7 +79,7 @@ run_v2() {
 printf -- '--- v2 LD_PRELOAD tests ---\n'
 # v2 had a _dl_sym resolution bug on glibc >= 2.34 (issue #445, fixed via
 # weak-symbol fallback). Skip until verified on Linux CI.
-if [ -n "$RETRACE_SKIP_V2" ]; then
+if [ -n "${RETRACE_SKIP_V2:-}" ]; then
     printf 'SKIP v2 tests (RETRACE_SKIP_V2 set; see issue #445)\n'
 else
     for entry in $TESTS; do


### PR DESCRIPTION
## Summary

PR #444 added a weak-symbol fallback from `_dl_sym` to `dlsym(RTLD_NEXT, ...)` for glibc >= 2.34. But `dlsym` was ITSELF in v2's intercept list — the comment in `funcs_symbols.S` literally said *"No suitable method besides dlsym, thus cannot shim it"* but the code shimmed it anyway. Calling `dlsym` inside the constructor entered v2's own trampoline → engine → `retrace_as_get_real_safe("dlsym")` → `dlsym` again → infinite recursion → segfault before `retrace_inited` could be set.

**This PR fixes that** — confirmed by CI output: v2 now reaches `retrace_logger_init` and prints `[\n` (the JSON-array opening) before segfaulting further down. The remaining segfault is somewhere in the engine/action handler when the first libc call lands, and needs proper gdb time on a Linux host.

## Changes

1. **`src/v2/funcs_symbols.S`**: remove `WRAPPER_ENTRY_SYSTEM_V dlsym`. dlsym is now passed through to libc untouched. Cost: target programs that call dlsym won't have their calls logged/modified. Benefit: v2 doesn't segfault in the constructor.

2. **`src/core/real_impls.c`**: stop failing init when `libpthread.so.0` dlopen returns NULL (glibc >= 2.34 has no separate libpthread; the symbols are already in libc).

3. **`test/CMakeLists.txt` + `test/runtests.sh.in`**: fix `TEST_DIR` substitution (`file(GENERATE)` doesn't substitute `@VAR@`; now chained `configure_file(@ONLY)` + `file(GENERATE)`).

The `RETRACE_SKIP_V2=1` skip stays in place — the integration tests still can't run end-to-end until the next segfault (in the engine path) is fixed. But this PR is a real step forward; debugging output proves it.

Partially addresses #445.

## Test plan

- [x] Linux x64: v2 now reaches `logger_init` (prints `[`) — previously died in constructor
- [ ] Linux x64: integration-runtests passes end-to-end (blocked on next segfault; tracked in #445)
- [x] No regression on macOS / Windows / MinGW (no skip needed there)
