### PR TITLE
website: Why section + SEO (sitemap, OG, JSON-LD, favicon)

### DIFF
--- a/website/public/favicon.svg
+++ b/website/public/favicon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- retrace favicon — three verb dots in a row. -->
+  <rect width="32" height="32" rx="6" fill="#07090d"/>
+  <circle cx="8" cy="16" r="3" fill="#5ee3ff"/>
+  <circle cx="16" cy="16" r="3" fill="#f2b441"/>
+  <circle cx="24" cy="16" r="3" fill="#ff6b5c"/>
+</svg>

--- a/website/public/og-image.svg
+++ b/website/public/og-image.svg
@@ -1,0 +1,94 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <!--
+    Open Graph / Twitter card image for retrace.
+    Deep ink background, three drifting verb-colored orbs (static
+    approximation since OG crawlers don't run animations), the
+    wordmark, and the three-verb headline.
+  -->
+  <defs>
+    <radialGradient id="seeGrad" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#5ee3ff" stop-opacity="0.4"/>
+      <stop offset="100%" stop-color="#5ee3ff" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="ctrlGrad" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#f2b441" stop-opacity="0.3"/>
+      <stop offset="100%" stop-color="#f2b441" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="breakGrad" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#ff6b5c" stop-opacity="0.3"/>
+      <stop offset="100%" stop-color="#ff6b5c" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="bgGrad" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#0b0d12"/>
+      <stop offset="100%" stop-color="#07090d"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="1200" height="630" fill="url(#bgGrad)"/>
+
+  <!-- Orbs -->
+  <circle cx="200" cy="120" r="320" fill="url(#seeGrad)"/>
+  <circle cx="1000" cy="540" r="380" fill="url(#ctrlGrad)"/>
+  <circle cx="700" cy="280" r="280" fill="url(#breakGrad)"/>
+
+  <!-- Wordmark -->
+  <g transform="translate(80, 90)">
+    <circle cx="14" cy="22" r="9" fill="#5ee3ff"/>
+    <text x="36" y="32" font-family="ui-monospace, SF Mono, Menlo, monospace"
+          font-size="32" font-weight="700" fill="#e8ecf1" letter-spacing="-0.02em">
+      retrace
+    </text>
+    <text x="36" y="62" font-family="ui-monospace, SF Mono, Menlo, monospace"
+          font-size="14" fill="#7e8694" letter-spacing="0.1em">
+      USERSPACE LIBC INTERCEPTOR
+    </text>
+  </g>
+
+  <!-- Three-verb headline -->
+  <g transform="translate(80, 240)">
+    <text x="0" y="0" font-family="ui-monospace, SF Mono, Menlo, monospace"
+          font-size="96" font-weight="700" fill="#5ee3ff" letter-spacing="-0.03em">
+      see
+    </text>
+    <circle cx="270" cy="-20" r="10" fill="#5ee3ff"/>
+
+    <text x="320" y="0" font-family="ui-monospace, SF Mono, Menlo, monospace"
+          font-size="96" font-weight="700" fill="#f2b441" letter-spacing="-0.03em">
+      control
+    </text>
+    <circle cx="730" cy="-20" r="10" fill="#f2b441"/>
+
+    <text x="780" y="0" font-family="ui-monospace, SF Mono, Menlo, monospace"
+          font-size="96" font-weight="700" fill="#ff6b5c" letter-spacing="-0.03em">
+      break
+    </text>
+    <circle cx="1060" cy="-20" r="10" fill="#ff6b5c"/>
+  </g>
+
+  <!-- Tagline -->
+  <text x="80" y="380" font-family="-apple-system, BlinkMacSystemFont, Segoe UI, system-ui, sans-serif"
+        font-size="32" font-weight="500" fill="#e8ecf1">
+    Every libc call. Your decision.
+  </text>
+
+  <!-- Stats row -->
+  <g transform="translate(80, 470)" font-family="ui-monospace, SF Mono, Menlo, monospace">
+    <text x="0" y="0" font-size="36" font-weight="700" fill="#e8ecf1">13</text>
+    <text x="0" y="28" font-size="12" fill="#7e8694" letter-spacing="0.16em">PLATFORMS</text>
+
+    <text x="200" y="0" font-size="36" font-weight="700" fill="#e8ecf1">12</text>
+    <text x="200" y="28" font-size="12" fill="#7e8694" letter-spacing="0.16em">ACTIONS</text>
+
+    <text x="380" y="0" font-size="36" font-weight="700" fill="#e8ecf1">~200 KB</text>
+    <text x="380" y="28" font-size="12" fill="#7e8694" letter-spacing="0.16em">BINARY</text>
+
+    <text x="620" y="0" font-size="36" font-weight="700" fill="#e8ecf1">0</text>
+    <text x="620" y="28" font-size="12" fill="#7e8694" letter-spacing="0.16em">RECOMPILES</text>
+  </g>
+
+  <!-- Install hint -->
+  <text x="80" y="580" font-family="ui-monospace, SF Mono, Menlo, monospace"
+        font-size="14" fill="#7e8694">
+    riboseinc.github.io/retrace
+  </text>
+</svg>

--- a/website/public/robots.txt
+++ b/website/public/robots.txt
@@ -1,0 +1,7 @@
+# retrace robots
+# Site: https://riboseinc.github.io/retrace/
+
+User-agent: *
+Allow: /
+
+Sitemap: https://riboseinc.github.io/retrace/sitemap.xml

--- a/website/public/sitemap.xml
+++ b/website/public/sitemap.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://riboseinc.github.io/retrace/</loc>
+    <lastmod>2026-08-02</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>

--- a/website/src/components/Why.astro
+++ b/website/src/components/Why.astro
@@ -1,0 +1,167 @@
+---
+// Why retrace — the problem statement. Sits between Hero and Install
+// to anchor the pitch: existing tools each do part of the job; retrace
+// is the only one that does all three on any binary.
+
+const competitors = [
+  {
+    name: "strace",
+    oneLiner: "Tells you what happened.",
+    gap: "Cannot modify arguments, override returns, or inject failures. Observe-only.",
+    accent: "see",
+  },
+  {
+    name: "Frida",
+    oneLiner: "Lets you script it.",
+    gap: "Requires JavaScript. 40 MB runtime. Heavyweight for simple interception.",
+    accent: "control",
+  },
+  {
+    name: "libFuzzer",
+    oneLiner: "Finds bugs in your own code.",
+    gap: "Requires source and recompilation. Cannot target binaries you didn't build.",
+    accent: "break",
+  },
+];
+---
+
+<section class="section why" id="why">
+  <div class="wrap">
+    <div class="section-head reveal">
+      <div class="eyebrow">Why retrace exists</div>
+      <h2>Every existing tool does part of the job. None does all of it.</h2>
+      <p>
+        strace observes. Frida mutates. libFuzzer fuzzes. Each is excellent at its verb and silent
+        on the other two. retrace is the first tool that does all three — observe, mutate, break —
+        on any dynamically-linked binary, without source, without recompiling, on thirteen platforms.
+      </p>
+    </div>
+
+    <div class="why-grid">
+      {
+        competitors.map((c, i) => (
+          <article class={`why-card glass-tight reveal accent-${c.accent}`} style={`transition-delay: ${i * 80}ms`}>
+            <div class={`why-tag tag-${c.accent}`}>{c.name}</div>
+            <p class="why-liner">{c.oneLiner}</p>
+            <p class="why-gap">{c.gap}</p>
+          </article>
+        ))
+      }
+    </div>
+
+    <div class="why-synthesis glass reveal">
+      <div class="syn-label">retrace</div>
+      <div class="syn-line">
+        <span class="syn-verb v-see">see</span>
+        <span class="syn-plus">+</span>
+        <span class="syn-verb v-control">control</span>
+        <span class="syn-plus">+</span>
+        <span class="syn-verb v-break">break</span>
+        <span class="syn-eq">=</span>
+        <span class="syn-result">every libc call, your decision</span>
+      </div>
+      <p class="syn-note">
+        One ~200 KB shared library. Twelve built-in actions. JSON config you can write in five
+        minutes. Runs on the binary you already have.
+      </p>
+    </div>
+  </div>
+</section>
+
+<style>
+.why-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 14px;
+  margin-bottom: 18px;
+}
+@media (max-width: 860px) {
+  .why-grid { grid-template-columns: 1fr; }
+}
+
+.why-card {
+  padding: 22px 22px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.why-tag {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  padding: 4px 10px;
+  border-radius: 3px;
+  align-self: flex-start;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+.why-tag.tag-see { color: var(--color-see); border-color: rgba(94, 227, 255, 0.25); }
+.why-tag.tag-control { color: var(--color-control); border-color: rgba(242, 180, 65, 0.25); }
+.why-tag.tag-break { color: var(--color-break); border-color: rgba(255, 107, 92, 0.25); }
+
+.why-liner {
+  font-size: 16px;
+  font-weight: 500;
+  color: var(--color-text);
+  letter-spacing: -0.005em;
+  line-height: 1.3;
+}
+.why-gap {
+  font-size: 13.5px;
+  color: var(--color-dim);
+  line-height: 1.55;
+  flex: 1;
+}
+
+.why-card.accent-see { border-left: 2px solid rgba(94, 227, 255, 0.35); }
+.why-card.accent-control { border-left: 2px solid rgba(242, 180, 65, 0.35); }
+.why-card.accent-break { border-left: 2px solid rgba(255, 107, 92, 0.35); }
+
+.why-synthesis {
+  margin-top: 8px;
+  padding: 28px 30px;
+  text-align: center;
+}
+.syn-label {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--color-dim);
+  margin-bottom: 16px;
+}
+.syn-line {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: center;
+  gap: 14px;
+  font-family: var(--font-mono);
+  font-size: clamp(20px, 3vw, 28px);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+.syn-verb { font-weight: 700; }
+.v-see { color: var(--color-see); }
+.v-control { color: var(--color-control); }
+.v-break { color: var(--color-break); }
+.syn-plus, .syn-eq { color: var(--color-dim); font-weight: 400; }
+.syn-result {
+  color: var(--color-text);
+  font-family: var(--font-sans);
+  font-size: clamp(15px, 2vw, 18px);
+  font-weight: 500;
+  letter-spacing: -0.005em;
+}
+.syn-note {
+  margin-top: 18px;
+  font-size: 13.5px;
+  color: var(--color-dim);
+  line-height: 1.55;
+  max-width: 580px;
+  margin-left: auto;
+  margin-right: auto;
+}
+</style>

--- a/website/src/layouts/Layout.astro
+++ b/website/src/layouts/Layout.astro
@@ -10,6 +10,9 @@ const {
   title = "retrace — See. Control. Break. Every libc call.",
   description = "A userspace libc interceptor. Observe, modify, and break any libc call — without source, without recompiling, on thirteen platforms. One shared library.",
 } = Astro.props;
+
+const site = "https://riboseinc.github.io/retrace";
+const ogImage = `${site}/og-image.svg`;
 ---
 
 <!doctype html>
@@ -20,7 +23,78 @@ const {
     <title>{title}</title>
     <meta name="description" content={description} />
     <meta name="generator" content={Astro.generator} />
-    <link rel="icon" href="data:," />
+
+    {/* Favicon — inline SVG dot matching the brand wordmark */}
+    <link rel="icon" type="image/svg+xml" href="/retrace/favicon.svg" />
+    <link rel="apple-touch-icon" href="/retrace/favicon.svg" />
+
+    {/* Canonical */}
+    <link rel="canonical" href={site} />
+
+    {/* Open Graph */}
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="retrace" />
+    <meta property="og:title" content={title} />
+    <meta property="og:description" content={description} />
+    <meta property="og:url" content={site} />
+    <meta property="og:image" content={ogImage} />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="retrace — See. Control. Break. Every libc call." />
+
+    {/* Twitter / X */}
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content={title} />
+    <meta name="twitter:description" content={description} />
+    <meta name="twitter:image" content={ogImage} />
+    <meta name="twitter:image:alt" content="retrace — See. Control. Break." />
+    <meta name="twitter:site" content="@riboseinc" />
+
+    {/* Theme color */}
+    <meta name="theme-color" content="#07090d" />
+    <meta name="color-scheme" content="dark" />
+
+    {/* Sitemap */}
+    <link rel="sitemap" type="application/xml" href="/retrace/sitemap.xml" />
+
+    {/* Structured data — SoftwareApplication per schema.org */}
+    <script
+      type="application/ld+json"
+      set:html={JSON.stringify({
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        name: "retrace",
+        applicationCategory: "DeveloperApplication",
+        operatingSystem: "Linux, macOS, Windows, FreeBSD, OpenBSD, NetBSD, Android",
+        url: site,
+        downloadUrl: "https://github.com/riboseinc/retrace/releases",
+        description,
+        softwareVersion: "2.1.0",
+        license: "https://opensource.org/licenses/BSD-2-Clause",
+        offers: {
+          "@type": "Offer",
+          price: "0",
+          priceCurrency: "USD",
+        },
+        publisher: {
+          "@type": "Organization",
+          name: "Ribose",
+          url: "https://www.ribose.com",
+        },
+        featureList: [
+          "log_params — observe libc calls as JSON",
+          "call_real — invoke real libc implementation",
+          "modify_in_param_str/int/arr — rewrite arguments",
+          "modify_return_value_int — override return values",
+          "memory_fuzz — random OOM injection",
+          "incomplete_io — short read/write injection",
+          "delay — latency injection",
+          "call_count_limit — resource exhaustion simulation",
+          "sandbox — runtime path deny-list",
+          "fuzzing_seed — deterministic RNG for reproducibility",
+        ],
+      })}
+    />
   </head>
   <body>
     <div class="orb-bg" aria-hidden="true">

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -2,6 +2,7 @@
 import Layout from "../layouts/Layout.astro";
 import Nav from "../components/Nav.astro";
 import Hero from "../components/Hero.astro";
+import Why from "../components/Why.astro";
 import Install from "../components/Install.astro";
 import PlaygroundSection from "../components/PlaygroundSection.astro";
 import Anatomy from "../components/Anatomy.astro";
@@ -18,6 +19,7 @@ import Footer from "../components/Footer.astro";
 <Layout>
   <Nav />
   <Hero />
+  <Why />
   <Install />
   <PlaygroundSection />
   <Anatomy />


### PR DESCRIPTION
## Summary

Two production-readiness gaps closed: (1) the pitch jumped straight from hero verbs to install without framing the problem retrace solves; (2) the site was invisible to search engines and shared without a preview card.

### Why.astro — the missing problem statement

New section between Hero and Install. Three competitor cards (**strace**, **Frida**, **libFuzzer**) each get a one-line summary ("tells you what happened", "lets you script it", "finds bugs in your own code") plus the gap that disqualifies them from doing all three jobs.

Below the cards: a synthesis glass card with the equation `see + control + break = every libc call, your decision`. The three verbs are colored per the page palette; the result line states the unique value prop in plain English.

This anchors the rest of the page. Before this, visitors had to infer the positioning from the comparison table buried below the fold. Now the positioning is established before they hit install.

### SEO infrastructure

The site had no search-engine metadata. Now it has:

- **`public/robots.txt`** — allows all crawlers, points to sitemap.
- **`public/sitemap.xml`** — single URL (the landing page), weekly changefreq, priority 1.0.
- **`public/favicon.svg`** — three verb-colored dots in a row on the deep-ink background. Matches the brand wordmark's dot.
- **`public/og-image.svg`** — 1200×630 SVG with the wordmark, the three-verb headline in mono at 96px, the "Every libc call. Your decision." tagline, and the 4-stat row. Static approximation of the orb background (crawlers don't run animations).

**`Layout.astro`** now sets:

- `<link rel="canonical">`
- Open Graph tags: `type`, `site_name`, `title`, `description`, `url`, `image` (with width/height/alt).
- Twitter card: `summary_large_image`, matching title/description/image, `site=@riboseinc`.
- `<meta name="theme-color" content="#07090d">`
- `<meta name="color-scheme" content="dark">`
- `<link rel="sitemap" type="application/xml">`
- **JSON-LD `SoftwareApplication`** structured data: name, category, operating systems, version, license, offers (free), publisher (Ribose), featureList (the 10 main actions).

The JSON-LD block makes the page eligible for rich search results and AI assistants that consult schema.org metadata.

All paths use the `/retrace/` base path configured in `astro.config.mjs` so they work correctly when deployed to GitHub Pages at `riboseinc.github.io/retrace/`.

### Page wiring

`index.astro` updated: Hero → **Why** → Install → Playground → Anatomy → Actions → UseCases → Tutorials → Platforms → Comparison → Recipes → FAQ → Footer.

## Test plan

- [ ] CI green on this branch.
- [ ] After merge, Pages re-deploys; verify:
  - Why section appears between Hero and Install. Three competitor cards (strace/Frida/libFuzzer) render with their gaps.
  - Synthesis line: `see + control + break = every libc call, your decision` with each verb in its semantic color.
  - `https://riboseinc.github.io/retrace/favicon.svg` returns the SVG.
  - `https://riboseinc.github.io/retrace/og-image.svg` returns the SVG.
  - `https://riboseinc.github.io/retrace/robots.txt` returns the robots file.
  - `https://riboseinc.github.io/retrace/sitemap.xml` returns the XML.
  - View source on the landing page: confirm og:image, twitter:card, theme-color, color-scheme, canonical, and JSON-LD SoftwareApplication schema are all present in <head>.
  - Paste the URL into the Slack/iMessage composer: confirm the OG image preview renders with the three-verb headline.
  - Browser tab shows the favicon (three colored dots).
