### PR TITLE
release: binary downloads + install script + macOS Intel re-enabled

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,9 @@ jobs:
           - platform: macos-arm64
             runner: macos-14
             os: macos
-          # macos-x86_64 disabled until #452 is fixed.
+          - platform: macos-x86_64
+            runner: macos-15-intel
+            os: macos
           - platform: windows-x64
             runner: windows-2022
             os: windows
@@ -157,6 +159,10 @@ jobs:
           tar -czf "retrace-${VERSION}-${{ matrix.platform }}.tar.gz" "$STAGE"
           sha256sum "retrace-${VERSION}-${{ matrix.platform }}.tar.gz" \
             > "retrace-${VERSION}-${{ matrix.platform }}.tar.gz.sha256"
+          # Also produce a bare library for curl + LD_PRELOAD use case
+          cp build/src/v2/libretrace.so.2.1.0 "libretrace-${{ matrix.platform }}.so"
+          sha256sum "libretrace-${{ matrix.platform }}.so" \
+            > "libretrace-${{ matrix.platform }}.so.sha256"
 
       - name: Stage binary (macOS)
         if: matrix.os == 'macos'
@@ -181,6 +187,10 @@ jobs:
           tar -czf "retrace-${VERSION}-${{ matrix.platform }}.tar.gz" "$STAGE"
           shasum -a 256 "retrace-${VERSION}-${{ matrix.platform }}.tar.gz" \
             > "retrace-${VERSION}-${{ matrix.platform }}.tar.gz.sha256"
+          # Bare library for curl + DYLD_INSERT use case
+          cp build/src/v2/libretrace.2.1.0.dylib "libretrace-${{ matrix.platform }}.dylib"
+          shasum -a 256 "libretrace-${{ matrix.platform }}.dylib" \
+            > "libretrace-${{ matrix.platform }}.dylib.sha256"
 
       # ----- Windows (MSVC) -----
       - name: Set up vcpkg (Windows)
@@ -249,6 +259,10 @@ jobs:
           path: |
             retrace-*.tar.gz
             retrace-*.tar.gz.sha256
+            libretrace-*.so
+            libretrace-*.so.sha256
+            libretrace-*.dylib
+            libretrace-*.dylib.sha256
             retrace-*.zip
             retrace-*.zip.sha256
 
@@ -449,3 +463,7 @@ jobs:
             artifacts/retrace-*.tar.gz.sha256
             artifacts/retrace-*.zip
             artifacts/retrace-*.zip.sha256
+            artifacts/libretrace-*.so
+            artifacts/libretrace-*.so.sha256
+            artifacts/libretrace-*.dylib
+            artifacts/libretrace-*.dylib.sha256

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,49 +1,86 @@
 # Docker integration
 
 retrace ships as a Docker image for zero-config tracing/fuzzing of
-containerized applications.
+containerized applications. Three ways to add it to your container:
 
-## Quick start: trace any binary
+## Option 1: Direct download (simplest)
+
+No multi-stage build needed. One RUN line downloads the pre-built
+library from GitHub releases:
+
+```dockerfile
+FROM your-app:latest
+RUN apt-get update && apt-get install -y curl \
+    && curl -sSL https://github.com/riboseinc/retrace/releases/latest/download/libretrace-linux-x86_64.so \
+       -o /usr/lib/libretrace.so \
+    && rm -rf /var/lib/apt/lists/*
+ENV LD_PRELOAD=/usr/lib/libretrace.so
+```
+
+Or with the install script:
+
+```dockerfile
+FROM your-app:latest
+RUN curl -sSL https://raw.githubusercontent.com/riboseinc/retrace/main/scripts/install.sh | sh
+ENV LD_PRELOAD=/usr/local/lib/libretrace.so
+```
+
+## Option 2: Multi-stage build (recommended for production)
+
+Copies from the pre-built Docker image — no curl, no download in
+the final image:
+
+```dockerfile
+FROM ghcr.io/riboseinc/retrace:latest AS retrace
+FROM your-app:latest
+COPY --from=retrace /usr/lib/libretrace.so* /usr/lib/
+ENV LD_PRELOAD=/usr/lib/libretrace.so
+```
+
+## Option 3: Run retrace as a container
 
 ```sh
 $ docker run --rm ghcr.io/riboseinc/retrace:latest \
     trace malloc -- /bin/ls
 ```
 
