### PR TITLE
website: Quick Reference cheat sheet + 3 more personas (25 total)

### DIFF
--- a/website/src/components/QuickReference.astro
+++ b/website/src/components/QuickReference.astro
@@ -1,0 +1,323 @@
+---
+// Quick Reference — the consolidated cheat sheet. Every key surface
+// on one card: CLI subcommands, actions, env vars, common config
+// patterns. Designed to be scannable in 30 seconds, screenshot-able,
+// and printable via @media print.
+
+const cli = [
+  { cmd: "trace [funcs]", desc: "Log calls (optionally --html)" },
+  { cmd: "mock <fn> <ret>", desc: "Override a return value" },
+  { cmd: "fuzz [<fn>] --rate R", desc: "Inject OOM at rate R" },
+  { cmd: "slow <fn> --ms N", desc: "Inject N ms latency" },
+  { cmd: "run --config F", desc: "JSON config-driven" },
+  { cmd: "pp <log.json>", desc: "Pretty-print a trace" },
+  { cmd: "html <log.json>", desc: "Convert log to HTML" },
+  { cmd: "list-functions", desc: "Enumerate interceptable" },
+  { cmd: "list-actions", desc: "Enumerate actions" },
+  { cmd: "validate <cfg.json>", desc: "Check a config" },
+];
+
+const actions = [
+  { name: "log_params", cat: "see", params: "(omit_params)" },
+  { name: "call_real", cat: "see", params: "—" },
+  { name: "fuzzing_seed", cat: "see", params: "seed" },
+  { name: "modify_in_param_str", cat: "control", params: "param_name, new_str, match_str?" },
+  { name: "modify_in_param_int", cat: "control", params: "param_name, new_int, match_int?" },
+  { name: "modify_in_param_arr", cat: "control", params: "param_name, new_arr, match_arr?" },
+  { name: "modify_return_value_int", cat: "control", params: "retval_int" },
+  { name: "delay", cat: "control", params: "ms" },
+  { name: "memory_fuzz", cat: "break", params: "fail_rate" },
+  { name: "incomplete_io", cat: "break", params: "rate" },
+  { name: "call_count_limit", cat: "break", params: "limit" },
+  { name: "sandbox", cat: "break", params: "deny_paths" },
+];
+
+const envVars = [
+  { name: "RETRACE_JSON_CONFIG", desc: "Path to JSON config" },
+  { name: "RETRACE_LIB", desc: "Override library path" },
+  { name: "RETRACE_LOGGER_DEF_FN", desc: "Log file path" },
+  { name: "RETRACE_LOGGER_DEF_ENA", desc: "0 = disable logging" },
+  { name: "RETRACE_LOGGER_DEF_STDOUT_ENA", desc: "0 = suppress stdout" },
+  { name: "RETRACE_LOGGER_ALLOWED_FUNCS", desc: "Comma allowlist" },
+  { name: "RETRACE_LOGGER_EXCLUDED_FUNCS", desc: "Comma denylist" },
+];
+
+const patterns = [
+  {
+    title: "Trace + run",
+    accent: "see",
+    json: `{
+  "func_name": "*",
+  "actions": [
+    { "action_name": "log_params" },
+    { "action_name": "call_real" }
+  ]
+}`,
+  },
+  {
+    title: "Rewrite + run",
+    accent: "control",
+    json: `{
+  "func_name": "open",
+  "actions": [
+    { "action_name": "modify_in_param_str",
+      "action_params": {
+        "param_name": "path",
+        "new_str": "/tmp/fake"
+      } },
+    { "action_name": "call_real" }
+  ]
+}`,
+  },
+  {
+    title: "Fail after N",
+    accent: "break",
+    json: `{
+  "func_name": "malloc",
+  "actions": [
+    { "action_name": "modify_return_value_int",
+      "action_params": { "retval_int": 0 } },
+    { "action_name": "call_count_limit",
+      "action_params": { "limit": 5 } },
+    { "action_name": "call_real" }
+  ]
+}`,
+  },
+];
+---
+
+<section class="section quick-ref" id="quick-ref">
+  <div class="wrap">
+    <div class="section-head reveal">
+      <div class="eyebrow">Quick reference</div>
+      <h2>The whole tool, on one page.</h2>
+      <p>
+        Screenshot this. Print it. Tape it to your monitor. Everything below is also in the
+        <a href="https://github.com/riboseinc/retrace/blob/main/docs/cli.md">CLI reference</a>
+        and <a href="https://github.com/riboseinc/retrace/blob/main/docs/configuration.md">configuration reference</a>,
+        but here it is at a glance.
+      </p>
+    </div>
+
+    <div class="ref-grid">
+      <article class="ref-card glass-tight reveal">
+        <header class="ref-head">
+          <div class="ref-tag accent-control">CLI</div>
+          <h3>Ten subcommands</h3>
+        </header>
+        <ul class="ref-list">
+          {cli.map((c) => (
+            <li class="ref-row">
+              <code class="ref-cmd">{c.cmd}</code>
+              <span class="ref-desc">{c.desc}</span>
+            </li>
+          ))}
+        </ul>
+      </article>
+
+      <article class="ref-card glass-tight reveal">
+        <header class="ref-head">
+          <div class="ref-tag accent-see">Actions</div>
+          <h3>Twelve built-in</h3>
+        </header>
+        <ul class="ref-list">
+          {actions.map((a) => (
+            <li class="ref-row">
+              <code class={`ref-cmd action-${a.cat}`}>{a.name}</code>
+              <span class="ref-desc">{a.params}</span>
+            </li>
+          ))}
+        </ul>
+      </article>
+
+      <article class="ref-card glass-tight reveal">
+        <header class="ref-head">
+          <div class="ref-tag accent-see">Env vars</div>
+          <h3>Seven tunables</h3>
+        </header>
+        <ul class="ref-list">
+          {envVars.map((v) => (
+            <li class="ref-row">
+              <code class="ref-cmd">{v.name}</code>
+              <span class="ref-desc">{v.desc}</span>
+            </li>
+          ))}
+        </ul>
+      </article>
+
+      <article class="ref-card patterns reveal">
+        <header class="ref-head">
+          <div class="ref-tag accent-break">Patterns</div>
+          <h3>Three config recipes</h3>
+        </header>
+        <div class="patterns-grid">
+          {patterns.map((p) => (
+            <div class={`pattern-block accent-${p.accent}`}>
+              <div class={`pattern-title accent-${p.accent}`}>{p.title}</div>
+              <pre class="pattern-json">{p.json}</pre>
+            </div>
+          ))}
+        </div>
+      </article>
+    </div>
+  </div>
+</section>
+
+<style>
+.quick-ref {
+  background:
+    radial-gradient(ellipse 60% 40% at 50% 0%, rgba(94, 227, 255, 0.025), transparent 60%);
+}
+
+.ref-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 14px;
+}
+@media (max-width: 860px) {
+  .ref-grid { grid-template-columns: 1fr; }
+}
+
+.ref-card {
+  padding: 22px 24px 20px;
+}
+
+.ref-head {
+  display: flex;
+  align-items: baseline;
+  gap: 14px;
+  margin-bottom: 16px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+}
+.ref-tag {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  padding: 3px 8px;
+  border-radius: 3px;
+  border: 1px solid;
+}
+.ref-tag.accent-see {
+  color: var(--color-see);
+  background: rgba(94, 227, 255, 0.08);
+  border-color: rgba(94, 227, 255, 0.25);
+}
+.ref-tag.accent-control {
+  color: var(--color-control);
+  background: rgba(242, 180, 65, 0.08);
+  border-color: rgba(242, 180, 65, 0.25);
+}
+.ref-tag.accent-break {
+  color: var(--color-break);
+  background: rgba(255, 107, 92, 0.08);
+  border-color: rgba(255, 107, 92, 0.25);
+}
+.ref-head h3 {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--color-text);
+  letter-spacing: -0.005em;
+}
+
+.ref-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+.ref-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr);
+  gap: 14px;
+  padding: 6px 8px;
+  border-radius: 4px;
+  align-items: baseline;
+  font-size: 12.5px;
+}
+.ref-row:hover {
+  background: rgba(255, 255, 255, 0.025);
+}
+.ref-cmd {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--color-text);
+  background: rgba(255, 255, 255, 0.04);
+  padding: 2px 6px;
+  border-radius: 3px;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.ref-cmd.action-see { color: var(--color-see); border-color: rgba(94, 227, 255, 0.18); }
+.ref-cmd.action-control { color: var(--color-control); border-color: rgba(242, 180, 65, 0.18); }
+.ref-cmd.action-break { color: var(--color-break); border-color: rgba(255, 107, 92, 0.18); }
+.ref-desc {
+  color: var(--color-dim);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.patterns-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 12px;
+}
+.pattern-block {
+  padding: 0;
+  border-left: 2px solid;
+}
+.pattern-block.accent-see { border-left-color: rgba(94, 227, 255, 0.4); }
+.pattern-block.accent-control { border-left-color: rgba(242, 180, 65, 0.4); }
+.pattern-block.accent-break { border-left-color: rgba(255, 107, 92, 0.4); }
+
+.pattern-title {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  padding: 8px 14px 4px;
+}
+.pattern-title.accent-see { color: var(--color-see); }
+.pattern-title.accent-control { color: var(--color-control); }
+.pattern-title.accent-break { color: var(--color-break); }
+.pattern-json {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.55;
+  color: var(--color-text);
+  background: rgba(7, 9, 13, 0.6);
+  padding: 8px 14px 12px;
+  margin: 0;
+  overflow-x: auto;
+  border-bottom-right-radius: 6px;
+}
+
+/* Print: hide everything except the quick-ref section. */
+@media print {
+  body { background: white; color: black; }
+  body > * { display: none !important; }
+  .quick-ref,
+  .quick-ref * {
+    display: revert !important;
+    color: black !important;
+    background: white !important;
+    border-color: #ccc !important;
+    box-shadow: none !important;
+    backdrop-filter: none !important;
+  }
+  .orb-bg { display: none !important; }
+  .ref-card { page-break-inside: avoid; }
+}
+
+.section-head a {
+  color: var(--color-see);
+  border-bottom: 1px solid rgba(94, 227, 255, 0.3);
+}
+</style>

