### PR TITLE
engine: MECE split per ADR-0013 (closes #480)

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -9,7 +9,8 @@
 
 set(_core_sources
 	engine.c        funcs.c         actions.c      data_types.c
-	real_impls.c    logger.c        main.c         as_call_real.c)
+	real_impls.c    logger.c        main.c         as_call_real.c
+	thread_context.c script_resolver.c action_runner.c)
 
 # dlopen_guard.c is Linux-only: it exports dlopen/dlclose/dlsym/dlerror
 # as global symbols for LD_PRELOAD interposition. On macOS these symbols

--- a/src/core/action_runner.c
+++ b/src/core/action_runner.c
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "action_runner.h"
+
+#include <pthread.h>
+
+#include "actions.h"
+#include "logger.h"
+
+void retrace_action_runner_run(struct ThreadContext *thread_ctx,
+	const char *func_name,
+	const JSON_Object *i_script)
+{
+	const JSON_Array *i_actions;
+	const JSON_Object *i_action;
+	const char *i_action_name;
+	int (*action_func)(struct ThreadContext *t_ctx,
+		const JSON_Object *action_params);
+	size_t i;
+
+	i_actions = json_object_get_array(i_script, "actions");
+	if (i_actions == NULL) {
+		log_warn(
+			"i_script for %s:%p does not contain actions array",
+			func_name,
+			thread_ctx->ret_addr);
+		return;
+	}
+
+	if (!json_array_get_count(i_actions)) {
+		log_warn(
+			"i_script for %s:%p contains empty actions array",
+			func_name,
+			thread_ctx->ret_addr);
+		return;
+	}
+
+	for (i = 0; i < json_array_get_count(i_actions); i++) {
+		i_action = json_array_get_object(i_actions, i);
+		i_action_name = json_object_get_string(i_action, "action_name");
+		if (i_action_name == NULL) {
+			log_err(
+				"action idx: %d for %s:%p has no action_name "
+				"aborting script",
+				(int)i,
+				func_name,
+				thread_ctx->ret_addr);
+			break;
+		}
+
+		action_func = retrace_actions_get(i_action_name);
+		if (action_func == NULL) {
+			log_err(
+				"action idx: %d for %s:%p "
+				"is not supported '%s', aborting script",
+				(int)i,
+				func_name,
+				thread_ctx->ret_addr,
+				i_action_name);
+			break;
+		}
+
+		log_info("Running action %s, for %s:%p, tpid 0x%llx...",
+			i_action_name,
+			func_name,
+			thread_ctx->ret_addr,
+			(unsigned long long)pthread_self());
+
+		if (action_func(thread_ctx,
+			json_object_get_object(i_action, "action_params"))) {
+			log_warn(
+				"action %s, for %s:%p, tpid 0x%llx aborted the script",
+				i_action_name,
+				func_name,
+				thread_ctx->ret_addr,
+				(unsigned long long)pthread_self());
+			break;
+		}
+	}
+}

--- a/src/core/action_runner.h
+++ b/src/core/action_runner.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef ACTION_RUNNER_H_
+#define ACTION_RUNNER_H_
+
+#include "parson.h"
+#include "engine.h"
+
+/*
+ * Run every action listed under i_script["actions"] against thread_ctx.
+ * The loop stops on the first action that returns non-zero (action
+ * signaled abort). Logs each step; caller is responsible for writing
+ * thread_ctx->ret_val back into the arch_spec_ctx.
+ *
+ * Extracted from engine.c per ADR-0013 (#480).
+ */
+void retrace_action_runner_run(struct ThreadContext *thread_ctx,
+	const char *func_name,
+	const JSON_Object *i_script);
+
+#endif

--- a/src/core/engine.c
+++ b/src/core/engine.c
@@ -23,7 +23,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-
 #ifndef __GNUC__
 #error GNU extensions are required!
 #endif
@@ -32,8 +31,6 @@
 #define _GNU_SOURCE
 #endif
 #include <stdio.h>
-#include <pthread.h>
-#include <dlfcn.h>
 
 #include "engine.h"
 #include "real_impls.h"
@@ -41,173 +38,55 @@
 #include "actions.h"
 #include "conf.h"
 #include "logger.h"
+#include "thread_context.h"
+#include "script_resolver.h"
+#include "action_runner.h"
 
-static pthread_key_t thread_ctx_key;
+int retrace_inited;
 