-## Add tracing to your own container (one line)
-
-```dockerfile
-FROM ghcr.io/riboseinc/retrace:latest AS retrace
-FROM your-app:latest
-COPY --from=retrace /usr/lib/libretrace.so* /usr/lib/
-ENV LD_PRELOAD=/usr/lib/libretrace.so
-```
-
-Now every libc call in `your-app` is automatically traced.
-
 ## Add fuzzing to CI (one line)
 
 ```dockerfile
-FROM ghcr.io/riboseinc/retrace:latest AS retrace
 FROM your-app:latest
-COPY --from=retrace /usr/lib/libretrace.so* /usr/lib/
+RUN curl -sSL https://github.com/riboseinc/retrace/releases/latest/download/libretrace-linux-x86_64.so \
+    -o /usr/lib/libretrace.so
 ENV LD_PRELOAD=/usr/lib/libretrace.so
 ENV RETRACE_JSON_CONFIG=/etc/retrace/fuzz.json
 RUN echo '{"intercept_scripts":[{"func_name":"malloc","actions":[{"action_name":"call_real"},{"action_name":"memory_fuzz","action_params":{"fail_rate":0.01}}]}]}' \
     > /etc/retrace/fuzz.json
 ```
 
-Every `docker run` of this image now fuzzes malloc at 1% failure rate.
-Run your test suite; if it crashes, you found an OOM bug.
+Every `docker run` now fuzzes malloc at 1% failure rate.
 
 ## Use cases
 
-| Goal | What to do |
-|------|------------|
-| See what files your app opens | `ENV RETRACE_JSON_CONFIG=/etc/retrace/trace-open.json` + a config that traces `open` |
-| Find OOM bugs | Set `fail_rate` to 0.01 in the fuzz config |
-| Profile hot spots | Run under trace config, then `retrace-flamegraph trace.json -o profile.svg` |
-| Security audit | Set `RETRACE_LOGGER_ALLOWED_FUNCS=system,execve` to see every command execution |
+| Goal | Config |
+|------|--------|
+| See what files your app opens | Trace `open`, `read` |
+| Find OOM bugs | `memory_fuzz` with `fail_rate=0.01` |
+| Profile hot spots | Trace all, then render flamegraph from JSON log |
+| Security audit | Trace `system`, `execve`, `open` |
+| Sandbox untrusted code | `sandbox` action with path deny-list |
+
+## Available download URLs
+
+Stable URLs that always point to the latest release:
+
+| Platform | URL |
+|----------|-----|
+| Linux x86_64 | `https://github.com/riboseinc/retrace/releases/latest/download/libretrace-linux-x86_64.so` |
+| Linux aarch64 | `https://github.com/riboseinc/retrace/releases/latest/download/libretrace-linux-aarch64.so` |
+| macOS arm64 | `https://github.com/riboseinc/retrace/releases/latest/download/libretrace-macos-arm64.dylib` |
+| macOS x86_64 | `https://github.com/riboseinc/retrace/releases/latest/download/libretrace-macos-x86_64.dylib` |
+
+Replace `latest` with a version tag (e.g., `v2.1.0`) for reproducible
+builds.
 
 ## Build locally
 
