### PR TITLE
prototypes: add time.h + remaining unistd.h gaps (#482)

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -16,7 +16,8 @@ set(_core_prototype_sources
 	prototypes/stdio.c  prototypes/stdlib.c prototypes/uio.c
 	prototypes/unistd.c prototypes/dirent.c
 	prototypes/string.c
-	prototypes/pthread.c)
+	prototypes/pthread.c
+	prototypes/time.c)
 
 set(_core_action_sources
 	actions/basic.c actions/memfuzz.c)

--- a/src/core/actions/basic.c
+++ b/src/core/actions/basic.c
@@ -137,6 +137,17 @@ static int ia_log_params
 			 * reference each other
 			 */
 
+			/* Skip the deref step entirely when the caller passed
+			 * NULL -- common for output params (e.g., time(NULL),
+			 * gettimeofday(tv, NULL)) where libc just uses the
+			 * return value.
+			 */
+			if (param->val == 0) {
+				log_dbg("NULL pointer for param '%s' -- skip deref",
+					param->param_meta.name);
+				goto next_param;
+			}
+
 			/* TODO: Maybe should cast via data_type? */
 
 			ref_data = (void *) param->val;

--- a/src/core/prototypes/time.c
+++ b/src/core/prototypes/time.c
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * time.h prototypes. Each entry mirrors a WRAPPER_ENTRY_SYSTEM_V line
+ * in src/v2/funcs_symbols.S.
+ *
+ * Conventions:
+ *
+ *   - time_t is "long" everywhere (glibc, musl, BSD, Darwin all define
+ *     it as an integer type large enough for epoch seconds).
+ *   - struct tm is opaque (the engine doesn't model it). Use CDM_NOMOD
+ *     for the pointer; log_params shows the address.
+ *   - Output buffers (char buf[26] for ctime_r) use CDM_POINTER with
+ *     ref_type_name = "sz" and PDIR_OUT so log_params shows the
+ *     post-call string.
+ */
+
+#include "funcs.h"
+
+retrace_func_define_prototypes(time) = {
+	{
+		.name = "time",
+		.conv = CC_SYSTEM_V,
+		.type_name = "long",
+		.params_cnt = 1,
+		.params = {
+			{
+				.name = "tloc",
+				.type_name = "ptr",
+				.modifiers = CDM_POINTER,
+				.ref_type_name = "long",
+				.direction = PDIR_OUT
+			}
+		}
+	},
+	{
+		.name = "ctime_r",
+		.conv = CC_SYSTEM_V,
+		.type_name = "ptr",
+		.params_cnt = 2,
+		.params = {
+			{
+				.name = "time",
+				.type_name = "ptr",
+				.modifiers = CDM_POINTER | CDM_CONST,
+				.ref_type_name = "long",
+				.direction = PDIR_IN
+			},
+			{
+				.name = "buf",
+				.type_name = "ptr",
+				.modifiers = CDM_POINTER,
+				.ref_type_name = "sz",
+				.direction = PDIR_OUT
+			}
+		}
+	},
+	{
+		.name = "localtime_r",
+		.conv = CC_SYSTEM_V,
+		.type_name = "ptr",
+		.params_cnt = 2,
+		.params = {
+			{
+				.name = "timep",
+				.type_name = "ptr",
+				.modifiers = CDM_POINTER | CDM_CONST,
+				.ref_type_name = "long",
+				.direction = PDIR_IN
+			},
+			{
+				/*
+				 * struct tm * -- opaque to retrace. Show the address;
+				 * don't try to deref (no struct member model).
+				 */
+				.name = "result",
+				.type_name = "ptr",
+				.modifiers = CDM_NOMOD,
+				.direction = PDIR_OUT
+			}
+		}
+	}
+};

--- a/src/core/prototypes/unistd.c
+++ b/src/core/prototypes/unistd.c
@@ -337,6 +337,116 @@ retrace_func_define_prototypes(unistd) = {
 			}
 		}
 	},
