### PR TITLE
examples: add v2 JSON configs for remaining examples (#484)

### DIFF
--- a/examples/dns-fuzz/retrace.conf.json
+++ b/examples/dns-fuzz/retrace.conf.json
@@ -1,0 +1,25 @@
+{
+  "intercept_scripts": [
+    {
+      "func_name": "sendto",
+      "actions": [
+        { "action_name": "log_params" },
+        { "action_name": "call_real" }
+      ]
+    },
+    {
+      "func_name": "recvfrom",
+      "actions": [
+        { "action_name": "log_params" },
+        { "action_name": "call_real" }
+      ]
+    },
+    {
+      "func_name": "socket",
+      "actions": [
+        { "action_name": "log_params" },
+        { "action_name": "call_real" }
+      ]
+    }
+  ]
+}

--- a/examples/http-server-overflow/README.md
+++ b/examples/http-server-overflow/README.md
@@ -6,7 +6,25 @@ I included a sample http server (```http-server.c```) which runs as a single pro
 
 Disclaimer: this was written for macOS
 
-# Preparation
+## v2 JSON config
+
+`retrace.conf.json` logs every network call and applies a 10% failure
+rate to `read` calls (via `memory_fuzz`) so the server sees truncated
+or failed reads — useful for exercising its parser's error paths.
+
+```sh
+$ gcc http-server.c -o /tmp/http-server -Wall
+$ cp /usr/bin/curl /tmp/curl
+$ # Terminal 1: start the server under retrace
+$ RETRACE_JSON_CONFIG=retrace.conf.json \
+    LD_PRELOAD=../../build/src/v2/libretrace.so /tmp/http-server
+```
+
+For the historical v1 string-injection walkthrough that triggers a real
+buffer overflow in the sample server, see the archived section at the
+bottom of this file.
+
+## Preparation
 
 Compile http-server.c and copy curl to /tmp/ to bypass SIP
 

--- a/examples/http-server-overflow/retrace.conf.json
+++ b/examples/http-server-overflow/retrace.conf.json
@@ -1,0 +1,47 @@
+{
+  "intercept_scripts": [
+    {
+      "func_name": "socket",
+      "actions": [
+        { "action_name": "log_params" },
+        { "action_name": "call_real" }
+      ]
+    },
+    {
+      "func_name": "bind",
+      "actions": [
+        { "action_name": "log_params" },
+        { "action_name": "call_real" }
+      ]
+    },
+    {
+      "func_name": "listen",
+      "actions": [
+        { "action_name": "log_params" },
+        { "action_name": "call_real" }
+      ]
+    },
+    {
+      "func_name": "accept",
+      "actions": [
+        { "action_name": "log_params" },
+        { "action_name": "call_real" }
+      ]
+    },
+    {
+      "func_name": "read",
+      "actions": [
+        { "action_name": "log_params" },
+        { "action_name": "call_real" },
+        { "action_name": "memory_fuzz", "action_params": { "fail_rate": 0.1 } }
+      ]
+    },
+    {
+      "func_name": "write",
+      "actions": [
+        { "action_name": "log_params" },
+        { "action_name": "call_real" }
+      ]
+    }
+  ]
+}

--- a/examples/net-fuzzing/README.md
+++ b/examples/net-fuzzing/README.md
@@ -2,8 +2,29 @@
 
 Retrace can be used to fuzz network related system calls.
 
+## v2 JSON config
 
-## Network fuzzing configuration syntax
+`retrace.conf.json` logs every network call and applies a 5% random
+failure rate to `send`/`recv` (via the `memory_fuzz` action) so you can
+see how the client copes with transport-level errors.
+
+```sh
+$ cc -o test_client test_client.c
+$ RETRACE_JSON_CONFIG=retrace.conf.json \
+    LD_PRELOAD=../../build/src/v2/libretrace.so ./test_client
+```
+
+Tune the failure rate by editing `fail_rate` in the JSON; pair with
+`fuzzing_seed` for deterministic runs.
+
+## v1 syntax (legacy, no longer wired up)
+
+The original text-config syntax exposed typed failure modes per call
+(`fuzzing-net,connect,ADDR_INUSE,0.5`). v2 collapses the universe of
+"force-fail this call" behaviors into the `memory_fuzz` action, which
+returns ENOMEM-style failures at a configurable rate. The typed modes
+(ADDR_INUSE, CONN_RESET, ...) can be reintroduced as additional
+actions; see `TODO.complete/10-v1-actions-port.md`.
 
 ```
 fuzzing-net,[function name],[fuzzing type],[fuzzing rate]

--- a/examples/net-fuzzing/retrace.conf.json
+++ b/examples/net-fuzzing/retrace.conf.json
@@ -1,0 +1,41 @@
+{
+  "intercept_scripts": [
+    {
+      "func_name": "socket",
+      "actions": [
+        { "action_name": "log_params" },
+        { "action_name": "call_real" }
+      ]
+    },
+    {
+      "func_name": "connect",
+      "actions": [
+        { "action_name": "log_params" },
+        { "action_name": "call_real" }
+      ]
+    },
+    {
+      "func_name": "getaddrinfo",
+      "actions": [
+        { "action_name": "log_params" },
+        { "action_name": "call_real" }
+      ]
+    },
+    {
+      "func_name": "send",
+      "actions": [
+        { "action_name": "log_params" },
+        { "action_name": "call_real" },
+        { "action_name": "memory_fuzz", "action_params": { "fail_rate": 0.05 } }
+      ]
+    },
+    {
+      "func_name": "recv",
+      "actions": [
+        { "action_name": "log_params" },
+        { "action_name": "call_real" },
+        { "action_name": "memory_fuzz", "action_params": { "fail_rate": 0.05 } }
+      ]
+    }
+  ]
+}

--- a/examples/stringinject/README.md
+++ b/examples/stringinject/README.md
@@ -3,6 +3,21 @@
 
 stringinjector inserts strings and/or replaces bytes in ascii and binary files. As the files can be ascii in nature (XML, JSON etc) or binary (think ELF) it needs to be able to write both. It needs to be fast as some files can be several megabytes big.
 
+## v2 JSON config
+
+`retrace.conf.json` logs every I/O call (file and socket) made by the
+test program so you can see exactly what buffers flow through each
+intercept point — the input data the string injector would target.
+
+```sh
+$ cc -o strinject_test strinject_test.c
+$ RETRACE_JSON_CONFIG=retrace.conf.json \
+    LD_PRELOAD=../../build/src/v2/libretrace.so ./strinject_test
+```
+
+Pair with `tools/stringinjector/stringinjector` for the actual byte
+rewriting; retrace logs the call sequence, the tool rewrites the file.
+
 # List of the functions to apply stringinject
 
 - File I/O functions

--- a/examples/stringinject/retrace.conf.json
+++ b/examples/stringinject/retrace.conf.json
@@ -1,0 +1,53 @@
+{
+  "intercept_scripts": [
+    {
+      "func_name": "fread",
+      "actions": [
+        { "action_name": "log_params" },
+        { "action_name": "call_real" }
+      ]
+    },
+    {
+      "func_name": "fwrite",
+      "actions": [
+        { "action_name": "log_params" },
+        { "action_name": "call_real" }
+      ]
+    },
+    {
+      "func_name": "fgets",
+      "actions": [
+        { "action_name": "log_params" },
+        { "action_name": "call_real" }
+      ]
+    },
+    {
+      "func_name": "read",
+      "actions": [
+        { "action_name": "log_params" },
+        { "action_name": "call_real" }
+      ]
+    },
+    {
+      "func_name": "write",
+      "actions": [
+        { "action_name": "log_params" },
+        { "action_name": "call_real" }
+      ]
+    },
+    {
+      "func_name": "send",
+      "actions": [
+        { "action_name": "log_params" },
+        { "action_name": "call_real" }
+      ]
+    },
+    {
+      "func_name": "recv",
+      "actions": [
+        { "action_name": "log_params" },
+        { "action_name": "call_real" }
+      ]
+    }
+  ]
+}

--- a/examples/unsafe-system/README.md
+++ b/examples/unsafe-system/README.md
@@ -45,6 +45,20 @@ $
 Retrace will show any unsafe use of `system()`:
 
 ```console
+$ gcc system.c -o system
+$ RETRACE_JSON_CONFIG=examples/unsafe-system/retrace.conf.json \
+    LD_PRELOAD=build/src/v2/libretrace.so ./system
+```
+
+The JSON config tells retrace to log every `system()` and `setuid()` call. The
+retrace log entry for `system()` shows the command string — a quick scan
+tells you whether the call passes a relative path (unsafe) or an absolute
+one (safe).
+
+The legacy v1 examples below show the original text-config output; the
+v2 JSON config above produces equivalent JSON log entries.
+
+```console
 $ ../../retrace ./system
 <SNIP>
 uid=501(test) gid=20(staff) groups=20(staff)

--- a/examples/unsafe-system/retrace.conf.json
+++ b/examples/unsafe-system/retrace.conf.json
@@ -1,0 +1,18 @@
+{
+  "intercept_scripts": [
+    {
+      "func_name": "system",
+      "actions": [
+        { "action_name": "log_params" },
+        { "action_name": "call_real" }
+      ]
+    },
+    {
+      "func_name": "setuid",
+      "actions": [
+        { "action_name": "log_params" },
+        { "action_name": "call_real" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds v2 JSON configs for the 5 examples PR #484 didn't cover: dns-fuzz, http-server-overflow, net-fuzzing, stringinject, unsafe-system.
- Each config wires up `log_params` + `call_real` for the libc symbols the example exercises. net-fuzzing and http-server-overflow additionally demonstrate `memory_fuzz` as a stand-in for the legacy `fuzzing-net` typed modes that v2 has collapsed into a single rate-based action.
- READMEs updated with v2 invocation; v1 walkthroughs kept as historical reference.

## Test plan

- [x] All 5 configs parse as valid JSON.
- [x] `RETRACE_JSON_CONFIG=examples/unsafe-system/retrace.conf.json DYLD_INSERT_LIBRARIES=.../libretrace.dylib /tmp/unsafe-system` emits JSON log entries for `setuid` and `system`.
- [x] Build still clean on arm64.

Closes #484.
