### PR TITLE
test: add unit tests for prototype/action/datatype registries (#481)

### DIFF
--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Unit tests for retrace_core registries. Link directly against the
+# retrace_core OBJECT library -- no LD_PRELOAD needed. Issue #481.
+
+# The arch-specific include is needed because data_types.h includes
+# arch_spec_macros.h, which differs per platform. Compute the path
+# here since _retrace_arch_include from src/core/CMakeLists.txt is
+# not in scope.
+if(RETRACE_PLATFORM_DARWIN)
+	if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64|ARM64")
+		set(_unit_arch_include
+			${CMAKE_SOURCE_DIR}/src/backends/preload_macho/aarch64)
+	else()
+		set(_unit_arch_include
+			${CMAKE_SOURCE_DIR}/src/backends/preload_macho/x86_64)
+	endif()
+elseif(RETRACE_PLATFORM_LINUX)
+	if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64|ARM64")
+		set(_unit_arch_include
+			${CMAKE_SOURCE_DIR}/src/backends/preload_elf/aarch64)
+	else()
+		set(_unit_arch_include
+			${CMAKE_SOURCE_DIR}/src/backends/preload_elf/x86_64)
+	endif()
+elseif(RETRACE_PLATFORM_FREEBSD OR RETRACE_PLATFORM_OPENBSD OR RETRACE_PLATFORM_NETBSD)
+	set(_unit_arch_include
+		${CMAKE_SOURCE_DIR}/src/backends/preload_bsd/x86_64)
+endif()
+
+add_executable(retrace_test_registries test_registries.c)
+set_target_properties(retrace_test_registries PROPERTIES
+    OUTPUT_NAME test_registries
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/test/unit")
+
+target_link_libraries(retrace_test_registries PRIVATE
+    retrace_core
+    retrace_config_json
+    retrace_backends
+    retrace_backend_preload_macho
+    retrace_preload_common
+    retrace_headers
+    ${CMAKE_DL_LIBS}
+    Threads::Threads)
+
+target_include_directories(retrace_test_registries PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/core
+    ${CMAKE_SOURCE_DIR}/src/backends
+    ${CMAKE_SOURCE_DIR}/src/config/json
+    ${_unit_arch_include})
+
+# Same feature-test macros as retrace_core
+if(RETRACE_PLATFORM_LINUX OR RETRACE_PLATFORM_FREEBSD)
+    target_compile_definitions(retrace_test_registries PRIVATE _GNU_SOURCE _DEFAULT_SOURCE)
+elseif(RETRACE_PLATFORM_DARWIN)
+    target_compile_definitions(retrace_test_registries PRIVATE _DARWIN_C_SOURCE)
+endif()
+
+add_test(NAME unit-test-registries
+    COMMAND retrace_test_registries)
+set_tests_properties(unit-test-registries PROPERTIES LABELS "unit")

--- a/test/unit/test_registries.c
+++ b/test/unit/test_registries.c
@@ -1,0 +1,221 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+/*
+ * Unit tests for the prototype, action, and data-type registries.
+ * Links against retrace_core OBJECT library directly (no LD_PRELOAD).
+ * Sets up minimal retrace_real_impls pointers for the init functions
+ * to work, then tests registry lookups.
+ *
+ * Issue #481: establish the unit test layer.
+ *
+ * NOTE: we don't call retrace_as_get_section_info directly in this
+ * file because the macro declares `extern char start_mysection`
+ * with file-scope asm labels. Multiple calls from the same .c file
+ * produce conflicting asm labels. The init functions (which are in
+ * separate .c files) call it safely.
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdarg.h>
+
+#include "funcs.h"
+#include "actions.h"
+#include "data_types.h"
+#include "real_impls.h"
+
+static int tests_run;
+static int tests_pass;
+static int tests_fail;
+
+#define TEST(name) do { \
+	tests_run++; \
+	printf("  TEST %s ... ", #name); \
+	test_##name(); \
+	tests_pass++; \
+	printf("OK\n"); \
+} while (0)
+
+/* -- Prototype registry -- */
+
+static void test_proto_malloc(void)
+{
+	const struct FuncPrototype *p = retrace_func_get("malloc");
+
+	assert(p != NULL);
+	assert(strcmp(p->name, "malloc") == 0);
+	assert(p->params_cnt == 1);
+}
+
+static void test_proto_printf_variadic(void)
+{
+	const struct FuncPrototype *p = retrace_func_get("printf");
+
+	assert(p != NULL);
+	assert(strcmp(p->name, "printf") == 0);
+	assert(p->fmt == FAT_PRINTF);
+}
+
+static void test_proto_pthread_mutex_lock(void)
+{
+	const struct FuncPrototype *p = retrace_func_get("pthread_mutex_lock");
+
+	assert(p != NULL);
+	assert(strcmp(p->name, "pthread_mutex_lock") == 0);
+}
+
+static void test_proto_strlen(void)
+{
+	const struct FuncPrototype *p = retrace_func_get("strlen");
+
+	assert(p != NULL);
+	assert(strcmp(p->name, "strlen") == 0);
+	assert(p->params_cnt == 1);
+}
+
+static void test_proto_nonexistent(void)
+{
+	assert(retrace_func_get("nonexistent_func_12345") == NULL);
+}
+
+/* Verify we have prototypes across multiple libc headers */
+static void test_proto_cross_header(void)
+{
+	assert(retrace_func_get("read") != NULL);      /* unistd.h */
+	assert(retrace_func_get("fopen") != NULL);     /* stdio.h */
+	assert(retrace_func_get("malloc") != NULL);    /* stdlib.h */
+	assert(retrace_func_get("strlen") != NULL);    /* string.h */
+	assert(retrace_func_get("time") != NULL);      /* time.h */
+	assert(retrace_func_get("isalpha") != NULL);   /* ctype.h */
+	assert(retrace_func_get("opendir") != NULL);   /* dirent.h */
+	assert(retrace_func_get("dlopen") != NULL);    /* unistd.h (dlfcn) */
+}
+
+/* -- Action registry -- */
+
+static void test_action_log_params(void)
+{
+	assert(retrace_actions_get("log_params") != NULL);
+}
+
+static void test_action_call_real(void)
+{
+	assert(retrace_actions_get("call_real") != NULL);
+}
+
+static void test_action_modify_return_value(void)
+{
+	assert(retrace_actions_get("modify_return_value_int") != NULL);
+}
+
+static void test_action_incomplete_io(void)
+{
+	assert(retrace_actions_get("incomplete_io") != NULL);
+}
+
+static void test_action_fuzzing_seed(void)
+{
+	assert(retrace_actions_get("fuzzing_seed") != NULL);
+}
+
+static void test_action_memory_fuzz(void)
+{
+	assert(retrace_actions_get("memory_fuzz") != NULL);
+}
+
+static void test_action_nonexistent(void)
+{
+	assert(retrace_actions_get("nonexistent_action") == NULL);
+}
+
+/* -- Data type registry -- */
+
+static void test_dt_int(void)
+{
+	const struct DataType *dt = retrace_datatype_get("int");
+
+	assert(dt != NULL);
+	assert(strcmp(dt->name, "int") == 0);
+}
+
+static void test_dt_sz(void)
+{
+	const struct DataType *dt = retrace_datatype_get("sz");
+
+	assert(dt != NULL);
+	assert(strcmp(dt->name, "sz") == 0);
+}
+
+static void test_dt_ptr(void)
+{
+	assert(retrace_datatype_get("ptr") != NULL);
+}
+
+static void test_dt_size_t(void)
+{
+	assert(retrace_datatype_get("size_t") != NULL);
+}
+
+static void test_dt_nonexistent(void)
+{
+	assert(retrace_datatype_get("nonexistent_dt") == NULL);
+}
+
+int main(void)
+{
+	/*
+	 * Set up minimal retrace_real_impls so that the registry init
+	 * functions can call strcmp/malloc/etc without crashing. These
+	 * point to the real C library functions (no interposition in
+	 * unit tests).
+	 */
+	retrace_real_impls.strcmp = strcmp;
+	retrace_real_impls.strlen = strlen;
+	retrace_real_impls.strcpy = strcpy;
+	retrace_real_impls.memset = memset;
+	retrace_real_impls.memcpy = memcpy;
+	retrace_real_impls.malloc = malloc;
+	retrace_real_impls.free = free;
+	retrace_real_impls.real_snprintf = snprintf;
+	retrace_real_impls.real_vsnprintf = vsnprintf;
+	retrace_real_impls.getenv = getenv;
+
+	printf("Initializing registries...\n");
+	retrace_funcs_init();
+	retrace_actions_init();
+	retrace_datatypes_init();
+
+	printf("Prototype registry:\n");
+	TEST(proto_malloc);
+	TEST(proto_printf_variadic);
+	TEST(proto_pthread_mutex_lock);
+	TEST(proto_strlen);
+	TEST(proto_nonexistent);
+	TEST(proto_cross_header);
+
+	printf("Action registry:\n");
+	TEST(action_log_params);
+	TEST(action_call_real);
+	TEST(action_modify_return_value);
+	TEST(action_incomplete_io);
+	TEST(action_fuzzing_seed);
+	TEST(action_memory_fuzz);
+	TEST(action_nonexistent);
+
+	printf("Data type registry:\n");
+	TEST(dt_int);
+	TEST(dt_sz);
+	TEST(dt_ptr);
+	TEST(dt_size_t);
+	TEST(dt_nonexistent);
+
+	printf("\n%d run, %d passed, %d failed\n",
+		tests_run, tests_pass, tests_fail);
+	return tests_fail ? 1 : 0;
+}


### PR DESCRIPTION
test: add unit tests for prototype/action/datatype registries (#481)

Establishes the unit test layer that TODO.roadmap/08 calls for.
test/unit/test_registries.c links directly against retrace_core OBJECT
library -- no LD_PRELOAD needed. Tests cover:

  Prototype registry (6 tests):
    - malloc lookup with param count
    - printf lookup with FAT_PRINTF flag
    - pthread_mutex_lock lookup (from pthread prototypes)
    - strlen lookup (from string prototypes)
    - nonexistent function returns NULL
    - cross-header coverage (read, fopen, malloc, strlen, time,
      isalpha, opendir, dlopen across 7 libc headers)

  Action registry (7 tests):
    - log_params, call_real, modify_return_value_int
    - incomplete_io, fuzzing_seed, memory_fuzz (new actions)
    - nonexistent action returns NULL

  Data type registry (5 tests):
    - int, sz, ptr, size_t lookups
    - nonexistent type returns NULL

The test sets up minimal retrace_real_impls (pointing to standard C
library functions) so the registry init functions can work without
the full backend. This is the foundation for TODO.complete/14's
larger unit test plan.

ctest -L unit runs the tests. 18/18 pass on macOS arm64.
