### PR TITLE
docs/cookbook: time-mock, network-capture, per-call-timing recipes

### DIFF
--- a/docs/cookbook/04-time-each-call.md
+++ b/docs/cookbook/04-time-each-call.md
@@ -1,0 +1,119 @@
+# 04 — Time each call
+
+## Problem
+
+You want to find the hot spots in a program — which libc calls are
+slow, and which are called too often. You need per-call timing, not
+just per-function totals.
+
+## Config
+
+`time-each-call.json`:
+
+```json
+{
+  "intercept_scripts": [
+    {
+      "func_name": "*",
+      "actions": [
+        { "action_name": "log_params" },
+        { "action_name": "call_real" }
+      ]
+    }
+  ]
+}
+```
+
+This is the same as [01-trace-all-calls](01-trace-all-calls.md).
+The timing comes for free: the engine measures each `call_real`
+with `clock_gettime(CLOCK_MONOTONIC)` and emits `call_duration_us`
+in the log entry.
+
+## Invocation
+
+```sh
+$ retrace run --config docs/cookbook/time-each-call.json \
+    --log /tmp/timed.json -- ./your-program
+$ python3 tools/logpp/logpp.py /tmp/timed.json
+[INFO ] FUNCS  malloc(ptr=0x... size=1024) ret=0x...
+[INFO ] FUNCS  call_duration_us=0 ret_val=5133861376
+[INFO ] FUNCS  open(path=/etc/hosts flags=0) ret=3
+[INFO ] FUNCS  call_duration_us=87 ret_val=3
+...
+```
+
+The `call_duration_us` field is microseconds. `open` took 87µs;
+`malloc` took <1µs.
+
+## Variations
+
+### Find slow calls
+
+```sh
+$ python3 tools/logpp/logpp.py /tmp/timed.json \
+    | grep call_duration_us \
+    | awk -F'call_duration_us=' '{ print $2 }' \
+    | awk '$1 > 1000 { print }'
+```
+
+This shows every call slower than 1ms.
+
+### Find chatty calls
+
+The logpp summary already counts calls per function. The top of
+the list is your chatty list:
+
+```sh
+$ python3 tools/logpp/logpp.py /tmp/timed.json | tail -15
+Summary
+  1247 calls intercepted
+  pthread_mutex_lock                  85 (  6.8%)
+  pthread_mutex_unlock                85 (  6.8%)
+  memset                              72 (  5.8%)
+  ...
+```
+
+If `pthread_mutex_lock` is high, you have lock contention. If
+`malloc` is high, you may benefit from a bulk allocator.
+
+### Sort by total time
+
+Combine the call count with the per-call duration:
+
+```sh
+$ python3 -c "
+import json, sys
+from collections import defaultdict
+
+data = json.load(open('/tmp/timed.json'))
+totals = defaultdict(lambda: [0, 0])  # func -> [count, total_us]
+
+i = 0
+while i < len(data):
+    msg = data[i].get('message', {})
+    func = msg.get('func')
+    if func and 'call_duration_us' in msg:
+        totals[func][0] += 1
+        totals[func][1] += msg['call_duration_us']
+    i += 1
+
+for func, (n, t) in sorted(totals.items(), key=lambda x: -x[1][1])[:10]:
+    print(f'{func:30s} {n:8d} calls  {t:10d}µs total  {t/n:8.1f}µs/call')
+"
+```
+
+## How it works
+
+The `call_real` action wraps the real libc invocation in
+`clock_gettime(CLOCK_MONOTONIC)` before and after. The delta is
+emitted as `call_duration_us`. This is per-call timing; aggregate
+yourself via the script above.
+
+`CLOCK_MONOTONIC` is NOT mocked by retrace, so the timing is
+trustworthy even when you're mocking `time()` or `gettimeofday()`
+(see [08-mock-time](08-mock-time.md)).
+
+## See also
+
+- [01 — Trace every libc call](01-trace-all-calls.md)
+- [03 — Count calls per function](03-count-calls.md) (planned)

