### PR TITLE
release.yml: LICENSE is LICENSE.md, not LICENSE

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,7 +137,7 @@ jobs:
           mkdir -p "$STAGE/lib" "$STAGE/include"
           cp build/src/v2/libretrace.so* "$STAGE/lib/"
           cp -r include/retrace/* "$STAGE/include/"
-          cp LICENSE README.adoc "$STAGE/"
+          cp LICENSE.md README.adoc "$STAGE/"
           cp .github/notice/THIRD_PARTY_NOTICES.posix-with-windows "$STAGE/THIRD_PARTY_NOTICES"
           tar -czf "retrace-${VERSION}-${{ matrix.platform }}.tar.gz" "$STAGE"
           sha256sum "retrace-${VERSION}-${{ matrix.platform }}.tar.gz" \
@@ -151,7 +151,7 @@ jobs:
           mkdir -p "$STAGE/lib" "$STAGE/include"
           cp build/src/v2/libretrace.*.dylib "$STAGE/lib/"
           cp -r include/retrace/* "$STAGE/include/"
-          cp LICENSE README.adoc "$STAGE/"
+          cp LICENSE.md README.adoc "$STAGE/"
           cp .github/notice/THIRD_PARTY_NOTICES.posix "$STAGE/THIRD_PARTY_NOTICES"
           tar -czf "retrace-${VERSION}-${{ matrix.platform }}.tar.gz" "$STAGE"
           shasum -a 256 "retrace-${VERSION}-${{ matrix.platform }}.tar.gz" \
@@ -197,7 +197,7 @@ jobs:
           $mingwDll = "build/src/backends/preload_mingw/Release/retrace_backend_preload_mingw.dll"
           if (Test-Path $mingwDll) { Copy-Item $mingwDll "$stage/bin/" }
           Copy-Item -Recurse include/retrace/* "$stage/include/"
-          Copy-Item LICENSE, README.adoc "$stage/"
+          Copy-Item LICENSE.md, README.adoc "$stage/"
           @"
           retrace third-party notices
           ===========================
@@ -264,7 +264,7 @@ jobs:
               mkdir -p "$STAGE/lib" "$STAGE/include"
               cp build/src/v2/libretrace.so* "$STAGE/lib/"
               cp -r include/retrace/* "$STAGE/include/"
-              cp LICENSE README.adoc "$STAGE/"
+              cp LICENSE.md README.adoc "$STAGE/"
               cp .github/notice/THIRD_PARTY_NOTICES.musl "$STAGE/THIRD_PARTY_NOTICES"
               tar -czf "retrace-${VERSION}-${{ matrix.platform }}.tar.gz" "$STAGE"
               sha256sum "retrace-${VERSION}-${{ matrix.platform }}.tar.gz" \
@@ -347,7 +347,7 @@ jobs:
           mkdir -p "$STAGE/lib" "$STAGE/include"
           cp build-ohos/src/v2/libretrace.so* "$STAGE/lib/"
           cp -r include/retrace/* "$STAGE/include/"
-          cp LICENSE README.adoc "$STAGE/"
+          cp LICENSE.md README.adoc "$STAGE/"
           cp .github/notice/THIRD_PARTY_NOTICES.ohos "$STAGE/THIRD_PARTY_NOTICES"
           tar -czf "retrace-${VERSION}-ohos-aarch64.tar.gz" "$STAGE"
           sha256sum "retrace-${VERSION}-ohos-aarch64.tar.gz" \


### PR DESCRIPTION
## Summary

Fix incorrect `LICENSE` filename in `release.yml`. The repository's license file is `LICENSE.md` (verified via `git ls-tree HEAD`), but every staging step tried to `cp LICENSE` and failed with `cp: cannot stat 'LICENSE': No such file or directory`.

The bug is latent since #453 (the workflow never ran a real release until v2.1.0 just now).

Five sites fixed:
- Linux staging: `cp LICENSE README.adoc` → `cp LICENSE.md README.adoc`
- macOS staging: same
- Windows staging (PowerShell): `Copy-Item LICENSE, README.adoc` → `Copy-Item LICENSE.md, README.adoc`
- Alpine staging (inside docker run sh -c): same
- OHOS staging: same

Spotted on the v2.1.0 `workflow_dispatch` run: https://github.com/riboseinc/retrace/actions/runs/30284307751

## Test plan

- [ ] CI green on this branch
- [ ] (After merge) re-trigger release workflow_dispatch with `ref=v2.1.0` and confirm all 9 artifacts land on the GH release
