### PR TITLE
website: interactive tutorial picker + 12 personas + stronger hero pitch

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ install, quick start, and platform support.
 
 | You want to… | Go to |
 |--------------|-------|
+| Solve a specific problem step-by-step | [Tutorials](tutorials.md) — 8 scenario-driven walkthroughs |
 | Look up a CLI subcommand or env var | [CLI reference](cli.md) |
 | Look up an action or write a JSON config | [Configuration reference](configuration.md) |
 | Run a specific scenario (trace, fuzz, mock, sandbox) | [Cookbook](cookbook/README.md) — 20 recipes with copy-paste JSON |
@@ -21,6 +22,7 @@ install, quick start, and platform support.
 ```
 docs/
 ├── README.md              ← you are here
+├── tutorials.md           ← 8 scenario-driven step-by-step walkthroughs
 ├── cli.md                 ← CLI subcommand + env var reference
 ├── configuration.md       ← JSON config schema + action parameter reference
 ├── cookbook/              ← 20 recipe-driven walkthroughs

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -1,0 +1,388 @@
+# retrace tutorials
+
+Scenario-driven walkthroughs. Each tutorial answers a specific
+question: "I have this problem — how do I use retrace to solve it?"
+Pick the one that matches your situation.
+
+> The website has an interactive version of these tutorials at
+> `https://riboseinc.github.io/retrace/#tutorials`. This page is the
+> text-only mirror for offline reading and search engines.
+
+## Tutorials
+
+1. [Find what's making my program slow](#1-find-whats-making-my-program-slow)
+2. [Test how my code handles malloc failures](#2-test-how-my-code-handles-malloc-failures)
+3. [Sandbox an untrusted binary](#3-sandbox-an-untrusted-binary)
+4. [See what a binary actually does](#4-see-what-a-binary-actually-does)
+5. [Make a binary think it's root (without sudo)](#5-make-a-binary-think-its-root-without-sudo)
+6. [Find a memory leak](#6-find-a-memory-leak)
+7. [Add fuzzing to my CI pipeline](#7-add-fuzzing-to-my-ci-pipeline)
+8. [Trace an Android app's native code](#8-trace-an-android-apps-native-code)
+
+---
+
+## 1. Find what's making my program slow
+
+**Time:** 5 minutes.
+**Goal:** identify which libc calls dominate your program's runtime.
+
+### Step 1 — install
+
+```sh
+curl -sSL https://raw.githubusercontent.com/riboseinc/retrace/main/scripts/install.sh | sh
+```
+
+### Step 2 — trace with HTML output
+
+```sh
+retrace trace --html --log /tmp/trace.json -- ./your-program
+# wrote /tmp/retrace-43892.html
+```
+
+### Step 3 — open the report
+
+```sh
+open /tmp/retrace-43892.html
+```
+
+### Step 4 — read the category breakdown
+
+The summary shows total time per category (I/O, MEM, NET, SYNC, …).
+The biggest one is your suspect.
+
+```
+[ I/O ]   485 calls  32.1 ms (66%)
+[ MEM ]   412 calls   8.3 ms (17%)
+[ SYNC ]  186 calls   4.1 ms ( 8%)
+```
+
+### Step 5 — CLI alternative
+
+For a text-only view of per-function totals:
+
+```sh
+retrace pp /tmp/trace.json | head -10
+```
+
+```
+open          48 calls   12.4ms total
+read         124 calls    8.7ms total
+write         64 calls    6.1ms total
+…
+```
+
+---
+
+## 2. Test how my code handles malloc failures
+
+**Time:** 5 minutes.
+**Goal:** find unhandled NULL returns from allocators.
+
+### Step 1 — quick fuzz
+
+```sh
+retrace fuzz malloc --rate 0.1 -- ./your-program
+```
+
+10% of `malloc` calls will return NULL. If your program crashes or
+misbehaves, that's a bug.
+
+### Step 2 — capture the trace
+
+```sh
+retrace fuzz malloc --rate 0.1 --log /tmp/fuzz.json -- ./your-program
+```
+
+### Step 3 — make failures deterministic
+
+Random failures are hard to reproduce. Pin the RNG seed:
+
+```sh
+cat > /tmp/fuzz.json <<'EOF'
+{
+  "intercept_scripts": [
+    {
+      "func_name": "malloc",
+      "actions": [
+        { "action_name": "fuzzing_seed",     "action_params": { "seed": 42 } },
+        { "action_name": "call_real" },
+        { "action_name": "memory_fuzz",      "action_params": { "fail_rate": 0.1 } }
+      ]
+    }
+  ]
+}
+EOF
+```
+
+### Step 4 — reproduce run-to-run
+
+```sh
+retrace run --config /tmp/fuzz.json -- ./your-program
+```
+
+Every run with seed 42 will fail the same calls. File the bug with
+the seed in the report.
+
+### Step 5 — extend to all allocators
+
+See [cookbook recipe 09](cookbook/09-fuzz-malloc.md) for the
+multi-allocator config (malloc + calloc + realloc).
+
+---
+
+## 3. Sandbox an untrusted binary
+
+**Time:** 4 minutes.
+**Goal:** block specific file accesses at runtime, no SELinux or AppArmor.
+
+### Step 1 — list sensitive paths
+
+Pick the paths the binary must not touch. Examples:
+`/etc/shadow`, `/etc/sudoers`, `/root/.ssh/`, `~/.aws/credentials`.
+
+### Step 2 — write the sandbox config
+
+```sh
+cat > /tmp/sandbox.json <<'EOF'
+{
+  "intercept_scripts": [
+    { "func_name": "open",
+      "actions": [{ "action_name": "sandbox",
+        "action_params": { "deny_paths": ["/etc/shadow", "/etc/sudoers", "/root/.ssh/"] } }] },
+    { "func_name": "openat",
+      "actions": [{ "action_name": "sandbox",
+        "action_params": { "deny_paths": ["/etc/shadow", "/etc/sudoers", "/root/.ssh/"] } }] }
+  ]
+}
+EOF
+```
+
+### Step 3 — run the binary under the sandbox
+
+```sh
+retrace run --config /tmp/sandbox.json -- ./untrusted-binary
+# sandbox: DENIED '/etc/shadow'  (open returned -2 / ENOENT)
+```
+
+### Step 4 — triage
+
+Any `DENIED` line in the log is an attempted access the sandbox
+blocked. See [cookbook recipe 20](cookbook/20-sandbox.md) for prefix
+matching and other variations.
+
+---
+
+## 4. See what a binary actually does
+
+**Time:** 3 minutes.
+**Goal:** map every libc call of a closed-source binary without a disassembler.
+
+### Step 1 — trace every call
+
+```sh
+retrace trace --log /tmp/trace.json -- ./mystery-binary
+```
+
+### Step 2 — filter to interesting functions
+
+```sh
+RETRACE_LOGGER_ALLOWED_FUNCS=open,openat,read,write,connect,execve,system \
+  retrace trace --log /tmp/io.json -- ./mystery-binary
+```
+
+### Step 3 — interactive HTML view
+
+```sh
+retrace html /tmp/io.json -o /tmp/view.html && open /tmp/view.html
+```
+
+### Step 4 — look for surprises
+
+- Files you didn't expect.
+- Outbound connects to surprising hosts.
+- `system()` calls with shell metacharacters.
+- `getenv()` reads of sensitive variables.
+
+Those are your leads.
+
+---
+
+## 5. Make a binary think it's root (without sudo)
+
+**Time:** 2 minutes.
+**Goal:** test root-path code without actually being root.
+
+### Step 1 — quick mock
+
+```sh
+retrace mock getuid 0 -- ./check-root
+# welcome, root
+```
+
+### Step 2 — mock getuid AND geteuid
+
+Most root checks consult both. Use a small JSON config:
+
+```sh
+cat > /tmp/root.json <<'EOF'
+{
+  "intercept_scripts": [
+    { "func_name": "getuid",
+      "actions": [{ "action_name": "modify_return_value_int",
+        "action_params": { "retval_int": 0 } }] },
+    { "func_name": "geteuid",
+      "actions": [{ "action_name": "modify_return_value_int",
+        "action_params": { "retval_int": 0 } }] }
+  ]
+}
+EOF
+retrace run --config /tmp/root.json -- ./check-root
+```
+
+See [cookbook recipe 05](cookbook/05-mock-getuid.md) for variations.
+
+---
+
+## 6. Find a memory leak
+
+**Time:** 6 minutes.
+**Goal:** find allocators that aren't being matched by frees.
+
+### Step 1 — trace allocators
+
+```sh
+retrace trace malloc,calloc,realloc,free --log /tmp/alloc.json -- ./your-program
+```
+
+### Step 2 — per-function counts
+
+```sh
+retrace pp /tmp/alloc.json | grep -E 'malloc|calloc|realloc|free'
+```
+
+```
+malloc    1247 calls
+calloc      42 calls
+realloc     18 calls
+free      1198 calls
+```
+
+### Step 3 — do the math
+
+```
+(1247 + 42 + 18) - 1198 = 109 outstanding allocations
+```
+
+If that number is non-zero and growing across multiple runs, you
+have a leak.
+
+### Step 4 — diff two runs of a server
+
+For long-running processes, capture a trace window, hit the server,
+then capture another. The diff is the leak signature:
+
+```sh
+timeout 10 retrace trace malloc,free --log /tmp/r1.json -- ./server &
+# ... send some traffic ...
+timeout 10 retrace trace malloc,free --log /tmp/r2.json -- ./server
+diff <(retrace pp /tmp/r1.json) <(retrace pp /tmp/r2.json)
+```
+
+---
+
+## 7. Add fuzzing to my CI pipeline
+
+**Time:** 10 minutes.
+**Goal:** catch OOM and short-IO bugs on every PR.
+
+### Step 1 — drop in the workflow
+
+```sh
+mkdir -p .github/workflows
+cat > .github/workflows/retrace-fuzz.yml <<'EOF'
+name: fuzz
+on: [pull_request]
+jobs:
+  fuzz:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install retrace
+        run: curl -sSL https://raw.githubusercontent.com/riboseinc/retrace/main/scripts/install.sh | sh
+      - name: Run tests under fuzz
+        run: retrace fuzz malloc --rate 0.05 --log /tmp/fuzz.json -- ./run-tests
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: retrace-fuzz-log
+          path: /tmp/fuzz.json
+EOF
+```
+
+### Step 2 — open a PR
+
+The workflow runs your tests with 5% of mallocs failing. Any
+unhandled NULL crashes the test run.
+
+### Step 3 — reproduce locally
+
+Download the artifact, extract the seed, replay:
+
+```sh
+gh run download <run-id> -n retrace-fuzz-log
+retrace run --config fuzz-seed-<N>.json -- ./run-tests
+```
+
+### Step 4 — full reference
+
+See [cookbook recipe 19](cookbook/19-ci-fuzzing.md) for the
+production-ready workflow with seed extraction and triage steps.
+
+---
+
+## 8. Trace an Android app's native code
+
+**Time:** 20 minutes.
+**Goal:** trace libc calls inside an Android app's native libraries.
+
+### Step 1 — cross-compile for arm64
+
+```sh
+cmake -B build-android \
+  -DCMAKE_TOOLCHAIN_FILE=cmake/android-toolchain.cmake \
+  -DANDROID_ABI=arm64-v8a
+cmake --build build-android
+```
+
+### Step 2 — push to device
+
+```sh
+adb push build-android/src/libretrace.so /data/local/tmp/
+
+cat > wrap.sh <<'EOF'
+#!/system/bin/sh
+export LD_PRELOAD=/data/local/tmp/libretrace.so
+exec "$@"
+EOF
+adb push wrap.sh /data/local/tmp/
+```
+
+### Step 3 — for debuggable apps
+
+```sh
+adb shell setprop wrap.<package.name> LD_PRELOAD=/data/local/tmp/libretrace.so
+adb shell am start -n <package.name>/<activity>
+```
+
+### Step 4 — for production apps
+
+Use Magisk's Zygisk module mechanism. See the
+[Android guide](android.md) for the full setup.
+
+---
+
+## See also
+
+- [Cookbook](cookbook/README.md) — 20 recipe-style walkthroughs.
+- [CLI reference](cli.md) — every subcommand.
+- [Configuration reference](configuration.md) — full JSON schema.

--- a/website/src/components/Hero.astro
+++ b/website/src/components/Hero.astro
@@ -44,9 +44,28 @@ const verbs = [
           Install
           <span class="arrow">→</span>
         </a>
-        <a class="btn btn-ghost" href="https://github.com/riboseinc/retrace">
-          View source
+        <a class="btn btn-ghost" href="#tutorials">
+          Try a tutorial
         </a>
+      </div>
+
+      <div class="hero-stats">
+        <div class="stat">
+          <div class="stat-num">13</div>
+          <div class="stat-label">platforms</div>
+        </div>
+        <div class="stat">
+          <div class="stat-num">12</div>
+          <div class="stat-label">actions</div>
+        </div>
+        <div class="stat">
+          <div class="stat-num">~200 KB</div>
+          <div class="stat-label">binary</div>
+        </div>
+        <div class="stat">
+          <div class="stat-num">0</div>
+          <div class="stat-label">recompiles</div>
+        </div>
       </div>
     </div>
 
@@ -168,6 +187,37 @@ const verbs = [
 }
 .btn .arrow { transition: transform 0.18s ease; }
 .btn:hover .arrow { transform: translateX(2px); }
+
+.hero-stats {
+  display: flex;
+  gap: 28px;
+  margin-top: 32px;
+  flex-wrap: wrap;
+}
+.stat {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.stat-num {
+  font-family: var(--font-mono);
+  font-size: 22px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1;
+  color: var(--color-text);
+}
+.stat-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--color-dim);
+}
+@media (max-width: 540px) {
+  .hero-stats { gap: 18px; }
+  .stat-num { font-size: 18px; }
+}
 
 .terminal-wrap {
   position: relative;

--- a/website/src/components/Nav.astro
+++ b/website/src/components/Nav.astro
@@ -11,6 +11,7 @@
       <a href="#anatomy">How it works</a>
       <a href="#actions">Actions</a>
       <a href="#use-cases">Use cases</a>
+      <a href="#tutorials">Tutorials</a>
       <a href="#platforms">Platforms</a>
       <a href="https://github.com/riboseinc/retrace/blob/main/docs/cookbook/README.md">Cookbook</a>
       <a href="https://github.com/riboseinc/retrace">GitHub</a>

--- a/website/src/components/TutorialPicker.vue
+++ b/website/src/components/TutorialPicker.vue
@@ -1,0 +1,594 @@
+<script setup>
+import { ref, computed } from "vue";
+
+// Each scenario is a clickable card. Selecting one reveals the
+// step-by-step walkthrough. Steps carry a description, a command
+// (optional, copyable), and an expected result.
+const scenarios = [
+  {
+    id: "slow",
+    title: "Find what's making my program slow",
+    icon: "⌛",
+    accent: "see",
+    summary: "Trace every libc call with timings, then sort by total time.",
+    minutes: 5,
+    steps: [
+      {
+        what: "Install retrace if you haven't already.",
+        cmd: "curl -sSL https://raw.githubusercontent.com/riboseinc/retrace/main/scripts/install.sh | sh",
+        out: "retrace 2.1.0 installed",
+      },
+      {
+        what: "Run your program under retrace with HTML output. The --html flag generates a self-contained interactive page.",
+        cmd: "retrace trace --html --log /tmp/trace.json -- ./your-program",
+        out: "wrote /tmp/retrace-43892.html",
+      },
+      {
+        what: "Open the report.",
+        cmd: "open /tmp/retrace-43892.html",
+        out: "(browser opens with summary cards + filterable table)",
+      },
+      {
+        what: "Look at the category breakdown. The biggest category by total time is your suspect. Click any function to filter the table.",
+        out: "[ I/O ]   485 calls  32.1 ms (66%)\n[ MEM ]   412 calls   8.3 ms (17%)\n...",
+      },
+      {
+        what: "For a CLI-only view of per-function totals, pretty-print the JSON log:",
+        cmd: "retrace pp /tmp/trace.json | head -10",
+        out: "open          48 calls   12.4ms total\nread         124 calls    8.7ms total\n...",
+      },
+    ],
+  },
+  {
+    id: "oom",
+    title: "Test how my code handles malloc failures",
+    icon: "💥",
+    accent: "break",
+    summary: "Inject OOM at a configurable rate to find unhandled NULL returns.",
+    minutes: 5,
+    steps: [
+      {
+        what: "Start with the quick subcommand. 10% of mallocs will return NULL.",
+        cmd: "retrace fuzz malloc --rate 0.1 -- ./your-program",
+        out: "(program either handles NULLs gracefully, or crashes — that's the test)",
+      },
+      {
+        what: "If it crashes, capture the trace to a log so you can replay:",
+        cmd: "retrace fuzz malloc --rate 0.1 --log /tmp/fuzz.json -- ./your-program",
+        out: "wrote log to /tmp/fuzz.json",
+      },
+      {
+        what: "Make the failure deterministic so it reproduces run-to-run. Add a seed via JSON config:",
+        cmd: 'echo \'{"intercept_scripts":[{"func_name":"malloc","actions":[{"action_name":"fuzzing_seed","action_params":{"seed":42}},{"action_name":"call_real"},{"action_name":"memory_fuzz","action_params":{"fail_rate":0.1}}]}]}\' > /tmp/fuzz.json',
+        out: "",
+      },
+      {
+        what: "Run with that config — every run with seed 42 will fail the same calls.",
+        cmd: "retrace run --config /tmp/fuzz.json -- ./your-program",
+        out: "(deterministic failures — file the bug)",
+      },
+      {
+        what: "To also fuzz calloc and realloc, copy docs/cookbook/09-fuzz-malloc.json and tweak.",
+        out: "(see cookbook recipe 09 for the full multi-allocator config)",
+      },
+    ],
+  },
+  {
+    id: "sandbox",
+    title: "Sandbox an untrusted binary",
+    icon: "🛡️",
+    accent: "break",
+    summary: "Block file access by path deny-list at runtime — no SELinux or AppArmor required.",
+    minutes: 4,
+    steps: [
+      {
+        what: "Decide which paths the binary must not touch.",
+        out: "/etc/shadow, /etc/sudoers, /root/.ssh/, ~/.aws/credentials",
+      },
+      {
+        what: "Write a sandbox.json config. Apply sandbox to every path-accepting call you want gated.",
+        cmd: `cat > /tmp/sandbox.json <<'EOF'
+{
+  "intercept_scripts": [
+    { "func_name": "open",
+      "actions": [{ "action_name": "sandbox",
+        "action_params": { "deny_paths": ["/etc/shadow", "/etc/sudoers", "/root/.ssh/"] } }] },
+    { "func_name": "openat",
+      "actions": [{ "action_name": "sandbox",
+        "action_params": { "deny_paths": ["/etc/shadow", "/etc/sudoers", "/root/.ssh/"] } }] }
+  ]
+}
+EOF`,
+        out: "",
+      },
+      {
+        what: "Run the binary under the sandbox. Any denied access is logged.",
+        cmd: "retrace run --config /tmp/sandbox.json -- ./untrusted-binary",
+        out: "sandbox: DENIED '/etc/shadow'  (open returned -2 / ENOENT)",
+      },
+      {
+        what: "Triage the log to confirm what the binary tried to access.",
+        out: "(any 'DENIED' line is an attempted access the sandbox blocked)",
+      },
+    ],
+  },
+  {
+    id: "reverse",
+    title: "See what a binary actually does",
+    icon: "🔍",
+    accent: "see",
+    summary: "Map every libc call of a closed-source binary without a disassembler.",
+    minutes: 3,
+    steps: [
+      {
+        what: "Trace every call (no func filter = wildcard). Pipe to a log.",
+        cmd: "retrace trace --log /tmp/trace.json -- ./mystery-binary",
+        out: "(binary runs; every libc call is captured)",
+      },
+      {
+        what: "Filter the log to just file/network/process operations. Set RETRACE_LOGGER_ALLOWED_FUNCS:",
+        cmd: "RETRACE_LOGGER_ALLOWED_FUNCS=open,openat,read,write,connect,execve,system retrace trace --log /tmp/io.json -- ./mystery-binary",
+        out: "(only the listed functions appear in the log)",
+      },
+      {
+        what: "Generate an interactive HTML report:",
+        cmd: "retrace html /tmp/io.json -o /tmp/view.html && open /tmp/view.html",
+        out: "(browser opens; filter by function name to drill down)",
+      },
+      {
+        what: "Look for: unexpected files opened, outbound connects to surprising hosts, system() calls with shell metacharacters. Those are your leads.",
+        out: "",
+      },
+    ],
+  },
+  {
+    id: "root",
+    title: "Make a binary think it's root (without sudo)",
+    icon: "🎭",
+    accent: "control",
+    summary: "Override getuid / geteuid / getgid return values to test root-path code.",
+    minutes: 2,
+    steps: [
+      {
+        what: "Run the binary with mocked getuid. It returns 0 (root's uid).",
+        cmd: "retrace mock getuid 0 -- ./check-root",
+        out: "welcome, root  (binary took the root path)",
+      },
+      {
+        what: "If the binary checks geteuid too, mock both via a small JSON config:",
+        cmd: `cat > /tmp/root.json <<'EOF'
+{
+  "intercept_scripts": [
+    { "func_name": "getuid",
+      "actions": [{ "action_name": "modify_return_value_int",
+        "action_params": { "retval_int": 0 } }] },
+    { "func_name": "geteuid",
+      "actions": [{ "action_name": "modify_return_value_int",
+        "action_params": { "retval_int": 0 } }] }
+  ]
+}
+EOF`,
+        out: "",
+      },
+      {
+        what: "Run with that config.",
+        cmd: "retrace run --config /tmp/root.json -- ./check-root",
+        out: "(binary now believes it's running as root)",
+      },
+    ],
+  },
+  {
+    id: "leak",
+    title: "Find a memory leak",
+    icon: "💧",
+    accent: "see",
+    summary: "Count malloc/free imbalance per function — more mallocs than frees indicates a leak.",
+    minutes: 6,
+    steps: [
+      {
+        what: "Trace allocators and free. The default config logs every call.",
+        cmd: "retrace trace malloc,calloc,realloc,free --log /tmp/alloc.json -- ./your-program",
+        out: "(program runs; every allocator call is logged with the pointer)",
+      },
+      {
+        what: "Pretty-print to see per-function counts:",
+        cmd: "retrace pp /tmp/alloc.json | grep -E 'malloc|calloc|realloc|free'",
+        out: "malloc    1247 calls\ncalloc      42 calls\nrealloc     18 calls\nfree      1198 calls",
+      },
+      {
+        what: "Subtract frees from allocations. If malloc+calloc+realloc > free, you have a leak. The diff is the leak count.",
+        out: "(1247 + 42 + 18) - 1198 = 109 outstanding allocations",
+      },
+      {
+        what: "For a tight loop, capture a windowed trace: run for N seconds, send SIGINT, then diff against a fresh run. The persistent allocations between runs are the leak.",
+        cmd: "timeout 10 retrace trace malloc,free --log /tmp/run1.json -- ./server &\n# ... wait, hit the server ...\ntimeout 10 retrace trace malloc,free --log /tmp/run2.json -- ./server\nretrace pp /tmp/run1.json > /tmp/run1.txt\nretrace pp /tmp/run2.json > /tmp/run2.txt\ndiff /tmp/run1.txt /tmp/run2.txt",
+        out: "(any function whose count grew between runs is leaking)",
+      },
+    ],
+  },
+  {
+    id: "ci",
+    title: "Add fuzzing to my CI pipeline",
+    icon: "🤖",
+    accent: "break",
+    summary: "A drop-in GitHub Action that catches OOM and short-IO bugs on every PR.",
+    minutes: 10,
+    steps: [
+      {
+        what: "Add a workflow file. The action installs retrace, runs your tests under fuzz, fails the build on crash.",
+        cmd: `mkdir -p .github/workflows
+cat > .github/workflows/retrace-fuzz.yml <<'EOF'
+name: fuzz
+on: [pull_request]
+jobs:
+  fuzz:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install retrace
+        run: curl -sSL https://raw.githubusercontent.com/riboseinc/retrace/main/scripts/install.sh | sh
+      - name: Run tests under fuzz
+        run: retrace fuzz malloc --rate 0.05 --log /tmp/fuzz.json -- ./run-tests
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: retrace-fuzz-log
+          path: /tmp/fuzz.json
+EOF`,
+        out: "",
+      },
+      {
+        what: "Open a PR. The workflow runs your tests with 5% of mallocs failing. Any unhandled NULL crashes the test run.",
+        out: "(CI fails if your code doesn't handle OOM gracefully)",
+      },
+      {
+        what: "When a failure happens, download the artifact and replay locally with a fixed seed:",
+        cmd: "gh run download <run-id> -n retrace-fuzz-log\n# extract the seed from the log, then:\nretrace run --config fuzz-seed-<N>.json -- ./run-tests",
+        out: "(reproduces the exact failure locally)",
+      },
+      {
+        what: "See docs/cookbook/19-ci-fuzzing.md for the complete drop-in workflow.",
+        out: "",
+      },
+    ],
+  },
+  {
+    id: "android",
+    title: "Trace an Android app's native code",
+    icon: "📱",
+    accent: "control",
+    summary: "Cross-compile retrace for arm64, push to device, trace via wrap.sh.",
+    minutes: 20,
+    steps: [
+      {
+        what: "Build retrace for arm64 Android using the NDK toolchain file.",
+        cmd: "cmake -B build-android -DCMAKE_TOOLCHAIN_FILE=cmake/android-toolchain.cmake -DANDROID_ABI=arm64-v8a\ncmake --build build-android",
+        out: "build-android/src/libretrace.so",
+      },
+      {
+        what: "Push the library and a wrapper script to the device.",
+        cmd: "adb push build-android/src/libretrace.so /data/local/tmp/\ncat > wrap.sh <<'EOF'\n#!/system/bin/sh\nexport LD_PRELOAD=/data/local/tmp/libretrace.so\nexec \"$@\"\nEOF\nadb push wrap.sh /data/local/tmp/",
+        out: "",
+      },
+      {
+        what: "For debuggable apps, set wrap.sh via the property. Then launch the app.",
+        cmd: "adb shell setprop wrap.<package.name> LD_PRELOAD=/data/local/tmp/libretrace.so\nadb shell am start -n <package.name>/<activity>",
+        out: "(app starts with retrace injected; traces flow to logcat)",
+      },
+      {
+        what: "For production apps, use Magisk's Zygisk module mechanism. See docs/android.md for the full setup.",
+        out: "",
+      },
+    ],
+  },
+];
+
+const selectedId = ref(scenarios[0].id);
+const selected = computed(() =>
+  scenarios.find((s) => s.id === selectedId.value)
+);
+
+function select(id) {
+  selectedId.value = id;
+}
+
+async function copyCmd(cmd) {
+  if (!cmd) return;
+  try {
+    await navigator.clipboard.writeText(cmd);
+  } catch (e) {
+    const ta = document.createElement("textarea");
+    ta.value = cmd;
+    document.body.appendChild(ta);
+    ta.select();
+    try { document.execCommand("copy"); } catch (_) {}
+    document.body.removeChild(ta);
+  }
+}
+</script>
+
+<template>
+  <div class="tutorial-grid">
+    <aside class="scenario-rail">
+      <div class="rail-label">Pick your scenario</div>
+      <ul class="scenario-list">
+        <li
+          v-for="s in scenarios"
+          :key="s.id"
+          :class="['scenario-item', `accent-${s.accent}`, { active: s.id === selectedId }]"
+          @click="select(s.id)"
+        >
+          <span class="scenario-icon">{{ s.icon }}</span>
+          <span class="scenario-text">
+            <span class="scenario-title">{{ s.title }}</span>
+            <span class="scenario-meta">{{ s.minutes }} min · {{ s.accent }}</span>
+          </span>
+        </li>
+      </ul>
+    </aside>
+
+    <div :class="['walkthrough-pane', `accent-${selected.accent}`]">
+      <header class="walk-head">
+        <div class="walk-eyebrow">{{ selected.icon }} {{ selected.accent }}</div>
+        <h3>{{ selected.title }}</h3>
+        <p class="walk-summary">{{ selected.summary }}</p>
+      </header>
+
+      <ol class="steps">
+        <li v-for="(step, i) in selected.steps" :key="i" class="step">
+          <div class="step-num">{{ String(i + 1).padStart(2, "0") }}</div>
+          <div class="step-body">
+            <p class="step-what">{{ step.what }}</p>
+            <div v-if="step.cmd" class="step-code">
+              <pre>{{ step.cmd }}</pre>
+              <button class="step-copy" @click="copyCmd(step.cmd)" aria-label="Copy command">copy</button>
+            </div>
+            <pre v-if="step.out" class="step-out">{{ step.out }}</pre>
+          </div>
+        </li>
+      </ol>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.tutorial-grid {
+  display: grid;
+  grid-template-columns: 320px 1fr;
+  gap: 16px;
+  align-items: start;
+}
+@media (max-width: 860px) {
+  .tutorial-grid { grid-template-columns: 1fr; }
+}
+
+.scenario-rail {
+  background: rgba(11, 13, 18, 0.5);
+  backdrop-filter: blur(14px) saturate(160%);
+  -webkit-backdrop-filter: blur(14px) saturate(160%);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 12px;
+  padding: 14px;
+  position: sticky;
+  top: 76px;
+}
+@media (max-width: 860px) {
+  .scenario-rail { position: static; }
+}
+
+.rail-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--color-dim);
+  padding: 4px 8px 10px;
+}
+
+.scenario-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+@media (max-width: 860px) {
+  .scenario-list {
+    flex-direction: row;
+    overflow-x: auto;
+    padding-bottom: 4px;
+  }
+  .scenario-item { min-width: 240px; }
+}
+
+.scenario-item {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+  padding: 10px 10px;
+  border-radius: 8px;
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition: all 0.2s var(--ease-glass);
+}
+.scenario-item:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
+.scenario-item.active {
+  background: rgba(255, 255, 255, 0.06);
+  border-color: rgba(255, 255, 255, 0.1);
+}
+.scenario-item.accent-see.active { border-left: 2px solid var(--color-see); }
+.scenario-item.accent-control.active { border-left: 2px solid var(--color-control); }
+.scenario-item.accent-break.active { border-left: 2px solid var(--color-break); }
+
+.scenario-icon {
+  font-size: 18px;
+  line-height: 1.3;
+}
+.scenario-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1;
+  min-width: 0;
+}
+.scenario-title {
+  font-size: 13px;
+  color: var(--color-text);
+  line-height: 1.35;
+  font-weight: 500;
+}
+.scenario-item.active .scenario-title { color: var(--color-text); }
+.scenario-meta {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--color-dim);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.walkthrough-pane {
+  background: linear-gradient(180deg, rgba(28, 33, 42, 0.55) 0%, rgba(20, 24, 30, 0.45) 100%);
+  backdrop-filter: blur(22px) saturate(180%);
+  -webkit-backdrop-filter: blur(22px) saturate(180%);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 14px;
+  padding: 28px 30px;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.07),
+    0 24px 60px -20px rgba(0, 0, 0, 0.55);
+}
+.walkthrough-pane.accent-see { border-top: 2px solid rgba(94, 227, 255, 0.4); }
+.walkthrough-pane.accent-control { border-top: 2px solid rgba(242, 180, 65, 0.4); }
+.walkthrough-pane.accent-break { border-top: 2px solid rgba(255, 107, 92, 0.4); }
+
+.walk-head { margin-bottom: 24px; }
+.walk-eyebrow {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--color-dim);
+  margin-bottom: 8px;
+}
+.walkthrough-pane.accent-see .walk-eyebrow { color: var(--color-see); }
+.walkthrough-pane.accent-control .walk-eyebrow { color: var(--color-control); }
+.walkthrough-pane.accent-break .walk-eyebrow { color: var(--color-break); }
+
+.walk-head h3 {
+  font-size: 22px;
+  font-weight: 600;
+  letter-spacing: -0.015em;
+  line-height: 1.2;
+  margin-bottom: 8px;
+}
+.walk-summary {
+  font-size: 14px;
+  color: var(--color-dim);
+  line-height: 1.5;
+}
+
+.steps {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+.step {
+  display: grid;
+  grid-template-columns: 36px 1fr;
+  gap: 14px;
+  position: relative;
+}
+.step:not(:last-child)::before {
+  content: "";
+  position: absolute;
+  left: 17px;
+  top: 32px;
+  bottom: -18px;
+  width: 1px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0));
+}
+.step-num {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: rgba(7, 9, 13, 0.7);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--color-text);
+  flex-shrink: 0;
+  z-index: 1;
+}
+.step-body {
+  padding-top: 6px;
+  min-width: 0;
+}
+.step-what {
+  font-size: 14px;
+  color: var(--color-text);
+  line-height: 1.55;
+  margin-bottom: 8px;
+}
+.step-code {
+  position: relative;
+  background: rgba(7, 9, 13, 0.75);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 8px;
+  padding: 12px 14px;
+  margin-bottom: 8px;
+}
+.step-code pre {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.55;
+  color: var(--color-text);
+  overflow-x: auto;
+  margin: 0;
+  white-space: pre;
+}
+.step-copy {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  color: var(--color-dim);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  padding: 3px 8px;
+  border-radius: 3px;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+.step-copy:hover {
+  color: var(--color-text);
+  border-color: rgba(255, 255, 255, 0.2);
+}
+.step-copy:active {
+  color: var(--color-see);
+  border-color: var(--color-see);
+}
+.step-out {
+  background: rgba(94, 227, 255, 0.04);
+  border: 1px solid rgba(94, 227, 255, 0.1);
+  border-radius: 6px;
+  padding: 8px 12px;
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--color-dim);
+  margin: 0;
+  white-space: pre-wrap;
+  line-height: 1.5;
+}
+</style>

--- a/website/src/components/Tutorials.astro
+++ b/website/src/components/Tutorials.astro
@@ -1,0 +1,53 @@
+---
+import TutorialPicker from "./TutorialPicker.vue";
+---
+
+<section class="section tutorials" id="tutorials">
+  <div class="wrap">
+    <div class="section-head reveal">
+      <div class="eyebrow">Tutorials</div>
+      <h2>Pick your scenario. We'll walk you through it.</h2>
+      <p>
+        Every newcomer's question is the same: <em>"I have this problem — how do I use retrace to solve it?"</em>
+        Click your scenario on the left; the steps appear on the right with copy-paste commands and expected
+        output. No prior retrace knowledge assumed.
+      </p>
+    </div>
+
+    <div class="reveal">
+      <TutorialPicker client:visible />
+    </div>
+
+    <p class="more-link reveal">
+      Looking for something else? The <a href="https://github.com/riboseinc/retrace/blob/main/docs/cookbook/README.md">cookbook</a>
+      has 20 more recipe-style walkthroughs — each is a single JSON config plus the command to run it.
+    </p>
+  </div>
+</section>
+
+<style>
+.tutorials {
+  background:
+    radial-gradient(ellipse 60% 40% at 50% 0%, rgba(94, 227, 255, 0.03), transparent 60%);
+}
+
+.more-link {
+  margin-top: 28px;
+  text-align: center;
+  font-size: 13.5px;
+  color: var(--color-dim);
+}
+.more-link a {
+  color: var(--color-see);
+  border-bottom: 1px solid rgba(94, 227, 255, 0.3);
+  padding-bottom: 1px;
+  transition: border-color 0.2s;
+}
+.more-link a:hover {
+  border-color: var(--color-see);
+}
+.more-link em {
+  color: var(--color-text);
+  font-style: italic;
+}
+</style>

--- a/website/src/components/UseCases.astro
+++ b/website/src/components/UseCases.astro
@@ -1,11 +1,12 @@
 ---
-// Use cases — five personas. NEW section framing the audience.
+// Use cases — twelve personas. Covers the full audience spectrum:
+// security research, testing, development, ops, education, forensics.
 const personas = [
   {
     tag: "security",
     accent: "see",
     who: "Security researcher",
-    what: "Reverse-engineer a binary you don't have source for. Map every <code>open</code>, every <code>connect</code>, every <code>system</code> call.",
+    what: "Reverse-engineer a binary you don't have source for. Map every <code>open</code>, every <code>connect</code>, every <code>system</code> call — in seconds, without a disassembler.",
     cmd: "retrace trace open,connect,system -- ./suspicious",
   },
   {
@@ -43,6 +44,48 @@ const personas = [
     what: "See exactly what <code>ls</code>, <code>cat</code>, <code>grep</code> actually do. The trace is the lesson — every libc call, in order, with timings.",
     cmd: "retrace trace --html -- /bin/ls",
   },
+  {
+    tag: "ctf",
+    accent: "control",
+    who: "CTF player",
+    what: "Solve tracing challenges fast. Watch the binary leak the flag through <code>write</code>, find the comparison via <code>strcmp</code>, time the side channel.",
+    cmd: "retrace trace strcmp,write -- ./challenge",
+  },
+  {
+    tag: "re",
+    accent: "see",
+    who: "Reverse engineer",
+    what: "Understand a closed-source binary's behavior without firing up IDA. Trace the calls; reconstruct the logic from observable I/O.",
+    cmd: "retrace trace -- ./closed-source-binary",
+  },
+  {
+    tag: "forensics",
+    accent: "see",
+    who: "Forensics analyst",
+    what: "Post-incident analysis: replay a captured trace to see exactly what a process did — files touched, sockets opened, env vars read.",
+    cmd: "retrace pp /tmp/trace.json",
+  },
+  {
+    tag: "bounty",
+    accent: "break",
+    who: "Bug bounty hunter",
+    what: "Find vulns by exhausting resources. Make the 1000th <code>malloc</code> fail, the 50th <code>open</code> return ENOENT, see if the program survives.",
+    cmd: "retrace run --config limit-then-fail.json -- ./target",
+  },
+  {
+    tag: "mobile",
+    accent: "control",
+    who: "Mobile developer",
+    what: "Trace any Android app's native libraries via <code>wrap.sh</code> or Magisk. Cross-compile once with the NDK; same JSON config as your desktop.",
+    cmd: "LD_PRELOAD=libretrace.so /data/local/tmp/wrap.sh",
+  },
+  {
+    tag: "sysadmin",
+    accent: "see",
+    who: "System administrator",
+    what: "Diagnose why a service is misbehaving without restarting it. Trace a single command's libc activity to see what's really being read, written, connected to.",
+    cmd: "retrace trace --html -- $(which dig) example.com",
+  },
 ];
 ---
 
@@ -50,18 +93,21 @@ const personas = [
   <div class="wrap">
     <div class="section-head reveal">
       <div class="eyebrow">Who uses retrace</div>
-      <h2>One tool, six jobs.</h2>
+      <h2>Twelve jobs. One shared library.</h2>
       <p>
-        retrace is small enough to slip into a one-off debugging session, generic enough to anchor a CI
-        fuzzing pipeline, principled enough to back a security audit. Below: who reaches for it, and the
-        command they reach for first.
+        retrace is small enough to slip into a one-off debugging session, generic enough to anchor a
+        CI fuzzing pipeline, principled enough to back a security audit. Below: every audience that
+        reaches for it, and the command they reach for first.
       </p>
     </div>
 
     <div class="persona-grid">
       {
         personas.map((p, i) => (
-          <article class={`persona glass glass-hover reveal accent-${p.accent}`} style={`transition-delay: ${i * 60}ms`}>
+          <article
+            class={`persona glass glass-hover reveal accent-${p.accent}`}
+            style={`transition-delay: ${Math.min(i, 8) * 50}ms`}
+          >
             <div class="tag-row">
               <div class={`tag tag-${p.accent}`}>{p.tag}</div>
               <div class="verb-mark">
@@ -81,14 +127,15 @@ const personas = [
 <style>
 .persona-grid {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 16px;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 14px;
 }
-@media (max-width: 960px) { .persona-grid { grid-template-columns: repeat(2, 1fr); } }
-@media (max-width: 600px) { .persona-grid { grid-template-columns: 1fr; } }
+@media (max-width: 1100px) { .persona-grid { grid-template-columns: repeat(3, 1fr); } }
+@media (max-width: 860px) { .persona-grid { grid-template-columns: repeat(2, 1fr); } }
+@media (max-width: 540px) { .persona-grid { grid-template-columns: 1fr; } }
 
 .persona {
-  padding: 22px;
+  padding: 20px;
   display: flex;
   flex-direction: column;
   gap: 10px;
@@ -127,19 +174,20 @@ const personas = [
 .vm-break { color: var(--color-break); }
 
 .persona h3 {
-  font-size: 16px;
+  font-size: 15px;
   font-weight: 600;
   letter-spacing: -0.01em;
+  line-height: 1.25;
 }
 .persona p {
-  font-size: 13.5px;
+  font-size: 13px;
   color: var(--color-dim);
   line-height: 1.55;
   flex: 1;
 }
 .persona p :global(code) {
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: 11.5px;
   color: var(--color-text);
   background: rgba(255, 255, 255, 0.05);
   padding: 1px 5px;
@@ -149,16 +197,16 @@ const personas = [
   background: rgba(7, 9, 13, 0.7);
   border: 1px solid rgba(255, 255, 255, 0.06);
   border-radius: 6px;
-  padding: 10px 12px;
+  padding: 9px 11px;
   font-family: var(--font-mono);
-  font-size: 11.5px;
+  font-size: 11px;
   color: var(--color-text);
   overflow-x: auto;
   margin: 0;
+  line-height: 1.4;
 }
 .persona .cmd .prompt { color: var(--color-break); margin-right: 6px; }
 
-/* Subtle accent edge per persona — left border tinted by verb color. */
 .accent-see { border-left: 2px solid rgba(94, 227, 255, 0.35); }
 .accent-control { border-left: 2px solid rgba(242, 180, 65, 0.35); }
 .accent-break { border-left: 2px solid rgba(255, 107, 92, 0.35); }

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -6,6 +6,7 @@ import Install from "../components/Install.astro";
 import Anatomy from "../components/Anatomy.astro";
 import Actions from "../components/Actions.astro";
 import UseCases from "../components/UseCases.astro";
+import Tutorials from "../components/Tutorials.astro";
 import Platforms from "../components/Platforms.astro";
 import Comparison from "../components/Comparison.astro";
 import Recipes from "../components/Recipes.astro";
@@ -19,6 +20,7 @@ import Footer from "../components/Footer.astro";
   <Anatomy />
   <Actions />
   <UseCases />
+  <Tutorials />
   <Platforms />
   <Comparison />
   <Recipes />


### PR DESCRIPTION
## Summary

Two new asks from the user, both delivered: (a) comprehensive coverage of every audience and use case, and (b) an interactive tutorial section where visitors click their scenario and get step-by-step instructions.

### TutorialPicker.vue — interactive tutorial section

A Vue island (`client:visible`) that delivers the "click your scenario" UX:

- **Left rail**: 8 scenario cards. Each carries an icon, a title, an estimated time, and the verb accent (see/control/break) it exercises.
- **Right pane**: the selected scenario's steps render with numbered markers, plain-language descriptions, copyable command blocks (each with a "copy" button), and expected output panels.
- A vertical connector line between steps signals sequence.

**The 8 scenarios cover the questions newcomers actually ask:**

1. Find what's making my program slow (see, 5 min)
2. Test how my code handles malloc failures (break, 5 min)
3. Sandbox an untrusted binary (break, 4 min)
4. See what a binary actually does (see, 3 min)
5. Make a binary think it's root (control, 2 min)
6. Find a memory leak (see, 6 min)
7. Add fuzzing to my CI pipeline (break, 10 min)
8. Trace an Android app's native code (control, 20 min)

Every step is concrete: every command is one a user can paste into a terminal, every "expected output" panel shows what they'll see if it worked. No vague "configure your environment" steps. The pane's top border is tinted by the selected scenario's verb accent.

### UseCases.astro — expanded from 6 to 12 personas

Six new personas to cover the full audience spectrum:

- **CTF player** — solve tracing challenges via `strcmp`/`write`
- **Reverse engineer** — understand closed-source binaries
- **Forensics analyst** — post-incident trace replay
- **Bug bounty hunter** — exhaust resources to find vulns
- **Mobile developer** — trace Android apps via `wrap.sh`
- **System administrator** — diagnose misbehaving services

Grid is now 4 columns on wide screens (was 3) to fit twelve cards without making the page too tall.

### Hero.astro — stronger pitch

- Secondary CTA now reads "Try a tutorial" (was "View source") — surfacing the new section from the hero.
- Added a four-stat row under the CTAs: `13 platforms · 12 actions · ~200 KB binary · 0 recompiles`. These are the four numbers that close the "is this serious?" loop in a visitor's head within the first viewport.

### Nav.astro — Tutorials link

Added "Tutorials" between "Use cases" and "Platforms" in the sticky nav.

### docs/tutorials.md — text mirror

Long-form text version of the same 8 tutorials. Each step is a header so the page is jumpable via anchor links. Reasons: search-engine indexing, offline reference, alternative for visitors who prefer reading to clicking.

### docs/README.md — index updated

Tutorials is now the first row in the "where to go next" table and appears in the documentation map.

## Test plan

- [ ] CI green on this branch.
- [ ] After merge, Pages re-deploys; visit `https://riboseinc.github.io/retrace/` and verify:
  - Hero now shows the four-stat row under the CTAs.
  - Nav has a "Tutorials" link.
  - Use Cases section shows 12 persona cards (was 6) in a 4-column grid.
  - Tutorials section appears between Use Cases and Platforms.
  - Clicking each scenario in the left rail swaps the right pane.
  - "copy" buttons on each step work (clipboard gets the command).
  - Pane's top border tint matches the selected scenario's verb color.
  - On mobile (< 860px), the rail collapses to a horizontal scrollable list above the walkthrough.
  - With `prefers-reduced-motion: reduce`, no animation regressions.
- [ ] `docs/tutorials.md` renders correctly on GitHub with anchor links.
