### PR TITLE
examples: add v2 JSON configs for id-redirection and getenv-fuzzing (#484)

### DIFF
--- a/examples/getenv-fuzzing/getenv-memory-fuzz.json
+++ b/examples/getenv-fuzzing/getenv-memory-fuzz.json
@@ -1,0 +1,18 @@
+{
+  "intercept_scripts": [
+    {
+      "func_name": "malloc",
+      "actions": [
+        { "action_name": "call_real" },
+        { "action_name": "memory_fuzz", "action_params": { "fail_rate": 0.1 } }
+      ]
+    },
+    {
+      "func_name": "getenv",
+      "actions": [
+        { "action_name": "log_params" },
+        { "action_name": "call_real" }
+      ]
+    }
+  ]
+}

--- a/examples/getenv-fuzzing/getenv-redirect.json
+++ b/examples/getenv-fuzzing/getenv-redirect.json
@@ -1,0 +1,19 @@
+{
+  "intercept_scripts": [
+    {
+      "func_name": "getenv",
+      "actions": [
+        { "action_name": "log_params" },
+        {
+          "action_name": "modify_in_param_str",
+          "action_params": {
+            "param_name": "name",
+            "match_str": "FOOBAR",
+            "new_str": "PATH"
+          }
+        },
+        { "action_name": "call_real" }
+      ]
+    }
+  ]
+}

--- a/examples/id-redirection/get-both-redirect.json
+++ b/examples/id-redirection/get-both-redirect.json
@@ -1,0 +1,18 @@
+{
+  "intercept_scripts": [
+    {
+      "func_name": "getuid",
+      "actions": [
+        { "action_name": "call_real" },
+        { "action_name": "modify_return_value_int", "action_params": { "retval_int": 0 } }
+      ]
+    },
+    {
+      "func_name": "geteuid",
+      "actions": [
+        { "action_name": "call_real" },
+        { "action_name": "modify_return_value_int", "action_params": { "retval_int": 0 } }
+      ]
+    }
+  ]
+}

--- a/examples/id-redirection/get-l33t-redirect.json
+++ b/examples/id-redirection/get-l33t-redirect.json
@@ -1,0 +1,18 @@
+{
+  "intercept_scripts": [
+    {
+      "func_name": "getuid",
+      "actions": [
+        { "action_name": "call_real" },
+        { "action_name": "modify_return_value_int", "action_params": { "retval_int": 1337 } }
+      ]
+    },
+    {
+      "func_name": "geteuid",
+      "actions": [
+        { "action_name": "call_real" },
+        { "action_name": "modify_return_value_int", "action_params": { "retval_int": 1337 } }
+      ]
+    }
+  ]
+}

--- a/examples/id-redirection/geteuid-redirect.json
+++ b/examples/id-redirection/geteuid-redirect.json
@@ -1,0 +1,11 @@
+{
+  "intercept_scripts": [
+    {
+      "func_name": "geteuid",
+      "actions": [
+        { "action_name": "call_real" },
+        { "action_name": "modify_return_value_int", "action_params": { "retval_int": 0 } }
+      ]
+    }
+  ]
+}

--- a/examples/id-redirection/getuid-redirect.json
+++ b/examples/id-redirection/getuid-redirect.json
@@ -1,0 +1,11 @@
+{
+  "intercept_scripts": [
+    {
+      "func_name": "getuid",
+      "actions": [
+        { "action_name": "call_real" },
+        { "action_name": "modify_return_value_int", "action_params": { "retval_int": 0 } }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## examples: add v2 JSON configs for id-redirection and getenv-fuzzing (#484)

Partial fix for #484. Ports two example directories as proof-of-concept for the v1 → v2 config migration.

### id-redirection (4 JSON configs)

| Config | v1 equivalent | Effect |
|--------|---------------|--------|
| `getuid-redirect.json` | `getuid,0` | Force `getuid()` to return 0 (root) |
| `geteuid-redirect.json` | `geteuid,0` | Force `geteuid()` to return 0 |
| `get-both-redirect.json` | `getuid,0\ngeteuid,0` | Both at once |
| `get-l33t-redirect.json` | `getuid,1337\ngeteuid,1337` | Both return 1337 |

### getenv-fuzzing (2 JSON configs)

| Config | Effect |
|--------|--------|
| `getenv-redirect.json` | Redirect `getenv("FOOBAR")` to `getenv("PATH")` |
| `getenv-memory-fuzz.json` | 10% malloc failure rate during getenv calls |

### Usage

```sh
RETRACE_JSON_CONFIG=examples/id-redirection/getuid-redirect.json \
  LD_PRELOAD=build/src/v2/libretrace.so ./your-program
```

v1 `.conf` files preserved alongside the JSON for historical reference. Remaining examples (dns-fuzz, http-server-overflow, net-fuzzing, stringinject, unsafe-system) follow the same pattern; deferred to a follow-up.

### Also

Wires `test/unit/` into `test/CMakeLists.txt` for the unit test infrastructure.
