### PR TITLE
printf: fix Darwin arm64 variadic ABI dispatch

### DIFF
--- a/src/backends/arch_spec.h
+++ b/src/backends/arch_spec.h
@@ -81,6 +81,26 @@ long retrace_as_call_real_dispatch(const void *real_impl,
 	const struct FuncParam params[],
 	int params_cnt);
 
+/*
+ * Variadic-aware dispatch: casts real_impl to a variadic-typed function
+ * pointer so the compiler emits the correct ABI for variadic calls:
+ *
+ *   - Linux/BSD AArch64 (AAPCS64): variadic args up to x0..x7, then stack
+ *   - Apple AArch64: variadic args ALWAYS go on the stack
+ *   - x86-64 (System V / Darwin): variadic args in rdi..r9 then stack
+ *
+ * Without this, the non-variadic dispatch puts variadic args in registers
+ * on Apple AArch64; real printf's va_start then reads garbage from the
+ * stack (e.g. strlen(NULL) segfault).
+ *
+ * named_count is proto->params_cnt -- the number of named parameters
+ * (printf: 1 for fmt; fprintf-style: 2 for stream+fmt).
+ */
+long retrace_as_call_real_variadic(const void *real_impl,
+	const struct FuncParam params[],
+	int params_cnt,
+	int named_count);
+
 /* schedules real_impl to run after retrace_engine_wrapper */
 void retrace_as_set_ret_val(void *arch_spec_ctx,
 	long ret_val);

--- a/src/backends/preload_macho/aarch64/arch_spec_bottom.c
+++ b/src/backends/preload_macho/aarch64/arch_spec_bottom.c
@@ -23,6 +23,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <limits.h>
 #include <printf.h>
 #include <pthread.h>
 
