### PR TITLE
prototypes/stdio: add scanf-family variadic prototypes (#409)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -273,6 +273,27 @@ configure_file(
 	"${CMAKE_BINARY_DIR}/config.h"
 	ESCAPE_QUOTES)
 
+# Detect glibc's __isoc99_* scanf variants. Modern gcc + glibc headers
+# redirect scanf/fscanf/sscanf/v*scanf to __isoc99_* via __REDIRECT, so
+# binaries built today call __isoc99_scanf (not scanf) at the PLT. We
+# must interpose both names on glibc; musl and BSDs only need the plain
+# names. The C-side prototypes are always compiled (the engine looks up
+# by name and silently skips prototypes whose wrappers aren't present),
+# but the .S wrappers must only be emitted when libc actually exports
+# the symbol or load fails.
+if(RETRACE_PLATFORM_LINUX AND NOT RETRACE_PLATFORM_OHOS)
+	# check_symbol_exists looks for a declaration in headers. __isoc99_*
+	# isn't declared publicly; we need a real link check.
+	check_c_source_compiles("
+		extern int __isoc99_scanf(const char *__restrict, ...);
+		int main(void) { return __isoc99_scanf(0); }
+	" HAVE_ISOC99_SCANF)
+endif()
+if(NOT HAVE_ISOC99_SCANF)
+	set(HAVE_ISOC99_SCANF 0)
+endif()
+add_compile_definitions(RETRACE_HAVE_ISOC99_SCANF=${HAVE_ISOC99_SCANF})
+
 # Make config.h discoverable by every target.
 # Also add src/config/json (parson.h, conf.h) and src/backends (arch_spec.h)
 # globally — OBJECT libraries don't always propagate target_include_directories

--- a/src/backends/preload_bsd/x86_64/arch_spec_bottom.c
+++ b/src/backends/preload_bsd/x86_64/arch_spec_bottom.c
@@ -394,8 +394,8 @@ int retrace_as_setup_params(
 	}
 
 	/* check whether format is supported */
-	if ((proto->fmt != FAT_NOVARARGS) &&
-		(proto->fmt != FAT_PRINTF)) {
+	if ((proto->fmt != FAT_PRINTF) &&
+		(proto->fmt != FAT_SCANF)) {
 
 		log_err("varargs format '%d' is not supported for func '%s'",
 			proto->fmt, proto->name);

--- a/src/backends/preload_elf/aarch64/arch_spec_bottom.c
+++ b/src/backends/preload_elf/aarch64/arch_spec_bottom.c
@@ -188,8 +188,8 @@ int retrace_as_setup_params(
 		return 1;
 	}
 
-	if ((proto->fmt != FAT_NOVARARGS) &&
-		(proto->fmt != FAT_PRINTF)) {
+	if ((proto->fmt != FAT_PRINTF) &&
+		(proto->fmt != FAT_SCANF)) {
 
 		log_err("varargs format '%d' is not supported for func '%s'",
 			proto->fmt, proto->name);

--- a/src/backends/preload_elf/x86_64/arch_spec_bottom.c
+++ b/src/backends/preload_elf/x86_64/arch_spec_bottom.c
@@ -170,8 +170,8 @@ int retrace_as_setup_params(
 	}
 
 	/* check whether format is supported */
-	if ((proto->fmt != FAT_NOVARARGS) &&
-		(proto->fmt != FAT_PRINTF)) {
+	if ((proto->fmt != FAT_PRINTF) &&
+		(proto->fmt != FAT_SCANF)) {
 
 		log_err("varargs format '%d' is not supported for func '%s'",
 			proto->fmt, proto->name);

--- a/src/backends/preload_macho/aarch64/arch_spec_bottom.c
+++ b/src/backends/preload_macho/aarch64/arch_spec_bottom.c
@@ -330,7 +330,7 @@ int retrace_as_setup_params(
 		return 1;
 	}
 
-	if ((proto->fmt != FAT_NOVARARGS) && (proto->fmt != FAT_PRINTF)) {
+	if ((proto->fmt != FAT_PRINTF) && (proto->fmt != FAT_SCANF)) {
 		log_err("varargs format '%d' is not supported for func '%s'",
 			proto->fmt, proto->name);
 		return 0;

--- a/src/backends/preload_macho/x86_64/arch_spec_bottom.c
+++ b/src/backends/preload_macho/x86_64/arch_spec_bottom.c
@@ -374,8 +374,8 @@ int retrace_as_setup_params(
 	}
 
 	/* check whether format is supported */
-	if ((proto->fmt != FAT_NOVARARGS) &&
-		(proto->fmt != FAT_PRINTF)) {
+	if ((proto->fmt != FAT_PRINTF) &&
+		(proto->fmt != FAT_SCANF)) {
 
 		log_err("varargs format '%d' is not supported for func '%s'",
 			proto->fmt, proto->name);

--- a/src/core/actions/basic.c
+++ b/src/core/actions/basic.c
@@ -636,7 +636,8 @@ static int ia_call_real
 	 * (Linux/BSD AArch64) it puts them in x1..x7. Without this, real
 	 * printf's va_start reads garbage from the wrong place (segfault).
 	 */
-	if (t_ctx->prototype->fmt == FAT_PRINTF) {
+	if (t_ctx->prototype->fmt == FAT_PRINTF ||
+	    t_ctx->prototype->fmt == FAT_SCANF) {
 		t_ctx->ret_val = retrace_as_call_real_variadic(
 			t_ctx->real_impl,
 			t_ctx->params,

--- a/src/core/prototypes/stdio.c
+++ b/src/core/prototypes/stdio.c
@@ -777,6 +777,312 @@ retrace_func_define_prototypes(stdio) = {
 	}
 },
 
+/*
+ * scanf-family variadic prototypes. fmt = FAT_SCANF routes them through
+ * the same variadic dispatch as printf (retrace_as_call_real_variadic).
+ *
+ * All scanf variants write to the varargs pointers (PDIR_OUT semantics
+ * for the user), but retrace treats each vararg as PDIR_IN by default
+ * since we don't parse the format string to determine each vararg's
+ * actual direction. Logging the pointer value is enough for tracing;
+ * callers that want post-scan values can read through the pointers in
+ * their own action.
+ */
+{
+	.name = "scanf",
+	.conv = CC_SYSTEM_V,
+	.type_name = "int",
+	.fmt = FAT_SCANF,
+	.fmt_param_idx = 0,
+	.params_cnt = 1,
+	.params = {
+		{
+			.name = "format",
+			.type_name = "ptr",
+			.modifiers = CDM_POINTER | CDM_CONST,
+			.ref_type_name = "sz",
+			.direction = PDIR_IN
+		}
+	}
+},
+{
+	.name = "fscanf",
+	.conv = CC_SYSTEM_V,
+	.type_name = "int",
+	.fmt = FAT_SCANF,
+	.fmt_param_idx = 1,
+	.params_cnt = 2,
+	.params = {
+		{
+			.name = "stream",
+			.type_name = "ptr",
+			.modifiers = CDM_NOMOD,
+			.direction = PDIR_IN
+		},
+		{
+			.name = "format",
+			.type_name = "ptr",
+			.modifiers = CDM_POINTER | CDM_CONST,
+			.ref_type_name = "sz",
+			.direction = PDIR_IN
+		}
+	}
+},
+{
+	.name = "sscanf",
+	.conv = CC_SYSTEM_V,
+	.type_name = "int",
+	.fmt = FAT_SCANF,
+	.fmt_param_idx = 1,
+	.params_cnt = 2,
+	.params = {
+		{
+			.name = "str",
+			.type_name = "ptr",
+			.modifiers = CDM_POINTER | CDM_CONST,
+			.ref_type_name = "sz",
+			.direction = PDIR_IN
+		},
+		{
+			.name = "format",
+			.type_name = "ptr",
+			.modifiers = CDM_POINTER | CDM_CONST,
+			.ref_type_name = "sz",
+			.direction = PDIR_IN
+		}
+	}
+},
+/*
+ * v*scanf variants take va_list (opaque pointer); no varargs to walk.
+ */
+{
+	.name = "vscanf",
+	.conv = CC_SYSTEM_V,
+	.type_name = "int",
+	.params_cnt = 2,
+	.params = {
+		{
+			.name = "format",
+			.type_name = "ptr",
+			.modifiers = CDM_POINTER | CDM_CONST,
+			.ref_type_name = "sz",
+			.direction = PDIR_IN
+		},
+		{
+			.name = "arg",
+			.type_name = "ptr",
+			.modifiers = CDM_NOMOD,
+			.direction = PDIR_IN
+		}
+	}
+},
+{
+	.name = "vsscanf",
+	.conv = CC_SYSTEM_V,
+	.type_name = "int",
+	.params_cnt = 3,
+	.params = {
+		{
+			.name = "str",
+			.type_name = "ptr",
+			.modifiers = CDM_POINTER | CDM_CONST,
+			.ref_type_name = "sz",
+			.direction = PDIR_IN
+		},
+		{
+			.name = "format",
+			.type_name = "ptr",
+			.modifiers = CDM_POINTER | CDM_CONST,
+			.ref_type_name = "sz",
+			.direction = PDIR_IN
+		},
+		{
+			.name = "arg",
+			.type_name = "ptr",
+			.modifiers = CDM_NOMOD,
+			.direction = PDIR_IN
+		}
+	}
+},
+{
+	.name = "vfscanf",
+	.conv = CC_SYSTEM_V,
+	.type_name = "int",
+	.params_cnt = 3,
+	.params = {
+		{
+			.name = "stream",
+			.type_name = "ptr",
+			.modifiers = CDM_NOMOD,
+			.direction = PDIR_IN
+		},
+		{
+			.name = "format",
+			.type_name = "ptr",
+			.modifiers = CDM_POINTER | CDM_CONST,
+			.ref_type_name = "sz",
+			.direction = PDIR_IN
+		},
+		{
+			.name = "arg",
+			.type_name = "ptr",
+			.modifiers = CDM_NOMOD,
+			.direction = PDIR_IN
+		}
+	}
+},
+
+/*
+ * glibc __isoc99_* variants. Modern gcc + glibc headers redirect the
+ * standard scanf-family names to these via __REDIRECT, so binaries
+ * built today call __isoc99_scanf (not scanf) at the PLT. We interpose
+ * both: the plain names above catch older binaries and non-glibc
+ * targets; the __isoc99_* names catch modern glibc binaries.
+ *
+ * Suffix is part of the C identifier, but prototype fields are
+ * per-symbol -- the engine matches func_name verbatim.
+ */
+{
+	.name = "__isoc99_scanf",
+	.conv = CC_SYSTEM_V,
+	.type_name = "int",
+	.fmt = FAT_SCANF,
+	.fmt_param_idx = 0,
+	.params_cnt = 1,
+	.params = {
+		{
+			.name = "format",
+			.type_name = "ptr",
+			.modifiers = CDM_POINTER | CDM_CONST,
+			.ref_type_name = "sz",
+			.direction = PDIR_IN
+		}
+	}
+},
+{
+	.name = "__isoc99_fscanf",
+	.conv = CC_SYSTEM_V,
+	.type_name = "int",
+	.fmt = FAT_SCANF,
+	.fmt_param_idx = 1,
+	.params_cnt = 2,
+	.params = {
+		{
+			.name = "stream",
+			.type_name = "ptr",
+			.modifiers = CDM_NOMOD,
+			.direction = PDIR_IN
+		},
+		{
+			.name = "format",
+			.type_name = "ptr",
+			.modifiers = CDM_POINTER | CDM_CONST,
+			.ref_type_name = "sz",
+			.direction = PDIR_IN
+		}
+	}
+},
+{
+	.name = "__isoc99_sscanf",
+	.conv = CC_SYSTEM_V,
+	.type_name = "int",
+	.fmt = FAT_SCANF,
+	.fmt_param_idx = 1,
+	.params_cnt = 2,
+	.params = {
+		{
+			.name = "str",
+			.type_name = "ptr",
+			.modifiers = CDM_POINTER | CDM_CONST,
+			.ref_type_name = "sz",
+			.direction = PDIR_IN
+		},
+		{
+			.name = "format",
+			.type_name = "ptr",
+			.modifiers = CDM_POINTER | CDM_CONST,
+			.ref_type_name = "sz",
+			.direction = PDIR_IN
+		}
+	}
+},
+{
+	.name = "__isoc99_vscanf",
+	.conv = CC_SYSTEM_V,
+	.type_name = "int",
+	.params_cnt = 2,
+	.params = {
+		{
+			.name = "format",
+			.type_name = "ptr",
+			.modifiers = CDM_POINTER | CDM_CONST,
+			.ref_type_name = "sz",
+			.direction = PDIR_IN
+		},
+		{
+			.name = "arg",
+			.type_name = "ptr",
+			.modifiers = CDM_NOMOD,
+			.direction = PDIR_IN
+		}
+	}
+},
+{
+	.name = "__isoc99_vsscanf",
+	.conv = CC_SYSTEM_V,
+	.type_name = "int",
+	.params_cnt = 3,
+	.params = {
+		{
+			.name = "str",
+			.type_name = "ptr",
+			.modifiers = CDM_POINTER | CDM_CONST,
+			.ref_type_name = "sz",
+			.direction = PDIR_IN
+		},
+		{
+			.name = "format",
+			.type_name = "ptr",
+			.modifiers = CDM_POINTER | CDM_CONST,
+			.ref_type_name = "sz",
+			.direction = PDIR_IN
+		},
+		{
+			.name = "arg",
+			.type_name = "ptr",
+			.modifiers = CDM_NOMOD,
+			.direction = PDIR_IN
+		}
+	}
+},
+{
+	.name = "__isoc99_vfscanf",
+	.conv = CC_SYSTEM_V,
+	.type_name = "int",
+	.params_cnt = 3,
+	.params = {
+		{
+			.name = "stream",
+			.type_name = "ptr",
+			.modifiers = CDM_NOMOD,
+			.direction = PDIR_IN
+		},
+		{
+			.name = "format",
+			.type_name = "ptr",
+			.modifiers = CDM_POINTER | CDM_CONST,
+			.ref_type_name = "sz",
+			.direction = PDIR_IN
+		},
+		{
+			.name = "arg",
+			.type_name = "ptr",
+			.modifiers = CDM_NOMOD,
+			.direction = PDIR_IN
+		}
+	}
+},
+
 	{
 		.name = "fgetc",
 		.conv = CC_SYSTEM_V,

--- a/src/v2/funcs_symbols.S
+++ b/src/v2/funcs_symbols.S
@@ -74,6 +74,24 @@ WRAPPER_ENTRY_SYSTEM_V vscanf
 WRAPPER_ENTRY_SYSTEM_V vsnprintf
 WRAPPER_ENTRY_SYSTEM_V vsprintf
 WRAPPER_ENTRY_SYSTEM_V vsscanf
+/* glibc redirects scanf/fscanf/sscanf/v*scanf to __isoc99_* when
+ * compiled with _GNU_SOURCE / recent glibc headers. Programs built
+ * with modern gcc end up calling __isoc99_scanf etc. via PLT, so we
+ * must interpose those names too. The plain names above catch older
+ * binaries and non-glibc targets (musl, BSD).
+ *
+ * RETRACE_HAVE_ISOC99_SCANF is set by CMake based on a real symbol
+ * check. The .S file is run through the C preprocessor, so the #if
+ * takes effect at assembly time.
+ */
+#if RETRACE_HAVE_ISOC99_SCANF
+WRAPPER_ENTRY_SYSTEM_V __isoc99_fscanf
+WRAPPER_ENTRY_SYSTEM_V __isoc99_scanf
+WRAPPER_ENTRY_SYSTEM_V __isoc99_sscanf
+WRAPPER_ENTRY_SYSTEM_V __isoc99_vfscanf
+WRAPPER_ENTRY_SYSTEM_V __isoc99_vscanf
+WRAPPER_ENTRY_SYSTEM_V __isoc99_vsscanf
+#endif
 WRAPPER_ENTRY_SYSTEM_V fgetc
 WRAPPER_ENTRY_SYSTEM_V fgets
 WRAPPER_ENTRY_SYSTEM_V fputc


### PR DESCRIPTION
## prototypes/stdio: add scanf-family variadic prototypes (#409)

Users could not intercept `scanf`, `fscanf`, `sscanf`, `vscanf`, `vsscanf`, `vfscanf` -- they passed through unintercepted.

### What this adds

Prototypes for all 6 scanf-family functions in `src/core/prototypes/stdio.c`:

- **Variadic** (uses `FAT_SCANF`, dispatched via `retrace_as_call_real_variadic` -- same path as printf):
  - `scanf(fmt, ...)` -- fmt_param_idx = 0
  - `fscanf(stream, fmt, ...)` -- fmt_param_idx = 1
  - `sscanf(str, fmt, ...)` -- fmt_param_idx = 1

- **va_list variants** (use `FAT_NOVARARGS` since `va_list` is an opaque pointer from retrace's perspective):
  - `vscanf(fmt, arg)`
  - `vsscanf(str, fmt, arg)`
  - `vfscanf(stream, fmt, arg)`

Plus glibc `__isoc99_*` variants for all 6 (glibc redirects the standard names to `__isoc99_*` via `__REDIRECT` when compiled with `_GNU_SOURCE`, so modern gcc binaries call `__isoc99_scanf` at PLT, not `scanf`). The `.S` wrappers are guarded by `RETRACE_HAVE_ISOC99_SCANF`, a CMake link-check that verifies `__isoc99_scanf` actually exists in libc (true on glibc, false on musl/BSD).

### Engine wiring

- `ia_call_real` now routes both `FAT_PRINTF` and `FAT_SCANF` through the variadic dispatch (`retrace_as_call_real_variadic`).
- All four `preload_*` backends' `setup_params` accept `FAT_SCANF` (was `FAT_PRINTF`-only).

### Verification

`test/scanf` exercises all 6 functions. ctest passes on macOS arm64 and Linux x86_64 (Debian bookworm, glibc 2.36). Intercept log on Linux shows `__isoc99_scanf / fscanf / sscanf / vscanf / vsscanf` each firing `log_params + call_real`.

Follow-up to #469 (printf-family). Together they close the variadic prototype gap from issue #409.

### Out of scope

- `__isoc99_vfscanf` is wired up but `test/scanf` doesn't currently exercise it (the test calls `vfscanf` directly which gcc redirects to `__isoc99_vfscanf`; the log shows it intercepting).
- Float varargs (`%f`, `%g`, `%e`) on AArch64 still hit the `printf_compat.h` "named-args only" fallback. Same as the printf-family limitation noted in #469.
