### PR TITLE
actions: add incomplete_io and fuzzing_seed (#483)

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -19,7 +19,8 @@ set(_core_prototype_sources
 	prototypes/pthread.c)
 
 set(_core_action_sources
-	actions/basic.c actions/memfuzz.c)
+	actions/basic.c actions/memfuzz.c
+	actions/incomplete_io.c actions/fuzzing_seed.c)
 
 set(_core_datatype_sources
 	datatypes/basic.c datatypes/uio.c datatypes/unistd.c)

--- a/src/core/actions.h
+++ b/src/core/actions.h
@@ -37,6 +37,14 @@ int(*retrace_actions_get(const char *action_name))
 
 int retrace_actions_init(void);
 
+/*
+ * If the user invoked the fuzzing_seed action, re-seed rand() so the
+ * next memory_fuzz call is deterministic. Cheap no-op when no seed
+ * was set. Declared here so memfuzz.c can call it without taking a
+ * circular include on fuzzing_seed.c.
+ */
+void retrace_actions_fuzzing_seed_maybe_apply(void);
+
 struct Action {
 	char name[MAXLEN_ACTION_NAME + 1];
 

--- a/src/core/actions/fuzzing_seed.c
+++ b/src/core/actions/fuzzing_seed.c
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdlib.h>
+
+#include "actions.h"
+#include "logger.h"
+#include "real_impls.h"
+
+/*
+ * fuzzing_seed -- make memory_fuzz deterministic.
+ *
+ * Port of v1's fuzzingseed. By default memory_fuzz uses rand() seeded
+ * from the PID, so failures are random per run. Setting a seed makes
+ * the failure sequence reproducible -- essential for debugging.
+ *
+ * State is process-global (matches v1): one seed per process, applied
+ * to every thread's memory_fuzz invocations.
+ *
+ * action_params:
+ *   seed  - unsigned int. Any value. Zero is a valid seed.
+ *
+ * The seed is applied lazily on the first memory_fuzz call AFTER this
+ * action runs, via srand(). The constructor path seeds from getpid(),
+ * so if fuzzing_seed is never invoked, behavior is the pre-existing
+ * non-deterministic mode.
+ *
+ * Example JSON:
+ *   {
+ *     "action_name": "fuzzing_seed",
+ *     "action_params": { "seed": 1498729252 }
+ *   }
+ */
+
+static unsigned int g_fuzzing_seed;
+static int g_fuzzing_seed_set;
+
+static int ia_fuzzing_seed(struct ThreadContext *t_ctx,
+			   const JSON_Object *action_params)
+{
+	double seed_value;
+
+	(void)t_ctx;
+
+	if (action_params == NULL) {
+		log_err("action_params required for fuzzing_seed");
+		return -1;
+	}
+
+	if (!json_object_has_value(action_params, "seed")) {
+		log_err("'seed' (unsigned int) required for fuzzing_seed");
+		return -1;
+	}
+
+	seed_value = json_object_get_number(action_params, "seed");
+	g_fuzzing_seed = (unsigned int)seed_value;
+	g_fuzzing_seed_set = 1;
+
+	/* Apply immediately so subsequent rand() calls in this thread
+	 * (and the next memory_fuzz call anywhere) are deterministic.
+	 */
+	srand(g_fuzzing_seed);
+
+	log_info("fuzzing_seed: set to %u", g_fuzzing_seed);
+
+	return 0;
+}
+
+/*
+ * Called by memfuzz.c::ia_memory_fuzz on each invocation. If a seed
+ * has been set, re-seed before the rand() call so we're deterministic
+ * across the whole run. This is cheap (srand is fast) and only runs
+ * if the user explicitly set a seed.
+ */
+void retrace_actions_fuzzing_seed_maybe_apply(void)
+{
+	if (g_fuzzing_seed_set)
+		srand(g_fuzzing_seed);
+}
+
+retrace_actions_define_package(fuzzing_seed) = {
+	{
+		.name = "fuzzing_seed",
+		.action = ia_fuzzing_seed
+	}
+};

--- a/src/core/actions/incomplete_io.c
+++ b/src/core/actions/incomplete_io.c
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "actions.h"
+#include "logger.h"
+#include "real_impls.h"
+
+/*
+ * incomplete_io -- partially fail I/O calls (short reads/writes).
+ *
+ * Port of v1's incompleteio. Useful for testing programs' handling of
+ * short I/O -- the kernel / libc is allowed to return fewer bytes
+ * than requested, but most programs assume the full count and break
+ * when that assumption is violated.
+ *
+ * Run AFTER call_real so t_ctx->ret_val holds the real byte count.
+ * Truncates ret_val to (real * rate). A rate of 0.0 forces every call
+ * to look like EOF; 1.0 is a no-op; 0.5 returns half the bytes.
+ *
+ * Only meaningful for: read, write, readv, writev, fread, fwrite,
+ * recv, send, recvfrom, sendto. Applying it to other functions is
+ * harmless but pointless.
+ *
+ * action_params:
+ *   rate     - float in [0.0, 1.0]. Fraction of real bytes to return.
+ *
+ * Example JSON:
+ *   {
+ *     "action_name": "incomplete_io",
+ *     "action_params": { "rate": 0.5 }
+ *   }
+ */
+
+static int ia_incomplete_io(struct ThreadContext *t_ctx,
+			    const JSON_Object *action_params)
+{
+	double rate;
+	long real_ret;
+
+	if (action_params == NULL) {
+		log_err("action_params required for incomplete_io");
+		return -1;
+	}
+
+	if (!json_object_has_value(action_params, "rate")) {
+		log_err("'rate' (0.0..1.0) required for incomplete_io");
+		return -1;
+	}
+
+	rate = json_object_get_number(action_params, "rate");
+
+	if (rate < 0.0)
+		rate = 0.0;
+	else if (rate > 1.0)
+		rate = 1.0;
+
+	real_ret = t_ctx->ret_val;
+
+	/* Negative returns (errors) and zero returns (EOF) are passed
+	 * through untouched. Only positive byte counts get truncated.
+	 */
+	if (real_ret <= 0)
+		return 0;
+
+	t_ctx->ret_val = (long)(real_ret * rate);
+
+	log_info("incomplete_io: %ld -> %ld bytes (rate=%.3f)",
+		real_ret, t_ctx->ret_val, rate);
+
+	return 0;
+}
+
+retrace_actions_define_package(incomplete_io) = {
+	{
+		.name = "incomplete_io",
+		.action = ia_incomplete_io
+	}
+};

--- a/src/core/actions/memfuzz.c
+++ b/src/core/actions/memfuzz.c
@@ -58,6 +58,15 @@ static int ia_memory_fuzz
 		}
 	}
 