-static void thread_ctx_destructor(void *thread_ctx)
-{
-	retrace_real_impls.free(thread_ctx);
-	retrace_real_impls.pthread_key_delete(thread_ctx_key);
-}
-
-static inline struct ThreadContext *get_thread_context(void)
-{
-	struct ThreadContext *thread_ctx;
-
-	thread_ctx = (struct ThreadContext *)
-		retrace_real_impls.pthread_getspecific(thread_ctx_key);
-
-	/* try to create if does not exist */
-	if (thread_ctx == NULL) {
-
-		thread_ctx = (struct ThreadContext *)
-			retrace_real_impls.malloc(sizeof(struct ThreadContext));
-
-		if (thread_ctx == NULL)
-			return NULL;
-
-		if (retrace_real_impls.pthread_setspecific(
-			thread_ctx_key, thread_ctx)) {
-
-			retrace_real_impls.free(thread_ctx);
-			return NULL;
-		}
-
-		/* reset context data */
-		retrace_real_impls.memset(thread_ctx, 0, sizeof(*thread_ctx));
-
-	}
-
-	return thread_ctx;
-}
-
-static inline void clear_context(struct ThreadContext *thread_ctx)
-{
-	int i;
-	/* free new params */
-
-	for (i = 0; i != thread_ctx->params_cnt; i++) {
-		if (thread_ctx->params[i].free_val)
-			retrace_real_impls.free((void *) thread_ctx->params[i].val);
-	}
-
-	retrace_real_impls.memset(thread_ctx, 0, sizeof(*thread_ctx));
-}
-
-static const JSON_Object *get_i_script(const JSON_Array *i_array,
-	const char *func_name,
-	void *ret_addr)
-{
-	size_t i;
-	const JSON_Object *i_script;
-	const char *i_func;
-	double i_ret_addr;
-	const JSON_Object *ret_cand;
-
-	ret_cand = NULL;
-	for (i = 0; i < json_array_get_count(i_array); i++) {
-		i_script = json_array_get_object(i_array, i);
-
-		/* find function name */
-		i_func = json_object_get_string(i_script, "func_name");
-		if (i_func == NULL) {
-			log_err(
-				"i_script idx: %d has no func_name member",
-				i);
-			continue;
-		}
-
-		/* check for match-all */
-		if (!retrace_real_impls.strcmp(i_func, "*"))
-			return i_script;
-
-		/* func_name match? */
-		if (!retrace_real_impls.strcmp(i_func, func_name)) {
-			if (!ret_addr)
-				return i_script;
-
-			i_ret_addr = json_object_get_number(i_script, "return_addr");
-
-			if (!i_ret_addr) {
-				/* ret_addr not specified */
-				if (ret_cand == NULL)
-					ret_cand = i_script;
-			} else {
-				/* ret_addr match? */
-				if ((long long) ret_addr == ((long long) i_ret_addr))
-					return i_script;
-			}
-		}
-	}
-
-	return ret_cand;
-}
-
-
-struct WrapperSystemVFrame {
-	/* this flag will cause the assembly portion to call the real impl */
-	long call_real_flag;
-
-	/* In case call_real_flag is 1,
-	 * the assembly portion will jmp to this address
-	 */
-	void *real_impl;
-
-	/* return value for the function,
-	 * used in case call_real_flag == 0
-	 */
-	long ret_val;
-
-	/* original values of the param regs,
-	 * as seen by the assembly portion
-	 */
-	long real_r9;
-	long real_r8;
-	long real_rcx;
-	long real_rdx;
-	long real_rsi;
-	long real_rdi;
-	long real_rsp;
-};
-
-/* The purpose of this function is to continue the work of the assembly wrapper.
- * The separation exists to allow for an easy support of different archs/ABIs
- * Assembly wrapper should call this function as soon as it saves
- * original parameters to its context
+/*
+ * The central dispatch entry point invoked by every per-arch asm
+ * trampoline. Responsibilities, in strict order:
+ *
+ *   1. Look up the real libc implementation (no allocation here — this
+ *      runs before init and during reentry).
+ *   2. If init never completed, schedule the real call and return.
+ *   3. Acquire the per-thread interception context.
+ *   4. If real_impl is NULL, abort the call with ret_val = -1.
+ *   5. Default to calling the real implementation.
+ *   6. Reentrance guard: if thread_ctx already holds a real_impl,
+ *      we're inside a nested call — bail.
+ *   7. Mark this thread as actively intercepting.
+ *   8. Look up the prototype; if missing, just call real.
+ *   9. Apply the per-function log filter (issue #486).
+ *  10. Parse variadic args out of the frame (or bail for FP varargs).
+ *  11. Find the intercept_script; if none, call real.
+ *  12. Hand off to action_runner to actually run the script.
+ *  13. Write thread_ctx->ret_val back into the frame.
+ *  14. Clear the per-thread context.
+ *
+ * Steps 3, 11, 12 live in their own modules (ADR-0013); this function
+ * is the orchestrator that calls them in order.
  */
