### PR TITLE
website: 14 tutorials + 15 personas + cookbook 21 (mock SSL verify)

### DIFF
--- a/docs/cookbook/21-mock-ssl-verify.md
+++ b/docs/cookbook/21-mock-ssl-verify.md
@@ -1,0 +1,94 @@
+# 21 — Mock OpenSSL certificate verification
+
+## Problem
+
+You're testing a client that connects to a TLS server. You want to
+verify how it handles different certificate verification outcomes
+(valid, expired, wrong host, self-signed, revoked) without standing
+up six different servers. retrace can force OpenSSL's verification
+result to any value you choose.
+
+## Config
+
+`mock-ssl-verify.json`:
+
+```json
+{
+  "intercept_scripts": [
+    {
+      "func_name": "SSL_get_verify_result",
+      "actions": [
+        { "action_name": "modify_return_value_int",
+          "action_params": { "retval_int": 10 } }
+      ]
+    }
+  ]
+}
+```
+
+`retval_int` is the X509_V_* error code. Common values:
+
+| Code | Constant                    | Meaning                                  |
+|------|-----------------------------|------------------------------------------|
+| 0    | X509_V_OK                   | Certificate is valid (success).          |
+| 2    | X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT | Issuer cert not found.            |
+| 9    | X509_V_ERR_CERT_NOT_YET_VALID | Certificate's not-before date is future. |
+| 10   | X509_V_ERR_CERT_HAS_EXPIRED | Certificate's not-after date is past.    |
+| 18   | X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT | Self-signed root in chain.     |
+| 24   | X509_V_ERR_INVALID_CA       | CA certificate is invalid.               |
+
+Without `call_real`, the real `SSL_get_verify_result` never runs —
+the caller immediately sees the synthesized code.
+
+## Invocation
+
+```sh
+$ retrace run --config docs/cookbook/mock-ssl-verify.json -- ./your-client https://example.com
+SSL_get_verify_result() → 10 (certificate has expired)
+your-client: error: certificate verification failed
+```
+
+## Variations
+
+### Test the happy path
+
+Force success even for a self-signed cert:
+
+```json
+{ "action_name": "modify_return_value_int",
+  "action_params": { "retval_int": 0 } }
+```
+
+### Mock SSL_CTX_set_verify instead
+
+Some clients install a custom verify callback via `SSL_CTX_set_verify`.
+The callback receives a `X509_STORE_CTX` pointer; mocking its return
+is more involved and may require a custom action. For most clients,
+mocking `SSL_get_verify_result` is sufficient.
+
+### BoringSSL / LibreSSL / mbed TLS
+
+retrace intercepts symbols by name. If the binary links BoringSSL,
+the same function name (`SSL_get_verify_result`) is intercepted.
+mbed TLS uses different names (`mbedtls_ssl_get_verify_result`); add
+those to the script.
+
+## How it works
+
+`SSL_get_verify_result` returns a `long` (X509_V_*). retrace's
+`modify_return_value_int` overrides it. The TLS handshake still
+completes (or fails) on its own merits; only the post-handshake
+verification code is overridden. So if the handshake itself fails
+(e.g., cipher mismatch), this mock does not help — the client never
+calls `SSL_get_verify_result`.
+
+For broader SSL mocking — including handshake-level interception —
+consider tracing `SSL_do_handshake`, `SSL_connect`, and the
+underlying `read`/`write` on the socket fd.
+
+## See also
+
+- [12 — Fail specific syscalls](12-fail-specific.md) — same pattern,
+  applied to libc functions.
+- [05 — Mock `getuid()` for root checks](05-mock-getuid.md) — same
+  pattern, applied to a different function.