@@ -97,90 +98,85 @@ static void as_thread_ctx_destructor(void *thread_ctx)
 }
 
 static int as_arginfo_function(const struct printf_info *__info,
-	     size_t __n, int *__argtypes)
+		     size_t __n, int *__argtypes)
 {
 	struct AsThreadContext *ctx =
 		(struct AsThreadContext *) __info->context;
+	int n_args = 0;
+	int type = 0;
+
+	/* Width '*' is indicated by width == INT_MIN on Darwin/FreeBSD. */
+	if (__info->width == INT_MIN) {
+		if (ctx->printf_args_cnt < ENGINE_MAXCOUNT_PARAMS)
+			ctx->printf_args_types[ctx->printf_args_cnt++] = PA_INT;
+		n_args++;
+	}
+
+	/* Precision '*' is indicated by prec == INT_MIN. */
+	if (__info->prec == INT_MIN) {
+		if (ctx->printf_args_cnt < ENGINE_MAXCOUNT_PARAMS)
+			ctx->printf_args_types[ctx->printf_args_cnt++] = PA_INT;
+		n_args++;
+	}
 
 	switch (__info->spec) {
 	case 'p':
-		ctx->printf_args_types[ctx->printf_args_cnt] = PA_POINTER;
+		type = PA_POINTER;
 		break;
 	case 's':
-		ctx->printf_args_types[ctx->printf_args_cnt] = PA_STRING;
+		type = PA_STRING;
 		break;
 	case 'S':
-		ctx->printf_args_types[ctx->printf_args_cnt] = PA_WSTRING;
-		break;
-	case 'g':
-		ctx->printf_args_types[ctx->printf_args_cnt] = PA_DOUBLE;
-		break;
-	case 'G':
-		ctx->printf_args_types[ctx->printf_args_cnt] = PA_DOUBLE;
-		break;
-	case 'a':
-		ctx->printf_args_types[ctx->printf_args_cnt] = PA_DOUBLE;
-		break;
-	case 'A':
-		ctx->printf_args_types[ctx->printf_args_cnt] = PA_DOUBLE;
+		type = PA_WSTRING;
 		break;
 	case 'c':
-		ctx->printf_args_types[ctx->printf_args_cnt] = PA_CHAR;
+		type = PA_CHAR;
 		break;
-	case 'E':
-		ctx->printf_args_types[ctx->printf_args_cnt] = PA_DOUBLE;
+	case 'g': case 'G':
+	case 'a': case 'A':
+	case 'e': case 'E':
+	case 'f': case 'F':
+		type = PA_DOUBLE;
 		break;
-	case 'e':
-		ctx->printf_args_types[ctx->printf_args_cnt] = PA_DOUBLE;
+	case 'x': case 'X':
+	case 'u': case 'o':
+	case 'd': case 'i':
+		type = PA_INT;
 		break;
-	case 'F':
-		ctx->printf_args_types[ctx->printf_args_cnt] = PA_DOUBLE;
-		break;
-	case 'f':
-		ctx->printf_args_types[ctx->printf_args_cnt] = PA_DOUBLE;
-		break;
-	case 'x':
-		ctx->printf_args_types[ctx->printf_args_cnt] = PA_INT;
-		break;
-	case 'X':
-		ctx->printf_args_types[ctx->printf_args_cnt] = PA_INT;
-		break;
-	case 'u':
-		ctx->printf_args_types[ctx->printf_args_cnt] = PA_INT;
-		break;
-	case 'o':
-		ctx->printf_args_types[ctx->printf_args_cnt] = PA_INT;
-		break;
-	case 'd':
-		ctx->printf_args_types[ctx->printf_args_cnt] = PA_INT;
-		break;
-	case 'i':
-		ctx->printf_args_types[ctx->printf_args_cnt] = PA_INT;
-		break;
+	case '%':
+		/* literal percent -- no conversion arg */
+		return n_args;
 	default:
-		ctx->printf_args_types[ctx->printf_args_cnt] = 0;
+		type = PA_INT;
 		break;
 	}
 
-	if (ctx->printf_args_types[ctx->printf_args_cnt]) {
-		if (__info->is_long_double)
-			ctx->printf_args_types[ctx->printf_args_cnt] |= PA_FLAG_LONG_LONG;
-		else if (__info->is_short)
-			ctx->printf_args_types[ctx->printf_args_cnt] |= PA_FLAG_SHORT;
-		else if (__info->is_long)
-			ctx->printf_args_types[ctx->printf_args_cnt] |= PA_FLAG_LONG;
-		else if (__info->is_quad)
-			ctx->printf_args_types[ctx->printf_args_cnt] |= PA_FLAG_QUAD;
-		else if (__info->is_intmax)
-			ctx->printf_args_types[ctx->printf_args_cnt] |= PA_FLAG_INTMAX;
-		else if (__info->is_ptrdiff)
-			ctx->printf_args_types[ctx->printf_args_cnt] |= PA_FLAG_PTRDIFF;
-		else if (__info->is_size)
-			ctx->printf_args_types[ctx->printf_args_cnt] |= PA_FLAG_SIZE;
-	}
+	if (__info->is_long_double)
+		type |= PA_FLAG_LONG_LONG;
+	else if (__info->is_short)
+		type |= PA_FLAG_SHORT;
+	else if (__info->is_long)
+		type |= PA_FLAG_LONG;
+	else if (__info->is_quad)
+		type |= PA_FLAG_QUAD;
+	else if (__info->is_intmax)
+		type |= PA_FLAG_INTMAX;
+	else if (__info->is_ptrdiff)
+		type |= PA_FLAG_PTRDIFF;
+	else if (__info->is_size)
+		type |= PA_FLAG_SIZE;
 
-	ctx->printf_args_cnt++;
-	return 0;
+	if (ctx->printf_args_cnt < ENGINE_MAXCOUNT_PARAMS)
+		ctx->printf_args_types[ctx->printf_args_cnt++] = type;
+	n_args++;
+
+	/*
+	 * Must return the number of arguments this conversion consumes.
+	 * Returning 0 (the old code) made new_printf_comp stop processing
+	 * subsequent conversions, so printf_args_cnt stayed incomplete
+	 * and call_real only passed the format string -- crash in strlen.
+	 */
+	return n_args;
 }
 
 static int
@@ -236,21 +232,40 @@ static inline struct AsThreadContext *as_get_thread_context(void)
 	return thread_ctx;
 }
 
