### PR TITLE
x86_64: save xmm0..xmm7 in trampoline for FP varargs (#478)

### DIFF
--- a/src/backends/preload_bsd/x86_64/arch_spec_bottom.c
+++ b/src/backends/preload_bsd/x86_64/arch_spec_bottom.c
@@ -48,6 +48,14 @@ struct WrapperSystemVFrame {
 	 */
 	long ret_val;
 
+	/*
+	 * FP varargs registers (xmm0..xmm7). Touched only by the asm
+	 * trampoline — saved on entry, restored before the Path A
+	 * tail-call. Required so printf("%f", ...) round-trips when the
+	 * engine defers to Path A. Issue #478.
+	 */
+	unsigned char _xmm_save[128];
+
 	/* original values of the param regs,
 	 * as seen by the assembly portion
 	 */
@@ -450,6 +458,27 @@ int retrace_as_setup_params(
 	printf_params = as_ctx->printf_args_cnt;
 	use_unk_dt = 0;
 #endif
+
+	/*
+	 * FP-detection bail: if any vararg is float/double, our integer-
+	 * only dispatch can't place it in xmm0..xmm7. Return 0 to make
+	 * the engine skip action processing and let the asm trampoline
+	 * tail-call real with all original regs (now including xmm0..7)
+	 * intact. The call works correctly; users lose log_params
+	 * visibility for that specific call.
+	 * See TODO.complete/01-float-varargs-aarch64.md (#478).
+	 */
+	for (i = 0; i < printf_params; i++) {
+		int basic = as_ctx->printf_args_types[i] & ~PA_FLAG_MASK;
+
+		if (basic == PA_FLOAT || basic == PA_DOUBLE) {
+			log_dbg(
+				"FP vararg in '%s' -- deferring to asm Path A",
+				proto->name);
+			*params_cnt = proto->params_cnt;
+			return 0;
+		}
+	}
 
 	for (i = 0; i != printf_params; i++, param_idx++) {
 		/* prep param meta */

--- a/src/backends/preload_bsd/x86_64/arch_spec_top.S
+++ b/src/backends/preload_bsd/x86_64/arch_spec_top.S
@@ -23,6 +23,12 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+/*
+ * BSD x86-64 trampoline. Frame layout matches src/backends/preload_elf/
+ * x86_64/arch_spec_top.S; see the commentary there. xmm0..xmm7 are
+ * saved for FP varargs (#478).
+ */
+
 .set OFFS_CALL_REAL_FLAG, 0
 .set OFFS_REAL_IMPL, 8
 .set OFFS_RET_VAL, 16
@@ -36,7 +42,8 @@
 
 \func_name\():
 \func_name\()_retrace_wrapper:
-#prep WrapperSystemVFrame_t struct starts on this rsp, alignment needed
+# Build WrapperSystemVFrame from low to high. Push order is reverse:
+# %rsp first (so it ends up at the highest address).
 pushq %rsp
 pushq %rdi
 pushq %rsi
@@ -45,37 +52,65 @@ pushq %rcx
 pushq %r8
 pushq %r9
 
-# for call_real_flag, real_impl, ret_val
+# Reserve and fill xmm save area. xmm0..xmm7 hold FP varargs per the
+# Sys V ABI; caller-saved, so the engine call would clobber them.
+subq $128, %rsp
+movdqu %xmm0, 0(%rsp)
+movdqu %xmm1, 16(%rsp)
+movdqu %xmm2, 32(%rsp)
+movdqu %xmm3, 48(%rsp)
+movdqu %xmm4, 64(%rsp)
+movdqu %xmm5, 80(%rsp)
+movdqu %xmm6, 96(%rsp)
+movdqu %xmm7, 112(%rsp)
+
+# Reserve control fields.
 subq $24, %rsp
 
-#reset WrapperSystemVFrame_t members
-#they are to be filled by the intercept logic
+# Zero control fields; the engine fills them.
 movq $0, OFFS_CALL_REAL_FLAG(%rsp)
 movq $0, OFFS_REAL_IMPL(%rsp)
 movq $0, OFFS_RET_VAL(%rsp)
-#pass function name as first param
+
+# Function name as first arg.
 leaq \func_name\()_real_name(%rip), %rdi
 
-#pass WrapperSystemVFrame_t as second param
+# WrapperSystemVFrame pointer as second arg.
 movq %rsp, %rsi
 
-#align rsp on 16
+# Align rsp on 16 before the call.
 subq $8, %rsp
 
-#call arch-unaware intercept wrapper
 movabs $retrace_engine_wrapper, %rax
 call *%rax
 
-#set back rsp to WrapperSystemVFrame_t
+# Back to WrapperSystemVFrame.
 addq $8, %rsp
 
-#check call_real_flag, 1 marks the call is needed
+# Check call_real_flag.
 cmpq $0, OFFS_CALL_REAL_FLAG(%rsp)
 jz \func_name\()_no_real
 
-#load registers and restore stack, jmp to real
-#note params values may be modified
+# Path A: tail-call real. Stash real_impl in %rax first; the
+# restorations below change %rsp, so a stack-relative load would need
+# a magic offset.
+movq OFFS_REAL_IMPL(%rsp), %rax
+
+# Drop control fields (24 bytes); rsp now at xmm save area.
 addq $24, %rsp
+
+# Restore FP arg regs.
+movdqu 0(%rsp), %xmm0
+movdqu 16(%rsp), %xmm1
+movdqu 32(%rsp), %xmm2
+movdqu 48(%rsp), %xmm3
+movdqu 64(%rsp), %xmm4
+movdqu 80(%rsp), %xmm5
+movdqu 96(%rsp), %xmm6
+movdqu 112(%rsp), %xmm7
+addq $128, %rsp
+
+# Restore integer arg regs and original rsp.
 popq %r9
 popq %r8
 popq %rcx
@@ -84,20 +119,16 @@ popq %rsi
 popq %rdi
 popq %rsp
 
-#jump to real, the real will return to the caller
-jmp *-72(%rsp)
+# Tail-call real; it returns to the original caller.
+jmpq *%rax
 
 \func_name\()_no_real:
-#TODO write back params?
-
-# set return value. TODO: support long long return
+# Path B: synthesized return value (integer return only).
 movq OFFS_RET_VAL(%rsp), %rax
-addq $80, %rsp
+addq $(24 + 128 + 56), %rsp
 retq
 
 .data
 \func_name\()_real_name:
 .string "\func_name"
 .endm
-
-

--- a/src/backends/preload_elf/x86_64/arch_spec_bottom.c
+++ b/src/backends/preload_elf/x86_64/arch_spec_bottom.c
@@ -44,6 +44,14 @@ struct WrapperSystemVFrame {
 	 */
 	long ret_val;
 
+	/*
+	 * FP varargs registers (xmm0..xmm7). Touched only by the asm
+	 * trampoline — saved on entry, restored before the Path A
+	 * tail-call. Required so printf("%f", ...) round-trips when the
+	 * engine defers to Path A. Issue #478.
+	 */
+	unsigned char _xmm_save[128];
+
 	/* original values of the param regs,
 	 * as seen by the assembly portion
 	 */
@@ -198,6 +206,28 @@ int retrace_as_setup_params(
 			(const char *) params[proto->fmt_param_idx].val,
 			printf_params,
 			types);
+
+	/*
+	 * FP-detection bail: if any vararg is float/double, our integer-
+	 * only dispatch can't place it in xmm0..xmm7. Return 0 to make
+	 * the engine skip action processing and let the asm trampoline
+	 * tail-call real with all original regs (now including xmm0..7)
+	 * intact. The call works correctly; users lose log_params
+	 * visibility for that specific call.
+	 * See TODO.complete/01-float-varargs-aarch64.md (#478).
+	 */
+	for (i = 0; i < printf_params; i++) {
+		int basic = types[i] & ~PA_FLAG_MASK;
+
+		if (basic == PA_FLOAT || basic == PA_DOUBLE) {
+			log_dbg(
+				"FP vararg in '%s' -- deferring to asm Path A",
+				proto->name);
+			retrace_real_impls.free(types);
+			*params_cnt = proto->params_cnt;
+			return 0;
+		}
+	}
 
 	for (i = 0; i != printf_params; i++, param_idx++) {
 		/* prep param meta */

--- a/src/backends/preload_elf/x86_64/arch_spec_top.S
+++ b/src/backends/preload_elf/x86_64/arch_spec_top.S
@@ -23,6 +23,38 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+/*
+ * Sys V x86-64 trampoline.
+ *
+ * Frame layout (offsets relative to %rsp at engine-entry time, i.e.
+ * after the final `subq $24` for the control fields):
+ *
+ *     0   call_real_flag    (engine writes 1 to defer to asm Path A)
+ *     8   real_impl         (address of real libc function)
+ *    16   ret_val           (engine writes synthesized return here)
+ *    24   xmm0              (128 bytes; xmm0..xmm7, 16 bytes each)
+ *    40   xmm1
+ *    56   xmm2
+ *    72   xmm3
+ *    88   xmm4
+ *   104   xmm5
+ *   120   xmm6
+ *   136   xmm7
+ *   152   saved r9          (7 integer arg regs + original rsp)
+ *   160   saved r8
+ *   168   saved rcx
+ *   176   saved rdx
+ *   184   saved rsi
+ *   192   saved rdi
+ *   200   saved rsp value
+ *   208   return address    (pushed by caller's `call`)
+ *
+ * The xmm save area is required for variadic functions (printf etc):
+ * the Sys V ABI passes FP varargs in xmm0..xmm7, which are caller-
+ * saved and would be clobbered by the engine call. Path A restores
+ * them before tail-calling real_impl. Issue #478.
+ */
+
 .set OFFS_CALL_REAL_FLAG, 0
 .set OFFS_REAL_IMPL, 8
 .set OFFS_RET_VAL, 16
@@ -36,7 +68,8 @@
 
 \func_name\():
 \func_name\()_retrace_wrapper:
-#prep WrapperSystemVFrame_t struct starts on this rsp, alignment needed
+# Build WrapperSystemVFrame from low to high. Push order is reverse:
+# %rsp first (so it ends up at the highest address).
 pushq %rsp
 pushq %rdi
 pushq %rsi
@@ -45,37 +78,66 @@ pushq %rcx
 pushq %r8
 pushq %r9
 
-# for call_real_flag, real_impl, ret_val
+# Reserve and fill xmm save area. xmm0..xmm7 hold FP varargs per the
+# Sys V ABI; caller-saved, so the engine call would clobber them.
+subq $128, %rsp
+movdqu %xmm0, 0(%rsp)
+movdqu %xmm1, 16(%rsp)
+movdqu %xmm2, 32(%rsp)
+movdqu %xmm3, 48(%rsp)
+movdqu %xmm4, 64(%rsp)
+movdqu %xmm5, 80(%rsp)
+movdqu %xmm6, 96(%rsp)
+movdqu %xmm7, 112(%rsp)
+
+# Reserve control fields.
 subq $24, %rsp
 
-#reset WrapperSystemVFrame_t members
-#they are to be filled by the intercept logic
+# Zero control fields; the engine fills them.
 movq $0, OFFS_CALL_REAL_FLAG(%rsp)
 movq $0, OFFS_REAL_IMPL(%rsp)
 movq $0, OFFS_RET_VAL(%rsp)
-#pass function name as first param
+
+# Function name as first arg.
 leaq \func_name\()_real_name(%rip), %rdi
 
-#pass WrapperSystemVFrame_t as second param
+# WrapperSystemVFrame pointer as second arg.
 movq %rsp, %rsi
 
-#align rsp on 16
+# Align rsp on 16 before the call (pushq sequence left rsp at 8 mod 16;
+# 56 + 128 + 24 = 208 bytes added; alignment unchanged at 8 mod 16).
 subq $8, %rsp
 
-#call arch-unaware intercept wrapper
 movabs $retrace_engine_wrapper, %rax
 call *%rax
 
-#set back rsp to WrapperSystemVFrame_t
+# Back to WrapperSystemVFrame.
 addq $8, %rsp
 
-#check call_real_flag, 1 marks the call is needed
+# Check call_real_flag.
 cmpq $0, OFFS_CALL_REAL_FLAG(%rsp)
 jz \func_name\()_no_real
 
-#load registers and restore stack, jmp to real
-#note params values may be modified
+# Path A: tail-call real. Stash real_impl in %rax first; the
+# restorations below change %rsp, so a stack-relative load would need
+# a magic offset.
+movq OFFS_REAL_IMPL(%rsp), %rax
+
+# Drop control fields (24 bytes); rsp now at xmm save area.
 addq $24, %rsp
+
+# Restore FP arg regs.
+movdqu 0(%rsp), %xmm0
+movdqu 16(%rsp), %xmm1
+movdqu 32(%rsp), %xmm2
+movdqu 48(%rsp), %xmm3
+movdqu 64(%rsp), %xmm4
+movdqu 80(%rsp), %xmm5
+movdqu 96(%rsp), %xmm6
+movdqu 112(%rsp), %xmm7
+addq $128, %rsp
+
+# Restore integer arg regs and original rsp.
 popq %r9
 popq %r8
 popq %rcx
@@ -84,20 +146,16 @@ popq %rsi
 popq %rdi
 popq %rsp
 
-#jump to real, the real will return to the caller
-jmp *-72(%rsp)
+# Tail-call real; it returns to the original caller.
+jmpq *%rax
 
 \func_name\()_no_real:
-#TODO write back params?
-
-# set return value. TODO: support long long return
+# Path B: synthesized return value (integer return only).
 movq OFFS_RET_VAL(%rsp), %rax
-addq $80, %rsp
+addq $(24 + 128 + 56), %rsp
 retq
 
 .data
 \func_name\()_real_name:
 .string "\func_name"
 .endm
-
-

--- a/src/backends/preload_macho/x86_64/arch_spec_bottom.c
+++ b/src/backends/preload_macho/x86_64/arch_spec_bottom.c
@@ -45,6 +45,14 @@ struct WrapperSystemVFrame {
 	 */
 	long ret_val;
 
+	/*
+	 * FP varargs registers (xmm0..xmm7). Touched only by the asm
+	 * trampoline — saved on entry, restored before the Path A
+	 * tail-call. Required so printf("%f", ...) round-trips when the
+	 * engine defers to Path A. Issue #478.
+	 */
+	unsigned char _xmm_save[128];
+
 	/* original values of the param regs,
 	 * as seen by the assembly portion
 	 */
@@ -426,6 +434,27 @@ int retrace_as_setup_params(
 	printf_params = as_ctx->printf_args_cnt;
 	use_unk_dt = 0;
 #endif
+
+	/*
+	 * FP-detection bail: if any vararg is float/double, our integer-
+	 * only dispatch can't place it in xmm0..xmm7. Return 0 to make
+	 * the engine skip action processing and let the asm trampoline
+	 * tail-call real with all original regs (now including xmm0..7)
+	 * intact. The call works correctly; users lose log_params
+	 * visibility for that specific call.
+	 * See TODO.complete/01-float-varargs-aarch64.md (#478).
+	 */
+	for (i = 0; i < printf_params; i++) {
+		int basic = as_ctx->printf_args_types[i] & ~PA_FLAG_MASK;
+
+		if (basic == PA_FLOAT || basic == PA_DOUBLE) {
+			log_dbg(
+				"FP vararg in '%s' -- deferring to asm Path A",
+				proto->name);
+			*params_cnt = proto->params_cnt;
+			return 0;
+		}
+	}
 
 	for (i = 0; i != printf_params; i++, param_idx++) {
 		/* prep param meta */

--- a/src/backends/preload_macho/x86_64/arch_spec_top.S
+++ b/src/backends/preload_macho/x86_64/arch_spec_top.S
@@ -23,6 +23,15 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+/*
+ * Darwin x86-64 trampoline.
+ *
+ * Frame layout matches src/backends/preload_elf/x86_64/arch_spec_top.S;
+ * see the commentary there. xmm0..xmm7 are saved for FP varargs (#478).
+ * Differences from ELF: section directives (__TEXT/__DATA), Apple symbol
+ * prefixes (_), local L labels, direct `call _retrace_engine_wrapper`.
+ */
+
 .set OFFS_CALL_REAL_FLAG, 0
 .set OFFS_REAL_IMPL, 8
 .set OFFS_RET_VAL, 16
@@ -34,7 +43,8 @@
 .section __TEXT, __text
 _\func_name\()_retrace_wrapper:
 
-#prep WrapperSystemVFrame_t struct starts on this rsp, alignment needed
+# Build WrapperSystemVFrame from low to high. Push order is reverse:
+# %rsp first (so it ends up at the highest address).
 pushq %rsp
 pushq %rdi
 pushq %rsi
@@ -43,37 +53,64 @@ pushq %rcx
 pushq %r8
 pushq %r9
 
-# for call_real_flag, real_impl, ret_val
+# Reserve and fill xmm save area. xmm0..xmm7 hold FP varargs per the
+# Sys V ABI; caller-saved, so the engine call would clobber them.
+subq $128, %rsp
+movdqu %xmm0, 0(%rsp)
+movdqu %xmm1, 16(%rsp)
+movdqu %xmm2, 32(%rsp)
+movdqu %xmm3, 48(%rsp)
+movdqu %xmm4, 64(%rsp)
+movdqu %xmm5, 80(%rsp)
+movdqu %xmm6, 96(%rsp)
+movdqu %xmm7, 112(%rsp)
+
+# Reserve control fields.
 subq $24, %rsp
 
-#reset WrapperSystemVFrame_t members
-#they are to be filled by the intercept logic
+# Zero control fields; the engine fills them.
 movq $0, OFFS_CALL_REAL_FLAG(%rsp)
 movq $0, OFFS_REAL_IMPL(%rsp)
 movq $0, OFFS_RET_VAL(%rsp)
 
-#pass function name as first param
+# Function name as first arg.
 leaq L\func_name\()_retrace_real_name(%rip), %rdi
 
-#pass WrapperSystemVFrame_t as second param
+# WrapperSystemVFrame pointer as second arg.
 movq %rsp, %rsi
 
-#align rsp on 16
+# Align rsp on 16 before the call.
 subq $8, %rsp
 
-#call arch-unaware intercept wrapper
 call _retrace_engine_wrapper
 
-#set back rsp to WrapperSystemVFrame_t
+# Back to WrapperSystemVFrame.
 addq $8, %rsp
 
-#check call_real_flag, 1 marks the call is needed
+# Check call_real_flag.
 cmpq $0, OFFS_CALL_REAL_FLAG(%rsp)
 jz L\func_name\()_retrace_no_real
 
-#load registers and restore stack, jmp to real
-#note params values may be modified
+# Path A: tail-call real. Stash real_impl in %rax first; the
+# restorations below change %rsp, so a stack-relative load would need
+# a magic offset.
+movq OFFS_REAL_IMPL(%rsp), %rax
+
+# Drop control fields (24 bytes); rsp now at xmm save area.
 addq $24, %rsp
+
+# Restore FP arg regs.
+movdqu 0(%rsp), %xmm0
+movdqu 16(%rsp), %xmm1
+movdqu 32(%rsp), %xmm2
+movdqu 48(%rsp), %xmm3
+movdqu 64(%rsp), %xmm4
+movdqu 80(%rsp), %xmm5
+movdqu 96(%rsp), %xmm6
+movdqu 112(%rsp), %xmm7
+addq $128, %rsp
+
+# Restore integer arg regs and original rsp.
 popq %r9
 popq %r8
 popq %rcx
@@ -82,19 +119,16 @@ popq %rsi
 popq %rdi
 popq %rsp
 
-#jump to real, the real will return to the caller
-jmpq *-72(%rsp)
+# Tail-call real; it returns to the original caller.
+jmpq *%rax
 
 L\func_name\()_retrace_no_real:
-#TODO write back params?
-
-# set return value. TODO: support long long return
+# Path B: synthesized return value (integer return only).
 movq OFFS_RET_VAL(%rsp), %rax
-addq $80, %rsp
+addq $(24 + 128 + 56), %rsp
 retq
 
 .section __DATA, __retrace_rimpls
-#.data
 L\func_name\()_retrace_real_name:
 .string "\func_name"
 L\func_name\()_retrace_real_name_size:


### PR DESCRIPTION
## Summary

- The x86_64 trampoline (ELF, BSD, Mach-O) now saves xmm0..xmm7 on entry and restores them before the Path A tail-call. Sys V x86-64 passes variadic FP args in xmm0..xmm7 — these are caller-saved, so the engine call would clobber them. Issue #478.
- Each backend's `setup_params` now scans parsed printf argtypes and bails to Path A when any vararg is `PA_FLOAT`/`PA_DOUBLE`. Same pattern as the existing aarch64 macho bail from PR #434.
- `WrapperSystemVFrame` struct gets a `_xmm_save[128]` field so C and asm agree on layout.

## Test plan

- [x] `cmake -B build -G Ninja -DCMAKE_OSX_ARCHITECTURES=x86_64 -DRETRACE_BUILD_TESTS=ON && cmake --build build` clean on Apple Silicon (cross-compile for x86_64).
- [x] `ctest --test-dir build` 100% pass under Rosetta.
- [x] `printf("int=%d fp=%.2f str=%s\n", 42, 3.14, "hello")` → `int=42 fp=3.14 str=hello` (matches baseline).
- [x] `snprintf` with 9 doubles (exceeds xmm0..7) → correct.
- [x] `printf` with `long double` → correct.
- [x] arm64 build still passes (aarch64 backends unchanged).
- [ ] GHA Linux x64, Linux arm64, BSD x86_64, macOS Intel, macOS arm64 all green.

Closes #478.