--- a/docs/cookbook/08-mock-time.md
+++ b/docs/cookbook/08-mock-time.md
@@ -1,0 +1,104 @@
+# 08 — Mock time() for time-sensitive code
+
+## Problem
+
+Your code branches on the current time — license expiry, token TTL,
+schedule windows — and you want to test boundary conditions without
+waiting for the right time to arrive.
+
+## Config
+
+`mock-time-fixed.json`:
+
+```json
+{
+  "intercept_scripts": [
+    {
+      "func_name": "time",
+      "actions": [
+        { "action_name": "modify_return_value_int",
+          "action_params": { "retval_int": 1893456000 } }
+      ]
+    },
+    {
+      "func_name": "localtime_r",
+      "actions": [
+        { "action_name": "log_params" },
+        { "action_name": "call_real" }
+      ]
+    }
+  ]
+}
+```
+
+`time()` returns the mocked epoch. `localtime_r()` still runs (it
+takes the time via its first argument, so we don't need to mock the
+return — the caller passes the mocked `time()` result).
+
+## Invocation
+
+```sh
+$ date -d @1893456000 2>/dev/null || date -r 1893456000
+# 2030-01-01 00:00:00 UTC
+
+$ cat license-check.c
+#include <time.h>
+#include <stdio.h>
+int main(void) {
+    time_t now = time(NULL);
+    if (now > 1893456000) {  /* Jan 1 2030 */
+        printf("license expired (now=%ld)\n", now);
+        return 1;
+    }
+    printf("license valid (now=%ld)\n", now);
+    return 0;
+}
+$ cc license-check.c -o license-check
+$ ./license-check
+license valid (now=1785400000)
+
+$ retrace run --config docs/cookbook/mock-time-fixed.json -- ./license-check
+license expired (now=1893456000)
+```
+
+## Variations
+
+### Mock a relative offset
+
+The current action can only set a fixed value. For "advance time by
+1 hour per call", track via [#503](https://github.com/riboseinc/retrace/issues/503)
+— the engine refactor enables a per-call increment action.
+
+Workaround: use a wrapper that calls real `time()`, adds the offset,
+and returns the result. This needs a custom action; see
+[18-custom-action.md](18-custom-action.md) (planned).
+
+### Mock `gettimeofday` too
+
+Some code uses `gettimeofday()` instead of `time()`. Intercept
+both:
+
+```json
+{
+  "intercept_scripts": [
+    { "func_name": "time",         "actions": [ ... ] },
+    { "func_name": "gettimeofday", "actions": [
+        { "action_name": "call_real" },
+        { "action_name": "modify_return_value_int",
+          "action_params": { "retval_int": 0 } }
+    ] }
+  ]
+}
+```
+
+### Mock `clock_gettime`
+
+`clock_gettime(CLOCK_REALTIME, ...)` is the modern API. The
+prototype is in `src/core/prototypes/time.c`. Note that
+`CLOCK_MONOTONIC` should NOT be mocked (it's used internally by
+retrace for `call_duration_us`).
+
+## See also
+
+- [05 — Mock getuid() for root checks](05-mock-getuid.md)
+- [06 — Redirect open() paths](06-redirect-open.md)

--- a/docs/cookbook/15-capture-network.md
+++ b/docs/cookbook/15-capture-network.md
@@ -1,0 +1,121 @@
+# 15 — Capture network traffic
+
+## Problem
+
+You want to see every byte a program sends or receives over the
+network, in call order, without setting up Wireshark or tcpdump.
+
+## Config
+
+`capture-network.json`:
+
+```json
+{
+  "intercept_scripts": [
+    {
+      "func_name": "socket",
+      "actions": [
+        { "action_name": "log_params" },
+        { "action_name": "call_real" }
+      ]
+    },
+    {
+      "func_name": "connect",
+      "actions": [
+        { "action_name": "log_params" },
+        { "action_name": "call_real" }
+      ]
+    },
+    {
+      "func_name": "send",
+      "actions": [
+        { "action_name": "log_params" },
+        { "action_name": "call_real" }
+      ]
+    },
+    {
+      "func_name": "recv",
+      "actions": [
+        { "action_name": "log_params" },
+        { "action_name": "call_real" }
+      ]
+    },
+    {
+      "func_name": "sendto",
+      "actions": [
+        { "action_name": "log_params" },
+        { "action_name": "call_real" }
+      ]
+    },
+    {
+      "func_name": "recvfrom",
+      "actions": [
+        { "action_name": "log_params" },
+        { "action_name": "call_real" }
+      ]
+    }
+  ]
+}
+```
+
+## Invocation
+
+```sh
+$ retrace run --config docs/cookbook/capture-network.json \
+    --log /tmp/net.json -- ./your-client
+$ python3 tools/logpp/logpp.py /tmp/net.json | less
+[INFO ] FUNCS  socket(domain=2 type=1 protocol=6) ret=3
+[INFO ] FUNCS  connect(fd=3 addr=127.0.0.1:8080 len=16) ret=0
+[INFO ] FUNCS  send(fd=3 buf=0x7fff... len=78 flags=0) ret=78
+[INFO ] FUNCS  recv(fd=3 buf=0x7fff... len=16384 flags=0) ret=74
+```
+
+## Variations
+
+### Filter to just one connection
+
+Use `RETRACE_LOGGER_ALLOWED_FUNCS` to narrow further:
+
+```sh
+$ RETRACE_LOGGER_ALLOWED_FUNCS=connect,send,recv \
+    retrace run --config docs/cookbook/capture-network.json -- ./your-client
+```
+
+### Fuzz the network
+
+Pair with `memory_fuzz` to simulate packet loss:
+
+```json
+{
+  "func_name": "send",
+  "actions": [
+    { "action_name": "call_real" },
+    { "action_name": "memory_fuzz",
+      "action_params": { "fail_rate": 0.05 } }
+  ]
+}
+```
+
+5% of `send()` calls return -1 — test your client's retry logic.
+
+### Use the net-fuzzing example
+
+The repo ships a worked version with fuzzing applied:
+
+```sh
+$ retrace run --config examples/net-fuzzing/retrace.conf.json \
+    -- ./test_client
+```
+
+## How it works
+
+`send`, `recv`, `sendto`, `recvfrom` prototypes live in
+`src/core/prototypes/uio.c`. The `buf` parameter is typed as a
+byte-array, so `log_params` dumps up to 16 bytes (configurable) of
+the buffer alongside the call. For full payload capture, post-
+process the JSON.
+
+## See also
+
+- [13 — Audit system() for injection](13-audit-system.md)
+- [07 — Redirect network connects](07-redirect-connect.md) (planned)

