### PR TITLE
docs: long-form CLI + config reference + bridge walkthrough on the site

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,8 @@ install, quick start, and platform support.
 
 | You want to… | Go to |
 |--------------|-------|
+| Look up a CLI subcommand or env var | [CLI reference](cli.md) |
+| Look up an action or write a JSON config | [Configuration reference](configuration.md) |
 | Run a specific scenario (trace, fuzz, mock, sandbox) | [Cookbook](cookbook/README.md) — 20 recipes with copy-paste JSON |
 | Add retrace to a Dockerfile or compose stack | [Docker guide](docker.md) |
 | Trace an Android app via `wrap.sh` or Magisk | [Android guide](android.md) |
@@ -19,8 +21,10 @@ install, quick start, and platform support.
 ```
 docs/
 ├── README.md              ← you are here
+├── cli.md                 ← CLI subcommand + env var reference
+├── configuration.md       ← JSON config schema + action parameter reference
 ├── cookbook/              ← 20 recipe-driven walkthroughs
-│   ├── README.md          ← index + action reference
+│   ├── README.md          ← index + compact action reference
 │   ├── 01-trace-all-calls.md
 │   ├── …
 │   └── 20-sandbox.md

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,267 @@
+# retrace CLI reference
+
+The `retrace` binary is a thin launcher. It locates the retrace shared
+library (`libretrace.so` / `.dylib` / `.dll`), sets the appropriate
+preload environment variable, and `execvp`s the target. The target
+then runs as if you had launched it directly — retrace's library is
+already in process.
+
+For the 90% case there are quick subcommands (`trace`, `mock`, `fuzz`,
+`slow`). For the long tail there is `run`, which takes a JSON config
+and unlocks the full action system.
+
+## Quick subcommands
+
+### `trace` — observe every call
+
+```sh
+retrace trace [--html] [funcs...] [--log FILE] [--quiet] -- <command>
+```
+
+Traces every libc call (or only the named `funcs`) by writing
+`log_params` output as JSON lines. With `--html`, an interactive
+self-contained HTML page is generated at `/tmp/retrace-<pid>.html`
+in addition to the JSON log.
+
+```sh
+$ retrace trace malloc,free -- /bin/ls
+malloc(1024) → 0x7f8e2a3b4000
+free(0x7f8e2a3b4000) → 0
+…
+
+$ retrace trace --html -- /bin/ls
+wrote /tmp/retrace-43892.html
+```
+
+If no `funcs` are named, every interceptable function is traced.
+
+### `mock` — override a return value
+
+```sh
+retrace mock <func> <retval> [--log FILE] [--quiet] -- <command>
+```
+
+Forces `<func>` to return `<retval>` (parsed as a C integer — `0`,
+`0x1000`, `0644`, etc.) after invoking the real implementation.
+
+```sh
+$ retrace mock getuid 0 -- ./check-root
+welcome, root
+```
+
+This is sugar for `modify_return_value_int` applied to a single
+function. For richer mocking (string rewriting, conditional logic,
+multi-function), use `run --config`.
+
+### `fuzz` — inject allocation failures
+
+```sh
+retrace fuzz [<func>] [--rate R] [--log FILE] [--quiet] -- <command>
+```
+
+Randomly returns `NULL` from `<func>` at failure rate `R` (0.0–1.0).
+Defaults: `func=malloc`, `rate=0.05`.
+
+```sh
+$ retrace fuzz malloc --rate 0.1 -- ./server
+malloc(1024) → 0x7f8e2a3b4000
+malloc(2048) → NULL    # injected
+malloc(512)  → 0x7f8e2a3b4200
+…
+```
+
+Sugar for the `memory_fuzz` action. To fuzz `calloc`/`realloc`/
+multiple allocators at once, use `run --config`.
+
+### `slow` — inject latency
+
+```sh
+retrace slow <func> [--ms N] [--log FILE] [--quiet] -- <command>
+```
+
+Adds `N` milliseconds of latency (via `nanosleep`) before every call
+to `<func>` returns. Default: `ms=100`.
+
+```sh
+$ retrace slow open --ms 100 -- ./file-heavy-app
+```
+
+Sugar for the `delay` action.
+
+## General subcommands
+
+### `run` — JSON config-driven
+
+```sh
+retrace run [--config FILE] [--log FILE] [--quiet] [--lib FILE] -- <command>
+```
+
+Launches the target with the given JSON config. This is the most
+flexible subcommand: every action and prototype is available, and
+multiple functions can be intercepted with different scripts.
+
+```sh
+$ retrace run --config docs/cookbook/20-sandbox.json -- ./untrusted-binary
+```
+
+Without `--config`, retrace falls back to the built-in default
+(`log_params` + `call_real` for every function).
+
+### `pp` — pretty-print a trace log
+
+```sh
+retrace pp <trace.json>
+```
+
+Reads a JSON-lines trace log and emits a human-readable text
+summary: per-function call counts, total time, average time.
+
+```sh
+$ retrace trace malloc,free --log /tmp/trace.json -- /bin/ls >/dev/null
+$ retrace pp /tmp/trace.json
+malloc          412 calls   8.3 ms total   20 µs avg
+free            408 calls   4.1 ms total   10 µs avg
+…
+```
+
+### `html` — convert a trace log to interactive HTML
+
+```sh
+retrace html <trace.json> [-o <output.html>]
+```
+
+Reads a JSON-lines trace log and produces a self-contained
+interactive HTML page: summary cards, category breakdown, filterable
+call table. With `-o`, writes to the named file; without, writes to
+stdout.
+
+```sh
+$ retrace trace malloc --log /tmp/trace.json -- /bin/ls >/dev/null
+$ retrace html /tmp/trace.json -o /tmp/view.html
+$ open /tmp/view.html
+```
+
+### `list-functions` — enumerate interceptable functions
+
+```sh
+retrace list-functions
+```
+
+Walks the function prototype registry and prints every interceptable
+function name, one per line. Use to discover what retrace knows about
+without reading source.
+
+```sh
+$ retrace list-functions | grep -E '^open'
+open
+openat
+opendir
+```
+
+### `list-actions` — enumerate built-in actions
+
+```sh
+retrace list-actions
+```
+
+Prints every registered action name. Useful for validating that your
+custom action loaded correctly, or for discovering what's available
+without consulting docs.
+
+```sh
+$ retrace list-actions
+log_params
+call_real
+modify_in_param_str
+modify_in_param_int
+modify_in_param_arr
+modify_return_value_int
+memory_fuzz
+incomplete_io
+fuzzing_seed
+delay
+call_count_limit
+sandbox
+```
+
+### `validate` — check a JSON config
+
+```sh
+retrace validate <config.json>
+```
+
+Parses the JSON config and verifies that every `func_name` and
+`action_name` is recognized. Catches typos before launch time. Exits
+non-zero with a diagnostic on failure.
+
+```sh
+$ retrace validate my-config.json
+ok: 4 scripts, 9 actions
+
+$ retrace validate bad-config.json
+error: unknown action 'modify_return_value' (did you mean modify_return_value_int?)
+```
+
+## Common options
+
+These apply to `run`, `trace`, `mock`, `fuzz`, and `slow`:
+
+| Option        | Environment var          | Effect                                       |
+|---------------|--------------------------|----------------------------------------------|
+| `--config F`  | `RETRACE_JSON_CONFIG`    | Path to the JSON config file.                |
+| `--log F`     | `RETRACE_LOGGER_DEF_FN`  | Path to write the JSON-lines log.            |
+| `--quiet`     | `RETRACE_LOGGER_DEF_ENA=0` | Suppress log output; interception still runs. |
+| `--lib F`     | `RETRACE_LIB`            | Override the retrace shared library path.    |
+
+Additional environment variables:
+
+| Variable                       | Effect                                                 |
+|--------------------------------|--------------------------------------------------------|
+| `RETRACE_LOGGER_DEF_STDOUT_ENA` | `0` to suppress stdout mirroring of the log.          |
+| `RETRACE_LOGGER_ALLOWED_FUNCS`  | Comma-separated allowlist of function names to log.  |
+| `RETRACE_LOGGER_EXCLUDED_FUNCS` | Comma-separated denylist of function names to skip.  |
+
+## Library resolution
+
+The launcher finds `libretrace.so` / `.dylib` / `.dll` in this order:
+
+1. `RETRACE_LIB` env var, if set.
+2. Alongside the `retrace` binary itself (same directory).
+3. Common install paths: `/usr/local/lib/`, `/usr/lib/`,
+   `/usr/lib/x86_64-linux-gnu/`, `/usr/lib/aarch64-linux-gnu/`.
+
+If none of those yield a readable library, the launcher exits with a
+diagnostic. Set `RETRACE_LIB` to point at a non-standard location.
+
+## Under the hood
+
+Every quick subcommand writes a small JSON config to a temp file and
+calls into the same code path as `run`. The configs they generate
+are equivalent to the cookbook recipes — for example, `retrace mock
+getuid 0` produces:
+
+```json
+{
+  "intercept_scripts": [
+    {
+      "func_name": "getuid",
+      "actions": [
+        { "action_name": "call_real" },
+        { "action_name": "modify_return_value_int",
+          "action_params": { "retval_int": 0 } }
+      ]
+    }
+  ]
+}
+```
+
+When a quick subcommand stops being enough — conditional logic,
+multi-function scripts, custom actions — graduate to `run --config`
+and the [configuration reference](configuration.md).
+
+## See also
+
+- [Configuration reference](configuration.md) — full JSON schema.
+- [Cookbook](cookbook/README.md) — 20 recipes with copy-paste JSON.
+- [Action reference](cookbook/README.md#action-reference) — table of
+  built-in actions and their parameters.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,413 @@
+# retrace configuration reference
+
+A retrace config is a JSON object describing one or more
+*intercept scripts*. Each script binds a function name (or wildcard)
+to an ordered list of *actions*. When the target binary calls that
+function, retrace runs each action in sequence, optionally modifying
+the call's arguments or return value before the caller sees them.
+
+The same config format works on every platform — Linux, macOS,
+Windows, FreeBSD, Android. The file is parsed with parson and tolerates
+// and /* */ comments.
+
+## Top-level shape
+
+```json
+{
+  "intercept_scripts": [
+    {
+      "func_name": "<function-name-or-*>",
+      "actions": [
+        {
+          "action_name": "<action>",
+          "action_params": { "...": "..." }
+        }
+      ]
+    }
+  ]
+}
+```
+
+| Field                | Type     | Required | Notes                                            |
+|----------------------|----------|----------|--------------------------------------------------|
+| `intercept_scripts`  | array    | yes      | One entry per function (or wildcard).            |
+| `intercept_scripts[].func_name` | string | yes | Function name, or `"*"` to match every interceptable function. |
+| `intercept_scripts[].actions`  | array  | yes | Ordered list. Each action runs in sequence.      |
+
+The first matching script wins. If multiple scripts match the same
+function, only the first one in the array runs.
+
+## Action shape
+
+```json
+{
+  "action_name": "modify_in_param_str",
+  "action_params": {
+    "param_name": "path",
+    "new_str": "/tmp/fake"
+  }
+}
+```
+
+| Field           | Type   | Required | Notes                                       |
+|-----------------|--------|----------|---------------------------------------------|
+| `action_name`   | string | yes      | One of the registered action names.        |
+| `action_params` | object | depends  | Required by most actions; see reference.   |
+
+Action names are stable across releases. New actions may be added; no
+action is renamed or removed within a major version (see
+[ADR-0006](adr/0006-semantic-versioning.md)).
+
+## Built-in actions
+
+Actions are grouped by the verb they implement. See also the
+[cookbook action reference](cookbook/README.md#action-reference) for
+the compact table form.
+
+### Observe
+
+Actions that do not affect the call's outcome.
+
+#### `log_params`
+
+Emits the call's arguments and return value as a JSON line to the log
+output. The most common action — usually paired with `call_real` so
+the program still works.
+
+```json
+{ "action_name": "log_params" }
+```
+
+Optional `action_params`:
+
+| Param          | Type    | Effect                                              |
+|----------------|---------|-----------------------------------------------------|
+| `omit_params`  | array   | Parameter names to omit from the log (e.g. large buffers). |
+
+#### `call_real`
+
+Invokes the real libc implementation. Without this, the caller
+receives whatever return value (if any) the script synthesized.
+
+```json
+{ "action_name": "call_real" }
+```
+
+No `action_params`.
+
+#### `fuzzing_seed`
+
+Pins the global RNG to a known value so `memory_fuzz` and
+`incomplete_io` produce reproducible failure patterns. Apply once at
+the top of the first script you want to seed.
+
+```json
+{ "action_name": "fuzzing_seed", "action_params": { "seed": 1498729252 } }
+```
+
+| Param  | Type   | Required | Notes                                       |
+|--------|--------|----------|---------------------------------------------|
+| `seed` | number | yes      | Any unsigned int. Zero is a valid seed.     |
+
+Without this action, the seed defaults to `getpid()`, so each run
+gets different failures.
+
+### Modify
+
+Actions that rewrite the call's arguments or return value.
+
+#### `modify_in_param_str`
+
+Replaces the value of a string parameter before the real call runs.
+
+```json
+{
+  "action_name": "modify_in_param_str",
+  "action_params": {
+    "param_name": "path",
+    "new_str": "/tmp/fake",
+    "match_str": "/etc/passwd"
+  }
+}
+```
+
+| Param        | Type   | Required | Notes                                                |
+|--------------|--------|----------|------------------------------------------------------|
+| `param_name` | string | yes      | Must match a named parameter in the prototype.       |
+| `new_str`    | string | yes      | The replacement string.                              |
+| `match_str`  | string | no       | Only modify if the current value equals this.        |
+
+The parameter must be a pointer to a NUL-terminated string in the
+function's prototype.
+
+#### `modify_in_param_int`
+
+Replaces the value of an integer parameter.
+
+```json
+{
+  "action_name": "modify_in_param_int",
+  "action_params": {
+    "param_name": "flags",
+    "new_int": 0,
+    "match_int": 1
+  }
+}
+```
+
+| Param        | Type   | Required | Notes                                                |
+|--------------|--------|----------|------------------------------------------------------|
+| `param_name` | string | yes      | Must match a named parameter in the prototype.       |
+| `new_int`    | number | yes      | The replacement value.                               |
+| `match_int`  | number | no       | Only modify if the current value equals this.        |
+
+#### `modify_in_param_arr`
+
+Replaces the contents of a byte-buffer parameter (e.g. `write`'s
+`buf`, `read`'s `buf`).
+
+```json
+{
+  "action_name": "modify_in_param_arr",
+  "action_params": {
+    "param_name": "buf",
+    "new_arr": [72, 101, 108, 108, 111],
+    "match_arr": [87, 111, 114, 108, 100]
+  }
+}
+```
+
+| Param        | Type   | Required | Notes                                                |
+|--------------|--------|----------|------------------------------------------------------|
+| `param_name` | string | yes      | Must match a named parameter in the prototype.       |
+| `new_arr`    | array  | yes      | Byte values (0–255) to write into the buffer.        |
+| `match_arr`  | array  | no       | Only modify if the current bytes equal this.         |
+
+The buffer must be writable (i.e. the caller's own memory, not
+read-only data).
+
+#### `modify_return_value_int`
+
+Overrides the call's return value.
+
+```json
+{
+  "action_name": "modify_return_value_int",
+  "action_params": { "retval_int": 0 }
+}
+```
+
+| Param        | Type   | Required | Notes                                              |
+|--------------|--------|----------|----------------------------------------------------|
+| `retval_int` | number | yes      | The new return value (parsed as a C integer).      |
+
+If placed *before* `call_real`, the real implementation runs but its
+return value is discarded. If placed *after* `call_real`, same
+effect — order does not matter for this action.
+
+### Fault
+
+Actions that inject failure conditions.
+
+#### `memory_fuzz`
+
+Randomly returns `NULL` from the wrapped allocator at a configurable
+rate. Pairs with `call_real` so successful calls still work.
+
+```json
+{
+  "action_name": "memory_fuzz",
+  "action_params": { "fail_rate": 0.1 }
+}
+```
+
+| Param       | Type   | Required | Notes                                                 |
+|-------------|--------|----------|-------------------------------------------------------|
+| `fail_rate` | number | yes      | Probability in [0.0, 1.0]. `0.1` = 10% of calls fail. |
+
+When the fuzz decision is "fail", the action aborts the rest of the
+script and synthesizes a `NULL` (or `0`) return value. `call_real`
+must precede `memory_fuzz` for the real allocator to run on
+successful calls.
+
+#### `incomplete_io`
+
+Truncates the return value of a read/write-like call at a
+configurable rate. Useful for testing retry logic.
+
+```json
+{
+  "action_name": "incomplete_io",
+  "action_params": { "rate": 0.5 }
+}
+```
+
+| Param  | Type   | Required | Notes                                              |
+|--------|--------|----------|----------------------------------------------------|
+| `rate` | number | yes      | Probability in [0.0, 1.0]. `0.5` = half of calls. |
+
+When the fuzz decision is "truncate", the action rewrites the return
+value to half of what the real call returned.
+
+### Control
+
+Actions that shape the run as a whole — gating, throttling, denying.
+
+#### `delay`
+
+Injects N milliseconds of latency before the call returns. Useful
+for reproducing timing-sensitive bugs without slow networks or disks.
+
+```json
+{
+  "action_name": "delay",
+  "action_params": { "ms": 100 }
+}
+```
+
+| Param | Type   | Required | Notes                                     |
+|-------|--------|----------|-------------------------------------------|
+| `ms`  | number | yes      | Milliseconds to sleep before returning.   |
+
+Implemented via `nanosleep`. The real call has already completed by
+the time this runs.
+
+#### `call_count_limit`
+
+Aborts the script (skipping subsequent actions) once the per-function
+invocation count crosses a threshold. Pairs with
+`modify_return_value_int` to simulate resource exhaustion.
+
+```json
+{
+  "action_name": "call_count_limit",
+  "action_params": { "limit": 5 }
+}
+```
+
+| Param   | Type   | Required | Notes                                                |
+|---------|--------|----------|------------------------------------------------------|
+| `limit` | number | yes      | After this many calls, the action aborts the script. |
+
+Counts are per-function-name across the process. The first
+`call_count_limit` action to fire for a given function claims that
+function's counter.
+
+#### `sandbox`
+
+Denies file access by path. The wrapped call returns `-ENOENT` if
+its path argument matches any entry in `deny_paths`.
+
+```json
+{
+  "action_name": "sandbox",
+  "action_params": {
+    "deny_paths": ["/etc/shadow", "/etc/sudoers", "/root/.ssh/"]
+  }
+}
+```
+
+| Param         | Type    | Required | Notes                                              |
+|---------------|---------|----------|----------------------------------------------------|
+| `deny_paths`  | array   | yes      | List of paths to block. Prefix match (e.g. `/root/.ssh/` blocks everything under that directory); exact match otherwise. |
+
+Apply to `open`, `openat`, `fopen`, and any other path-accepting
+call you want to gate.
+
+## Order matters
+
+Actions run in the order they appear in the `actions` array. Some
+patterns:
+
+**Trace, then run the real call:**
+```json
+"actions": [
+  { "action_name": "log_params" },
+  { "action_name": "call_real" }
+]
+```
+
+**Rewrite a path, then run:**
+```json
+"actions": [
+  { "action_name": "modify_in_param_str",
+    "action_params": { "param_name": "path", "new_str": "/tmp/fake" } },
+  { "action_name": "call_real" }
+]
+```
+
+**Fail after the 5th call:**
+```json
+"actions": [
+  { "action_name": "modify_return_value_int",
+    "action_params": { "retval_int": 0 } },
+  { "action_name": "call_count_limit",
+    "action_params": { "limit": 5 } },
+  { "action_name": "call_real" }
+]
+```
+
+The first 5 calls: `modify_return_value_int` sets ret to 0,
+`call_count_limit` doesn't fire (under threshold), `call_real` runs
+and overwrites ret with the real pointer. Effective: real pointer.
+
+The 6th+ calls: `modify_return_value_int` sets ret to 0,
+`call_count_limit` fires and aborts, `call_real` never runs.
+Effective: NULL.
+
+## Comments
+
+parson parses with comments enabled. Both line (`//`) and block
+(`/* */`) comments are allowed anywhere whitespace is allowed.
+
+```json
+{
+  // First script: trace every call.
+  "intercept_scripts": [
+    {
+      "func_name": "*",            // wildcard
+      "actions": [
+        { "action_name": "log_params" },
+        { "action_name": "call_real" }
+      ]
+    }
+  ]
+}
+```
+
+## Default config
+
+If no `--config` file is given (and `RETRACE_JSON_CONFIG` is unset),
+retrace uses this built-in:
+
+```json
+{
+  "intercept_scripts": [
+    {
+      "func_name": "*",
+      "actions": [
+        { "action_name": "log_params" },
+        { "action_name": "call_real" }
+      ]
+    }
+  ]
+}
+```
+
+Every interceptable function is logged, then forwarded to the real
+implementation.
+
+## Validating
+
+Run `retrace validate <config.json>` to parse and check the file
+before launching the target. This catches:
+
+- Malformed JSON.
+- Unknown `action_name` values (with a "did you mean" hint).
+- Missing required `action_params`.
+
+## See also
+
+- [CLI reference](cli.md) — every subcommand and option.
+- [Cookbook](cookbook/README.md) — 20 ready-to-run recipes.
+- [ADR-0007](adr/0007-json-as-canonical-config.md) — why JSON.

