### PR TITLE
Drop _v2 suffix from installed library name

### DIFF
--- a/.github/scripts/ohos-smoke-test.c
+++ b/.github/scripts/ohos-smoke-test.c
@@ -1,7 +1,7 @@
 /*
- * OHOS smoke test for retrace v2 library loadability.
+ * OHOS smoke test for retrace library loadability.
  *
- * The retrace v2 public API (retrace.h) is currently scaffold-only; the
+ * The retrace public API (retrace.h) is currently scaffold-only; the
  * actual entry point is `retrace_engine_wrapper`, an internal symbol
  * invoked by per-function trampolines when the library is LD_PRELOADed
  * into a target process. The symbol is hidden by default
@@ -34,12 +34,12 @@
 
 int main(void)
 {
-    void *handle = dlopen("./libretrace_v2.so.2", RTLD_NOW | RTLD_LOCAL);
+    void *handle = dlopen("./libretrace.so.2", RTLD_NOW | RTLD_LOCAL);
     if (handle == NULL) {
-        fprintf(stderr, "FAIL: dlopen(libretrace_v2.so.2) failed: %s\n", dlerror());
+        fprintf(stderr, "FAIL: dlopen(libretrace.so.2) failed: %s\n", dlerror());
         return 2;
     }
-    printf("dlopen(libretrace_v2.so.2): OK (constructor ran)\n");
+    printf("dlopen(libretrace.so.2): OK (constructor ran)\n");
     printf("OK\n");
     fflush(stdout);
 

--- a/.github/workflows/alpine.yml
+++ b/.github/workflows/alpine.yml
@@ -94,7 +94,7 @@ jobs:
         env:
           RETRACE_LOGGER_DEF_STDOUT_ENA: "0"
         run: |
-          LD_PRELOAD="$(pwd)/build/src/v2/libretrace_v2.so" /bin/id
+          LD_PRELOAD="$(pwd)/build/src/v2/libretrace.so" /bin/id
 
   build-aarch64:
     runs-on: ubuntu-latest

--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -104,14 +104,14 @@ jobs:
 
       - name: Verify .so is ARM aarch64
         run: |
-          ls -la build-ohos/src/v2/libretrace_v2.so*
-          file build-ohos/src/v2/libretrace_v2.so.2.1.0 | tee /dev/stderr | grep -q 'ELF 64-bit LSB .* ARM aarch64'
+          ls -la build-ohos/src/v2/libretrace.so*
+          file build-ohos/src/v2/libretrace.so.2.1.0 | tee /dev/stderr | grep -q 'ELF 64-bit LSB .* ARM aarch64'
 
       - name: Code-sign .so (required by OHOS at dlopen time)
         run: |
-          for f in build-ohos/src/v2/libretrace_v2.so \
-                   build-ohos/src/v2/libretrace_v2.so.2 \
-                   build-ohos/src/v2/libretrace_v2.so.2.1.0; do
+          for f in build-ohos/src/v2/libretrace.so \
+                   build-ohos/src/v2/libretrace.so.2 \
+                   build-ohos/src/v2/libretrace.so.2.1.0; do
             [ -e "$f" ] || continue
             /opt/ohos/ohos-sdk/linux/toolchains/lib/binary-sign-tool sign \
               -selfSign 1 -inFile "$f" -outFile "$f"
@@ -140,9 +140,9 @@ jobs:
       - name: Stage verification bundle
         run: |
           mkdir -p ohos-verify
-          cp -a build-ohos/src/v2/libretrace_v2.so           ohos-verify/
-          cp -a build-ohos/src/v2/libretrace_v2.so.2         ohos-verify/ 2>/dev/null || true
-          cp -a build-ohos/src/v2/libretrace_v2.so.2.1.0     ohos-verify/ 2>/dev/null || true
+          cp -a build-ohos/src/v2/libretrace.so           ohos-verify/
+          cp -a build-ohos/src/v2/libretrace.so.2         ohos-verify/ 2>/dev/null || true
+          cp -a build-ohos/src/v2/libretrace.so.2.1.0     ohos-verify/ 2>/dev/null || true
           cp -a build-ohos/ohos-smoke-test                    ohos-verify/
           cp -a build-ohos/ohos-ldpreload-target              ohos-verify/
           cp -a .github/scripts/ohos-ldpreload-config.json    ohos-verify/retrace-config.json
@@ -171,7 +171,7 @@ jobs:
             -v "$PWD/ohos-verify:/work" -w /work \
             ghcr.io/hqzing/dockerharmony:latest \
             sh -c '
-              LD_LIBRARY_PATH=. LD_PRELOAD=./libretrace_v2.so.2 \
+              LD_LIBRARY_PATH=. LD_PRELOAD=./libretrace.so.2 \
               RETRACE_JSON_CONFIG=./retrace-config.json \
               ./ohos-ldpreload-target 2>&1
             ' 2>&1)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,7 +134,7 @@ jobs:
           VERSION="$(awk -F\" '/^#define RETRACE_VERSION_STRING/ {print $2}' include/retrace/version.h)"
           STAGE="retrace-${VERSION}-${{ matrix.platform }}"
           mkdir -p "$STAGE/lib" "$STAGE/include"
-          cp build/src/v2/libretrace_v2.so* "$STAGE/lib/"
+          cp build/src/v2/libretrace.so* "$STAGE/lib/"
           cp -r include/retrace/* "$STAGE/include/"
           cp LICENSE README.adoc "$STAGE/"
           cat > "$STAGE/THIRD_PARTY_NOTICES" <<'NOTICES'
@@ -162,7 +162,7 @@ NOTICES
           VERSION="$(awk -F\" '/^#define RETRACE_VERSION_STRING/ {print $2}' include/retrace/version.h)"
           STAGE="retrace-${VERSION}-${{ matrix.platform }}"
           mkdir -p "$STAGE/lib" "$STAGE/include"
-          cp build/src/v2/libretrace_v2.*.dylib "$STAGE/lib/"
+          cp build/src/v2/libretrace.*.dylib "$STAGE/lib/"
           cp -r include/retrace/* "$STAGE/include/"
           cp LICENSE README.adoc "$STAGE/"
           cat > "$STAGE/THIRD_PARTY_NOTICES" <<'NOTICES'
@@ -283,7 +283,7 @@ NOTICES
               VERSION=$(awk -F"\"" "/^#define RETRACE_VERSION_STRING/ {print \$2}" include/retrace/version.h)
               STAGE="retrace-${VERSION}-${{ matrix.platform }}"
               mkdir -p "$STAGE/lib" "$STAGE/include"
-              cp build/src/v2/libretrace_v2.so* "$STAGE/lib/"
+              cp build/src/v2/libretrace.so* "$STAGE/lib/"
               cp -r include/retrace/* "$STAGE/include/"
               cp LICENSE README.adoc "$STAGE/"
               cat > "$STAGE/THIRD_PARTY_NOTICES" <<"NOTICES"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ sudo cmake --install build
 
 Useful CMake options:
 
-- `RETRACE_BUILD_V2` (default ON) — build the v2 shared library (`libretrace_v2.{so,dylib}`).
+- `RETRACE_BUILD_V2` (default ON) — build the retrace shared library (`libretrace.{so,dylib}`). The internal CMake target name is `retrace_v2` for historical reasons (v1 source was deleted in Phase 9 / ADR-0011; only one library remains).
 - `RETRACE_BUILD_CLI` (default ON) — build the CLI launcher (placeholder; new CLI lands in Phase 10).
 - `RETRACE_BUILD_TESTS` (default OFF) — build the per-feature test binaries in `test/`.
 - `RETRACE_BUILD_EXAMPLES` (default OFF) — build the demos under `examples/`.
@@ -37,7 +37,7 @@ The CMake build does feature probes (`CheckIncludeFile`, `CheckSymbolExists`, `C
 ## Running
 
 ```sh
-RETRACE_JSON_CONFIG=<conf.json> LD_PRELOAD=build/src/v2/libretrace_v2.so <binary>
+RETRACE_JSON_CONFIG=<conf.json> LD_PRELOAD=build/src/v2/libretrace.so <binary>
 ```
 
 v2 reads `RETRACE_JSON_CONFIG` (path to JSON config; defaults to log_params+call_real for all funcs), `RETRACE_LOGGER_DEF_ENA`, `RETRACE_LOGGER_DEF_STDOUT_ENA`, `RETRACE_LOGGER_DEF_FN` (log output control).

--- a/src/v2/CMakeLists.txt
+++ b/src/v2/CMakeLists.txt
@@ -78,7 +78,7 @@ target_include_directories(retrace_v2
 	PRIVATE ${CMAKE_SOURCE_DIR}/src/backends ${_v2_arch_dir})
 
 set_target_properties(retrace_v2 PROPERTIES
-	OUTPUT_NAME retrace_v2
+	OUTPUT_NAME retrace
 	VERSION ${PROJECT_VERSION}
 	SOVERSION ${PROJECT_VERSION_MAJOR}
 	C_VISIBILITY_PRESET hidden


### PR DESCRIPTION
## Summary

Drop the `_v2` suffix from the installed library filename. Only one retrace library remains (v1 source was deleted in Phase 9 / ADR-0011), so the parallel-versioning suffix is dead weight — and confusing, since users reasonably wonder whether they should be using "v1" when there is no v1 to use.

**Installed artifact names:**

| Before | After |
|--------|-------|
| `libretrace_v2.so.2.1.0` | `libretrace.so.2.1.0` |
| `libretrace_v2.2.1.0.dylib` | `libretrace.2.1.0.dylib` |
| `retrace_v2.dll` | `retrace.dll` |

**What changes:**

- `src/v2/CMakeLists.txt`: `OUTPUT_NAME retrace_v2` → `OUTPUT_NAME retrace`
- `release.yml`, `alpine.yml`, `ohos.yml`: stage/copy/code-sign/LD_PRELOAD paths
- `ohos-smoke-test.c`: `dlopen("./libretrace.so.2")`
- `CLAUDE.md`: build-flag description + example invocation

**What stays the same (intentional):**

- Internal CMake target name `retrace_v2` (renaming would ripple through every `target_link_libraries(retrace_v2 ...)` call, the `retrace::v2` alias, and any external consumer's CMake for zero user-visible benefit)
- The `src/v2/` directory name (same reason — path churn without user benefit)
- Build flag `RETRACE_BUILD_V2` (it's the on/off switch for the only build)
- The historical v1 → v2 references in ADRs and `READMEv2.adoc` (those describe the transition; rewriting them would lose context)

## Test plan

- [ ] CI green on this branch
- [ ] `libretrace.so.2.1.0` (not `libretrace_v2.so.2.1.0`) is produced by every platform's build
- [ ] OHOS workflow passes with new dlopen + LD_PRELOAD paths
- [ ] Release.yml staging paths match the new artifact name

## Follow-ups (separate PRs)

- Rename internal CMake target to `retrace` (cosmetic; bigger ripple)
- Replace `READMEv2.adoc` with current CMake build instructions (the file still references deleted Autotools)
