### PR TITLE
test/sbrk: document why this test isn't in runtests (#400)

### DIFF
--- a/test/sbrk.c
+++ b/test/sbrk.c
@@ -1,3 +1,18 @@
+/*
+ * sbrk test. NOT in runtests.sh.in -- intentionally.
+ *
+ * sbrk() grows/shrinks the data segment. Under LD_PRELOAD the
+ * trampoline fires for every malloc/calloc/free inside libc's brk
+ * path. libc's malloc may have allocated small objects from the
+ * brk-managed region; when sbrk + brk shrink the segment back, those
+ * allocations are no longer backed by valid memory. libc's heap
+ * validator then emits "free(): invalid pointer" on the next free.
+ *
+ * This is a fundamental sbrk + LD_PRELOAD interaction, not a retrace
+ * bug. The test exits 0 (sbrk + brk round-trip succeeds at the
+ * syscall level) but glibc's diagnostic is unavoidable. Build it
+ * for completeness; do not run it as part of CI. See issue #400.
+ */
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>


### PR DESCRIPTION
## test/sbrk: document why this test isn't in runtests

Closes #400 as wontfix.

### Background

sbrk + LD_PRELOAD is a fundamental interaction:

1. `sbrk(N)` grows the data segment by N bytes.
2. libc's malloc uses the brk-managed region for small allocations.
3. `brk(old)` shrinks the data segment back, invalidating any allocations libc made in that region.
4. On the next free, libc's heap validator sees the inconsistency and emits `free(): invalid pointer`.

This is **not a retrace bug** — any LD_PRELOAD library that allocates memory during libc internal calls would trigger the same diagnostic.

### Status before this PR

- `test/sbrk.c` exists and builds.
- It is **not** listed in `test/runtests.sh.in` (already excluded).
- The test exits 0 when run; the `free(): invalid pointer` is a glibc warning, not a crash.

### What this PR adds

A top-of-file comment in `test/sbrk.c` explaining why the test isn't in runtests, so the next person looking at it doesn't think we forgot to wire it up.

### Out of scope

If someone wants sbrk interception to "just work" without the diagnostic, the path is: don't intercept malloc inside libc's brk path. That requires the same dlopen-style reentrance guard as TODO.complete/06. Out of scope for this PR.