--- a/docs/cookbook/03-count-calls.md
+++ b/docs/cookbook/03-count-calls.md
@@ -1,0 +1,103 @@
+# 03 — Count calls per function
+
+## Problem
+
+You want a quick histogram: which libc functions does this binary call
+the most? You don't need per-call timing or arguments — just the
+count, so you can spot a chatty function or a tight loop.
+
+## Config
+
+`count-calls.json`:
+
+```json
+{
+  "intercept_scripts": [
+    {
+      "func_name": "*",
+      "actions": [
+        { "action_name": "log_params" },
+        { "action_name": "call_real" }
+      ]
+    }
+  ]
+}
+```
+
+Identical to [01-trace-all-calls](01-trace-all-calls.md). The
+histogram is built from the log, not from a special action.
+
+## Invocation
+
+```sh
+$ retrace run --config docs/cookbook/count-calls.json \
+    --log /tmp/counts.json -- ./your-program
+
+$ retrace pp /tmp/counts.json
+```
+
+`retrace pp` produces a per-function table:
+
+```
+malloc          412 calls
+free            408 calls
+memcpy          287 calls
+memset          245 calls
+strlen          189 calls
+write            64 calls
+read             42 calls
+open              8 calls
+…
+```
+
+## Variations
+
+### Top 10 by call count
+
+Pipe through `head`:
+
+```sh
+$ retrace pp /tmp/counts.json | head -10
+```
+
+### Only I/O calls
+
+Filter the log to just file/network functions before pretty-printing.
+Set `RETRACE_LOGGER_ALLOWED_FUNCS`:
+
+```sh
+$ RETRACE_LOGGER_ALLOWED_FUNCS=open,openat,read,write,close,connect,send,recv \
+    retrace run --config docs/cookbook/count-calls.json \
+    --log /tmp/io-only.json -- ./your-program
+$ retrace pp /tmp/io-only.json
+```
+
+### Compare two binaries
+
+Run the same config against two binaries, then diff the pretty-printed
+output:
+
+```sh
+$ retrace run --config docs/cookbook/count-calls.json \
+    --log /tmp/v1.json -- ./binary-v1
+$ retrace run --config docs/cookbook/count-calls.json \
+    --log /tmp/v2.json -- ./binary-v2
+$ diff <(retrace pp /tmp/v1.json) <(retrace pp /tmp/v2.json)
+```
+
+Functions that moved sharply up or down between versions are usually
+worth investigating.
+
+## How it works
+
+`log_params` emits one JSON object per call. The CLI's built-in
+`pp` subcommand reads the JSON-lines log and aggregates call counts
+per `func` field in pure C — no Python, no `jq`, no extra tools.
+
+For richer aggregation (percentages, sort by total time, filter by
+duration), see [04-time-each-call](04-time-each-call.md).
+
+## See also
+
+- [01 — Trace every libc call](01-trace-all-calls.md)
+- [04 — Time each call](04-time-each-call.md)

