### PR TITLE
Release v2.1.0: version bump + binary artifacts workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,13 +17,26 @@
 # BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
 # CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
 # SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# INTERRUPTION) HOWEVER CAUSED AND ON OF CONTRACT, TORT OR OTHERWISE, ARISING
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-# Builds a source-only retrace-<version>.tar.gz and attaches it to the
-# GitHub Release for the pushed tag. Mirrors the libemf2svg release.yml.
+# Release pipeline for retrace.
+#
+# Produces, per tag push:
+#   - retrace-<version>.tar.gz             (source)
+#   - retrace-<version>-<platform>.tar.gz  (binary, POSIX)
+#   - retrace-<version>-<platform>.zip     (binary, Windows)
+#
+# Binary platforms:
+#   linux-x86_64, linux-aarch64
+#   macos-arm64                     (macos-x86_64 disabled pending #452)
+#   windows-x64, windows-arm64
+#   alpine-x86_64, alpine-aarch64
+#
+# Each binary archive ships the v2 shared library, public headers, LICENSE,
+# README, and a THIRD_PARTY_NOTICES confirming no MinHook/Detours linkage
+# (per ADR-0009).
 
 name: Release
 
@@ -43,7 +56,10 @@ permissions:
   contents: write
 
 jobs:
-  build-and-publish:
+  # ---------------------------------------------------------------
+  # Source tarball -- single job, runs on Linux.
+  # ---------------------------------------------------------------
+  source-tarball:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -55,6 +71,250 @@ jobs:
       - name: Build source tarball
         run: ./scripts/build-release-tarball.sh "$RUNNER_TEMP"
 
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: source-tarball
+          path: |
+            ${{ runner.temp }}/retrace-*.tar.gz
+            ${{ runner.temp }}/retrace-*.tar.gz.sha256
+
+  # ---------------------------------------------------------------
+  # Binary artifacts -- matrix across (OS, arch).
+  # ---------------------------------------------------------------
+  binary:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux-x86_64
+            runner: ubuntu-22.04
+            os: linux
+          - platform: linux-aarch64
+            runner: ubuntu-22.04-arm
+            os: linux
+          - platform: macos-arm64
+            runner: macos-14
+            os: macos
+          # macos-x86_64 disabled until #452 is fixed.
+          - platform: windows-x64
+            runner: windows-2022
+            os: windows
+          - platform: windows-arm64
+            runner: windows-11-arm
+            os: windows
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      # ----- POSIX (Linux, macOS) -----
+      - name: Install deps (Linux)
+        if: matrix.os == 'linux'
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq cmake ninja-build libssl-dev
+
+      - name: Install deps (macOS)
+        if: matrix.os == 'macos'
+        run: |
+          brew install cmake ninja openssl
+
+      - name: Configure & build (POSIX)
+        if: matrix.os != 'windows'
+        run: |
+          cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release
+          cmake --build build
+
+      - name: Stage binary (Linux)
+        if: matrix.os == 'linux'
+        run: |
+          VERSION="$(awk -F\" '/^#define RETRACE_VERSION_STRING/ {print $2}' include/retrace/version.h)"
+          STAGE="retrace-${VERSION}-${{ matrix.platform }}"
+          mkdir -p "$STAGE/lib" "$STAGE/include"
+          cp build/src/v2/libretrace_v2.so* "$STAGE/lib/"
+          cp -r include/retrace/* "$STAGE/include/"
+          cp LICENSE README.adoc "$STAGE/"
+          cat > "$STAGE/THIRD_PARTY_NOTICES" <<'NOTICES'
+retrace third-party notices
+===========================
+
+retrace is BSD-2-Clause licensed.
+
+This build does NOT link against or include:
+  - MinHook (https://github.com/TsudaKageyu/minhook)
+  - Microsoft Detours (https://github.com/microsoft/Detours)
+
+The Windows inline-hooking backends (src/backends/win_common/) are
+implemented from scratch per ADR-0009. The JSON parser (parson) is
+vendored under src/config/json/parson.{c,h} and retains its MIT
+license header in those files.
+NOTICES
+          tar -czf "retrace-${VERSION}-${{ matrix.platform }}.tar.gz" "$STAGE"
+          sha256sum "retrace-${VERSION}-${{ matrix.platform }}.tar.gz" \
+            > "retrace-${VERSION}-${{ matrix.platform }}.tar.gz.sha256"
+
+      - name: Stage binary (macOS)
+        if: matrix.os == 'macos'
+        run: |
+          VERSION="$(awk -F\" '/^#define RETRACE_VERSION_STRING/ {print $2}' include/retrace/version.h)"
+          STAGE="retrace-${VERSION}-${{ matrix.platform }}"
+          mkdir -p "$STAGE/lib" "$STAGE/include"
+          cp build/src/v2/libretrace_v2.*.dylib "$STAGE/lib/"
+          cp -r include/retrace/* "$STAGE/include/"
+          cp LICENSE README.adoc "$STAGE/"
+          cat > "$STAGE/THIRD_PARTY_NOTICES" <<'NOTICES'
+retrace third-party notices
+===========================
+
+retrace is BSD-2-Clause licensed.
+
+The JSON parser (parson) is vendored under src/config/json/parson.{c,h}
+and retains its MIT license header in those files.
+NOTICES
+          tar -czf "retrace-${VERSION}-${{ matrix.platform }}.tar.gz" "$STAGE"
+          shasum -a 256 "retrace-${VERSION}-${{ matrix.platform }}.tar.gz" \
+            > "retrace-${VERSION}-${{ matrix.platform }}.tar.gz.sha256"
+
+      # ----- Windows (MSVC) -----
+      - name: Set up vcpkg (Windows)
+        if: matrix.os == 'windows'
+        shell: pwsh
+        run: |
+          if ('${{ matrix.platform }}' -eq 'windows-arm64') {
+            $triplet = 'arm64-windows'
+          } else {
+            $triplet = 'x64-windows'
+          }
+          if (-not (Test-Path vcpkg)) {
+            git clone --depth 1 https://github.com/microsoft/vcpkg.git vcpkg
+          }
+          cd vcpkg
+          if (-not (Test-Path vcpkg.exe)) { .\bootstrap-vcpkg.bat -disableMetrics }
+          "VCPKG_TRIPLET=$triplet" | Out-File -Append $env:GITHUB_ENV
+
+      - name: Configure & build (Windows)
+        if: matrix.os == 'windows'
+        shell: pwsh
+        run: |
+          $toolchain = "${{ github.workspace }}\vcpkg\scripts\buildsystems\vcpkg.cmake"
+          cmake -B build "-DCMAKE_BUILD_TYPE=Release" `
+            "-DVCPKG_TARGET_TRIPLET=$env:VCPKG_TRIPLET" `
+            "-DCMAKE_TOOLCHAIN_FILE=$toolchain"
+          cmake --build build --config Release
+
+      - name: Stage binary (Windows)
+        if: matrix.os == 'windows'
+        shell: pwsh
+        run: |
+          $version = (Select-String -Path include/retrace/version.h `
+            -Pattern '#define RETRACE_VERSION_STRING "([^"]+)"').Matches.Groups[1].Value
+          $stage = "retrace-$version-${{ matrix.platform }}"
+          New-Item -ItemType Directory -Force -Path "$stage/bin", "$stage/include"
+          $msvcDll = "build/src/backends/preload_msvc/Release/retrace_backend_preload_msvc.dll"
+          if (Test-Path $msvcDll) { Copy-Item $msvcDll "$stage/bin/" }
+          $mingwDll = "build/src/backends/preload_mingw/Release/retrace_backend_preload_mingw.dll"
+          if (Test-Path $mingwDll) { Copy-Item $mingwDll "$stage/bin/" }
+          Copy-Item -Recurse include/retrace/* "$stage/include/"
+          Copy-Item LICENSE, README.adoc "$stage/"
+          @"
+          retrace third-party notices
+          ===========================
+
+          retrace is BSD-2-Clause licensed.
+
+          This build does NOT link against or include:
+            - MinHook (https://github.com/TsudaKageyu/minhook)
+            - Microsoft Detours (https://github.com/microsoft/Detours)
+
+          The Windows inline-hooking backends (src/backends/win_common/) are
+          implemented from scratch per ADR-0009. The JSON parser (parson) is
+          vendored under src/config/json/parson.{c,h} and retains its MIT
+          license header in those files.
+          "@ | Out-File -Encoding ascii "$stage/THIRD_PARTY_NOTICES"
+          Compress-Archive -Path $stage -DestinationPath "retrace-$version-${{ matrix.platform }}.zip"
+          $hash = (Get-FileHash "retrace-$version-${{ matrix.platform }}.zip" -Algorithm SHA256).Hash
+          "$hash *retrace-$version-${{ matrix.platform }}.zip" | Out-File -Encoding ascii "retrace-$version-${{ matrix.platform }}.zip.sha256"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: binary-${{ matrix.platform }}
+          path: |
+            retrace-*.tar.gz
+            retrace-*.tar.gz.sha256
+            retrace-*.zip
+            retrace-*.zip.sha256
+
+  # ---------------------------------------------------------------
+  # Alpine (musl) binaries -- container-based, runs on Linux x86_64
+  # with QEMU for aarch64.
+  # ---------------------------------------------------------------
+  alpine-binary:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: alpine-x86_64
+            arch: amd64
+          - platform: alpine-aarch64
+            arch: arm64
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Build in Alpine container
+        run: |
+          docker run --rm --platform linux/${{ matrix.arch }} \
+            -v "$PWD:/work" -w /work alpine:latest \
+            sh -c '
+              set -eu
+              apk add --no-cache cmake ninja gcc musl-dev linux-headers openssl-dev
+              cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release
+              cmake --build build
+              VERSION=$(awk -F"\"" "/^#define RETRACE_VERSION_STRING/ {print \$2}" include/retrace/version.h)
+              STAGE="retrace-${VERSION}-${{ matrix.platform }}"
+              mkdir -p "$STAGE/lib" "$STAGE/include"
+              cp build/src/v2/libretrace_v2.so* "$STAGE/lib/"
+              cp -r include/retrace/* "$STAGE/include/"
+              cp LICENSE README.adoc "$STAGE/"
+              cat > "$STAGE/THIRD_PARTY_NOTICES" <<"NOTICES"
+          retrace third-party notices
+          ===========================
+
+          retrace is BSD-2-Clause licensed. Built against musl libc.
+          The JSON parser (parson) is vendored under
+          src/config/json/parson.{c,h} and retains its MIT license header
+          in those files.
+          NOTICES
+              tar -czf "retrace-${VERSION}-${{ matrix.platform }}.tar.gz" "$STAGE"
+              sha256sum "retrace-${VERSION}-${{ matrix.platform }}.tar.gz" \
+                > "retrace-${VERSION}-${{ matrix.platform }}.tar.gz.sha256"
+            '
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: binary-${{ matrix.platform }}
+          path: |
+            retrace-*.tar.gz
+            retrace-*.tar.gz.sha256
+
+  # ---------------------------------------------------------------
+  # Publish: gather all artifacts, attach to GitHub Release.
+  # ---------------------------------------------------------------
+  publish:
+    needs: [source-tarball, binary, alpine-binary]
+    runs-on: ubuntu-latest
+    steps:
       - name: Resolve tag name
         id: tag
         run: |
@@ -66,6 +326,15 @@ jobs:
           ref="${ref#refs/tags/}"
           echo "tag=$ref" >> "$GITHUB_OUTPUT"
 
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: List artifacts
+        run: find artifacts -type f | sort
+
       - name: Upload to GitHub Releases
         uses: softprops/action-gh-release@v2
         with:
@@ -73,5 +342,7 @@ jobs:
           name: ${{ steps.tag.outputs.tag }}
           generate_release_notes: true
           files: |
-            ${{ runner.temp }}/retrace-*.tar.gz
-            ${{ runner.temp }}/retrace-*.tar.gz.sha256
+            artifacts/retrace-*.tar.gz
+            artifacts/retrace-*.tar.gz.sha256
+            artifacts/retrace-*.zip
+            artifacts/retrace-*.zip.sha256

--- a/include/retrace/version.h
+++ b/include/retrace/version.h
@@ -37,10 +37,10 @@
 #define RETRACE_VERSION_H
 
 #define RETRACE_VERSION_MAJOR 2
-#define RETRACE_VERSION_MINOR 0
-#define RETRACE_VERSION_PATCH 1
+#define RETRACE_VERSION_MINOR 1
+#define RETRACE_VERSION_PATCH 0
 
-#define RETRACE_VERSION_STRING "2.0.1"
+#define RETRACE_VERSION_STRING "2.1.0"
 
 #define RETRACE_VERSION_ATLEAST(maj, min, pat)                  \
 	(RETRACE_VERSION_MAJOR > (maj) ||                       \


### PR DESCRIPTION
## Summary

Two commits preparing the v2.1.0 release.

**Commit 1 — Bump version to 2.1.0** (`include/retrace/version.h`)

Per ADR-0006 (semantic versioning) and ADR-0011 (v1 removal at v2.1.0). MINOR bump per ADR-0006: backwards-compatible additions (new backend plugin API, Windows support, ptrace backend, action system).

v2.1.0 ships:
- Modern CMake-only build (Autotools tree deleted, PR #446)
- v2 reaches feature parity on every v1 platform: Linux x86_64 + aarch64, macOS arm64 (Intel under investigation #452), FreeBSD/OpenBSD/NetBSD x86_64, Windows MSVC x86_64 + arm64, Alpine musl x86_64 + aarch64, MinGW
- Backend plugin architecture (`retrace_backend_t`)
- From-scratch Windows inline-hooking backends (ADR-0009)
- ptrace backend for statically-linked Linux binaries
- JSON-driven action system
- Test pyramid: integration runner with CTest labels
- Public C API with opaque types (ADR-0008)

**Commit 2 — `release.yml` produces per-platform binary artifacts**

Old workflow shipped source-only. The new matrix produces 7 binary archives per tag push:
- `retrace-<ver>-linux-x86_64.tar.gz`
- `retrace-<ver>-linux-aarch64.tar.gz`
- `retrace-<ver>-macos-arm64.tar.gz` (Intel pending #452)
- `retrace-<ver>-windows-x64.zip`
- `retrace-<ver>-windows-arm64.zip`
- `retrace-<ver>-alpine-x86_64.tar.gz`
- `retrace-<ver>-alpine-aarch64.tar.gz`

Each binary archive ships `libretrace_v2.{so,dylib}` (or `retrace_backend_preload_*.dll` on Windows), public headers, `LICENSE`, `README.adoc`, and a `THIRD_PARTY_NOTICES` confirming no MinHook/Detours linkage per ADR-0009.

Jobs:
- `source-tarball` — unchanged, builds `retrace-<ver>.tar.gz`
- `binary` — matrix for non-Alpine POSIX + Windows
- `alpine-binary` — matrix via Alpine containers + QEMU
- `publish` — gathers all artifacts, attaches to GH Release via `softprops/action-gh-release@v2`

## Test plan

- [ ] CI green on this branch
- [ ] (After merge) User pushes `v2.1.0` tag → release workflow produces source + 7 binary archives

## Known follow-ups (not blocking release)

- #450 dlopen segfault on Linux
- #451 printf/writev segfault on macOS arm64
- #452 all v2 tests segfault on macOS Intel