@@ -52,12 +89,9 @@ $ docker build -t retrace .
 $ docker run --rm retrace trace malloc -- /bin/ls
 ```
 
-## How it works
+## Install without Docker
 
-The image is based on Ubuntu 24.04 with `LD_PRELOAD` set by default.
-When you `COPY --from=retrace /usr/lib/libretrace.so* /usr/lib/` into
-your app image, the library is loaded into every process. The
-`RETRACE_JSON_CONFIG` env var controls which actions run.
-
-The image is ~150MB (Ubuntu base + retrace library + CLI). For a
-smaller image, use Alpine as the base (retrace builds on musl).
+```sh
+$ curl -sSL https://raw.githubusercontent.com/riboseinc/retrace/main/scripts/install.sh | sh
+$ LD_PRELOAD=/usr/local/lib/libretrace.so /bin/ls
+```

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,87 @@
+#!/bin/sh
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# retrace install script — detects OS + arch, downloads the right
+# pre-built binary from GitHub releases, installs it.
+#
+# Usage:
+#   curl -sSL https://raw.githubusercontent.com/riboseinc/retrace/main/scripts/install.sh | sh
+#
+# Or with specific version:
+#   sh scripts/install.sh v2.1.0
+#
+# Installs to /usr/local/lib/libretrace.{so,dylib} by default.
+# Override with DESTDIR= to install elsewhere.
+
+set -eu
+
+VERSION="${1:-latest}"
+PREFIX="${DESTDIR:-/usr/local}"
+
+OS=$(uname -s)
+ARCH=$(uname -m)
+
+# Map to release asset name
+case "$OS" in
+    Linux)
+        case "$ARCH" in
+            x86_64|amd64) PLATFORM="linux-x86_64"; EXT="so"; ENV_VAR="LD_PRELOAD" ;;
+            aarch64|arm64) PLATFORM="linux-aarch64"; EXT="so"; ENV_VAR="LD_PRELOAD" ;;
+            *) echo "retrace: unsupported Linux arch '$ARCH'" >&2; exit 1 ;;
+        esac
+        ;;
+    Darwin)
+        case "$ARCH" in
+            arm64|aarch64) PLATFORM="macos-arm64"; EXT="dylib"; ENV_VAR="DYLD_INSERT_LIBRARIES" ;;
+            x86_64) PLATFORM="macos-x86_64"; EXT="dylib"; ENV_VAR="DYLD_INSERT_LIBRARIES" ;;
+            *) echo "retrace: unsupported macOS arch '$ARCH'" >&2; exit 1 ;;
+        esac
+        ;;
+    *) echo "retrace: unsupported OS '$OS'" >&2; exit 1 ;;
+esac
+
+ASSET="libretrace-${PLATFORM}.${EXT}"
+LIBNAME="libretrace.${EXT}"
+
+if [ "$VERSION" = "latest" ]; then
+    URL="https://github.com/riboseinc/retrace/releases/latest/download/${ASSET}"
+else
+    URL="https://github.com/riboseinc/retrace/releases/download/${VERSION}/${ASSET}"
+fi
+
+DEST="${PREFIX}/lib/${LIBNAME}"
+
+echo "retrace: downloading $ASSET ($VERSION)..."
+mkdir -p "${PREFIX}/lib"
+
+if command -v curl >/dev/null 2>&1; then
+    curl -fsSL "$URL" -o "$DEST" || {
+        echo "retrace: download failed. Check the version or your network." >&2
+        exit 1
+    }
+elif command -v wget >/dev/null 2>&1; then
+    wget -qO "$DEST" "$URL" || {
+        echo "retrace: download failed. Check the version or your network." >&2
+        exit 1
+    }
+else
+    echo "retrace: curl or wget required." >&2
+    exit 1
+fi
+
+chmod 755 "$DEST"
+
+if [ "$OS" = "Linux" ]; then
+    ldconfig 2>/dev/null || true
+fi
+
+echo ""
+echo "retrace installed to $DEST"
+echo ""
+echo "Quick start:"
+echo "  $ENV_VAR=$DEST /bin/ls        # trace all libc calls"
+echo ""
+echo "  # Or install the CLI too:"
+echo "  git clone https://github.com/riboseinc/retrace.git"
+echo "  cd retrace && cmake -B build -G Ninja && cmake --build build"
+echo "  RETRACE_LIB=$DEST ./build/src/cli/retrace trace malloc -- /bin/ls"


### PR DESCRIPTION
## Summary

Makes retrace installable without building from source — the single biggest remaining distribution barrier.

**release.yml changes:**
- Re-enabled macOS Intel (was disabled pending #452/#506, now fixed via dlsym(RTLD_NEXT) fallback in PR #508)
- Added bare-library upload alongside each tarball: `libretrace-linux-x86_64.so`, `libretrace-macos-arm64.dylib`, etc.
- These produce stable download URLs: `https://github.com/riboseinc/retrace/releases/latest/download/libretrace-linux-x86_64.so`

**scripts/install.sh:**
- Detects OS + arch via `uname`
- Downloads the right binary from GitHub releases
- Installs to `/usr/local/lib/` (override with `DESTDIR=`)
- Prints usage instructions after install
- Usage: `curl -sSL https://raw.githubusercontent.com/riboseinc/retrace/main/scripts/install.sh | sh`

**docs/docker.md:**
- Rewritten with three integration patterns: direct download (one RUN curl), multi-stage build, run-as-container
- Includes stable URL table for every platform
- Shows the "add fuzzing to CI in one line" Dockerfile pattern

## Test plan

- [x] install.sh syntax-checked locally
- [x] release.yml updated with macOS Intel and bare-library steps
- [x] docker.md rewritten with direct-download pattern
- [ ] First `v*` tag push produces all binary assets (tested on next release)