--- a/docs/cookbook/04-time-each-call.md
+++ b/docs/cookbook/04-time-each-call.md
@@ -116,4 +116,4 @@ trustworthy even when you're mocking `time()` or `gettimeofday()`
 ## See also
 
 - [01 — Trace every libc call](01-trace-all-calls.md)
-- [03 — Count calls per function](03-count-calls.md) (planned)
+- [03 — Count calls per function](03-count-calls.md)

--- a/docs/cookbook/12-fail-specific.md
+++ b/docs/cookbook/12-fail-specific.md
@@ -1,0 +1,148 @@
+# 12 — Fail specific syscalls
+
+## Problem
+
+You want to test how your program handles a specific libc failure.
+Maybe you want to verify that `open()` returning `-ENOENT` is handled
+cleanly, or that `connect()` returning `-ECONNREFUSED` triggers the
+right retry logic. Real failures are hard to reproduce; injecting
+them deterministically is easier.
+
+## Config
+
+`fail-open.json` — fail every `open()` with `-ENOENT`:
+
+```json
+{
+  "intercept_scripts": [
+    {
+      "func_name": "open",
+      "actions": [
+        { "action_name": "modify_return_value_int",
+          "action_params": { "retval_int": -2 } }
+      ]
+    },
+    {
+      "func_name": "openat",
+      "actions": [
+        { "action_name": "modify_return_value_int",
+          "action_params": { "retval_int": -2 } }
+      ]
+    }
+  ]
+}
+```
+
+`-2` is `ENOENT` on Linux. Check `errno.h` for the value on your
+platform. Because the action runs *instead of* `call_real`, the real
+`open` never executes — the caller immediately sees the synthesized
+return value.
+
+## Invocation
+
+```sh
+$ retrace run --config docs/cookbook/fail-open.json -- ./your-program
+open(path="/etc/missing") → -2 (ENOENT)  [injected]
+your-program: error: configuration file not found
+```
+
+## Variations
+
+### Fail only after the Nth call
+
+Allow the first few calls to succeed (so the program initializes),
+then fail every subsequent call. Pair `call_count_limit` with
+`modify_return_value_int` and `call_real`:
+
+```json
+{
+  "intercept_scripts": [
+    {
+      "func_name": "open",
+      "actions": [
+        { "action_name": "modify_return_value_int",
+          "action_params": { "retval_int": -2 } },
+        { "action_name": "call_count_limit",
+          "action_params": { "limit": 5 } },
+        { "action_name": "call_real" }
+      ]
+    }
+  ]
+}
+```
+
+The first 5 `open` calls: `modify_return_value_int` sets ret to
+`-2`, `call_count_limit` doesn't fire (under threshold),
+`call_real` runs and overwrites ret with the real fd. Effective: real
+fd. The 6th+ calls: `modify_return_value_int` sets ret to `-2`,
+`call_count_limit` fires and aborts, `call_real` never runs.
+Effective: `-ENOENT`.
+
+### Fail network connects
+
+To make every outbound `connect()` fail with `ECONNREFUSED`
+(`-111` on Linux):
+
+```json
+{
+  "intercept_scripts": [
+    {
+      "func_name": "connect",
+      "actions": [
+        { "action_name": "modify_return_value_int",
+          "action_params": { "retval_int": -111 } }
+      ]
+    }
+  ]
+}
+```
+
+Useful for testing whether your HTTP client retries, falls back to a
+cache, or surfaces a clean error to the user.
+
+### Fail one specific path
+
+Combine with `modify_in_param_str`'s `match_str` semantics — but
+since `modify_return_value_int` has no built-in match, use a
+per-path script instead:
+
+```json
+{
+  "intercept_scripts": [
+    {
+      "func_name": "open",
+      "actions": [
+        { "action_name": "modify_in_param_str",
+          "action_params": {
+            "param_name": "path",
+            "match_str": "/etc/passwd",
+            "new_str": "/etc/passwd"
+          } },
+        { "action_name": "modify_return_value_int",
+          "action_params": { "retval_int": -2 } }
+      ]
+    }
+  ]
+}
+```
+
+The `modify_in_param_str` only rewrites if the current value is
+`/etc/passwd` — and rewriting it to itself is a no-op for the path,
+but the fact that the action *ran* confirms the match. Then
+`modify_return_value_int` injects the failure. (For a cleaner
+match-then-fail pattern, write a [custom action](../README.md).)
+
+## How it works
+
+Without `call_real` in the action list, the engine never invokes the
+real libc function. The synthesized `retval_int` is what the caller
+sees. This is the simplest possible fault injection — no timing, no
+randomness, no state. For probabilistic failure see
+[09-fuzz-malloc](09-fuzz-malloc.md); for resource-exhaustion patterns
+see [10-incomplete-io](10-incomplete-io.md).
+
+## See also
+
+- [09 — Fuzz malloc failures](09-fuzz-malloc.md) — probabilistic OOM.
+- [10 — Partial I/O](10-incomplete-io.md) — probabilistic short reads.
+- [20 — Sandbox a binary](20-sandbox.md) — deny file access by path.