--- a/website/src/components/UseCases.astro
+++ b/website/src/components/UseCases.astro
@@ -156,6 +156,27 @@ const personas = [
     what: "Wire fault-injection into CI. Run the test suite under <code>memory_fuzz</code> on every PR; catch OOM-as-bug before users do.",
     cmd: "retrace fuzz malloc --rate 0.05 -- ./run-tests",
   },
+  {
+    tag: "db",
+    accent: "see",
+    who: "Database engineer",
+    what: "Trace a DB client's libc surface to find the slow query path. See which <code>read</code>/<code>write</code> syscalls each query triggers, and where time goes.",
+    cmd: "retrace trace read,write,fsync --log /tmp/db.json -- ./db-client",
+  },
+  {
+    tag: "dist",
+    accent: "control",
+    who: "Distributed systems engineer",
+    what: "Reproduce a flaky consensus vote by mocking <code>time</code>, fuzzing <code>malloc</code>, and forcing <code>fsync</code> to fail. The bug only happens under specific conditions — retrace makes them deterministic.",
+    cmd: "retrace run --config consensus-repro.json -- ./raft-node",
+  },
+  {
+    tag: "ml",
+    accent: "see",
+    who: "ML engineer",
+    what: "Debug a Python/C++ native binding. Trace the interpreter's libc calls to find which model-loading step is bottlenecked on disk I/O vs. computation.",
+    cmd: "retrace trace fopen,read,mmap -- python3 train.py",
+  },
 ];
 ---
 
