### PR TITLE
release.yml: fix YAML parse failure (heredoc bodies at column 1)

### DIFF
--- a/.github/notice/THIRD_PARTY_NOTICES.musl
+++ b/.github/notice/THIRD_PARTY_NOTICES.musl
@@ -1,0 +1,7 @@
+retrace third-party notices
+===========================
+
+retrace is BSD-2-Clause licensed. Built against musl libc.
+The JSON parser (parson) is vendored under
+src/config/json/parson.{c,h} and retains its MIT license header
+in those files.

--- a/.github/notice/THIRD_PARTY_NOTICES.ohos
+++ b/.github/notice/THIRD_PARTY_NOTICES.ohos
@@ -1,0 +1,11 @@
+retrace third-party notices
+===========================
+
+retrace is BSD-2-Clause licensed. Built against OHOS musl libc.
+The JSON parser (parson) is vendored under
+src/config/json/parson.{c,h} and retains its MIT license header
+in those files.
+
+This .so is self-signed (-selfSign 1) for OHOS userland load and app
+distribution. Production Huawei-managed deployments may require
+re-signing with an enrolled cert.

--- a/.github/notice/THIRD_PARTY_NOTICES.posix
+++ b/.github/notice/THIRD_PARTY_NOTICES.posix
@@ -1,0 +1,7 @@
+retrace third-party notices
+===========================
+
+retrace is BSD-2-Clause licensed.
+
+The JSON parser (parson) is vendored under src/config/json/parson.{c,h}
+and retains its MIT license header in those files.