--- a/docs/cookbook/README.md
+++ b/docs/cookbook/README.md
@@ -39,7 +39,7 @@ $ retrace run --config cookbook/<recipe>.json -- <your-program>
 |---|--------|-----------------|
 | 01 | [Trace every libc call](01-trace-all-calls.md) | The default; log every interceptable call as JSON. |
 | 02 | [Filter by function name](02-filter-by-function.md) | Use `RETRACE_LOGGER_ALLOWED_FUNCS` to focus on a handful of calls. |
-| 03 | [Count calls per function](03-count-calls.md) | Aggregate stats: which libc calls dominate your program. *(planned)* |
+| 03 | [Count calls per function](03-count-calls.md) | Aggregate stats: which libc calls dominate your program. |
 | 04 | [Time each call](04-time-each-call.md) | Find hot spots via `call_duration_us` in the log. |
 
 ### Redirection & mocking
@@ -58,7 +58,7 @@ $ retrace run --config cookbook/<recipe>.json -- <your-program>
 | 09 | [Fuzz `malloc` failures](09-fuzz-malloc.md) | Inject OOM into a target to test error paths. |
 | 10 | [Partial I/O (short reads/writes)](10-incomplete-io.md) | Make `read`/`write` return short to exercise retry logic. |
 | 11 | [Deterministic fuzzing seed](11-deterministic-fuzz.md) | Reproduce a fuzz run by pinning the RNG seed. |