+/*
+ * Apple AArch64 ABI distinguishes NAMED and VARIADIC args:
+ *
+ *   - Named args (idx < named_count): passed in x0..x7 (saved in
+ *     frame->real_x0..real_x7). Beyond x7 they spill onto the caller's
+ *     stack at orig_sp + 8*(idx-8).
+ *   - Variadic args (idx >= named_count): Apple always pushes variadic
+ *     args onto the caller's stack before the call. Variadic arg k is at
+ *     orig_sp + 8*k (NOT in x1..x7 as AAPCS64 allows on Linux/BSD).
+ *
+ * This split lets the same struct + read path serve both named and
+ * variadic args for any FAT_PRINTF-style function.
+ */
 static unsigned long wrapper_frame_get_arg(
-	const struct WrapperAArch64Frame *frame, int idx)
+	const struct WrapperAArch64Frame *frame, int idx, int named_count)
 {
-	switch (idx) {
-	case 0: return frame->real_x0;
-	case 1: return frame->real_x1;
-	case 2: return frame->real_x2;
-	case 3: return frame->real_x3;
-	case 4: return frame->real_x4;
-	case 5: return frame->real_x5;
-	case 6: return frame->real_x6;
-	case 7: return frame->real_x7;
-	default:
-		return *(unsigned long *)(frame->orig_sp + sizeof(void *) * (idx - 8));
+	if (idx < named_count) {
+		switch (idx) {
+		case 0: return frame->real_x0;
+		case 1: return frame->real_x1;
+		case 2: return frame->real_x2;
+		case 3: return frame->real_x3;
+		case 4: return frame->real_x4;
+		case 5: return frame->real_x5;
+		case 6: return frame->real_x6;
+		case 7: return frame->real_x7;
+		default:
+			return *(unsigned long *)(frame->orig_sp +
+				sizeof(void *) * (idx - 8));
+		}
 	}
+
+	return *(unsigned long *)(frame->orig_sp +
+		sizeof(void *) * (idx - named_count));
 }
 
 long retrace_as_call_real(const void *real_impl,
@@ -306,7 +321,8 @@ int retrace_as_setup_params(
 		params[param_idx].data_type =
 			retrace_datatype_get(proto->params[param_idx].type_name);
 		params[param_idx].val =
-			(long) wrapper_frame_get_arg(frame, param_idx);
+			(long) wrapper_frame_get_arg(frame, param_idx,
+				proto->params_cnt);
 	}
 
 	if (proto->fmt == FAT_NOVARARGS) {
@@ -358,7 +374,8 @@ int retrace_as_setup_params(
 
 		params[param_idx].data_type = dt;
 		params[param_idx].val =
-			(long) wrapper_frame_get_arg(frame, param_idx);
+			(long) wrapper_frame_get_arg(frame, param_idx,
+				proto->params_cnt);
 	}
 
 	*params_cnt = param_idx;

--- a/src/backends/preload_macho/x86_64/arch_spec_bottom.c
+++ b/src/backends/preload_macho/x86_64/arch_spec_bottom.c
@@ -23,6 +23,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <limits.h>
 #include <printf.h>
 #include <pthread.h>
 
@@ -83,121 +84,85 @@ static void as_thread_ctx_destructor(void *thread_ctx)
 }
 
 static int as_arginfo_function(const struct printf_info *__info,
-	     size_t __n, int *__argtypes)
+		     size_t __n, int *__argtypes)
 {
 	struct AsThreadContext *ctx =
 		(struct AsThreadContext *) __info->context;
+	int n_args = 0;
+	int type = 0;
+
+	/* Width '*' is indicated by width == INT_MIN on Darwin/FreeBSD. */
+	if (__info->width == INT_MIN) {
+		if (ctx->printf_args_cnt < ENGINE_MAXCOUNT_PARAMS)
+			ctx->printf_args_types[ctx->printf_args_cnt++] = PA_INT;
+		n_args++;
+	}
+
+	/* Precision '*' is indicated by prec == INT_MIN. */
+	if (__info->prec == INT_MIN) {
+		if (ctx->printf_args_cnt < ENGINE_MAXCOUNT_PARAMS)
+			ctx->printf_args_types[ctx->printf_args_cnt++] = PA_INT;
+		n_args++;
+	}
 
 	switch (__info->spec) {
 	case 'p':
-		ctx->printf_args_types[ctx->printf_args_cnt] = PA_POINTER;
+		type = PA_POINTER;
 		break;
-
 	case 's':
-		ctx->printf_args_types[ctx->printf_args_cnt] = PA_STRING;
+		type = PA_STRING;
 		break;
-
 	case 'S':
-		ctx->printf_args_types[ctx->printf_args_cnt] = PA_WSTRING;
+		type = PA_WSTRING;
 		break;
-
-	case 'g':
-		ctx->printf_args_types[ctx->printf_args_cnt] = PA_DOUBLE;
-		break;
-
-	case 'G':
-		ctx->printf_args_types[ctx->printf_args_cnt] = PA_DOUBLE;
-		break;
-
-	case 'a':
-		ctx->printf_args_types[ctx->printf_args_cnt] = PA_DOUBLE;
-		break;
-
-	case 'A':
-		ctx->printf_args_types[ctx->printf_args_cnt] = PA_DOUBLE;
-		break;
-
 	case 'c':
-		ctx->printf_args_types[ctx->printf_args_cnt] = PA_CHAR;
+		type = PA_CHAR;
 		break;
-
-	case 'E':
-		ctx->printf_args_types[ctx->printf_args_cnt] = PA_DOUBLE;
+	case 'g': case 'G':
+	case 'a': case 'A':
+	case 'e': case 'E':
+	case 'f': case 'F':
+		type = PA_DOUBLE;
 		break;
-
-	case 'e':
-		ctx->printf_args_types[ctx->printf_args_cnt] = PA_DOUBLE;
+	case 'x': case 'X':
+	case 'u': case 'o':
+	case 'd': case 'i':
+		type = PA_INT;
 		break;
-
-	case 'F':
-		ctx->printf_args_types[ctx->printf_args_cnt] = PA_DOUBLE;
-		break;
-
-	case 'f':
-		ctx->printf_args_types[ctx->printf_args_cnt] = PA_DOUBLE;
-		break;
-
-	case 'x':
-		ctx->printf_args_types[ctx->printf_args_cnt] = PA_INT;
-		break;
-
-	case 'X':
-		ctx->printf_args_types[ctx->printf_args_cnt] = PA_INT;
-		break;
-
-	case 'u':
-		ctx->printf_args_types[ctx->printf_args_cnt] = PA_INT;
-		break;
-
-	case 'o':
-		ctx->printf_args_types[ctx->printf_args_cnt] = PA_INT;
-		break;
-
-	case 'd':
-		ctx->printf_args_types[ctx->printf_args_cnt] = PA_INT;
-		break;
-
-	case 'i':
-		ctx->printf_args_types[ctx->printf_args_cnt] = PA_INT;
-		break;
-
+	case '%':
+		/* literal percent -- no conversion arg */
+		return n_args;
 	default:
-		ctx->printf_args_types[ctx->printf_args_cnt] = 0;
-		/*
-		 * Better not to challenge the printf here
-		 * log_err("unknown varargs format '%d'", __info->spec);
-		 */
+		type = PA_INT;
+		break;
 	}
 
-	/* setup flags */
-	if (ctx->printf_args_types[ctx->printf_args_cnt]) {
-		if (__info->is_long_double) {
-			ctx->printf_args_types[ctx->printf_args_cnt] |=
-				PA_FLAG_LONG_LONG;
-		} else if (__info->is_short) {
-			ctx->printf_args_types[ctx->printf_args_cnt] |=
-				PA_FLAG_SHORT;
-		} else if (__info->is_long) {
-			ctx->printf_args_types[ctx->printf_args_cnt] |=
-				PA_FLAG_LONG;
-		} else if (__info->is_quad) {
-			ctx->printf_args_types[ctx->printf_args_cnt] |=
-				PA_FLAG_QUAD;
-		} else if (__info->is_intmax) {
-			ctx->printf_args_types[ctx->printf_args_cnt] |=
-				PA_FLAG_INTMAX;
-		} else if (__info->is_ptrdiff) {
-			ctx->printf_args_types[ctx->printf_args_cnt] |=
-				PA_FLAG_PTRDIFF;
-		} else if (__info->is_size) {
-			ctx->printf_args_types[ctx->printf_args_cnt] |=
-				PA_FLAG_SIZE;
-		}
+	if (__info->is_long_double)
+		type |= PA_FLAG_LONG_LONG;
+	else if (__info->is_short)
+		type |= PA_FLAG_SHORT;
+	else if (__info->is_long)
+		type |= PA_FLAG_LONG;
+	else if (__info->is_quad)
+		type |= PA_FLAG_QUAD;
+	else if (__info->is_intmax)
+		type |= PA_FLAG_INTMAX;
+	else if (__info->is_ptrdiff)
+		type |= PA_FLAG_PTRDIFF;
+	else if (__info->is_size)
+		type |= PA_FLAG_SIZE;
 
-	}
+	if (ctx->printf_args_cnt < ENGINE_MAXCOUNT_PARAMS)
+		ctx->printf_args_types[ctx->printf_args_cnt++] = type;
+	n_args++;
 
-	ctx->printf_args_cnt++;
-	return 0;
+	/*
+	 * Must return the number of arguments this conversion consumes.
+	 * Returning 0 (the old code) made new_printf_comp stop processing
+	 * subsequent conversions, so printf_args_cnt stayed incomplete
+	 * and call_real only passed the format string -- crash in strlen.
+	 */
+	return n_args;
 }
 
 static int

--- a/src/core/actions/basic.c
+++ b/src/core/actions/basic.c
@@ -629,9 +629,24 @@ static int ia_call_real
 			(long) t_ctx->real_impl,
 			t_ctx->prototype->name);
 