--- a/.github/notice/THIRD_PARTY_NOTICES.posix-with-windows
+++ b/.github/notice/THIRD_PARTY_NOTICES.posix-with-windows
@@ -1,0 +1,13 @@
+retrace third-party notices
+===========================
+
+retrace is BSD-2-Clause licensed.
+
+This build does NOT link against or include:
+  - MinHook (https://github.com/TsudaKageyu/minhook)
+  - Microsoft Detours (https://github.com/microsoft/Detours)
+
+The Windows inline-hooking backends (src/backends/win_common/) are
+implemented from scratch per ADR-0009. The JSON parser (parson) is
+vendored under src/config/json/parson.{c,h} and retains its MIT
+license header in those files.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,21 +138,7 @@ jobs:
           cp build/src/v2/libretrace.so* "$STAGE/lib/"
           cp -r include/retrace/* "$STAGE/include/"
           cp LICENSE README.adoc "$STAGE/"
-          cat > "$STAGE/THIRD_PARTY_NOTICES" <<'NOTICES'
-retrace third-party notices
-===========================
-
-retrace is BSD-2-Clause licensed.
-
-This build does NOT link against or include:
-  - MinHook (https://github.com/TsudaKageyu/minhook)
-  - Microsoft Detours (https://github.com/microsoft/Detours)
-
-The Windows inline-hooking backends (src/backends/win_common/) are
-implemented from scratch per ADR-0009. The JSON parser (parson) is
-vendored under src/config/json/parson.{c,h} and retains its MIT
-license header in those files.
-NOTICES
+          cp .github/notice/THIRD_PARTY_NOTICES.posix-with-windows "$STAGE/THIRD_PARTY_NOTICES"
           tar -czf "retrace-${VERSION}-${{ matrix.platform }}.tar.gz" "$STAGE"
           sha256sum "retrace-${VERSION}-${{ matrix.platform }}.tar.gz" \
             > "retrace-${VERSION}-${{ matrix.platform }}.tar.gz.sha256"
@@ -166,15 +152,7 @@ NOTICES
           cp build/src/v2/libretrace.*.dylib "$STAGE/lib/"
           cp -r include/retrace/* "$STAGE/include/"
           cp LICENSE README.adoc "$STAGE/"
-          cat > "$STAGE/THIRD_PARTY_NOTICES" <<'NOTICES'
-retrace third-party notices
-===========================
-
-retrace is BSD-2-Clause licensed.
-
-The JSON parser (parson) is vendored under src/config/json/parson.{c,h}
-and retains its MIT license header in those files.
-NOTICES
+          cp .github/notice/THIRD_PARTY_NOTICES.posix "$STAGE/THIRD_PARTY_NOTICES"
           tar -czf "retrace-${VERSION}-${{ matrix.platform }}.tar.gz" "$STAGE"
           shasum -a 256 "retrace-${VERSION}-${{ matrix.platform }}.tar.gz" \
             > "retrace-${VERSION}-${{ matrix.platform }}.tar.gz.sha256"
@@ -287,15 +265,7 @@ NOTICES
               cp build/src/v2/libretrace.so* "$STAGE/lib/"
               cp -r include/retrace/* "$STAGE/include/"
               cp LICENSE README.adoc "$STAGE/"
-              cat > "$STAGE/THIRD_PARTY_NOTICES" <<"NOTICES"
-          retrace third-party notices
-          ===========================
-
-          retrace is BSD-2-Clause licensed. Built against musl libc.
-          The JSON parser (parson) is vendored under
-          src/config/json/parson.{c,h} and retains its MIT license header
-          in those files.
-          NOTICES
+              cp .github/notice/THIRD_PARTY_NOTICES.musl "$STAGE/THIRD_PARTY_NOTICES"
               tar -czf "retrace-${VERSION}-${{ matrix.platform }}.tar.gz" "$STAGE"
               sha256sum "retrace-${VERSION}-${{ matrix.platform }}.tar.gz" \
                 > "retrace-${VERSION}-${{ matrix.platform }}.tar.gz.sha256"
@@ -378,19 +348,7 @@ NOTICES
           cp build-ohos/src/v2/libretrace.so* "$STAGE/lib/"
           cp -r include/retrace/* "$STAGE/include/"
           cp LICENSE README.adoc "$STAGE/"
-          cat > "$STAGE/THIRD_PARTY_NOTICES" <<'NOTICES'
-retrace third-party notices
-===========================
-
-retrace is BSD-2-Clause licensed. Built against OHOS musl libc.
-The JSON parser (parson) is vendored under
-src/config/json/parson.{c,h} and retains its MIT license header
-in those files.
-
-This .so is self-signed (-selfSign 1) for OHOS userland load and app
-distribution. Production Huawei-managed deployments may require
-re-signing with an enrolled cert.
-NOTICES
+          cp .github/notice/THIRD_PARTY_NOTICES.ohos "$STAGE/THIRD_PARTY_NOTICES"
           tar -czf "retrace-${VERSION}-ohos-aarch64.tar.gz" "$STAGE"
           sha256sum "retrace-${VERSION}-ohos-aarch64.tar.gz" \
             > "retrace-${VERSION}-ohos-aarch64.tar.gz.sha256"


### PR DESCRIPTION
## Summary

Hotfix for the broken v2.1.0 release workflow. The `release.yml` file fails YAML parsing because four `cat > $STAGE/THIRD_PARTY_NOTICES <<'NOTICES'` heredoc bodies are at column 1 inside `run: |` literal-block scalars. YAML requires every body line to be indented past the `run:` key.

The bug has been latent since #453 (the workflow was never tag-pushed before v2.1.0 just now).

Run failure on the v2.1.0 tag push: https://github.com/riboseinc/retrace/actions/runs/30282497438 (failed before any job could start, "workflow file issue").

**Fix:** hoist the four notice variants into static files under `.github/notice/` and `cp` them into place.

| File | Used by |
|------|---------|
| `THIRD_PARTY_NOTICES.posix-with-windows` | Linux jobs |
| `THIRD_PARTY_NOTICES.posix` | macOS jobs |
| `THIRD_PARTY_NOTICES.musl` | Alpine jobs |
| `THIRD_PARTY_NOTICES.ohos` | OHOS job |

The PowerShell here-string in the Windows staging step is left alone — its body was already indented to match the YAML literal-scalar block, so it parses fine.

## Test plan

- [ ] CI green on this branch
- [ ] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` succeeds
- [ ] (After merge) `workflow_dispatch` on main with `ref=v2.1.0` produces all 9 artifacts on the v2.1.0 GH release

## Follow-up

After this lands, I'll trigger the release via `workflow_dispatch` on main with `ref=v2.1.0` — the workflow FILE resolves from main (fixed), the checkout/build resolves from the v2.1.0 tag, and the publish step attaches artifacts to the v2.1.0 release.
