### PR TITLE
printf: bail to asm Path A when FP varargs detected (#391)

### DIFF
--- a/src/backends/preload_macho/aarch64/arch_spec_bottom.c
+++ b/src/backends/preload_macho/aarch64/arch_spec_bottom.c
@@ -353,6 +353,26 @@ int retrace_as_setup_params(
 
 	printf_params = as_ctx->printf_args_cnt;
 
+	/*
+	 * FP-detection bail: if any vararg is a float/double, our integer-only
+	 * dispatch can't place it in the correct register file (v0..v7 for
+	 * AAPCS64, xmm0..xmm7 for Sys V x86-64, caller stack for Apple
+	 * AArch64). Return 0 to make the engine skip action processing and
+	 * let the asm trampoline tail-call real with all original regs/stack
+	 * intact. The call works correctly; users lose log_params visibility
+	 * for that specific call. See TODO.complete/01-float-varargs-aarch64.md.
+	 */
+	for (i = 0; i < printf_params; i++) {
+		int basic = as_ctx->printf_args_types[i] & ~PA_FLAG_MASK;
+
+		if (basic == PA_FLOAT || basic == PA_DOUBLE) {
+			log_dbg(
+				"FP vararg in '%s' -- deferring to asm Path A",
+				proto->name);
+			return 0;
+		}
+	}
+
 	for (i = 0; i != printf_params; i++, param_idx++) {
 		dt = retrace_datatype_printf_to_dt(as_ctx->printf_args_types[i]);
 


### PR DESCRIPTION
## printf: bail to asm Path A when FP varargs detected (#391)

Closes #391 (the user-visible symptom). The deeper "log FP varargs with full visibility" is tracked as TODO.complete/01.

### What was broken

`printf("%f", 3.14)` produced garbage output (or crashed) on every platform because retrace's variadic dispatch only knows how to place integer args:

- **AAPCS64 (Linux/BSD ARM64)**: FP args go in `v0..v7`, separate from integer args in `x0..x7`. We captured both, but the C dispatch only forwards integers.
- **Apple AArch64**: FP varargs go on the caller's stack alongside integer varargs.
- **Sys V x86-64 / Darwin x86-64**: FP args go in `xmm0..xmm7`.

The previous bail in `printf_compat.h` returned 0 from `parse_printf_format` when FP was detected, which made `setup_params` think there were no varargs. The engine ran `call_real` with named-args-only. Real `printf`'s `va_start` then read garbage from where the missing FP args should have been.

### Fix

Moves the FP-detection bail OUT of the parser and INTO each backend's `setup_params`. When FP is detected (by walking the parsed argtypes and checking for `PA_FLOAT`/`PA_DOUBLE`), `setup_params` returns 0. The engine sees the failure, logs `"failed to setup params"`, and falls through to `clean_up`. Because `retrace_as_sched_real` was called earlier and `retrace_as_cancel_sched_real` is only called when a script's actions are about to run, `call_real_flag` stays at 1, and the asm trampoline's tail-call path runs:

- AAPCS64: restore `x0..x7` AND `v0..v7`, branch to real.
- Apple AArch64: restore `x0..x7` (caller stack already has FP varargs), branch to real.
- x86-64: restore `rdi..r9` AND `xmm0..xmm7`, branch to real.

The call works correctly with original registers untouched. Users lose `log_params` visibility for that specific call -- it appears as `"failed to setup params for printf(), will not proceed"` plus a `log_dbg` `"FP vararg in 'printf' -- deferring to asm Path A"`.

### Verification (macOS arm64, Apple M1 Max)

```c
printf("integer=%d string=%s float=%f double=%g\n",
       42, "hello", 3.14, 2.71828);
printf("just int=%d\n", 99);
printf("just float=%f\n", 1.5);
```

Output under `DYLD_INSERT_LIBRARIES`:
```
integer=42 string=hello float=3.140000 double=2.71828
just int=99
just float=1.500000
```

Previously: garbage / crash. Now: correct.

The "just int" call still gets full `log_params` visibility (`vararg00: 99`) because it has no FP. Only FP-containing calls bail.

ctest green on macOS arm64.

### Applied uniformly

Same FP-detection logic added to all five `preload_*` backends:

- `src/backends/preload_elf/aarch64/arch_spec_bottom.c` (Linux ARM64)
- `src/backends/preload_elf/x86_64/arch_spec_bottom.c` (Linux/BSD x86_64 via ELF)
- `src/backends/preload_macho/aarch64/arch_spec_bottom.c` (Apple Silicon)
- `src/backends/preload_macho/x86_64/arch_spec_bottom.c` (Intel macOS)
- `src/backends/preload_bsd/x86_64/arch_spec_bottom.c` (FreeBSD/OpenBSD/NetBSD)

Also removed the now-redundant bail in `src/core/printf_compat.h` (musl shim). The shim returns the real count including FP slots; each consumer's `setup_params` catches FP itself.

### Out of scope (follow-up TODO.complete/01)

The deeper fix -- per-arch SIMD-aware dispatch that DOES place FP args correctly so `log_params` visibility is preserved -- is tracked in `TODO.complete/01-float-varargs-aarch64.md`. This PR is the minimum to make `%f` produce correct output; the follow-up will make it observable.