+	/*
+	 * If the user has invoked the fuzzing_seed action at any point
+	 * (typically at the top of the script), honor it. This makes the
+	 * sequence deterministic across multiple memory_fuzz invocations
+	 * and across runs. Cheap; only fires when the user explicitly
+	 * opted in. See fuzzing_seed.c.
+	 */
+	retrace_actions_fuzzing_seed_maybe_apply();
+
 	if (!json_object_has_value(action_params, "fail_rate")) {
 		log_err("fail_rate must exist in action_params "
 			"for memory_fuzz");


### PR DESCRIPTION
## actions: add incomplete_io and fuzzing_seed (#483)

Closes #483. Ports the two remaining v1 actions that users asked about.

### `incomplete_io` -- partially fail I/O calls

Useful for testing programs' handling of short I/O. The kernel/libc may legally return fewer bytes than requested, but most programs assume the full count and break when that assumption is violated.

Run **AFTER** `call_real` so `t_ctx->ret_val` holds the real byte count. Truncates `ret_val` to `(real * rate)`:

- `rate = 0.0` -- every call looks like EOF
- `rate = 1.0` -- no-op
- `rate = 0.5` -- returns half the bytes

Only meaningful for `read`/`write`/`readv`/`writev`/`fread`/`fwrite`/`recv`/`send`/`recvfrom`/`sendto`. Applying it to other functions is harmless but pointless. Negative/zero returns (errors / EOF) are passed through untouched.

`action_params`: `{ "rate": 0.5 }`

### `fuzzing_seed` -- deterministic `memory_fuzz`

By default `memory_fuzz` uses `rand()` seeded from the PID, so failures are random per run. Setting a seed makes the failure sequence reproducible -- essential for debugging.

- State is process-global (matches v1): one seed per process, applied to every thread's `memory_fuzz` invocations.
- `memfuzz.c` now calls `retrace_actions_fuzzing_seed_maybe_apply()` at the start of every `memory_fuzz` invocation. Cheap no-op when no seed was set; otherwise re-seeds `rand()`.

`action_params`: `{ "seed": 1498729252 }` (any unsigned int; 0 is valid)

### JSON recipe example

```json
{
  "intercept_scripts": [
    {
      "func_name": "malloc",
      "actions": [
        { "action_name": "fuzzing_seed", "action_params": {"seed": 42} },
        { "action_name": "log_params" },
        { "action_name": "call_real" },
        { "action_name": "memory_fuzz", "action_params": {"fail_rate": 0.1} }
      ]
    },
    {
      "func_name": "read",
      "actions": [
        { "action_name": "log_params" },
        { "action_name": "call_real" },
        { "action_name": "incomplete_io", "action_params": {"rate": 0.5} }
      ]
    }
  ]
}
```

### Architecture notes

- Each action lives in its own file under `src/core/actions/` -- OCP: new behavior = new file, no engine change.
- `fuzzing_seed.c` exports a non-action symbol (`retrace_actions_fuzzing_seed_maybe_apply`) that `memfuzz.c` calls. Forward-declared in `actions.h` to avoid a circular include.
- Both actions validate their `action_params` and emit `log_err` if missing required fields. Returns -1 to abort the script -- same convention as other actions.

### Verification

ctest green on macOS arm64. Action registration verified by JSON config that exercises both new actions.

### Out of scope

`redirect_connect`, `redirect_open`, `ssl_verify_result` are NOT new actions -- they're already possible via `modify_in_param_arr` / `modify_in_param_str` / `modify_return_value_int`. README has recipes.
