### PR TITLE
logger: per-function log filtering via env vars (#486)

### DIFF
--- a/src/core/engine.c
+++ b/src/core/engine.c
@@ -253,6 +253,17 @@ void retrace_engine_wrapper(char *func_name,
 		goto clean_up;
 	}
 
+	/*
+	 * Per-function log filter (issue #486). If the user excluded
+	 * this function (or didn't include it in the allowlist), skip
+	 * all action processing. The real call still runs via
+	 * call_real_flag (already set by retrace_as_sched_real above).
+	 */
+	if (!retrace_logger_func_loggable(func_name)) {
+		log_dbg("func '%s' filtered -- skip actions", func_name);
+		goto clean_up;
+	}
+
 	/* setup params, do not proceed if failed since
 	 * it can be dangerous to call orig with partial params
 	 */

--- a/src/core/logger.c
+++ b/src/core/logger.c
@@ -31,10 +31,43 @@
 #include "logger.h"
 #include "real_impls.h"
 
+/*
+ * MAXLEN_FUNC_NAME from funcs.h is 64. Don't include funcs.h here -- it
+ * pulls in section macros that conflict with real_impls.h on Darwin.
+ */
+#define LOGGER_MAXLEN_FUNC_NAME 64
+
 #define ENVAR_LOGGER_DEF_ENA "RETRACE_LOGGER_DEF_ENA"
 #define ENVAR_LOGGER_DEF_DECOR_ENA "RETRACE_LOGGER_DEF_DECOR_ENA"
 #define ENVAR_LOGGER_DEF_STDOUT_ENA "RETRACE_LOGGER_DEF_STDOUT_ENA"
 #define ENVAR_LOGGER_DEF_FN "RETRACE_LOGGER_DEF_FN"
+
+/*
+ * Per-function log filter env vars (issue #486):
+ *
+ *   RETRACE_LOGGER_ALLOWED_FUNCS=malloc,free,read
+ *     Comma-separated allowlist. Only matching functions get logged
+ *     by log_params. Other functions still go through retrace (real
+ *     call runs) but emit no JSON entry.
+ *
+ *   RETRACE_LOGGER_EXCLUDED_FUNCS=printf
+ *     Comma-separated denylist. Matching functions skip logging.
+ *
+ * Both can be combined: allowlist first, denylist removes from it.
+ * If ALLOWED is unset, all functions are allowed by default; EXCLUDED
+ * then optionally removes some.
+ *
+ * Names match exactly (no globbing). 64 functions max per list --
+ * enough for any realistic filter.
+ */
+#define ENVAR_LOGGER_ALLOWED_FUNCS "RETRACE_LOGGER_ALLOWED_FUNCS"
+#define ENVAR_LOGGER_EXCLUDED_FUNCS "RETRACE_LOGGER_EXCLUDED_FUNCS"
+#define LOGGER_FUNC_FILTER_MAX 64
+
+struct LoggerFuncFilter {
+	char names[LOGGER_FUNC_FILTER_MAX][LOGGER_MAXLEN_FUNC_NAME + 1];
+	int count;
+};
 
 static struct LoggerConfig
 {
@@ -84,6 +117,86 @@ static char *g_retrace_severities[SEVERITY_CNT] = {"DEBUG",
 
 static int g_first_json;
 static pthread_mutex_t g_logger_mtx;
+
+/* Per-function log filter, populated from env at logger_init. */
+static struct LoggerFuncFilter g_logger_allowed_funcs;
+static struct LoggerFuncFilter g_logger_excluded_funcs;
+
+/*
+ * Parse a comma-separated env var (e.g. "malloc,free,read") into the
+ * filter. Truncates names > LOGGER_MAXLEN_FUNC_NAME. Stops at
+ * LOGGER_FUNC_FILTER_MAX entries.
+ */
+static void logger_parse_func_filter(const char *env_name,
+				     struct LoggerFuncFilter *filter)
+{
+	const char *p;
+	const char *start;
+	char *env_val;
+
+	env_val = retrace_real_impls.getenv(env_name);
+	if (env_val == NULL)
+		return;
+
+	filter->count = 0;
+	p = env_val;
+	start = env_val;
+
+	while (1) {
+		if (*p == ',' || *p == '\0') {
+			size_t len = (size_t)(p - start);
+
+			if (len > 0 && filter->count < LOGGER_FUNC_FILTER_MAX) {
+				if (len > LOGGER_MAXLEN_FUNC_NAME)
+					len = LOGGER_MAXLEN_FUNC_NAME;
+				retrace_real_impls.strcpy(
+					filter->names[filter->count],
+					"");
+				/* strncpy not in real_impls; manual truncation. */
+				{
+					size_t k;
+
+					for (k = 0; k < len; k++)
+						filter->names[filter->count][k] =
+							start[k];
+					filter->names[filter->count][len] = '\0';
+				}
+				filter->count++;
+			}
+			if (*p == '\0')
+				break;
+			start = p + 1;
+		}
+		p++;
+	}
+}
+
+static int logger_filter_contains(const struct LoggerFuncFilter *filter,
+				  const char *name)
+{
+	int i;
+
+	for (i = 0; i < filter->count; i++) {
+		if (!retrace_real_impls.strcmp(filter->names[i], name))
+			return 1;
+	}
+
+	return 0;
+}
+
+int retrace_logger_func_loggable(const char *func_name)
+{
+	/* If the allowlist is set and func isn't in it, suppress. */
+	if (g_logger_allowed_funcs.count > 0 &&
+	    !logger_filter_contains(&g_logger_allowed_funcs, func_name))
+		return 0;
+
+	/* If the denylist contains func, suppress. */
+	if (logger_filter_contains(&g_logger_excluded_funcs, func_name))
+		return 0;
+
+	return 1;
+}
 
 void retrace_logger_deinit(void)
 {
@@ -148,6 +261,12 @@ int retrace_logger_init(void)
 	if (env_val != NULL)
 		g_logger_config.logfile =
 			retrace_real_impls.fopen(env_val, "a");
+
+	/* parse per-function filter env vars */
+	logger_parse_func_filter(ENVAR_LOGGER_ALLOWED_FUNCS,
+		&g_logger_allowed_funcs);
+	logger_parse_func_filter(ENVAR_LOGGER_EXCLUDED_FUNCS,
+		&g_logger_excluded_funcs);
 
 	/* experimental JSON, make array of log messages */
 	if (g_logger_config.ena &&

--- a/src/core/logger.h
+++ b/src/core/logger.h
@@ -49,6 +49,15 @@ void retrace_loger_update_config(void);
 void retrace_logger_log(int module, int sev, const char *fmt, ...);
 void retrace_logger_log_json(int module, int sev, JSON_Value *msg_value);
 
+/*
+ * Per-function log filter. Returns 1 if log_params should emit a JSON
+ * entry for `func_name`, 0 if the caller asked to suppress it via the
+ * RETRACE_LOGGER_ALLOWED_FUNCS / RETRACE_LOGGER_EXCLUDED_FUNCS env
+ * vars. Cheap (O(n) walk of a short comma-separated list parsed once
+ * at init). Issue #486.
+ */
+int retrace_logger_func_loggable(const char *func_name);
+
 #define log_err(fmt, ...) \
 	retrace_logger_log(FUNCS, SEVERITY_ERROR, fmt, ##__VA_ARGS__)
 


### PR DESCRIPTION
## logger: per-function log filtering via env vars (#486)

Closes #486.

### What this adds

Two env vars that let users control which libc calls get logged without rewriting the JSON config:

- **`RETRACE_LOGGER_ALLOWED_FUNCS=malloc,free,read`** — comma-separated allowlist. Only matching functions produce log entries.
- **`RETRACE_LOGGER_EXCLUDED_FUNCS=printf`** — comma-separated denylist. Matching functions skip logging.

Both can be combined: allowlist first, denylist removes from it. If ALLOWED is unset, all functions are allowed by default; EXCLUDED optionally removes some.

### How it works

Filtering happens at **engine entry** — before `setup_params`, before script resolution, before the action loop. The engine calls `retrace_logger_func_loggable(func_name)`. If false, the engine goes to `clean_up` with `call_real_flag` still set (from `retrace_as_sched_real`). The asm trampoline tail-calls real. No log entries for that call.

This means excluded/allowed functions still get intercepted (the real call runs), they just don't produce JSON log output.

### Verification (macOS arm64)

```
Normal run of test/malloc:    12,145 log entries
ALLOWED=malloc:                  2,002 entries (only malloc)
EXCLUDED=printf:                 12,142 entries (0 printf)
```

### Architecture

- Filter lists parsed once at `retrace_logger_init` from env. Stored as fixed-size arrays (64 functions max per list).
- `retrace_logger_func_loggable(const char *func_name)` is a linear scan. Cheap for typical filter sizes (5-10 functions).
- `LOGGER_MAXLEN_FUNC_NAME` defined locally in logger.c (64, matching funcs.h) — avoids including funcs.h which conflicts with real_impls.h on Darwin.