+	/*
+	 * execl / execle / execlp take a variable arg list terminated by a
+	 * (char *)NULL sentinel. They are technically variadic but the
+	 * sentinel-termination makes a va_list-style walk unsuitable.
+	 * Register them as FAT_NOVARARGS -- the engine fills just the
+	 * named params (path + first arg slot) and the asm trampoline's
+	 * tail-call path passes the original register state (including
+	 * subsequent args) to real. log_params shows the path; the rest
+	 * flow through unlogged.
+	 */
+	{
+		.name = "execl",
+		.conv = CC_SYSTEM_V,
+		.type_name = "int",
+		.params_cnt = 2,
+		.params = {
+			{
+				.name = "path",
+				.type_name = "ptr",
+				.modifiers = CDM_POINTER | CDM_CONST,
+				.ref_type_name = "sz",
+				.direction = PDIR_IN
+			},
+			{
+				.name = "arg0",
+				.type_name = "ptr",
+				.modifiers = CDM_POINTER | CDM_CONST,
+				.ref_type_name = "sz",
+				.direction = PDIR_IN
+			}
+		}
+	},
+	{
+		.name = "execle",
+		.conv = CC_SYSTEM_V,
+		.type_name = "int",
+		.params_cnt = 2,
+		.params = {
+			{
+				.name = "path",
+				.type_name = "ptr",
+				.modifiers = CDM_POINTER | CDM_CONST,
+				.ref_type_name = "sz",
+				.direction = PDIR_IN
+			},
+			{
+				.name = "arg0",
+				.type_name = "ptr",
+				.modifiers = CDM_POINTER | CDM_CONST,
+				.ref_type_name = "sz",
+				.direction = PDIR_IN
+			}
+		}
+	},
+	{
+		.name = "execlp",
+		.conv = CC_SYSTEM_V,
+		.type_name = "int",
+		.params_cnt = 2,
+		.params = {
+			{
+				.name = "file",
+				.type_name = "ptr",
+				.modifiers = CDM_POINTER | CDM_CONST,
+				.ref_type_name = "sz",
+				.direction = PDIR_IN
+			},
+			{
+				.name = "arg0",
+				.type_name = "ptr",
+				.modifiers = CDM_POINTER | CDM_CONST,
+				.ref_type_name = "sz",
+				.direction = PDIR_IN
+			}
+		}
+	},
+	{
+		.name = "fdatasync",
+		.conv = CC_SYSTEM_V,
+		.type_name = "int",
+		.params_cnt = 1,
+		.params = {
+			{
+				.name = "fd",
+				.type_name = "int",
+				.modifiers = CDM_NOMOD,
+				.direction = PDIR_IN
+			}
+		}
+	},
+	{
+		.name = "tcsetpgrp",
+		.conv = CC_SYSTEM_V,
+		.type_name = "int",
+		.params_cnt = 2,
+		.params = {
+			{
+				.name = "fd",
+				.type_name = "int",
+				.modifiers = CDM_NOMOD,
+				.direction = PDIR_IN
+			},
+			{
+				.name = "pgrp_id",
+				.type_name = "int",
+				.modifiers = CDM_NOMOD,
+				.direction = PDIR_IN
+			}
+		}
+	},
 	{
 		.name = "execvp",
 		.conv = CC_SYSTEM_V,


### PR DESCRIPTION
## prototypes: add time.h + remaining unistd.h gaps (#482)

Closes the last "wrapper without prototype" gap from issue #409. After this PR, every `WRAPPER_ENTRY_SYSTEM_V` line in `funcs_symbols.S` has a matching prototype in `src/core/prototypes/`.

### What this adds

**New file** `src/core/prototypes/time.c` (3 prototypes):

| Function | Signature | Notes |
|---|---|---|
| `time` | `time_t time(time_t *tloc)` | `tloc` is `PDIR_OUT` |
| `ctime_r` | `char *ctime_r(const time_t *time, char *buf)` | `buf` is `PDIR_OUT` with `ref_type_name = "sz"` |
| `localtime_r` | `struct tm *localtime_r(const time_t *time, struct tm *result)` | `result` is opaque (`CDM_NOMOD`) since retrace doesn't model `struct tm` |

**Added to `src/core/prototypes/unistd.c`** (5 prototypes):

| Function | Notes |
|---|---|
| `fdatasync(int fd)` | Simple int-in/int-out |
| `tcsetpgrp(int fd, pid_t pgrp_id)` | Two ints |
| `execl` / `execle` / `execlp` | Sentinel-terminated variadic. Registered as `FAT_NOVARARGS` -- the engine fills named args (path + arg0) and the asm Path A passes original register state. log_params shows the path; subsequent args flow through unlogged. Documented inline. |

### Bug fix bundled

`src/core/actions/basic.c::ia_log_params` used to dereference any pointer param to show its target value. For output params called with NULL (`time(NULL)`, `gettimeofday(tv, NULL)`, `pthread_mutex_init(&m, NULL)`) the deref segfaulted.

Added a NULL check that skips the deref step and logs `"NULL pointer for param '%s' -- skip deref"` via `log_dbg`. The call is still recorded; only the deref is suppressed.

### Verification

ctest green on macOS arm64. `test/time` (which calls `time(NULL)`) now passes -- previously segfaulted at the deref step.

### Part of #409

Closes #409 fully -- `comm -23 <(wrapped) <(prototyped)` is now empty.

Closes #482 (the tracking issue I filed for this work).
