### PR TITLE
website: 3 more tutorials (21), 3 more personas (22), Trust section

### DIFF
--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -28,6 +28,9 @@ Pick the one that matches your situation.
 16. [Verify a binary makes no outbound network calls](#16-verify-a-binary-makes-no-outbound-network-calls)
 17. [Generate a flamegraph of libc calls](#17-generate-a-flamegraph-of-libc-calls)
 18. [Profile lock contention](#18-profile-lock-contention)
+19. [Write a custom action](#19-write-a-custom-action)
+20. [Debug a production issue (safely)](#20-debug-a-production-issue-safely)
+21. [Integrate retrace into your build](#21-integrate-retrace-into-your-build)
 
 ---
 
@@ -776,6 +779,151 @@ Compare to total wall time to decide if it's worth fixing.
 
 For which call site is contended, pair with a debugger or use the
 return-address routing pattern (cookbook recipe 17, planned).
+
+---
+
+## 19. Write a custom action
+
+**Time:** 25 minutes.
+**Goal:** extend retrace with your own action — a single .c file that registers itself.
+
+### Step 1 — actions live in `src/core/actions/`
+
+Each action is a `.c` file that defines a `struct RetraceAction` and
+registers via the `RETRACE_ACTION_REGISTER` macro. Existing actions
+to read first:
+
+- `basic.c` — `log_params`, `call_real`, `modify_in_*`, `modify_return_value_int`
+- `memfuzz.c` — `memory_fuzz`
+- `incomplete_io.c` — `incomplete_io`
+- `delay.c`, `call_count_limit.c`, `sandbox.c`, `fuzzing_seed.c`
+
+### Step 2 — pick a template
+
+The interface you implement is per-action: parse your JSON params,
+decide whether to mutate the call, set the return value.
+
+### Step 3 — drop your file in
+
+```sh
+ls src/core/actions/
+# add your heuristic_action.c alongside the others
+```
+
+The build system auto-includes the directory.
+
+### Step 4 — build and run
+
+```sh
+cmake --build build
+retrace run --config your-config.json -- ./your-target
+```
+
+Your action is now first-class: it shows up in `retrace list-actions`
+and can be referenced in any JSON config.
+
+### Step 5 — for the full interface definition
+
+See `include/retrace/retrace_action.h` and the existing actions in
+`src/core/actions/`.
+
+---
+
+## 20. Debug a production issue (safely)
+
+**Time:** 15 minutes.
+**Goal:** capture a production trace without restarting or modifying the binary — only the path you care about.
+
+### Step 1 — restrict to suspects
+
+Logging everything in production is overkill. Restrict to the
+functions relevant to the incident.
+
+```sh
+RETRACE_LOGGER_ALLOWED_FUNCS=open,openat,read,write,connect,recv,send
+```
+
+### Step 2 — limit the trace window
+
+A 60-second slice is enough to catch a slow path; a full hour is
+enough to fill a disk.
+
+```sh
+timeout 60 retrace trace --log /tmp/incident.json -- ./your-service &
+PID=$!
+# ... wait, gather data, then:
+wait $PID
+```
+
+### Step 3 — scrub before persisting
+
+The log may contain PII, secrets, or sensitive paths. Grep out
+known-sensitive patterns before sharing.
+
+```sh
+grep -v 'SECRET\|password\|/etc/shadow' /tmp/incident.json > /tmp/incident-scrubbed.json
+```
+
+### Step 4 — analyze locally
+
+```sh
+retrace html /tmp/incident-scrubbed.json -o /tmp/postmortem.html && open /tmp/postmortem.html
+```
+
+Interactive page: filter by function, sort by duration, find the
+outlier.
+
+### Step 5 — the critical safety step
+
+Never set `RETRACE_LOGGER_DEF_ENA=1` with write access to the log
+file from the same user as the target. Stash everything in a
+directory only root can read.
+
+---
+
+## 21. Integrate retrace into your build
+
+**Time:** 20 minutes.
+**Goal:** run the test suite under retrace-fault-injection on every CI build. Catch error-path bugs before users do.
+
+### Step 1 — add a `fuzz-test` target
+
+```make
+# Makefile
+fuzz-test: tests
+    LD_PRELOAD=$$RETRACE_LIB retrace fuzz malloc --rate 0.05 \
+      --log test-output/fuzz.json -- ./run-tests
+```
+
+### Step 2 — or in CMake
+
+```cmake
+add_custom_target(fuzz-test
+    COMMAND $<TARGET_FILE:run-tests>
+    ENVIRONMENT LD_PRELOAD=$<TARGET_FILE:libretrace.so>
+    COMMAND retrace fuzz malloc --rate 0.05
+    USES_TERMINAL)
+add_dependencies(fuzz-test run-tests)
+```
+
+### Step 3 — try it locally first
+
+```sh
+make fuzz-test
+```
+
+Either the tests pass cleanly (good — your code handles OOM), or
+they crash (that's the bug you wanted to catch).
+
+### Step 4 — wire it into CI
+
+See the `retrace-fuzz.yml` workflow in [cookbook recipe 19](cookbook/19-ci-fuzzing.md)
+— a drop-in GitHub Actions workflow that runs on every PR.
+
+### Step 5 — when CI fuzz fails
+
+The seed is captured in the log. Replay locally with the fixed seed
+to debug.
 
 ---
 

--- a/website/src/components/Trust.astro
+++ b/website/src/components/Trust.astro
@@ -1,0 +1,128 @@
+---
+// Trust section — the "is this safe to run?" receipts block sceptical
+// visitors look for between the pitch and the install. Single glass
+// card with a row of receipt-style items.
+
+const items = [
+  {
+    label: "License",
+    value: "BSD-2-Clause",
+    note: "No copyleft. Use in commercial, academic, and proprietary code.",
+    accent: "see",
+  },
+  {
+    label: "Telemetry",
+    value: "None",
+    note: "No network calls, no phone-home, no usage data. The library doesn't even depend on a network stack.",
+    accent: "control",
+  },
+  {
+    label: "Dependencies",
+    value: "Zero at runtime",
+    note: "Links only against the platform's libc. No third-party C libraries. No JavaScript runtime. No Python.",
+    accent: "see",
+  },
+  {
+    label: "Code of conduct",
+    value: "Ribose community",
+    note: "Same standard Ribose applies to its open-source projects: respectful, technical, no jerks.",
+    accent: "control",
+  },
+  {
+    label: "Maintainer",
+    value: "Ribose",
+    note: "Open-source subsidiary of Ribose, an ISO/IEC 27001 + 27701 certified company. Active since 2017.",
+    accent: "see",
+  },
+  {
+    label: "CVE status",
+    value: "None reported",
+    note: "No known security vulnerabilities in retrace itself. Tracked via GitHub Security Advisories.",
+    accent: "control",
+  },
+];
+---
+
+<section class="section trust" id="trust">
+  <div class="wrap">
+    <div class="section-head reveal">
+      <div class="eyebrow">Trust</div>
+      <h2>The receipts. Read them before you install.</h2>
+      <p>
+        retrace preloads a shared library into the target process. That's the same mechanism that
+        malware uses to inject code. You should be skeptical. Here's what we have to say about it.
+      </p>
+    </div>
+
+    <div class="trust-grid glass reveal">
+      {
+        items.map((it, i) => (
+          <div class={`trust-item accent-${it.accent}`}>
+            <div class="trust-label">{it.label}</div>
+            <div class="trust-value">{it.value}</div>
+            <div class="trust-note">{it.note}</div>
+          </div>
+        ))
+      }
+    </div>
+  </div>
+</section>
+
+<style>
+.trust-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0;
+  padding: 0;
+  overflow: hidden;
+}
+@media (max-width: 960px) { .trust-grid { grid-template-columns: repeat(2, 1fr); } }
+@media (max-width: 540px) { .trust-grid { grid-template-columns: 1fr; } }
+
+.trust-item {
+  padding: 22px 24px;
+  border-right: 1px solid rgba(255, 255, 255, 0.05);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+}
+.trust-item:nth-child(3n) { border-right: none; }
+.trust-item:nth-last-child(-n+3) { border-bottom: none; }
+@media (max-width: 960px) {
+  .trust-item:nth-child(3n) { border-right: 1px solid rgba(255, 255, 255, 0.05); }
+  .trust-item:nth-child(2n) { border-right: none; }
+  .trust-item:nth-last-child(-n+3) { border-bottom: 1px solid rgba(255, 255, 255, 0.05); }
+  .trust-item:nth-last-child(-n+2) { border-bottom: none; }
+  .trust-item:nth-child(2n+1):nth-last-child(2) { border-bottom: none; }
+}
+@media (max-width: 540px) {
+  .trust-item { border-right: none !important; }
+  .trust-item:nth-child(3n) { border-right: none; }
+  .trust-item:not(:last-child) { border-bottom: 1px solid rgba(255, 255, 255, 0.05); }
+}
+
+.trust-label {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--color-dim);
+  margin-bottom: 8px;
+}
+.trust-value {
+  font-family: var(--font-mono);
+  font-size: 18px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  letter-spacing: -0.01em;
+  margin-bottom: 8px;
+  line-height: 1.2;
+}
+.trust-item.accent-see .trust-value { color: var(--color-see); }
+.trust-item.accent-control .trust-value { color: var(--color-control); }
+.trust-item.accent-break .trust-value { color: var(--color-break); }
+.trust-note {
+  font-size: 13px;
+  color: var(--color-dim);
+  line-height: 1.5;
+}
+</style>

--- a/website/src/components/TutorialPicker.vue
+++ b/website/src/components/TutorialPicker.vue
@@ -22,9 +22,13 @@ const TAGS = {
   airgap:    ["security"],
   flamegraph:["performance", "debug"],
   locks:     ["performance", "debug"],
+  custom:    ["extend", "ci"],
+  prod:      ["debug", "production"],
+  build:     ["ci", "test", "fault"],
 };
 
-// Tag display metadata: label + accent color.
+// Register tags that aren't auto-derived from scenarios (extend doesn't
+// appear in any scenario's TAGS list otherwise).
 const TAG_META = {
   debug:       { label: "Debugging",       accent: "see" },
   test:        { label: "Testing",         accent: "control" },
@@ -36,6 +40,7 @@ const TAG_META = {
   production:  { label: "Production-safe", accent: "see" },
   ci:          { label: "CI/CD",           accent: "break" },
   reverse:     { label: "Reverse eng.",    accent: "see" },
+  extend:      { label: "Extend",          accent: "control" },
 };
 
 // Each scenario is a clickable card. Selecting one reveals the
@@ -636,6 +641,105 @@ EOF`,
       },
       {
         what: "For finer detail (which call site is contended), pair with a debugger or use the return-address routing pattern (cookbook recipe 17, planned).",
+        out: "",
+      },
+    ],
+  },
+  {
+    id: "custom",
+    title: "Write a custom action",
+    icon: "🛠️",
+    accent: "control",
+    summary: "Extend retrace with your own action — a single .c file that registers itself.",
+    minutes: 25,
+    steps: [
+      {
+        what: "Actions live in src/core/actions/. Each is a .c file that defines a struct RetraceAction and registers via the RETRACE_ACTION_REGISTER macro.",
+        out: "src/core/actions/basic.c     -- log_params, call_real, modify_in_*, modify_return_value_int\nsrc/core/actions/memfuzz.c     -- memory_fuzz\nsrc/core/actions/incomplete_io.c -- incomplete_io\n...",
+      },
+      {
+        what: "Pick a src/core/actions/*.c file like basic.c as a template. The interface you implement is per-action: parse your JSON params, decide whether to mutate the call, set the return value.",
+        out: "",
+      },
+      {
+        what: "Drop your new file in. Add an entry to Make-equivalent / CMakeLists (the build system auto-includes the directory).",
+        cmd: "ls src/core/actions/\n# add your heuristic_action.c alongside the others",
+        out: "",
+      },
+      {
+        what: "Build and run. Your action is now first-class: it shows up in `retrace list-actions` and can be referenced in any JSON config.",
+        cmd: "cmake --build build\nretrace run --config your-config.json -- ./your-target",
+        out: "your action runs at every call to the function it intercepts",
+      },
+      {
+        what: "For the full interface definition, see include/retrace/retrace_action.h and the existing actions in src/core/actions/.",
+        out: "",
+      },
+    ],
+  },
+  {
+    id: "prod",
+    title: "Debug a production issue (safely)",
+    icon: "🚑",
+    accent: "see",
+    summary: "Capture a production trace without restarting or modifying the binary — only the path you care about.",
+    minutes: 15,
+    steps: [
+      {
+        what: "Decide which functions are relevant. Logging everything in production is overkill; restrict to the suspects.",
+        cmd: "RETRACE_LOGGER_ALLOWED_FUNCS=open,openat,read,write,connect,recv,send",
+        out: "",
+      },
+      {
+        what: "Limit the trace to a short window. A 60-second slice is enough to catch a slow path; a full hour is enough to fill a disk.",
+        cmd: "timeout 60 retrace trace --log /tmp/incident.json -- ./your-service &\nPID=$!\n# ... wait, gather data, then:\nwait $PID",
+        out: "(trace stops after 60 seconds; log is bounded)",
+      },
+      {
+        what: "Scrub before persisting. The log may contain PII, secrets, or sensitive paths. Run a grep -v pass for known-sensitive patterns.",
+        cmd: "grep -v 'SECRET\\|password\\|/etc/shadow' /tmp/incident.json > /tmp/incident-scrubbed.json",
+        out: "(scrubbed file is safe to share with the post-mortem author)",
+      },
+      {
+        what: "Analyze locally with the HTML viewer.",
+        cmd: "retrace html /tmp/incident-scrubbed.json -o /tmp/postmortem.html && open /tmp/postmortem.html",
+        out: "(interactive page; filter by function, sort by duration, find the outlier)",
+      },
+      {
+        what: "The critical safety step: NEVER set RETRACE_LOGGER_DEF_ENA=1 with write access to the log file from the same user as the target. Stash everything in a directory only root can read.",
+        out: "",
+      },
+    ],
+  },
+  {
+    id: "build",
+    title: "Integrate retrace into your build",
+    icon: "🏗️",
+    accent: "control",
+    summary: "Run the test suite under retrace-fault-injection on every CI build. Catch error-path bugs before users do.",
+    minutes: 20,
+    steps: [
+      {
+        what: "Add a `fuzz-test` target to your project's build system that runs the test suite under a deterministic fuzz.",
+        cmd: "make fuzz-test\n# which is, in your Makefile:\n# fuzz-test: tests\n# \tLD_PRELOAD=$$RETRACE_LIB retrace fuzz malloc --rate 0.05 \\\\\n# \t  --log test-output/fuzz.json -- ./run-tests",
+        out: "",
+      },
+      {
+        what: "Or, in CMake, add a custom target that wires the library automatically:",
+        cmd: "add_custom_target(fuzz-test\n    COMMAND $<TARGET_FILE:run-tests>\n    ENVIRONMENT LD_PRELOAD=$<TARGET_FILE:libretrace.so>\n    COMMAND retrace fuzz malloc --rate 0.05\n    USES_TERMINAL)\nadd_dependencies(fuzz-test run-tests)",
+        out: "",
+      },
+      {
+        what: "Run it locally first to confirm your tests survive 5% OOM. If they crash, that's the bug you wanted to catch.",
+        cmd: "make fuzz-test",
+        out: "(either tests pass cleanly, or you find a handlenull-on-failure path that needs fixing)",
+      },
+      {
+        what: "Wire it into CI. See the retrace-fuzz.yml workflow in the cookbook recipe 19 — a drop-in GitHub Actions workflow that runs on every PR.",
+        out: "",
+      },
+      {
+        what: "When a CI fuzz run fails, the seed is captured in the log. Replay locally with the fixed seed to debug.",
         out: "",
       },
     ],

--- a/website/src/components/UseCases.astro
+++ b/website/src/components/UseCases.astro
@@ -135,6 +135,27 @@ const personas = [
     what: "Hunt for zero-days by exhausting every boundary. Make the 1000th call fail, the buffer exactly full, the path exactly too long. See what breaks.",
     cmd: "retrace run --config edge-cases.json -- ./target",
   },
+  {
+    tag: "game",
+    accent: "control",
+    who: "Game developer",
+    what: "Trace native game libraries. Find the asset load that's slow, the audio callback that allocates, the render path that reads from disk mid-frame.",
+    cmd: "retrace trace fopen,read,mmap -- ./game-binary",
+  },
+  {
+    tag: "compiler",
+    accent: "see",
+    who: "Compiler engineer",
+    what: "Validate your libc intercept before shipping. Trace every call to a target function across all your test workloads; flag any unexpected arg shape.",
+    cmd: "retrace trace 'your_lib_*' --log ./baseline.json -- ./test-suite",
+  },
+  {
+    tag: "build",
+    accent: "control",
+    who: "Build / release engineer",
+    what: "Wire fault-injection into CI. Run the test suite under <code>memory_fuzz</code> on every PR; catch OOM-as-bug before users do.",
+    cmd: "retrace fuzz malloc --rate 0.05 -- ./run-tests",
+  },
 ];
 ---
 
@@ -142,7 +163,7 @@ const personas = [
   <div class="wrap">
     <div class="section-head reveal">
       <div class="eyebrow">Who uses retrace</div>
-      <h2>Nineteen jobs. One shared library.</h2>
+      <h2>Twenty-two jobs. One shared library.</h2>
       <p>
         retrace is small enough to slip into a one-off debugging session, generic enough to anchor a
         CI fuzzing pipeline, principled enough to back a security audit. Below: every audience that

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -3,6 +3,7 @@ import Layout from "../layouts/Layout.astro";
 import Nav from "../components/Nav.astro";
 import Hero from "../components/Hero.astro";
 import Why from "../components/Why.astro";
+import Trust from "../components/Trust.astro";
 import Install from "../components/Install.astro";
 import PlaygroundSection from "../components/PlaygroundSection.astro";
 import Anatomy from "../components/Anatomy.astro";
@@ -20,6 +21,7 @@ import Footer from "../components/Footer.astro";
   <Nav />
   <Hero />
   <Why />
+  <Trust />
   <Install />
   <PlaygroundSection />
   <Anatomy />


### PR DESCRIPTION
## Summary

Three gaps closed this pass: (1) three tutorials that experienced users want but weren't yet covered, (2) three personas that have come up in discussions, and (3) a Trust section between Why and Install — the "is this safe to run?" block sceptical visitors look for before installing.

### TutorialPicker.vue — 18 → 21 scenarios

**19. Write a custom action** (control, 25 min) — for engine developers. Drop one `.c` file in `src/core/actions/`, build, run. Action is now first-class in `retrace list-actions` and any JSON config.

**20. Debug a production issue (safely)** (see, 15 min) — for on-call engineers. Restrict by logger allowlist, cap window with `timeout`, scrub before persisting, analyze with the HTML viewer. Emphasizes the safety step: never write trace logs from the same user as the target.

**21. Integrate retrace into your build** (control, 20 min) — for build/release engineers. Two recipes (Make and CMake) for a `fuzz-test` target that runs the test suite under `memory_fuzz` at 5%. Local try first, then CI.

Configured in the `TAGS` map so they show up under the right filter chips. Added a new tag `extend` (cyan accent) for the custom-action tutorial that doesn't fit any existing category.

### UseCases.astro — 19 → 22 personas

Three new personas:

- **Game developer** (control) — trace native game libraries.
- **Compiler engineer** (see) — validate libc intercept before shipping.
- **Build / release engineer** (control) — wire fault-injection into CI.

Headline updated from "Nineteen jobs" to "Twenty-two jobs."

### Trust.astro — the receipts block

A new section between Why and Install. Single glass card with a 3×2 grid of receipt-style items answering the skeptical visitor's "is this safe to run?" questions:

| Item | Value | Why it matters |
|---|---|---|
| License | BSD-2-Clause | No copyleft |
| Telemetry | None | No network calls, no phone-home |
| Dependencies | Zero at runtime | libc only, no third-party |
| Code of conduct | Ribose community | Same as Ribose's other OSS |
| Maintainer | Ribose | ISO/IEC 27001 certified |
| CVE status | None reported | Tracked via GitHub Security Advisories |

Each item has a label, a one-line value (in mono, in the verb accent of its category), and a one-sentence note explaining what it means in practice. Cell-border tint alternates between the see and control accents.

Positioned between Why (problem) and Install (action), it answers the second question visitors have after "why does this exist?" — "can I trust the package?" — before they make the install decision.

### docs/tutorials.md

Text mirror extended to all 21 tutorials. Each new tutorial has the same step-by-step walkthrough as the interactive picker.

### Page flow

Hero → Why → **Trust** → Install → Playground → Anatomy → Actions → UseCases → Tutorials → Platforms → Comparison → Recipes → FAQ → Footer.

## Test plan

- [ ] CI green on this branch.
- [ ] After merge, Pages re-deploys; verify:
  - Trust section appears between Why and Install. Six receipt items render in a 3×2 grid (2×1 on mobile).
  - Use Cases section shows 22 cards in a 4-column grid. "Twenty-two jobs" headline.
  - Tutorial picker left rail shows 21 cards. Three new ones at the end: "Write a custom action", "Debug a production issue (safely)", "Integrate retrace into your build".
  - New tag chip "Extend" appears in the filter bar.
  - Each new tutorial has its tags displayed in the walkthrough pane header.