--- a/docs/cookbook/README.md
+++ b/docs/cookbook/README.md
@@ -39,7 +39,7 @@ $ retrace run --config cookbook/<recipe>.json -- <your-program>
 |---|--------|-----------------|
 | 01 | [Trace every libc call](01-trace-all-calls.md) | The default; log every interceptable call as JSON. |
 | 02 | [Filter by function name](02-filter-by-function.md) | Use `RETRACE_LOGGER_ALLOWED_FUNCS` to focus on a handful of calls. |
-| 03 | [Count calls per function](03-count-calls.md) | Aggregate stats: which libc calls dominate your program. |
+| 03 | [Count calls per function](03-count-calls.md) | Aggregate stats: which libc calls dominate your program. *(planned)* |
 | 04 | [Time each call](04-time-each-call.md) | Find hot spots via `call_duration_us` in the log. |
 
 ### Redirection & mocking
@@ -48,7 +48,7 @@ $ retrace run --config cookbook/<recipe>.json -- <your-program>
 |---|--------|-----------------|
 | 05 | [Mock `getuid()` for root checks](05-mock-getuid.md) | Make a binary think it's root (or any uid). |
 | 06 | [Redirect `open()` paths](06-redirect-open.md) | Swap one file for another without touching the binary. |
-| 07 | [Redirect network connects](07-redirect-connect.md) | Point `connect()` at a different host/port. |
+| 07 | [Redirect network connects](07-redirect-connect.md) | Point `connect()` at a different host/port. *(planned)* |
 | 08 | [Mock `time()` for time-sensitive code](08-mock-time.md) | Freeze or shift time for replay / boundary tests. |
 
 ### Fuzzing & fault injection
@@ -58,7 +58,7 @@ $ retrace run --config cookbook/<recipe>.json -- <your-program>
 | 09 | [Fuzz `malloc` failures](09-fuzz-malloc.md) | Inject OOM into a target to test error paths. |
 | 10 | [Partial I/O (short reads/writes)](10-incomplete-io.md) | Make `read`/`write` return short to exercise retry logic. |
 | 11 | [Deterministic fuzzing seed](11-deterministic-fuzz.md) | Reproduce a fuzz run by pinning the RNG seed. |
-| 12 | [Fail specific syscalls](12-fail-specific.md) | Force `connect`/`open`/etc. to return an error code. |
+| 12 | [Fail specific syscalls](12-fail-specific.md) | Force `connect`/`open`/etc. to return an error code. *(planned)* |
 
 ### Security audit
 
@@ -73,7 +73,7 @@ $ retrace run --config cookbook/<recipe>.json -- <your-program>
 | # | Recipe | What it teaches |
 |---|--------|-----------------|
 | 16 | [Multi-function script](16-multi-script.md) | Compose actions across many functions in one config. |
-| 17 | [Per-return-address routing](17-return-addr-routing.md) | Different behavior for different call sites of the same function. |
+| 17 | [Per-return-address routing](17-return-addr-routing.md) | Different behavior for different call sites of the same function. *(planned)* |
 
 ## Action reference
 


### PR DESCRIPTION
Fills 3 more stubbed entries: 04, 08, 15. Index updated to mark 03/07/12/17 as (planned).