-	t_ctx->ret_val = retrace_as_call_real(t_ctx->real_impl,
-		t_ctx->params,
-		t_ctx->params_cnt);
+	/*
+	 * Variadic dispatch: route through the variadic-aware helper so the
+	 * compiler emits the correct variadic ABI for the host arch. On
+	 * Apple AArch64 this puts varargs on the stack; on AAPCS64
+	 * (Linux/BSD AArch64) it puts them in x1..x7. Without this, real
+	 * printf's va_start reads garbage from the wrong place (segfault).
+	 */
+	if (t_ctx->prototype->fmt == FAT_PRINTF) {
+		t_ctx->ret_val = retrace_as_call_real_variadic(
+			t_ctx->real_impl,
+			t_ctx->params,
+			t_ctx->params_cnt,
+			t_ctx->prototype->params_cnt);
+	} else {
+		t_ctx->ret_val = retrace_as_call_real(t_ctx->real_impl,
+			t_ctx->params,
+			t_ctx->params_cnt);
+	}
 
 	log_dbg("real returned val=0x%lx", t_ctx->ret_val);
 

--- a/src/core/as_call_real.c
+++ b/src/core/as_call_real.c
@@ -106,3 +106,137 @@ long retrace_as_call_real_dispatch(const void *real_impl,
 	retrace_real_impls.free(vals);
 	return ret_val;
 }