--- a/docs/cookbook/README.md
+++ b/docs/cookbook/README.md
@@ -77,6 +77,7 @@ $ retrace run --config cookbook/<recipe>.json -- <your-program>
 | 18 | [Fuzz enprot's EPT parser](18-fuzz-enprot.md) | Cross-project recipe: stress-test [engyon/enprot](https://github.com/engyon/enprot) via retrace — audit file access, fuzz malloc, simulate short reads. |
 | 19 | [CI fuzzing](19-ci-fuzzing.md) | Drop-in `.github/workflows/retrace-fuzz.yml` that catches OOM + short-IO bugs on every PR. |
 | 20 | [Sandbox a binary](20-sandbox.md) | Runtime file-access deny-list: block `/etc/shadow`, `/root/.ssh/`, etc. |
+| 21 | [Mock SSL certificate verification](21-mock-ssl-verify.md) | Force `SSL_get_verify_result` to any X509_V_* code — test cert handling without standing up servers. |
 
 ## Action reference
 

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -18,6 +18,12 @@ Pick the one that matches your situation.
 6. [Find a memory leak](#6-find-a-memory-leak)
 7. [Add fuzzing to my CI pipeline](#7-add-fuzzing-to-my-ci-pipeline)
 8. [Trace an Android app's native code](#8-trace-an-android-apps-native-code)
+9. [Test how my code handles network failures](#9-test-how-my-code-handles-network-failures)
+10. [Mock the system clock for time-sensitive tests](#10-mock-the-system-clock-for-time-sensitive-tests)
+11. [Redirect a file path to somewhere else](#11-redirect-a-file-path-to-somewhere-else)
+12. [Audit what environment variables a binary reads](#12-audit-what-environment-variables-a-binary-reads)
+13. [Capture all network traffic as JSON](#13-capture-all-network-traffic-as-json)
+14. [Trace a statically-linked binary](#14-trace-a-statically-linked-binary)
 
 ---
 
@@ -381,8 +387,241 @@ Use Magisk's Zygisk module mechanism. See the
 
 ---
 
+## 9. Test how my code handles network failures
+
+**Time:** 4 minutes.
+**Goal:** force connect() to fail with ECONNREFUSED or ENETUNREACH without pulling the network cable.
+
+### Step 1 — decide which errno to inject
+
+Common POSIX network errnos:
+- ECONNREFUSED = 111
+- ENETUNREACH = 101
+- ETIMEDOUT = 110
+- EHOSTUNREACH = 113
+
+### Step 2 — write the config
+
+```sh
+cat > /tmp/netfail.json <<'EOF'
+{
+  "intercept_scripts": [
+    { "func_name": "connect",
+      "actions": [{ "action_name": "modify_return_value_int",
+        "action_params": { "retval_int": -111 } }] }
+  ]
+}
+EOF
+```
+
+### Step 3 — run your client
+
+```sh
+retrace run --config /tmp/netfail.json -- ./your-client
+# connect: Connection refused (os error 111)
+```
+
+Every outbound `connect()` returns -111 immediately. If your client
+has retry or fallback logic, this is how you exercise it without
+iptables or flaky WiFi.
+
+---
+
+## 10. Mock the system clock for time-sensitive tests
+
+**Time:** 3 minutes.
+**Goal:** freeze or shift time for testing expiry, schedules, TTLs.
+
+### Step 1 — override time()
+
+```sh
+retrace mock time 1735689600 -- ./your-program
+# (program now believes it's 2025-01-01 00:00:00 UTC)
+```
+
+### Step 2 — most programs also call gettimeofday() or clock_gettime()
+
+Mock them too:
+
+```sh
+cat > /tmp/freeze.json <<'EOF'
+{
+  "intercept_scripts": [
+    { "func_name": "time",      "actions": [{ "action_name": "modify_return_value_int", "action_params": { "retval_int": 1735689600 } }] },
+    { "func_name": "gettimeofday", "actions": [{ "action_name": "call_real" }] }
+  ]
+}
+EOF
+retrace run --config /tmp/freeze.json -- ./your-program
+```
+
+Note: `clock_gettime` writes to a struct, so fully mocking it
+requires a custom action. Mocking `time()` covers most cases.
+
+### Step 3 — verify
+
+Time-sensitive logic — token expiry, schedule triggers, rate-limit
+windows — now behaves as if it's the mocked time.
+
+---
+
+## 11. Redirect a file path to somewhere else
+
+**Time:** 3 minutes.
+**Goal:** swap `/etc/config` for `/tmp/fake` without modifying the binary or root filesystem.
+
+### Step 1 — write the redirect config
+
+```sh
+cat > /tmp/redirect.json <<'EOF'
+{
+  "intercept_scripts": [
+    { "func_name": "open",
+      "actions": [
+        { "action_name": "modify_in_param_str",
+          "action_params": { "param_name": "path", "match_str": "/etc/config", "new_str": "/tmp/fake-config" } },
+        { "action_name": "call_real" }
+      ] }
+  ]
+}
+EOF
+```
+
+### Step 2 — prepare the fake file
+
+```sh
+echo 'debug = true' > /tmp/fake-config
+```
+
+### Step 3 — run
+
+```sh
+retrace run --config /tmp/redirect.json -- ./your-program
+```
+
+Every `open("/etc/config")` is transparently redirected to
+`/tmp/fake-config`. No root, no chroot, no namespace.
+
+This is also how you A/B test config files, swap certificates, or
+feed known-bad inputs to parsers.
+
+---
+
+## 12. Audit what environment variables a binary reads
+
+**Time:** 2 minutes.
+**Goal:** map every getenv() call — catch secret leaks, config sniffing, debug backdoors.
+
+### Step 1 — trace getenv
+
+```sh
+retrace trace getenv --log /tmp/env.json -- ./your-program
+```
+
+### Step 2 — pretty-print
+
+```sh
+retrace pp /tmp/env.json
+```
+
+```
+getenv      42 calls
+  getenv(name=PATH)
+  getenv(name=HOME)
+  getenv(name=DEBUG)         ← suspicious
+  getenv(name=SECRET_TOKEN)  ← very suspicious
+```
+
+### Step 3 — triage
+
+Anything sensitive in that list is a finding. Document it; report
+it; or feed it garbage via `modify_in_param_str` to test handling.
+
+Same pattern works for `execve` (what commands does it spawn?),
+`system` (what shell does it run?), `dlopen` (what libraries does it
+load at runtime?).
+
+---
+
+## 13. Capture all network traffic as JSON
+
+**Time:** 3 minutes.
+**Goal:** log every send/recv with payload — a pcap-style stream without tcpdump or root.
+
+### Step 1 — trace network I/O
+
+```sh
+retrace trace send,sendto,recv,recvfrom --log /tmp/net.json -- ./your-server
+```
+
+### Step 2 — pretty-print
+
+```sh
+retrace pp /tmp/net.json | head -10
+```
+
+```
+sendto    248 calls   2.1 MB total
+recvfrom  247 calls   1.8 MB total
+```
+
+### Step 3 — interactive HTML view
+
+```sh
+retrace html /tmp/net.json -o /tmp/net.html && open /tmp/net.html
+```
+
+### Why this beats tcpdump sometimes
+
+- No root required.
+- Payloads are linked to the calling code.
+- You can mix in malloc/open traces for full context.
+
+---
+
+## 14. Trace a statically-linked binary
+
+**Time:** 8 minutes.
+**Goal:** LD_PRELOAD doesn't work on static binaries. Use the ptrace backend instead.
+
+### Step 1 — confirm it's static
+
+```sh
+file ./your-static-binary
+# ./your-static-binary: ELF ... statically linked
+```
+
+If it has no INTERP segment, LD_PRELOAD can't intercept it.
+
+### Step 2 — build retrace with ptrace backend
+
+```sh
+cmake -B build -DRETRACE_BACKEND_PTRACE=ON
+cmake --build build
+# build/src/backends/ptrace/libretrace_ptrace.so
+```
+
+### Step 3 — use the ptrace launcher
+
+```sh
+retrace ptrace --log /tmp/trace.json -- ./your-static-binary
+```
+
+The ptrace backend attaches to the target, sets breakpoints on libc
+entry points, and reconstructs the calls.
+
+### Caveat
+
+ptrace is slower than LD_PRELOAD (each call is a context switch).
+Reserve it for static binaries; use preload everywhere else.
+
+See `src/backends/ptrace/README.md` for the full ptrace backend
+reference.
+
+---
+
 ## See also
 
-- [Cookbook](cookbook/README.md) — 20 recipe-style walkthroughs.
+- [Cookbook](cookbook/README.md) — 21 recipe-style walkthroughs.
 - [CLI reference](cli.md) — every subcommand.
 - [Configuration reference](configuration.md) — full JSON schema.

--- a/website/src/components/TutorialPicker.vue
+++ b/website/src/components/TutorialPicker.vue
@@ -281,6 +281,210 @@ EOF`,
       },
     ],
   },
+  {
+    id: "netfail",
+    title: "Test how my code handles network failures",
+    icon: "📡",
+    accent: "break",
+    summary: "Force connect() to fail with ECONNREFUSED or ENETUNREACH — without pulling the network cable.",
+    minutes: 4,
+    steps: [
+      {
+        what: "Decide which network error to inject. Common POSIX errnos: ECONNREFUSED=111, ENETUNREACH=101, ETIMEDOUT=110, EHOSTUNREACH=113.",
+        out: "",
+      },
+      {
+        what: "Write a config that overrides connect's return value to -111 (ECONNREFUSED). Without call_real, the real connect never runs.",
+        cmd: `cat > /tmp/netfail.json <<'EOF'
+{
+  "intercept_scripts": [
+    { "func_name": "connect",
+      "actions": [{ "action_name": "modify_return_value_int",
+        "action_params": { "retval_int": -111 } }] }
+  ]
+}
+EOF`,
+        out: "",
+      },
+      {
+        what: "Run your client under the fault. Every outbound connect() returns -111 immediately.",
+        cmd: "retrace run --config /tmp/netfail.json -- ./your-client",
+        out: "connect: Connection refused (os error 111)",
+      },
+      {
+        what: "If your client has retry / fallback logic, this is how you test it without iptables or a flaky WiFi.",
+        out: "",
+      },
+      {
+        what: "To fail only specific destinations, combine with sandbox or write a custom action that inspects the sockaddr. See docs/configuration.md.",
+        out: "",
+      },
+    ],
+  },
+  {
+    id: "time",
+    title: "Mock the system clock for time-sensitive tests",
+    icon: "🕒",
+    accent: "control",
+    summary: "Freeze time, shift it, or replay a sequence — for testing expiry, schedules, and TTLs.",
+    minutes: 3,
+    steps: [
+      {
+        what: "Override time() to always return a fixed timestamp (Unix epoch seconds).",
+        cmd: `retrace mock time 1735689600 -- ./your-program
+# or, equivalently:
+echo '{"intercept_scripts":[{"func_name":"time","actions":[{"action_name":"modify_return_value_int","action_params":{"retval_int":1735689600}}]}]}' > /tmp/freeze.json
+retrace run --config /tmp/freeze.json -- ./your-program`,
+        out: "(program now believes it's 2025-01-01 00:00:00 UTC)",
+      },
+      {
+        what: "Most programs also call gettimeofday() or clock_gettime(). Mock them too:",
+        cmd: `cat > /tmp/freeze.json <<'EOF'
+{
+  "intercept_scripts": [
+    { "func_name": "time",      "actions": [{ "action_name": "modify_return_value_int", "action_params": { "retval_int": 1735689600 } }] },
+    { "func_name": "gettimeofday", "actions": [{ "action_name": "call_real" }] }
+  ]
+}
+EOF`,
+        out: "(extend as needed — clock_gettime uses a struct, which requires a custom action to fully mock)",
+      },
+      {
+        what: "Verify your time-sensitive logic: token expiry, schedule triggers, rate-limit windows.",
+        out: "(tests that depended on `sleep` now run instantly and deterministically)",
+      },
+    ],
+  },
+  {
+    id: "redirect",
+    title: "Redirect a file path to somewhere else",
+    icon: "🔀",
+    accent: "control",
+    summary: "Swap /etc/config for /tmp/fake without modifying the binary or root filesystem.",
+    minutes: 3,
+    steps: [
+      {
+        what: "Use modify_in_param_str to rewrite the path argument before open runs.",
+        cmd: `cat > /tmp/redirect.json <<'EOF'
+{
+  "intercept_scripts": [
+    { "func_name": "open",
+      "actions": [
+        { "action_name": "modify_in_param_str",
+          "action_params": { "param_name": "path", "match_str": "/etc/config", "new_str": "/tmp/fake-config" } },
+        { "action_name": "call_real" }
+      ] }
+  ]
+}
+EOF`,
+        out: "",
+      },
+      {
+        what: "Prepare the fake file at the new path.",
+        cmd: "echo 'debug = true' > /tmp/fake-config",
+        out: "",
+      },
+      {
+        what: "Run the binary. Every open(\"/etc/config\") is transparently redirected to /tmp/fake-config.",
+        cmd: "retrace run --config /tmp/redirect.json -- ./your-program",
+        out: "(binary reads your fake config — no root, no chroot, no namespace)",
+      },
+      {
+        what: "This is also how you A/B test config files, swap certificates, or feed known-bad inputs to parsers.",
+        out: "",
+      },
+    ],
+  },
+  {
+    id: "envaudit",
+    title: "Audit what environment variables a binary reads",
+    icon: "🗝️",
+    accent: "see",
+    summary: "Map every getenv() call a binary makes — catch secret leaks, config sniffing, debug backdoors.",
+    minutes: 2,
+    steps: [
+      {
+        what: "Trace getenv specifically. Each call's argument is the variable name being read.",
+        cmd: "retrace trace getenv --log /tmp/env.json -- ./your-program",
+        out: "(program runs; every getenv call is captured with its argument)",
+      },
+      {
+        what: "Pretty-print to see which variables were read, in order:",
+        cmd: "retrace pp /tmp/env.json",
+        out: "getenv      42 calls\n  getenv(name=PATH)\n  getenv(name=HOME)\n  getenv(name=LD_LIBRARY_PATH)\n  getenv(name=DEBUG)         ← suspicious\n  getenv(name=SECRET_TOKEN)  ← very suspicious\n  ...",
+      },
+      {
+        what: "Anything sensitive in that list is a finding. Document it; report it; or feed it garbage via modify_in_param_str to test handling.",
+        out: "(does the binary crash on a malformed env value? does it leak it to a log?)",
+      },
+      {
+        what: "Same pattern works for tracing execve (what commands does it spawn?), system (what shell does it run?), dlopen (what libraries does it load at runtime?).",
+        out: "",
+      },
+    ],
+  },
+  {
+    id: "traffic",
+    title: "Capture all network traffic as JSON",
+    icon: "📥",
+    accent: "see",
+    summary: "Log every send/recv with payload — a pcap-style stream without tcpdump or root.",
+    minutes: 3,
+    steps: [
+      {
+        what: "Trace send, sendto, recv, recvfrom, write (for sockets), read (for sockets).",
+        cmd: "retrace trace send,sendto,recv,recvfrom --log /tmp/net.json -- ./your-server",
+        out: "(server runs; every network I/O is captured)",
+      },
+      {
+        what: "Pretty-print to see per-call summaries:",
+        cmd: "retrace pp /tmp/net.json | head -10",
+        out: "sendto    248 calls   2.1 MB total\nrecvfrom  247 calls   1.8 MB total\n...",
+      },
+      {
+        what: "For full payloads, generate an interactive HTML view and filter by function:",
+        cmd: "retrace html /tmp/net.json -o /tmp/net.html && open /tmp/net.html",
+        out: "(browser opens; click any row to see args including buffer addresses)",
+      },
+      {
+        what: "Compare to tcpdump: no root required, payloads are linked to the calling code, and you can mix in malloc/open traces for full context.",
+        out: "",
+      },
+    ],
+  },
+  {
+    id: "static",
+    title: "Trace a statically-linked binary",
+    icon: "🧱",
+    accent: "see",
+    summary: "LD_PRELOAD doesn't work on static binaries. Use the ptrace backend instead.",
+    minutes: 8,
+    steps: [
+      {
+        what: "Confirm the binary is statically linked. If it has no INTERP segment, LD_PRELOAD can't intercept it.",
+        cmd: "file ./your-static-binary\n# ./your-static-binary: ELF ... statically linked",
+        out: "",
+      },
+      {
+        what: "Build retrace with the ptrace backend enabled.",
+        cmd: "cmake -B build -DRETRACE_BACKEND_PTRACE=ON\ncmake --build build",
+        out: "build/src/backends/ptrace/libretrace_ptrace.so",
+      },
+      {
+        what: "Use the ptrace launcher. It attaches to the target, sets breakpoints on libc entry points, and reconstructs the calls.",
+        cmd: "retrace ptrace --log /tmp/trace.json -- ./your-static-binary",
+        out: "(binary runs; libc calls captured via ptrace)",
+      },
+      {
+        what: "Caveat: ptrace is slower than LD_PRELOAD (each call is a context switch). Reserve it for static binaries; use preload everywhere else.",
+        out: "",
+      },
+      {
+        what: "See src/backends/ptrace/README.md for the full ptrace backend reference.",
+        out: "",
+      },
+    ],
+  },
 ];
 
 const selectedId = ref(scenarios[0].id);

--- a/website/src/components/Tutorials.astro
+++ b/website/src/components/Tutorials.astro
@@ -9,8 +9,9 @@ import TutorialPicker from "./TutorialPicker.vue";
       <h2>Pick your scenario. We'll walk you through it.</h2>
       <p>
         Every newcomer's question is the same: <em>"I have this problem — how do I use retrace to solve it?"</em>
-        Click your scenario on the left; the steps appear on the right with copy-paste commands and expected
-        output. No prior retrace knowledge assumed.
+        Fourteen scenarios below cover the questions users actually ask. Click yours on the left; the
+        steps appear on the right with copy-paste commands and expected output. No prior retrace
+        knowledge assumed.
       </p>
     </div>
 
@@ -20,7 +21,7 @@ import TutorialPicker from "./TutorialPicker.vue";
 
     <p class="more-link reveal">
       Looking for something else? The <a href="https://github.com/riboseinc/retrace/blob/main/docs/cookbook/README.md">cookbook</a>
-      has 20 more recipe-style walkthroughs — each is a single JSON config plus the command to run it.
+      has 21 more recipe-style walkthroughs — each is a single JSON config plus the command to run it.
     </p>
   </div>
 </section>

--- a/website/src/components/UseCases.astro
+++ b/website/src/components/UseCases.astro
@@ -86,6 +86,27 @@ const personas = [
     what: "Diagnose why a service is misbehaving without restarting it. Trace a single command's libc activity to see what's really being read, written, connected to.",
     cmd: "retrace trace --html -- $(which dig) example.com",
   },
+  {
+    tag: "crypto",
+    accent: "control",
+    who: "Cryptography auditor",
+    what: "Verify a binary uses the right crypto primitives. Trace <code>RAND_bytes</code>, <code>EVP_DigestInit</code>, <code>SSL_CTX_set_verify</code> — see every algorithm and parameter.",
+    cmd: "retrace trace RAND_bytes,EVP_* -- ./crypto-app",
+  },
+  {
+    tag: "embedded",
+    accent: "break",
+    who: "Embedded developer",
+    what: "Stress-test firmware error paths. Inject short reads on flash, ENOSPC on write, timeouts on i2c-sysfs — without desoldering a thing.",
+    cmd: "retrace run --config incomplete-io.json -- ./firmware-test",
+  },
+  {
+    tag: "lib author",
+    accent: "see",
+    who: "Library author",
+    what: "Confirm your library's ABI surface in practice. Trace which functions downstream callers actually invoke, with what arguments, and how often.",
+    cmd: "retrace trace 'mylib_*' -- ./downstream-app",
+  },
 ];
 ---
 
@@ -93,7 +114,7 @@ const personas = [
   <div class="wrap">
     <div class="section-head reveal">
       <div class="eyebrow">Who uses retrace</div>
-      <h2>Twelve jobs. One shared library.</h2>
+      <h2>Fifteen jobs. One shared library.</h2>
       <p>
         retrace is small enough to slip into a one-off debugging session, generic enough to anchor a
         CI fuzzing pipeline, principled enough to back a security audit. Below: every audience that


### PR DESCRIPTION
## Summary

Two clear gaps from the previous pass, both closed: (1) the tutorial picker had 8 scenarios but at least six more high-frequency questions go unanswered; (2) the personas grid could absorb three more distinct audiences without diluting. Plus a new cookbook recipe that comes up frequently in security audits.

### TutorialPicker.vue — 8 → 14 scenarios

Six new tutorials cover the questions users actually ask after the first 30 seconds:

9. **Test how my code handles network failures** (break, 4 min) — force `connect()` to fail with `ECONNREFUSED`/`ENETUNREACH`.
10. **Mock the system clock for time-sensitive tests** (control, 3 min) — override `time()` / `gettimeofday()` for token-expiry and schedule tests.
11. **Redirect a file path to somewhere else** (control, 3 min) — swap `/etc/config` for `/tmp/fake` without chroot.
12. **Audit what environment variables a binary reads** (see, 2 min) — map every `getenv()` call; find secret leaks.
13. **Capture all network traffic as JSON** (see, 3 min) — pcap-style send/recv logging without root.
14. **Trace a statically-linked binary** (see, 8 min) — LD_PRELOAD can't reach static binaries; use the ptrace backend.

All six carry the same structure: numbered steps, plain-language descriptions, copyable command blocks, expected output panels. Pane top-border tint matches the scenario's verb accent.

### UseCases.astro — 12 → 15 personas

Three new personas:

- **Cryptography auditor** — verify `RAND_bytes`, `EVP_*`, `SSL_CTX_set_verify`.
- **Embedded developer** — inject short reads on flash, ENOSPC on write.
- **Library author** — confirm your library's ABI surface in practice.

Grid remains 4 columns wide. Section headline updated from "Twelve jobs" to "Fifteen jobs."

### Tutorials.astro copy

Section description now reads "Fourteen scenarios below cover the questions users actually ask" instead of the vague "Click your scenario." The "more recipes" footer pointer now references 21 cookbook recipes (was 20).

### docs/tutorials.md — text mirror extended

All 14 scenarios, each with a step-by-step walkthrough identical to the interactive picker. Header numbering goes 1–14; TOC at the top has anchor links to each.

### docs/cookbook/21-mock-ssl-verify.md — new recipe

Frequent security-audit ask: "how do I test how my client handles different cert verification outcomes without standing up six TLS servers?" This recipe shows the answer — `modify_return_value_int` applied to `SSL_get_verify_result` with the X509_V_* code table (0=OK, 9=NOT_YET_VALID, 10=EXPIRED, 18=SELF_SIGNED, 24=INVALID_CA).

Includes three variations (happy path, `SSL_CTX_set_verify` alt, BoringSSL/mbed TLS symbol-name notes) and the caveat that handshake-level failures are not covered by this mock.

### docs/cookbook/README.md

Recipe index extended with row 21. Action reference unchanged.

## Test plan

- [ ] CI green on this branch.
- [ ] After merge, Pages re-deploys; visit `https://riboseinc.github.io/retrace/#tutorials` and verify:
  - All 14 scenario cards appear in the left rail.
  - Clicking each scenario swaps the right pane to its steps.
  - Use Cases section shows 15 persona cards in a 4-column grid.
  - "Fifteen jobs" headline replaces "Twelve jobs."
  - Tutorials section header reads "Fourteen scenarios."
- [ ] Spot-check `docs/cookbook/21-mock-ssl-verify.md` and `docs/tutorials.md` for markdown rendering on GitHub.
