### PR TITLE
macho: add getsectiondata() fallback for section bounds lookup (#479)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -146,6 +146,10 @@ jobs:
 
       # ----- Smoke tests (POSIX only — no LD_PRELOAD on Windows) -----
       # Best-effort: skipped if the v2 library wasn't produced.
+      # The CMake target is `retrace_v2` for historical reasons but the
+      # output library is `libretrace.{so,dylib}` (Phase 9 / ADR-0011).
+      # Uses /usr/bin/id (works on both Linux and macOS; /bin/id does
+      # not exist on newer macOS).
       - name: Smoke test v2 (POSIX)
         if: runner.os != 'Windows'
         continue-on-error: true
@@ -153,12 +157,12 @@ jobs:
           RETRACE_LOGGER_DEF_STDOUT_ENA: "0"
         run: |
           ext="${{ runner.os == 'Linux' && 'so' || 'dylib' }}"
-          lib="build/src/v2/libretrace_v2.$ext"
+          lib="build/src/v2/libretrace.$ext"
           [ -f "$lib" ] || { echo "v2 library missing; skipping"; exit 0; }
           if [ "${{ runner.os }}" = "Linux" ]; then
-            LD_PRELOAD="$(pwd)/$lib" /bin/id
+            LD_PRELOAD="$(pwd)/$lib" /usr/bin/id
           else
-            DYLD_INSERT_LIBRARIES="$(pwd)/$lib" /bin/id
+            DYLD_INSERT_LIBRARIES="$(pwd)/$lib" /usr/bin/id
           fi
 
   # ----- Coverage as a separate job in the same workflow -----

--- a/src/backends/preload_macho/macho_sections.h
+++ b/src/backends/preload_macho/macho_sections.h
@@ -23,37 +23,54 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef ARCH_SPEC_MACROS_H_
-#define ARCH_SPEC_MACROS_H_
-
-#include "macho_sections.h"
-
-#define retrace_as_define_var_in_sec(type, name, seg_name, sec_name) \
-	static type name __attribute__((used, section(seg_name","sec_name)))
-
 /*
- * Section bounds lookup.
+ * Section-bounds lookup for Mach-O backends.
  *
- * Primary path: section$start / section$end magic linker symbols
- * (works on Apple Silicon; returns size=0 on Intel — issue #479).
+ * The previous implementation used the magic linker symbols
+ * section$start$__DATA$__SEC / section$end$__DATA$__SEC via __asm().
+ * That works on Apple Silicon but returns size=0 on Intel macOS,
+ * causing retrace_real_impls_init to silently fail (issue #479).
  *
- * Fallback path: getsectiondata() iteration over loaded images.
- * Required for Intel macOS; inert on Apple Silicon where the primary
- * path already succeeds.
+ * The supported replacement is getsectiondata(), which has been
+ * available since macOS 10.6 (well below our 10.12 minimum) and
+ * works identically on Intel and Apple Silicon. We iterate every
+ * loaded image because retrace itself is loaded via
+ * DYLD_INSERT_LIBRARIES and is not necessarily image[0].
  */
-#define retrace_as_get_section_info(seg_name, sec_name, addr_ptr, size_ptr) \
-do { \
-	extern char start_mysection \
-		__asm("section$start$"seg_name"$"sec_name); \
-	extern char stop_mysection \
-		__asm("section$end$"seg_name"$"sec_name); \
-\
-	*(size_ptr) = (&stop_mysection) - (&start_mysection); \
-	*(addr_ptr) = (void *)&start_mysection; \
-\
-	if (*(size_ptr) == 0) \
-		retrace_macho_get_section((seg_name), (sec_name), \
-					  (void **)(addr_ptr), (size_ptr)); \
-} while (0)
+#ifndef PRELOAD_MACHO_MACHO_SECTIONS_H_
+#define PRELOAD_MACHO_MACHO_SECTIONS_H_
+
+#include <mach-o/getsect.h>
+#include <mach-o/dyld.h>
+
+static inline void
+retrace_macho_get_section(const char *seg_name, const char *sec_name,
+			  void **addr_ptr, unsigned long *size_ptr)
+{
+	uint32_t i;
+	uint32_t count;
+
+	*size_ptr = 0;
+	*addr_ptr = NULL;
+
+	count = _dyld_image_count();
+	for (i = 0; i < count; i++) {
+		const struct mach_header_64 *hdr;
+		unsigned long sz = 0;
+		void *a;
+
+		hdr = (const struct mach_header_64 *)
+			_dyld_get_image_header(i);
+		if (hdr == NULL)
+			continue;
+
+		a = getsectiondata(hdr, seg_name, sec_name, &sz);
+		if (a != NULL && sz > 0) {
+			*addr_ptr = a;
+			*size_ptr = sz;
+			return;
+		}
+	}
+}
 
 #endif

--- a/src/backends/preload_macho/x86_64/arch_spec_macros.h
+++ b/src/backends/preload_macho/x86_64/arch_spec_macros.h
@@ -26,9 +26,21 @@
 #ifndef ARCH_SPEC_MACROS_H_
 #define ARCH_SPEC_MACROS_H_
 
+#include "macho_sections.h"
+
 #define retrace_as_define_var_in_sec(type, name, seg_name, sec_name) \
 	static type name __attribute__((used, section(seg_name","sec_name)))
 
+/*
+ * Section bounds lookup.
+ *
+ * Primary path: section$start / section$end magic linker symbols
+ * (works on Apple Silicon; returns size=0 on Intel — issue #479).
+ *
+ * Fallback path: getsectiondata() iteration over loaded images.
+ * Required for Intel macOS; inert on Apple Silicon where the primary
+ * path already succeeds.
+ */
 #define retrace_as_get_section_info(seg_name, sec_name, addr_ptr, size_ptr) \
 do { \
 	extern char start_mysection \
@@ -36,8 +48,12 @@ do { \
 	extern char stop_mysection \
 		__asm("section$end$"seg_name"$"sec_name); \
 \
-	*size_ptr = (&stop_mysection)-(&start_mysection); \
-	*addr_ptr = (void *) &start_mysection; \
+	*(size_ptr) = (&stop_mysection) - (&start_mysection); \
+	*(addr_ptr) = (void *)&start_mysection; \
+\
+	if (*(size_ptr) == 0) \
+		retrace_macho_get_section((seg_name), (sec_name), \
+					  (void **)(addr_ptr), (size_ptr)); \
 } while (0)
 
 #endif

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -61,6 +61,7 @@ elseif(RETRACE_PLATFORM_DARWIN)
 		set(_retrace_arch_dir x86_64)
 	endif()
 	set(_retrace_arch_include ${CMAKE_SOURCE_DIR}/src/backends/preload_macho/${_retrace_arch_dir})
+	set(_retrace_backend_include  ${CMAKE_SOURCE_DIR}/src/backends/preload_macho)
 elseif(RETRACE_PLATFORM_FREEBSD OR RETRACE_PLATFORM_OPENBSD OR RETRACE_PLATFORM_NETBSD)
 	set(_retrace_arch_include ${CMAKE_SOURCE_DIR}/src/backends/preload_bsd/x86_64)
 endif()
@@ -72,6 +73,7 @@ target_include_directories(retrace_core
 		$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src/config/json>         # conf.h, parson.h (the v2 plan/04 decouples)
 	PRIVATE
 		${_retrace_arch_include}                                       # macros.h per-platform
+		${_retrace_backend_include}                                    # macho_sections.h (Darwin only)
 		${CMAKE_CURRENT_SOURCE_DIR}/prototypes
 		${CMAKE_CURRENT_SOURCE_DIR}/actions
 		${CMAKE_CURRENT_SOURCE_DIR}/datatypes)


### PR DESCRIPTION
## Summary

- macOS Intel has been silently broken since the v2 port: the magic linker symbols `section$start$__DATA$__SEC` / `section$end$__DATA$__SEC` return size=0 on Intel, so `retrace_real_impls_init` finds nothing and every `retrace_real_impls.*` field stays NULL. PR #452 worked around the symptom (destructor crash) with defensive NULL checks but the underlying init still failed.
- This PR adds a `getsectiondata()` fallback: magic symbols stay as the primary path on Apple Silicon (zero-risk, proven), and when they return size=0 we fall back to `getsectiondata()` iterating loaded images. Available since macOS 10.6.
- Helper lives in a shared `macho_sections.h` consumed by both x86_64 and aarch64 backend variants.

## Test plan

- [x] `cmake -B build -G Ninja && cmake --build build` clean on arm64 with no new warnings.
- [x] `ctest --test-dir build` passes on Apple Silicon (no regression — magic symbols still primary there).
- [x] `DYLD_INSERT_LIBRARIES=.../libretrace.dylib /tmp/test_getuid` runs and reports the intercepted `getuid`.
- [ ] GHA `macos-15-intel` confirms `retrace_real_impls.printf` is no longer NULL.
- [ ] GHA `macos-26-intel` confirms same.
- [ ] Follow-up: remove defensive NULL checks in `retrace_logger_deinit` once Intel is verified green.

Closes #479.
