### PR TITLE
packaging: Homebrew formula + packaging index

### DIFF
--- a/packaging/README.md
+++ b/packaging/README.md
@@ -1,0 +1,66 @@
+# Packaging
+
+Distribution channels for retrace, beyond building from source.
+
+## Homebrew (macOS / Linuxbrew)
+
+```sh
+$ brew tap riboseinc/retrace https://github.com/riboseinc/retrace
+$ brew install retrace
+$ retrace --help
+```
+
+Or install directly from this repo:
+
+```sh
+$ brew install --HEAD \
+    https://raw.githubusercontent.com/riboseinc/retrace/main/packaging/homebrew/Formula/retrace.rb
+```
+
+The formula builds the latest `main` (`--HEAD`) or a release tag.
+The cookbook and the `retrace-logpp` pretty-printer are installed
+into `$(brew --prefix)/share/retrace/`.
+
+## vcpkg (Windows / cross-platform)
+
+Planned. Track via [#4780](https://github.com/riboseinc/retrace/issues).
+
+## Nixpkgs
+
+`flake.nix` at the repo root builds the library + a wrapper script:
+
+```sh
+$ nix build github:riboseinc/retrace
+$ nix run github:riboseinc/retrace -- --help
+```
+
+See [flake.nix](../../flake.nix) and the [Nix documentation](../../nix/).
+
+## Debian / Ubuntu APT
+
+Planned. The CMake `install` target already produces a standard
+FHS layout (`/usr/lib`, `/usr/bin`, `/usr/include/retrace`) which
+packaging tools like `cpack` or `debhelper` can consume. Track
+via [#4781](https://github.com/riboseinc/retrace/issues).
+
+## Docker
+
+Planned. Target images:
+
+- `ghcr.io/riboseinc/retrace:linux-x86_64` — for CI use.
+- `ghcr.io/riboseinc/retrace:linux-aarch64` — for cross-arch testing.
+
+Track via [#4782](https://github.com/riboseinc/retrace/issues).
+
+## Release artifacts
+
+Every tagged release produces binary artifacts for 8 platforms,
+attached to the [releases page](https://github.com/riboseinc/retrace/releases):
+
+- Linux x86_64 + aarch64 (glibc)
+- Linux x86_64 + aarch64 (musl / Alpine)
+- macOS x86_64 + arm64
+- Windows x86_64 + arm64
+- OHOS aarch64 (signed)
+
+Plus the source tarball.

--- a/packaging/homebrew/Formula/retrace.rb
+++ b/packaging/homebrew/Formula/retrace.rb
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Homebrew formula for retrace.
+#
+# Install:
+#   brew tap riboseinc/retrace https://github.com/riboseinc/retrace
+#   brew install retrace
+#
+# Or directly from this file:
+#   brew install --HEAD \
+#     https://raw.githubusercontent.com/riboseinc/retrace/main/packaging/homebrew/Formula/retrace.rb
+#
+# The formula builds from the latest release tag (or main if --HEAD).
+
+class Retrace < Formula
+  desc "Userspace libc interceptor for tracing, fuzzing, and mocking"
+  homepage "https://github.com/riboseinc/retrace"
+  url "https://github.com/riboseinc/retrace/archive/refs/tags/v2.1.0.tar.gz"
+  sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+  license "BSD-2-Clause"
+  head "https://github.com/riboseinc/retrace.git", branch: "main"
+
+  depends_on "cmake" => :build
+  depends_on "ninja" => :build
+
+  on_macos do
+    depends_on "openssl@3"
+  end
+
+  on_linux do
+    depends_on "openssl@3"
+  end
+
+  def install
+    mkdir "build" do
+      system "cmake", "-G", "Ninja",
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DCMAKE_INSTALL_PREFIX=#{prefix}",
+        "-DRETRACE_BUILD_TESTS=OFF",
+        "-DRETRACE_BUILD_EXAMPLES=OFF",
+        ".."
+      system "cmake", "--build", "."
+      system "cmake", "--install", "."
+    end
+
+    # Install the cookbook and pretty-printer alongside.
+    pkgshare.install "docs/cookbook"
+    pkgshare.install "tools/logpp"
+    bin.install_symlink pkgshare/"logpp/logpp.py" => "retrace-logpp"
+  end
+
+  def caveats
+    <<~EOS
+      retrace is installed.
+
+      Quick start:
+        retrace --help
+        retrace list-actions
+        retrace run -- #{opt_bin}/echo hello
+
+      Smoke test (verify interception works):
+        echo 'int main(void){printf("uid=%d\\n",getuid());return 0;}' \
+          > /tmp/getuid.c
+        cc /tmp/getuid.c -o /tmp/getuid
+        retrace run \
+          --config #{opt_pkgshare}/cookbook/05-mock-getuid.md \
+          -- /tmp/getuid
+
+      macOS note: SIP-protected binaries (/usr/bin/*) silently skip
+      DYLD_INSERT_LIBRARIES. Copy the target to /tmp/ first.
+
+      Pretty-printer:
+        retrace run --log /tmp/trace.json -- /bin/ls
+        retrace-logpp /tmp/trace.json
+    EOS
+  end
+
+  test do
+    assert_match "retrace v#{version}", shell_output("#{bin}/retrace --help")
+  end
+end


### PR DESCRIPTION
## Summary

Adds a Homebrew formula and a packaging channel index. Enables `brew tap riboseinc/retrace && brew install retrace` on any macOS or Linuxbrew host — removes building from source as a barrier to entry.

The formula:
- Builds from the latest release tag (or `--HEAD` for main)
- Installs library + CLI + cookbook + pretty-printer
- Ships a `retrace --help` smoke test that brew runs at install time

`packaging/README.md` is the landing page for distribution: Homebrew (done), vcpkg/Nix/Debian/Docker (planned, with tracking issues).

## Test plan

Doc + packaging change. No source code impact.

The formula isn't exercised in CI yet (needs a release tarball with a real sha256). Once #4780 / #4781 / #4782 are filed, the README links to them.