@@ -163,7 +184,7 @@ const personas = [
   <div class="wrap">
     <div class="section-head reveal">
       <div class="eyebrow">Who uses retrace</div>
-      <h2>Twenty-two jobs. One shared library.</h2>
+      <h2>Twenty-five jobs. One shared library.</h2>
       <p>
         retrace is small enough to slip into a one-off debugging session, generic enough to anchor a
         CI fuzzing pipeline, principled enough to back a security audit. Below: every audience that

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -16,6 +16,7 @@ import Platforms from "../components/Platforms.astro";
 import Comparison from "../components/Comparison.astro";
 import Recipes from "../components/Recipes.astro";
 import FAQ from "../components/FAQ.astro";
+import QuickReference from "../components/QuickReference.astro";
 import Footer from "../components/Footer.astro";
 ---
 
@@ -36,6 +37,7 @@ import Footer from "../components/Footer.astro";
   <Comparison />
   <Recipes />
   <FAQ />
+  <QuickReference />
   <Footer />
 </Layout>
 


### PR DESCRIPTION
## Summary

Two consolidation moves:

1. **A Quick Reference section** — the whole tool on one page. The site had scattered this info across Hero, Install, Anatomy, Actions, and Tutorials. Now there's a single screenshot-able, printable card a visitor can refer to without scrolling.
2. **Three more personas** (database, distributed systems, ML engineers) — audiences that have come up in discussions but weren't in the grid.

### QuickReference.astro

A new section between FAQ and Footer — the last content block before the page ends. Four glass-tight cards in a 2-column grid:

1. **CLI** (control accent) — all ten subcommands with one-line descriptions.
2. **Actions** (see accent) — all twelve built-in actions with their parameter signatures, color-coded by category.
3. **Env vars** (see accent) — the seven `RETRACE_LOGGER_*` and `RETRACE_LIB` / `RETRACE_JSON_CONFIG` tunables.
4. **Patterns** (break accent) — three ready-to-paste JSON config recipes: "Trace + run", "Rewrite + run", "Fail after N".

### Print mode

A dedicated `@media print` block hides everything except the Quick Reference section, flips colors to black-on-white, removes backdrop-filters and shadows, and sets `page-break-inside: avoid` on each card. Print to PDF from the browser gets a clean reference card.

### Position

Between FAQ (handle objections) and Footer (links). The Quick Reference is the parting gift: a one-page summary visitors can take with them after they've read everything else.

### UseCases.astro — 22 → 25 personas

Three new personas:

- **Database engineer** (see) — trace a DB client's libc surface to find slow query paths.
- **Distributed systems engineer** (control) — reproduce flaky consensus votes by mocking time + fuzzing malloc + forcing fsync failures.
- **ML engineer** (see) — debug Python/C++ native bindings, find model-loading I/O bottlenecks.

Headline updated from "Twenty-two jobs" to "Twenty-five jobs."

### Page flow

Hero → Why → Trust → Install → Playground → Anatomy → Performance → Actions → Function Catalog → UseCases → Tutorials → Platforms → Comparison → Recipes → FAQ → **Quick Reference** → Footer.

## Test plan

- [ ] CI green on this branch.
- [ ] After merge, Pages re-deploys; verify:
  - Quick Reference section appears between FAQ and Footer.
  - Four glass-tight cards in a 2-column grid: CLI, Actions, Env vars, Patterns.
  - All 10 CLI subcommands, 12 actions, 7 env vars render with one-line descriptions.
  - Three JSON config patterns render with colored left borders and syntax-highlighted JSON.
  - Use Cases section shows 25 cards. "Twenty-five jobs" headline.
  - Print the page (Cmd+P) → only the Quick Reference section appears in black-on-white.