+
+/*
+ * Variadic-aware dispatch. Used by ia_call_real for functions with
+ * proto->fmt != FAT_NOVARARGS (currently printf).
+ *
+ * Casting real_impl to a variadic-typed function pointer makes the
+ * compiler emit the correct variadic ABI for the host arch:
+ *
+ *   - Apple AArch64: variadic args pushed on the stack (NOT in x1..x7)
+ *   - Linux/BSD AArch64 (AAPCS64): variadic args in x1..x7, then stack
+ *   - x86-64 (Sys V / Darwin x86-64): variadic args in rsi..r9, then stack
+ *
+ * real_impl is a void* with the static type lost; the variadic typedef
+ * restores the "..." info that the compiler needs at the call site.
+ * The callee (real printf, real fprintf, etc.) reads variadic args from
+ * wherever its compiler put them per the same ABI.
+ *
+ * named_count is proto->params_cnt -- the number of NAMED arguments the
+ * prototype declares (printf: 1 for fmt; fprintf-style: 2 for stream+fmt).
+ */
+long retrace_as_call_real_variadic(const void *real_impl,
+				   const struct FuncParam params[],
+				   int params_cnt,
+				   int named_count)
+{
+	long *vals;
+	long ret_val;
+	int i;
+
+	if (named_count > params_cnt)
+		named_count = params_cnt;
+
+	vals = (long *)retrace_real_impls.malloc(sizeof(long) * params_cnt);
+	if (vals == NULL && params_cnt > 0)
+		return -1;
+
+	for (i = 0; i < params_cnt; i++)
+		vals[i] = params[i].val;
+
+	/* The typedef has exactly `named_count` named parameters followed
+	 * by `...`; everything passed beyond named_count is variadic. The
+	 * compiler emits the host arch's variadic ABI for the call:
+	 *
+	 *   Apple AArch64    -> variadic args pushed to stack
+	 *   AAPCS64 ARM64    -> variadic args in regs then stack
+	 *   x86-64 Sys V     -> variadic args in regs then stack
+	 *
+	 * If params_cnt == named_count there are no variadic args to pass;
+	 * the same variadic typedef still compiles and the compiler emits a
+	 * regular call.
+	 */
+	switch (named_count) {
+	case 1: {
+		typedef long (*fn_t)(long, ...);
+
+		switch (params_cnt) {
+		case 0:
+			/* nothing to call */
+			ret_val = -1;
+			break;
+		case 1:
+			ret_val = ((fn_t) real_impl)(vals[0]);
+			break;
+		case 2:
+			ret_val = ((fn_t) real_impl)(vals[0], vals[1]);
+			break;
+		case 3:
+			ret_val = ((fn_t) real_impl)(
+				vals[0], vals[1], vals[2]);
+			break;
+		case 4:
+			ret_val = ((fn_t) real_impl)(vals[0], vals[1],
+				vals[2], vals[3]);
+			break;
+		case 5:
+			ret_val = ((fn_t) real_impl)(vals[0], vals[1],
+				vals[2], vals[3], vals[4]);
+			break;
+		case 6:
+			ret_val = ((fn_t) real_impl)(vals[0], vals[1],
+				vals[2], vals[3], vals[4], vals[5]);
+			break;
+		default:
+			ret_val = -1;
+			break;
+		}
+		break;
+	}
+
+	case 2: {
+		typedef long (*fn_t)(long, long, ...);
+
+		switch (params_cnt) {
+		case 0:
+		case 1:
+			ret_val = -1;
+			break;
+		case 2:
+			ret_val = ((fn_t) real_impl)(vals[0], vals[1]);
+			break;
+		case 3:
+			ret_val = ((fn_t) real_impl)(
+				vals[0], vals[1], vals[2]);
+			break;
+		case 4:
+			ret_val = ((fn_t) real_impl)(vals[0], vals[1],
+				vals[2], vals[3]);
+			break;
+		case 5:
+			ret_val = ((fn_t) real_impl)(vals[0], vals[1],
+				vals[2], vals[3], vals[4]);
+			break;
+		case 6:
+			ret_val = ((fn_t) real_impl)(vals[0], vals[1],
+				vals[2], vals[3], vals[4], vals[5]);
+			break;
+		default:
+			ret_val = -1;
+			break;
+		}
+		break;
+	}
+
+	default:
+		/* named_count out of range; should not happen for printf
+		 * (1) or fprintf-style (2) prototypes we currently model.
+		 */
+		ret_val = -1;
+		break;
+	}
+
+	retrace_real_impls.free(vals);
+	return ret_val;
+}

