### PR TITLE
prototypes/stdio: add printf-family variadic prototypes (#409 partial)

### DIFF
--- a/src/core/prototypes/stdio.c
+++ b/src/core/prototypes/stdio.c
@@ -521,16 +521,261 @@ retrace_func_define_prototypes(stdio) = {
 /* FIXME: Prototype when vararg funcs are supported by the engine */
 
 /*
+ * Variadic printf-family prototypes. fmt = FAT_PRINTF routes them through
+ * retrace_as_call_real_variadic (src/core/as_call_real.c) so the compiler
+ * emits the correct per-arch variadic ABI:
  *
- *	int fprintf(FILE *stream, const char *format, ...)
- *	int sprintf(char *str, const char *format, ...)
- *	int vfprintf(FILE *stream, const char *format, va_list arg)
- *	int vprintf(const char *format, va_list arg)
- *	int vsprintf(char *str, const char *format, va_list arg)
- *	int fscanf(FILE *stream, const char *format, ...)
- *	int scanf(const char *format, ...)
- *	int sscanf(const char *str, const char *format, ...)
+ *   - Apple AArch64: variadic args pushed to stack
+ *   - AAPCS64 (Linux/BSD ARM64): variadic args in x1..x7 then stack
+ *   - Sys V x86-64: variadic args in rsi..r9 then stack
+ *
+ * v*printf variants take a va_list (typed as ptr) -- they are NOT variadic
+ * from retrace's perspective, so they use FAT_NOVARARGS.
  */
+
+/*
+ * int fprintf(FILE *stream, const char *format, ...);
+ */
+{
+	.name = "fprintf",
+	.conv = CC_SYSTEM_V,
+	.type_name = "int",
+	.fmt = FAT_PRINTF,
+	.fmt_param_idx = 1,
+	.params_cnt = 2,
+	.params = {
+		{
+			.name = "stream",
+			.type_name = "ptr",
+			.modifiers = CDM_NOMOD,
+			.direction = PDIR_IN
+		},
+		{
+			.name = "format",
+			.type_name = "ptr",
+			.modifiers = CDM_POINTER | CDM_CONST,
+			.ref_type_name = "sz",
+			.direction = PDIR_IN
+		}
+	}
+},
+{
+	.name = "sprintf",
+	.conv = CC_SYSTEM_V,
+	.type_name = "int",
+	.fmt = FAT_PRINTF,
+	.fmt_param_idx = 1,
+	.params_cnt = 2,
+	.params = {
+		{
+			.name = "str",
+			.type_name = "ptr",
+			.modifiers = CDM_POINTER,
+			.ref_type_name = "sz",
+			.direction = PDIR_OUT
+		},
+		{
+			.name = "format",
+			.type_name = "ptr",
+			.modifiers = CDM_POINTER | CDM_CONST,
+			.ref_type_name = "sz",
+			.direction = PDIR_IN
+		}
+	}
+},
+{
+	.name = "snprintf",
+	.conv = CC_SYSTEM_V,
+	.type_name = "int",
+	.fmt = FAT_PRINTF,
+	.fmt_param_idx = 2,
+	.params_cnt = 3,
+	.params = {
+		{
+			.name = "str",
+			.type_name = "ptr",
+			.modifiers = CDM_POINTER,
+			.ref_type_name = "sz",
+			.direction = PDIR_OUT
+		},
+		{
+			.name = "size",
+			.type_name = "size_t",
+			.modifiers = CDM_NOMOD,
+			.direction = PDIR_IN
+		},
+		{
+			.name = "format",
+			.type_name = "ptr",
+			.modifiers = CDM_POINTER | CDM_CONST,
+			.ref_type_name = "sz",
+			.direction = PDIR_IN
+		}
+	}
+},
+{
+	.name = "dprintf",
+	.conv = CC_SYSTEM_V,
+	.type_name = "int",
+	.fmt = FAT_PRINTF,
+	.fmt_param_idx = 1,
+	.params_cnt = 2,
+	.params = {
+		{
+			.name = "fd",
+			.type_name = "int",
+			.modifiers = CDM_NOMOD,
+			.direction = PDIR_IN
+		},
+		{
+			.name = "format",
+			.type_name = "ptr",
+			.modifiers = CDM_POINTER | CDM_CONST,
+			.ref_type_name = "sz",
+			.direction = PDIR_IN
+		}
+	}
+},
+/*
+ * v*printf variants take va_list (opaque pointer); no varargs to walk.
+ */
+{
+	.name = "vprintf",
+	.conv = CC_SYSTEM_V,
+	.type_name = "int",
+	.params_cnt = 2,
+	.params = {
+		{
+			.name = "format",
+			.type_name = "ptr",
+			.modifiers = CDM_POINTER | CDM_CONST,
+			.ref_type_name = "sz",
+			.direction = PDIR_IN
+		},
+		{
+			.name = "arg",
+			.type_name = "ptr",
+			.modifiers = CDM_NOMOD,
+			.direction = PDIR_IN
+		}
+	}
+},
+{
+	.name = "vfprintf",
+	.conv = CC_SYSTEM_V,
+	.type_name = "int",
+	.params_cnt = 3,
+	.params = {
+		{
+			.name = "stream",
+			.type_name = "ptr",
+			.modifiers = CDM_NOMOD,
+			.direction = PDIR_IN
+		},
+		{
+			.name = "format",
+			.type_name = "ptr",
+			.modifiers = CDM_POINTER | CDM_CONST,
+			.ref_type_name = "sz",
+			.direction = PDIR_IN
+		},
+		{
+			.name = "arg",
+			.type_name = "ptr",
+			.modifiers = CDM_NOMOD,
+			.direction = PDIR_IN
+		}
+	}
+},
+{
+	.name = "vsprintf",
+	.conv = CC_SYSTEM_V,
+	.type_name = "int",
+	.params_cnt = 3,
+	.params = {
+		{
+			.name = "str",
+			.type_name = "ptr",
+			.modifiers = CDM_POINTER,
+			.ref_type_name = "sz",
+			.direction = PDIR_OUT
+		},
+		{
+			.name = "format",
+			.type_name = "ptr",
+			.modifiers = CDM_POINTER | CDM_CONST,
+			.ref_type_name = "sz",
+			.direction = PDIR_IN
+		},
+		{
+			.name = "arg",
+			.type_name = "ptr",
+			.modifiers = CDM_NOMOD,
+			.direction = PDIR_IN
+		}
+	}
+},
+{
+	.name = "vsnprintf",
+	.conv = CC_SYSTEM_V,
+	.type_name = "int",
+	.params_cnt = 4,
+	.params = {
+		{
+			.name = "str",
+			.type_name = "ptr",
+			.modifiers = CDM_POINTER,
+			.ref_type_name = "sz",
+			.direction = PDIR_OUT
+		},
+		{
+			.name = "size",
+			.type_name = "size_t",
+			.modifiers = CDM_NOMOD,
+			.direction = PDIR_IN
+		},
+		{
+			.name = "format",
+			.type_name = "ptr",
+			.modifiers = CDM_POINTER | CDM_CONST,
+			.ref_type_name = "sz",
+			.direction = PDIR_IN
+		},
+		{
+			.name = "arg",
+			.type_name = "ptr",
+			.modifiers = CDM_NOMOD,
+			.direction = PDIR_IN
+		}
+	}
+},
+{
+	.name = "vdprintf",
+	.conv = CC_SYSTEM_V,
+	.type_name = "int",
+	.params_cnt = 3,
+	.params = {
+		{
+			.name = "fd",
+			.type_name = "int",
+			.modifiers = CDM_NOMOD,
+			.direction = PDIR_IN
+		},
+		{
+			.name = "format",
+			.type_name = "ptr",
+			.modifiers = CDM_POINTER | CDM_CONST,
+			.ref_type_name = "sz",
+			.direction = PDIR_IN
+		},
+		{
+			.name = "arg",
+			.type_name = "ptr",
+			.modifiers = CDM_NOMOD,
+			.direction = PDIR_IN
+		}
+	}
+},
 
 	{
 		.name = "fgetc",


### PR DESCRIPTION
## prototypes/stdio: add printf-family variadic prototypes (Issue #409 partial)

Users could not intercept `sprintf`, `snprintf`, `fprintf`, `dprintf`, `vprintf`, `vfprintf`, `vsprintf`, `vsnprintf`, `vdprintf` -- they passed through unintercepted. Only `printf` had a `FAT_PRINTF` prototype.

### What this adds

Prototypes for all 9 printf-family functions in `src/core/prototypes/stdio.c`, replacing the FIXME comment that listed them as TODO:

- **Variadic** (uses `FAT_PRINTF`, dispatched via `retrace_as_call_real_variadic` so the compiler emits the correct per-arch variadic ABI):
  - `sprintf(str, fmt, ...)` — fmt_param_idx = 1
  - `snprintf(str, size, fmt, ...)` — fmt_param_idx = 2
  - `fprintf(stream, fmt, ...)` — fmt_param_idx = 1
  - `dprintf(fd, fmt, ...)` — fmt_param_idx = 1

- **va_list variants** (use `FAT_NOVARARGS` since `va_list` is an opaque pointer from retrace's perspective):
  - `vprintf(fmt, arg)`
  - `vfprintf(stream, fmt, arg)`
  - `vsprintf(str, fmt, arg)`
  - `vsnprintf(str, size, fmt, arg)`
  - `vdprintf(fd, fmt, arg)`

### Verification

`test/printf` exercises all of these. Output on macOS arm64 and Linux x86_64 (Debian bookworm, glibc 2.36) is identical:

```
Another test 52           (dprintf)
Format String 42          (vprintf)
Test 42 forty two         (printf)
TEST 2a                   (fprintf)
Format String 42          (vdprintf)
[stderr] Format String 42 (vfprintf)
```

`sprintf` / `snprintf` / `vsprintf` / `vsnprintf` write to buffers and have no direct output; retrace log shows `log_params` + `call_real` running for each. ctest green on both platforms.

### Per-arch variadic ABI

`retrace_as_call_real_variadic` (landed in #467 for the printf Darwin-arm64 fix) handles the per-arch dispatch:

- **Apple AArch64**: variadic args pushed to stack
- **AAPCS64 (Linux/BSD ARM64)**: variadic args in x1..x7 then stack
- **Sys V x86-64**: variadic args in rsi..r9 then stack

The `named_count` parameter (proto->params_cnt) tells the dispatch how many named args to put in registers vs how many are variadic.

### Partial fix for #409

The `scanf` / `fscanf` / `sscanf` family still needs prototypes (they would use `FAT_SCANF` which the engine doesn't yet dispatch differently from `FAT_PRINTF` -- that's a follow-up).

### Out of scope

- Adding `FAT_SCANF`-aware dispatch (currently `FAT_SCANF` is defined but not used). Follow-up.
- Intercepting `asprintf` / `vasprintf` (GNU extensions). Follow-up.
