### PR TITLE
README: document fuzzing-only mode (#155)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -333,6 +333,42 @@ SIMD-reg save-area walk that is on the roadmap (ADR-0010).
 }
 ----
 
+=== Fuzzing-only mode (no log noise)
+
+When you're running `memory_fuzz` over a large program, the default
+`log_params` + `call_real` for every libc call produces gigabytes of
+JSON you don't care about. Two ways to suppress it:
+
+**1. Disable the logger entirely** (zero JSON output, fuzz still runs):
+
+[source,console]
+----
+$ RETRACE_LOGGER_DEF_ENA=0 \
+  RETRACE_JSON_CONFIG=fuzz.json \
+  LD_PRELOAD=build/src/v2/libretrace.so ./your-program
+----
+
+**2. Allowlist only the function you're fuzzing** (log only malloc):
+
+[source,json]
+----
+{
+  "intercept_scripts": [
+    {
+      "func_name": "malloc",
+      "actions": [
+        { "action_name": "log_params" },
+        { "action_name": "call_real" },
+        { "action_name": "memory_fuzz", "action_params": { "fail_rate": 0.1 } }
+      ]
+    }
+    /* NOTE: no "*" wildcard script -- every other libc call goes
+     * through retrace's trampoline but the engine finds no matching
+     * script and just calls real. No log noise. */
+  ]
+}
+----
+
 
 == End-to-end examples under `examples/`
 


### PR DESCRIPTION
## README: document fuzzing-only mode (#155)

Closes #155.

### Background

Issue #155 (from 2017) asked for "a way to disable all verbose call way in case if any of fuzzing options is enabled, because right now it produce a lot of junk".

retrace already supports this via two existing mechanisms; the issue was a documentation gap.

### What this PR adds

A new "Fuzzing-only mode (no log noise)" subsection under Examples that shows two ways to suppress the noise:

1. **`RETRACE_LOGGER_DEF_ENA=0`** — disables the logger entirely. Fuzzing still runs; zero JSON output.
2. **Omit the `"*"` wildcard script** from `intercept_scripts`. Only the functions you explicitly list get `log_params`; every other libc call goes through retrace's trampoline but the engine finds no matching script and just calls real. No log noise.

Both patterns are already used by the test suite; this just makes them discoverable.

### Verification

Pure doc change — no build impact.