--- a/test/runtests.sh.in
+++ b/test/runtests.sh.in
@@ -68,9 +68,6 @@ failed_tests=""
 # Tests known to fail on specific OSes (skip on those).
 #   dlopen  — segfaults on Linux/glibc (malloc path inside dlopen;
 #             tracked in follow-up to #445).
-#   printf  — segfaults on macOS (varargs/abi difference; the plain
-#             C dispatch in as_call_real.c doesn't handle macOS printf
-#             correctly yet).
 #   writev  — non-zero rc on macOS (probably writes data that fails).
 # All v2 tests fail on macOS x86_64 (Intel) due to a separate mach-O
 # x86_64 backend issue. Skip the whole runner on that platform until
@@ -82,7 +79,7 @@ should_skip() {
         x86_64) return 0 ;;   # skip all on Intel macOS
         esac
         case "$1" in
-        printf|writev) return 0 ;;
+        writev) return 0 ;;
         esac
         ;;
     esac


### PR DESCRIPTION
## printf: fix Darwin arm64 variadic ABI dispatch (Closes #451)

`printf("%d %s", 42, "...")` segfaulted on Apple Silicon in `strlen(NULL)` inside `vfprintf`. Root cause: the C-level `retrace_as_call_real_dispatch` cast `real_impl` to a *fixed-arity* function pointer, so the compiler put variadic args in `x1`/`x2`. **Apple AArch64 always pushes variadic args onto the caller's stack** (unlike AAPCS64 which allows them in regs), so real `printf`'s `va_start` read garbage from the stack.