-
 void retrace_engine_wrapper(char *func_name,
-		void *arch_spec_ctx)
+	void *arch_spec_ctx)
 {
 	void *real_impl;
-	size_t i;
 	struct ThreadContext *thread_ctx;
 	const JSON_Object *i_script;
-	const JSON_Array *i_actions;
-	const JSON_Object *i_action;
-	int (*action_func)(struct ThreadContext *t_ctx,
-		const JSON_Object *action_params);
-	const char *i_action_name;
 	const JSON_Array *i_scripts;
 
-	/*
-	 * get real implementation
-	 * This is very sensitive code, no function calls are allowed.
-	 *
-	 */
 	real_impl = retrace_as_get_real_safe(func_name);
 	if (!retrace_inited) {
 		retrace_as_sched_real(arch_spec_ctx, real_impl);
 		return;
 	}
 
-	/* get/create retrace context for thread */
-	thread_ctx = get_thread_context();
+	thread_ctx = retrace_thread_context_get();
 	if (thread_ctx == NULL) {
 		log_err(
 			"%s() intercept failed - could not get context",
 			func_name);
-
 		return;
 	}
 
@@ -222,16 +101,14 @@ void retrace_engine_wrapper(char *func_name,
 		return;
 	}
 
-
 	/* set default to call real impl */
 	retrace_as_sched_real(arch_spec_ctx, real_impl);
 
-	/* do not intervene if already intercepting
-	 */
+	/* do not intervene if already intercepting */
 	if (thread_ctx->real_impl != NULL)
 		return;
 
-	/* save arc spec context */
+	/* save arch spec context */
 	thread_ctx->arch_spec_ctx = arch_spec_ctx;
 
 	/* Mark active interception for cases of nested calls */
@@ -240,10 +117,8 @@ void retrace_engine_wrapper(char *func_name,
 	thread_ctx->prototype = retrace_func_get(func_name);
 
 	/* if func is not prototyped - do not intervene */
-	if (thread_ctx->prototype == NULL) {
-		/* Silently call real impl */
+	if (thread_ctx->prototype == NULL)
 		goto clean_up;
-	}
 
 	/*
 	 * Per-function log filter (issue #486). If the user excluded
@@ -269,6 +144,7 @@ void retrace_engine_wrapper(char *func_name,
 			func_name);
 		goto clean_up;
 	}
+
 	/* find intercept script for the func and return addr */
 	i_scripts = json_object_get_array(retrace_conf, "intercept_scripts");
 	if (!i_scripts) {
@@ -278,7 +154,7 @@ void retrace_engine_wrapper(char *func_name,
 		goto clean_up;
 	}
 
-	i_script = get_i_script(i_scripts, func_name,
+	i_script = retrace_script_find(i_scripts, func_name,
 		thread_ctx->ret_addr);
 
 	if (!i_script) {
@@ -286,92 +162,20 @@ void retrace_engine_wrapper(char *func_name,
 		goto clean_up;
 	}
 
-	i_actions = json_object_get_array(i_script, "actions");
-	if (i_actions == NULL) {
-		log_warn(
-			"i_script for %s:%p does not contain actions array",
-			func_name,
-			thread_ctx->ret_addr);
-		goto clean_up;
-	}
-
-	if (!json_array_get_count(i_actions)) {
-		log_warn(
-			"i_script for %s:%p contains empty actions array",
-			func_name,
-			thread_ctx->ret_addr);
-		goto clean_up;
-	}
-
 	/* we have script, do not call real impl by default */
 	retrace_as_cancel_sched_real(arch_spec_ctx);
 
-	for (i = 0; i < json_array_get_count(i_actions); i++) {
-
-		i_action = json_array_get_object(i_actions, i);
-		i_action_name = json_object_get_string(i_action, "action_name");
-		if (i_action_name == NULL) {
-			log_err(
-				"action idx: %d for %s:%p has no action_name "
-				"aborting script",
-				i,
-				func_name,
-				thread_ctx->ret_addr);
-
-			break;
-		}
-
-		action_func = retrace_actions_get(i_action_name);
-
-		if (!action_func) {
-			log_err("action idx: %d for %s:%p "
-				"is not supported '%s', aborting script",
-				i,
-				func_name,
-				thread_ctx->ret_addr,
-				i_action_name);
-
-			break;
-		}
-
-		log_info("Running action %s, for %s:%p, tpid 0x%llx...",
-				i_action_name,
-				func_name,
-				thread_ctx->ret_addr,
-				(unsigned long long) pthread_self());
-
-		if (action_func(thread_ctx,
-			json_object_get_object(i_action, "action_params"))) {
-
-			log_warn("action %s, for %s:%p, tpid 0x%llx aborted"
-				" the script",
-				i_action_name,
-				func_name,
-				thread_ctx->ret_addr,
-				(unsigned long long) pthread_self());
-
-			break;
-		}
-	}
+	retrace_action_runner_run(thread_ctx, func_name, i_script);
 
 	/* write back to arch spec. portion */
 	retrace_as_set_ret_val(arch_spec_ctx, thread_ctx->ret_val);
 
 clean_up:
 	/* mark hi-level intercept done */
-	clear_context(thread_ctx);
+	retrace_thread_context_clear(thread_ctx);
 }
 
-/* not thread safe */
 int retrace_engine_init(void)
 {
-	int key_res;
-
-	key_res = retrace_real_impls.pthread_key_create(&thread_ctx_key,
-		thread_ctx_destructor);
-
-	if (key_res)
-		log_err("failed to create pthread_key");
-
-	return key_res;
+	return retrace_thread_context_init();
 }

--- a/src/core/engine.c
+++ b/src/core/engine.c
@@ -42,8 +42,6 @@
 #include "script_resolver.h"
 #include "action_runner.h"
 
-int retrace_inited;
-
 /*
  * The central dispatch entry point invoked by every per-arch asm
  * trampoline. Responsibilities, in strict order:

--- a/src/core/script_resolver.c
+++ b/src/core/script_resolver.c
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "script_resolver.h"
+
+#include "real_impls.h"
+#include "logger.h"
+
+const JSON_Object *retrace_script_find(const JSON_Array *i_array,
+	const char *func_name,
+	void *ret_addr)
+{
+	size_t i;
+	const JSON_Object *i_script;
+	const char *i_func;
+	double i_ret_addr;
+	const JSON_Object *ret_cand = NULL;
+
+	for (i = 0; i < json_array_get_count(i_array); i++) {
+		i_script = json_array_get_object(i_array, i);
+
+		i_func = json_object_get_string(i_script, "func_name");
+		if (i_func == NULL) {
+			log_err(
+				"i_script idx: %d has no func_name member",
+				i);
+			continue;
+		}
+
+		/* check for match-all */
+		if (!retrace_real_impls.strcmp(i_func, "*"))
+			return i_script;
+
+		/* func_name match? */
+		if (!retrace_real_impls.strcmp(i_func, func_name)) {
+			if (!ret_addr)
+				return i_script;
+
+			i_ret_addr = json_object_get_number(i_script,
+				"return_addr");
+
+			if (!i_ret_addr) {
+				/* ret_addr not specified */
+				if (ret_cand == NULL)
+					ret_cand = i_script;
+			} else {
+				/* ret_addr match? */
+				if ((long long)ret_addr ==
+					((long long)i_ret_addr))
+					return i_script;
+			}
+		}
+	}
+
+	return ret_cand;
+}

--- a/src/core/script_resolver.h
+++ b/src/core/script_resolver.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SCRIPT_RESOLVER_H_
+#define SCRIPT_RESOLVER_H_
+
+#include "parson.h"
+
+/*
+ * Find the intercept_script entry in `i_array` that matches `func_name`
+ * (and optionally `ret_addr`). Wildcard "*" matches every function.
+ * When multiple entries match by name but differ in return_addr, the
+ * most specific (return_addr-bearing) entry wins; absent that, the
+ * first name-only match wins.
+ *
+ * Returns NULL if no entry matches.
+ *
+ * Extracted from engine.c per ADR-0013 (#480).
+ */
+const JSON_Object *retrace_script_find(const JSON_Array *i_array,
+	const char *func_name,
+	void *ret_addr);
+
+#endif

--- a/src/core/thread_context.c
+++ b/src/core/thread_context.c
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "thread_context.h"
+
+#include <pthread.h>
+
+#include "real_impls.h"
+#include "logger.h"
+
+static pthread_key_t thread_ctx_key;
+
+static void thread_ctx_destructor(void *thread_ctx)
+{
+	retrace_real_impls.free(thread_ctx);
+	retrace_real_impls.pthread_key_delete(thread_ctx_key);
+}
+
+int retrace_thread_context_init(void)
+{
+	int rc = retrace_real_impls.pthread_key_create(&thread_ctx_key,
+		thread_ctx_destructor);
+
+	if (rc)
+		log_err("failed to create pthread_key");
+
+	return rc;
+}
+
+struct ThreadContext *retrace_thread_context_get(void)
+{
+	struct ThreadContext *thread_ctx;
+
+	thread_ctx = (struct ThreadContext *)
+		retrace_real_impls.pthread_getspecific(thread_ctx_key);
+
+	if (thread_ctx == NULL) {
+		thread_ctx = (struct ThreadContext *)
+			retrace_real_impls.malloc(sizeof(struct ThreadContext));
+
+		if (thread_ctx == NULL)
+			return NULL;
+
+		if (retrace_real_impls.pthread_setspecific(
+			thread_ctx_key, thread_ctx)) {
+
+			retrace_real_impls.free(thread_ctx);
+			return NULL;
+		}
+
+		retrace_real_impls.memset(thread_ctx, 0, sizeof(*thread_ctx));
+	}
+
+	return thread_ctx;
+}
+
+void retrace_thread_context_clear(struct ThreadContext *thread_ctx)
+{
+	int i;
+
+	for (i = 0; i != thread_ctx->params_cnt; i++) {
+		if (thread_ctx->params[i].free_val)
+			retrace_real_impls.free((void *)thread_ctx->params[i].val);
+	}
+
+	retrace_real_impls.memset(thread_ctx, 0, sizeof(*thread_ctx));
+}

--- a/src/core/thread_context.h
+++ b/src/core/thread_context.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef THREAD_CONTEXT_H_
+#define THREAD_CONTEXT_H_
+
+#include <stddef.h>
+
+#include "engine.h"
+
+/*
+ * Per-thread interception state. Owns the pthread_key that holds the
+ * ThreadContext pointer. Extracted from engine.c per ADR-0013 (#480).
+ */
+
+int retrace_thread_context_init(void);
+
+struct ThreadContext *retrace_thread_context_get(void);
+
+void retrace_thread_context_clear(struct ThreadContext *thread_ctx);
+
+#endif


### PR DESCRIPTION
## Summary

Implements ADR-0013: splits `src/core/engine.c` (377 lines) into four focused modules:
- `engine.c` (181 lines) — the dispatcher, now a readable 14-step orchestration
- `thread_context.{h,c}` — per-thread state lifecycle
- `script_resolver.{h,c}` — find matching `intercept_script` in JSON config
- `action_runner.{h,c}` — iterate actions, dispatch via registry

Behavior is preserved exactly. Same call order, same log messages, same public API. Also removes a dead `struct WrapperSystemVFrame` declaration that lived in engine.c but was only used by the per-backend `arch_spec_bottom.c` files.

## Test plan

- [x] `cmake -B build -G Ninja -DRETRACE_BUILD_TESTS=ON && cmake --build build` clean on arm64, no new warnings in `src/core/`.
- [x] `ctest --test-dir build` 3/3 pass (integration-runtests + unit-test-registries + unit-test-printf-format).
- [x] `RETRACE_JSON_CONFIG=examples/id-redirection/getuid-redirect.json DYLD_INSERT_LIBRARIES=.../libretrace.dylib /tmp/test_getuid` → `uid=0` (modify_return_value_int fires).
- [x] Non-FP `printf("%d %s", 42, "hello")` produces correct output + JSON log entries.
- [ ] GHA matrix green across Linux x64/arm64, macOS Intel+arm64, Windows, MinGW.

Closes #480.
