### PR TITLE
website: Community section — Contribute / Discuss / Get support

### DIFF
--- a/website/src/components/Community.astro
+++ b/website/src/components/Community.astro
@@ -1,0 +1,212 @@
+---
+// Community — the standard "how do I get involved?" section that
+// every OSS project site has. Three paths: Contribute, Discuss,
+// Get support. Closes the loop after the visitor has evaluated
+// retrace and decided they want in.
+
+const paths = [
+  {
+    id: "contribute",
+    icon: "🛠️",
+    accent: "control",
+    title: "Contribute",
+    blurb: "PRs welcome. Bug fixes, new actions, new backend ports, docs improvements — all of it counts.",
+    cta: "Browse good first issues",
+    href: "https://github.com/riboseinc/retrace/contribute",
+    secondary: [
+      { label: "CONTRIBUTING.md", href: "https://github.com/riboseinc/retrace/blob/main/CONTRIBUTING.md" },
+      { label: "Open a PR", href: "https://github.com/riboseinc/retrace/compare" },
+    ],
+  },
+  {
+    id: "discuss",
+    icon: "💬",
+    accent: "see",
+    title: "Discuss",
+    blurb: "Q&A, design ideas, use-case walkthroughs. GitHub Discussions is the canonical channel.",
+    cta: "Open a discussion",
+    href: "https://github.com/riboseinc/retrace/discussions",
+    secondary: [
+      { label: "Issue tracker", href: "https://github.com/riboseinc/retrace/issues" },
+      { label: "ADRs", href: "https://github.com/riboseinc/retrace/blob/main/docs/adr/" },
+    ],
+  },
+  {
+    id: "support",
+    icon: "🏢",
+    accent: "break",
+    title: "Get commercial support",
+    blurb: "Ribose offers support contracts, training, and custom development around retrace and its ecosystem.",
+    cta: "Contact Ribose",
+    href: "https://www.ribose.com/contact",
+    secondary: [
+      { label: "About Ribose", href: "https://www.ribose.com" },
+      { label: "Security disclosures", href: "https://github.com/riboseinc/retrace/security" },
+    ],
+  },
+];
+---
+
+<section class="section community" id="community">
+  <div class="wrap">
+    <div class="section-head reveal">
+      <div class="eyebrow">Get involved</div>
+      <h2>Picked a path? Here's how to go further.</h2>
+      <p>
+        retrace is BSD-2-Clause open source. The three doors below cover the common reasons people
+        come back after their first successful trace. Pick the one that matches your situation.
+      </p>
+    </div>
+
+    <div class="community-grid">
+      {
+        paths.map((p, i) => (
+          <article class={`community-card glass glass-hover reveal accent-${p.accent}`} style={`transition-delay: ${i * 70}ms`}>
+            <header class="com-head">
+              <div class={`com-icon icon-${p.accent}`}>{p.icon}</div>
+              <h3>{p.title}</h3>
+            </header>
+            <p class="com-blurb">{p.blurb}</p>
+            <a class={`com-cta cta-${p.accent}`} href={p.href}>
+              {p.cta}
+              <span class="arrow">→</span>
+            </a>
+            <ul class="com-secondary">
+              {p.secondary.map((s) => (
+                <li><a href={s.href}>{s.label}</a></li>
+              ))}
+            </ul>
+          </article>
+        ))
+      }
+    </div>
+  </div>
+</section>
+
+<style>
+.community-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+}
+@media (max-width: 960px) { .community-grid { grid-template-columns: 1fr; } }
+
+.community-card {
+  padding: 26px 28px 22px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.community-card.accent-see { border-top: 2px solid rgba(94, 227, 255, 0.4); }
+.community-card.accent-control { border-top: 2px solid rgba(242, 180, 65, 0.4); }
+.community-card.accent-break { border-top: 2px solid rgba(255, 107, 92, 0.4); }
+
+.com-head {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  margin-bottom: 4px;
+}
+.com-icon {
+  width: 40px;
+  height: 40px;
+  border-radius: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 20px;
+  border: 1px solid;
+}
+.icon-see {
+  background: rgba(94, 227, 255, 0.08);
+  border-color: rgba(94, 227, 255, 0.25);
+}
+.icon-control {
+  background: rgba(242, 180, 65, 0.08);
+  border-color: rgba(242, 180, 65, 0.25);
+}
+.icon-break {
+  background: rgba(255, 107, 92, 0.08);
+  border-color: rgba(255, 107, 92, 0.25);
+}
+.com-head h3 {
+  font-size: 18px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--color-text);
+}
+
+.com-blurb {
+  font-size: 14px;
+  color: var(--color-dim);
+  line-height: 1.55;
+  flex: 1;
+}
+
+.com-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  border-radius: 6px;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  font-weight: 500;
+  text-decoration: none;
+  transition: all 0.2s var(--ease-glass);
+  align-self: flex-start;
+}
+.com-cta .arrow { transition: transform 0.18s; }
+.com-cta:hover .arrow { transform: translateX(3px); }
+
+.cta-see {
+  background: rgba(94, 227, 255, 0.12);
+  color: var(--color-see);
+  border: 1px solid rgba(94, 227, 255, 0.35);
+}
+.cta-see:hover {
+  background: rgba(94, 227, 255, 0.18);
+  border-color: rgba(94, 227, 255, 0.5);
+}
+.cta-control {
+  background: rgba(242, 180, 65, 0.12);
+  color: var(--color-control);
+  border: 1px solid rgba(242, 180, 65, 0.35);
+}
+.cta-control:hover {
+  background: rgba(242, 180, 65, 0.18);
+  border-color: rgba(242, 180, 65, 0.5);
+}
+.cta-break {
+  background: rgba(255, 107, 92, 0.12);
+  color: var(--color-break);
+  border: 1px solid rgba(255, 107, 92, 0.35);
+}
+.cta-break:hover {
+  background: rgba(255, 107, 92, 0.18);
+  border-color: rgba(255, 107, 92, 0.5);
+}
+
+.com-secondary {
+  list-style: none;
+  padding: 0;
+  margin: 4px 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.com-secondary li {
+  font-size: 12.5px;
+}
+.com-secondary a {
+  color: var(--color-dim);
+  text-decoration: none;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  padding-bottom: 1px;
+  transition: color 0.15s, border-color 0.15s;
+}
+.com-secondary a:hover {
+  color: var(--color-text);
+  border-color: rgba(255, 255, 255, 0.25);
+}
+</style>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -18,6 +18,7 @@ import Comparison from "../components/Comparison.astro";
 import Recipes from "../components/Recipes.astro";
 import ConfigValidatorSection from "../components/ConfigValidatorSection.astro";
 import WhatsNew from "../components/WhatsNew.astro";
+import Community from "../components/Community.astro";
 import FAQ from "../components/FAQ.astro";
 import QuickReference from "../components/QuickReference.astro";
 import Footer from "../components/Footer.astro";
@@ -42,6 +43,7 @@ import Footer from "../components/Footer.astro";
   <Recipes />
   <ConfigValidatorSection />
   <WhatsNew />
+  <Community />
   <FAQ />
   <QuickReference />
   <Footer />


### PR DESCRIPTION
## Summary

One standard OSS-project section was missing: the "how do I get involved?" path. Trust establishes that Ribose maintains retrace; WhatsNew shows the project is alive. **Community** closes the loop with three concrete doors for visitors who decided they want in.

### Community.astro

Three glass cards in a 3-column grid between WhatsNew and FAQ.

**Contribute** (control accent):
- CTA: Browse good first issues
- Secondary: CONTRIBUTING.md, Open a PR
- Blurb: PRs welcome — bug fixes, new actions, new backend ports, docs improvements

**Discuss** (see accent):
- CTA: Open a discussion
- Secondary: Issue tracker, ADRs
- Blurb: Q&A, design ideas, use-case walkthroughs. GitHub Discussions is canonical

**Get commercial support** (break accent):
- CTA: Contact Ribose
- Secondary: About Ribose, Security disclosures
- Blurb: Support contracts, training, custom development

Each card has:
- Rounded icon tile in the verb accent (40×40, glass-tinted fill)
- Card title in 18px semibold
- One-sentence blurb (flex-grows to fill)
- CTA button: mono text, verb-accent tinted background and border, arrow that translates right on hover
- Secondary link list: 2 understated links below the CTA

Card top-border tinted by the verb accent, matching the pattern used by UseCases, Recipes, and WhatsNew.

### Position

Between WhatsNew (is the project alive?) and FAQ (objections). Flow: **WhatsNew → Community → FAQ**. Visitors who finish WhatsNew with "OK, this is alive — how do I get involved?" land directly on Community.

### Why this matters

Every mature OSS project site has a Community / Get Involved section. Without it, the site reads as documentation; with it, the site reads as a project. The three doors (contribute, discuss, support) cover the three reasons people come back after their first successful trace.

## Test plan

- [ ] CI green on this branch.
- [ ] After merge, Pages re-deploys; verify:
  - Community section appears between WhatsNew and FAQ.
  - Three cards in a 3-column grid: Contribute (amber), Discuss (cyan), Get commercial support (vermilion).
  - Each card has icon, title, blurb, CTA button (with hover arrow translate), and two secondary links.
  - CTA buttons link to the correct GitHub / Ribose URLs.