Disassembling the test binary confirmed: `str x8, [sp+0]` (the variadic `42`) and `str x8, [sp+8]` (the variadic string ptr), with `x0` holding only the format string.

### Three coordinated changes

1. **`wrapper_frame_get_arg` on Darwin aarch64** now takes `named_count` and reads variadic args from `frame->orig_sp + 8*(idx-named_count)` — matching where the caller pushed them on Apple AArch64. Named args still come from `frame->real_x0..real_x7`.

2. **New `retrace_as_call_real_variadic`** (declared in `arch_spec.h`, defined in `src/core/as_call_real.c`) casts `real_impl` to a variadic-typed function pointer so the compiler emits the correct variadic ABI per arch:
   - Apple AArch64 → variadic args pushed to stack
   - AAPCS64 → variadic args in `x1..x7`, then stack
   - Sys V x86-64 → variadic args in `rsi..r9`, then stack

3. **`ia_call_real`** routes `FAT_PRINTF` prototypes through the new dispatch, passing `proto->params_cnt` as `named_count` so the typedef has exactly that many named parameters followed by `...`.

### Cleanup bundled in

- Consolidates the macho `aarch64` + `x86_64` `as_arginfo_function`: returns `n_args` (was 0, which silently stopped `new_printf_comp` mid-format-string), handles `INT_MIN` width/precision, bounds-checks `printf_args_cnt`. This was already half-done in the working tree — fold the symmetric fix into this PR.
- `test/runtests.sh.in`: re-enables `printf` on Darwin arm64 (no longer needed as a skip).

### Verification

```
ctest --test-dir build-rel
Test project /Users/mulgogi/src/retrace/build-rel
    Start 1: integration-runtests
1/1 Test #1: integration-runtests .............   Passed    1.82 sec
```

Direct test:

```
$ DYLD_INSERT_LIBRARIES=build-rel/src/v2/libretrace.dylib build-rel/test/printf
Another test 52
Format String 42
Test 42 forty two
TEST 2a
Format String 42
Format String 42
```

`%d`, `%s`, `%x`, `%o`, `%u`, `sprintf`, `snprintf`, `fprintf`, `dprintf`, `vprintf`, `vfprintf`, `vdprintf`, `vsprintf`, `vsnprintf` — all print the correct value.

Also cross-built for `x86_64` (`-DCMAKE_OSX_ARCHITECTURES=x86_64`) and verified it compiles cleanly.

### Out of scope

The stashed `fp-asm-wip` (`stash@{0}` on this branch) adds SIMD-reg FP vararg support for AAPCS64 (real doubles in `%f` etc.). That's a separate, bigger piece of work — `%f`/`%g` still hits the printf bail in `printf_compat.h` for both Apple and Linux. Filed as follow-up.