-| 12 | [Fail specific syscalls](12-fail-specific.md) | Force `connect`/`open`/etc. to return an error code. *(planned)* |
+| 12 | [Fail specific syscalls](12-fail-specific.md) | Force `connect`/`open`/etc. to return an error code. |
 
 ### Security audit
 
@@ -80,6 +80,9 @@ $ retrace run --config cookbook/<recipe>.json -- <your-program>
 
 ## Action reference
 
+Compact form. For the full schema and parameter reference, see
+[configuration.md](../configuration.md#built-in-actions).
+
 | Action | Effect |
 |--------|--------|
 | `log_params` | Log call args + return value as JSON. |
@@ -96,6 +99,9 @@ $ retrace run --config cookbook/<recipe>.json -- <your-program>
 | `sandbox` | Deny file access by path deny-list at runtime. |
 
 ## Environment variables
+
+Compact form. For the full CLI and env var reference, see
+[cli.md](../cli.md#common-options).
 
 | Variable | Effect |
 |----------|--------|

--- a/website/index.html
+++ b/website/index.html
@@ -481,6 +481,62 @@ a { color: inherit; text-decoration: none; }
 .install-cmd button:hover { color: var(--text); border-color: var(--dim); }
 .install-cmd button.copied { color: var(--see); border-color: var(--see); }
 
+/* ── First-insight walkthrough ─────────────────────────────────── */
+.walkthrough {
+  margin-top: 32px;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0;
+  border: 1px solid var(--rule);
+  border-radius: 6px;
+  overflow: hidden;
+  background: var(--surface);
+}
+@media (max-width: 860px) { .walkthrough { grid-template-columns: 1fr; } }
+
+.walk-step {
+  padding: 22px 22px 20px;
+  border-right: 1px solid var(--rule);
+  position: relative;
+}
+.walk-step:last-child { border-right: none; }
+@media (max-width: 860px) {
+  .walk-step { border-right: none; border-bottom: 1px solid var(--rule); }
+  .walk-step:last-child { border-bottom: none; }
+}
+
+.walk-step .num {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  color: var(--dim);
+  margin-bottom: 10px;
+}
+.walk-step .what {
+  font-size: 13.5px;
+  color: var(--text);
+  margin-bottom: 12px;
+  line-height: 1.45;
+}
+.walk-step .what strong { font-weight: 500; }
+.walk-step pre {
+  background: var(--ink);
+  border: 1px solid var(--rule);
+  border-radius: 4px;
+  padding: 10px 12px;
+  font-family: var(--mono);
+  font-size: 11.5px;
+  line-height: 1.55;
+  color: var(--text);
+  overflow-x: auto;
+  margin: 0;
+}
+.walk-step pre .p { color: var(--break); }
+.walk-step pre .c { color: var(--dim); }
+.walk-step pre .ok { color: var(--see); }
+.walk-step pre .arg { color: var(--control); }
+
 /* ── Platforms ─────────────────────────────────────────────────── */
 .platforms-grid {
   display: grid;
@@ -696,6 +752,32 @@ footer {
         <span class="p">$</span>
         <span>curl -sSL <span class="url">https://raw.githubusercontent.com/riboseinc/retrace/main/scripts/install.sh</span> | sh</span>
         <button id="copy-btn" type="button" aria-label="Copy install command">copy</button>
+      </div>
+    </div>
+
+    <div class="walkthrough">
+      <div class="walk-step">
+        <div class="num">01 &middot; INSTALL</div>
+        <div class="what">The script puts <strong>retrace</strong> on your <code class="mono">PATH</code> and <strong>libretrace</strong> in your loader path. About five seconds.</div>
+<pre><span class="c"># detect OS + arch, fetch the right binary</span>
+<span class="p">$</span> curl -sSL .../install.sh | sh
+<span class="ok">retrace 2.1.0 installed</span></pre>
+      </div>
+      <div class="walk-step">
+        <div class="num">02 &middot; TRACE</div>
+        <div class="what">Trace any binary. Add <code class="mono">--html</code> for an interactive report. No source. No recompile. No config file.</div>
+<pre><span class="p">$</span> retrace trace malloc,free \
+      --html -- /bin/ls
+<span class="ok">wrote /tmp/retrace-43892.html</span></pre>
+      </div>
+      <div class="walk-step">
+        <div class="num">03 &middot; OPEN</div>
+        <div class="what">Self-contained HTML &mdash; summary cards, category breakdown, filterable call table. No Python, no server, no CDN.</div>
+<pre><span class="p">$</span> open /tmp/retrace-43892.html
+
+<span class="arg">  1,247 calls · 48.3 ms · 42 functions</span>
+<span class="arg">  [ I/O ]  485 calls  32.1 ms (66%)</span>
+<span class="arg">  [ MEM ]  412 calls   8.3 ms (17%)</span></pre>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary

Builds on PR #529 (the website redesign) with two doc references the site was missing, plus a bridge section on the page itself.

### Website: bridge between install and anatomy

The first redesign's flow was hook → install → how-it-works. Visitors who installed retrace had no "first win" before hitting the architecture diagram. This adds a three-column "install → trace → open" walkthrough directly under the install bar — numbered eyebrows, one-sentence explanations, mono code blocks showing the actual command and result. Visitors see the full happy path (install script runs, `retrace trace --html` produces a file, opening that file shows category breakdown) before the anatomy diagram.

Quiet styling: no big numbers, no flashy graphics — the hero terminal remains the signature. Colored output accents tie back to the verb palette.

### Docs: long-form references

Two new top-level docs that didn't exist:

- **`docs/cli.md`** — every subcommand in one place (`run`, `trace`, `mock`, `fuzz`, `slow`, `pp`, `html`, `list-functions`, `list-actions`, `validate`). For each: signature, behavior, example with real output, and (where relevant) the JSON config the quick subcommand generates under the hood. Common options table maps flags to env-var equivalents. Library resolution order documented.

- **`docs/configuration.md`** — full JSON schema: top-level shape, per-script structure, one section per built-in action with its `action_params` table. Parameter names verified against `src/core/actions/*.c`. Order-matters section with three common patterns (trace-then-call, rewrite-then-call, fail-after-N). Comments section notes parson's tolerance for `//` and `/* */`.

### Cookbook: filled-in placeholders

Two `(planned)` recipes that the existing action set already supports are now fully written:

- **`03-count-calls.md`** — aggregate call-frequency profile via `retrace pp`. Variations: top-N, filter via `RETRACE_LOGGER_ALLOWED_FUNCS`, diff two binaries.
- **`12-fail-specific.md`** — deterministic syscall failure via `modify_return_value_int` without `call_real`. Includes the `call_count_limit` "fail after Nth call" pattern, `connect`/`ECONNREFUSED` for network fault injection, and a match-then-fail pattern combining `modify_in_param_str` with `modify_return_value_int`.

Cookbook README markers for 03 and 12 flipped from `(planned)` to live; the action reference and env-var sections now point at the long-form docs as canonical, leaving the cookbook README as the compact quick-glance table.

### docs/README.md

Index updated to list `cli.md` and `configuration.md` first in the "where to go next" table. Documentation map reflects the new files.

## Test plan

Doc + website. No source code impact.

- [ ] CI green on this branch.
- [ ] After merge, GitHub Pages re-deploys; visit `https://riboseinc.github.io/retrace/` and verify:
  - New "01 · INSTALL / 02 · TRACE / 03 · OPEN" walkthrough renders under the install bar.
  - Three columns on desktop, stacked on mobile.
  - All other sections render unchanged.
- [ ] Spot-check `docs/cli.md` and `docs/configuration.md` for markdown rendering on GitHub.
- [ ] Verify cookbook 03 and 12 links from `docs/cookbook/README.md` resolve.
