### PR TITLE
docs: development guide + architecture deep-dive

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,11 +8,13 @@ install, quick start, and platform support.
 
 | You want to… | Go to |
 |--------------|-------|
-| Solve a specific problem step-by-step | [Tutorials](tutorials.md) — 18 scenario-driven walkthroughs |
+| Solve a specific problem step-by-step | [Tutorials](tutorials.md) — 22 scenario-driven walkthroughs |
 | Get an answer to a common question | [FAQ](faq.md) — language support, overhead, production use, more |
 | Look up a CLI subcommand or env var | [CLI reference](cli.md) |
 | Look up an action or write a JSON config | [Configuration reference](configuration.md) |
 | Run a specific scenario (trace, fuzz, mock, sandbox) | [Cookbook](cookbook/README.md) — 21 recipes with copy-paste JSON |
+| Contribute, build, test, or debug retrace | [Development guide](development.md) |
+| Understand the engine, backends, and actions | [Architecture](architecture.md) |
 | Add retrace to a Dockerfile or compose stack | [Docker guide](docker.md) |
 | Trace an Android app via `wrap.sh` or Magisk | [Android guide](android.md) |
 | Understand a design decision | [Architecture decisions (ADR)](adr/README.md) |
@@ -23,10 +25,12 @@ install, quick start, and platform support.
 ```
 docs/
 ├── README.md              ← you are here
-├── tutorials.md           ← 18 scenario-driven step-by-step walkthroughs
+├── tutorials.md           ← 22 scenario-driven step-by-step walkthroughs
 ├── faq.md                 ← common questions: language support, overhead, etc.
 ├── cli.md                 ← CLI subcommand + env var reference
 ├── configuration.md       ← JSON config schema + action parameter reference
+├── development.md         ← building, testing, contributing, debugging retrace
+├── architecture.md        ← how engine, backends, and actions fit together
 ├── cookbook/              ← 21 recipe-driven walkthroughs
 │   ├── README.md          ← index + compact action reference
 │   ├── 01-trace-all-calls.md

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,363 @@
+# Architecture
+
+How retrace's components fit together. Read this if you're
+contributing to the engine, writing a new backend, or just want to
+understand why the code is shaped the way it is.
+
+Forthcoming ADRs (in `docs/adr/`) capture specific decisions; this
+page is the synthesis.
+
+## The one-paragraph model
+
+A target binary makes a libc call. The dynamic linker (or, on
+Windows, an inline hook) routes the call through retrace's
+**trampoline**. The trampoline saves the call's register arguments
+into a **frame** struct and invokes the **engine**
+(`retrace_engine_wrapper`). The engine looks up the matching
+**intercept script** in the loaded JSON config, parses the args
+using the function's **prototype**, then runs the script's
+**actions** in order. Each action can log, modify args, override
+the return value, or inject a failure. When the script finishes,
+the engine either tail-calls the **real libc function** (if
+`call_real` ran) or synthesizes a return value into the frame.
+
+## Layered view
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ Target binary (your program)                                 │
+└─────────────────────────────────────────────────────────────┘
+                            │
+                            │ libc symbol lookup
+                            ▼
+┌─────────────────────────────────────────────────────────────┐
+│ Backend layer (src/backends/<name>/)                         │
+│   preload_elf   preload_macho   preload_bsd                  │
+│   preload_msvc  preload_mingw   ptrace                       │
+│                                                               │
+│   Per-arch trampoline (.S) saves regs into frame, calls      │
+│   engine. Resolves real libc via dlsym/interpose/IAT.        │
+└─────────────────────────────────────────────────────────────┘
+                            │
+                            │ retrace_engine_wrapper(name, frame)
+                            ▼
+┌─────────────────────────────────────────────────────────────┐
+│ Engine layer (src/core/engine.c)                             │
+│   Looks up script, parses args via prototype, runs actions.  │
+└─────────────────────────────────────────────────────────────┘
+                            │
+                            │ ia_<action>(t_ctx, params)
+                            ▼
+┌─────────────────────────────────────────────────────────────┐
+│ Action layer (src/core/actions/*.c)                          │
+│   log_params  call_real  modify_in_param_*                   │
+│   modify_return_value_int  memory_fuzz  incomplete_io        │
+│   delay  call_count_limit  sandbox  fuzzing_seed             │
+└─────────────────────────────────────────────────────────────┘
+                            │
+                            │ retrace_real_impls.<fn>
+                            ▼
+┌─────────────────────────────────────────────────────────────┐
+│ Real libc (resolved once at init via dlsym(RTLD_NEXT, ...))  │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Init order
+
+The retrace library has a constructor that runs before any
+intercepted call. The order is strict and load-bearing
+(`src/core/main.c`):
+
+```c
+__attribute__((constructor(101)))   // very high priority
+static void retrace_init(void)
+{
+    retrace_as_init();              // 1. set up backend section data
+    retrace_real_impls_init();      // 2. dlsym(RTLD_NEXT, ...) all
+                                    //    libc functions retrace uses
+    retrace_logger_init();          // 3. log infra
+    parson_alloc_hooks(...);        // 4. parson uses retrace's malloc
+    retrace_conf_init();            // 5. parse RETRACE_JSON_CONFIG
+    retrace_loger_update_config();  // 6. apply log config
+    retrace_engine_init();          // 7. per-thread context pool
+    retrace_funcs_init();           // 8. function prototype registry
+    retrace_datatypes_init();       // 9. type metadata
+    retrace_actions_init();         // 10. action registry
+    retrace_as_init_late();         // 11. backend claims resources
+}
+```
+
+Each step has a single responsibility. Out-of-order init is the
+single most common source of retrace-internal bugs.
+
+## The frame
+
+Every backend saves register arguments into a C struct before
+invoking the engine. The frame's shape depends on the calling
+convention.
+
+### Sys V x86-64 (`WrapperSystemVFrame`)
+
+```c
+struct WrapperSystemVFrame {
+    /* Saved integer argument registers (per ABI). */
+    long int_arg[6];                 /* rdi, rsi, rdx, rcx, r8, r9 */
+
+    /* Saved XMM registers for FP/double args. */
+    double fp_arg[8];                /* xmm0..xmm7 */
+
+    /* Saved return address and original stack pointer. */
+    long return_address;
+    long original_sp;
+
+    /* Control fields filled by the engine. */
+    int   call_real_flag;
+    void *real_impl;                 /* pointer to real libc fn */
+    long  ret_val;                   /* synthesized return value */
+};
+```
+
+### AArch64 PCS (`WrapperAArch64Frame`)
+
+```c
+struct WrapperAArch64Frame {
+    /* Saved x0..x7 (integer argument registers). */
+    long int_arg[8];
+
+    /* Saved v0..v7 (FP/SIMD argument registers, 16 bytes each). */
+    unsigned char fp_arg[8][16];
+
+    /* Saved link register and original SP. */
+    long link_register;              /* x30 — no return-address on stack */
+    long original_sp;
+
+    /* Control fields filled by the engine. */
+    int   call_real_flag;
+    void *real_impl;
+    union {
+        long   int_val;
+        double fp_val;
+    } ret_val;                       /* tagged by prototype's return type */
+};
+```
+
+The frame layout is consumed by both the trampoline (which writes
+into it on entry, reads return value on exit) and the engine
+(which reads args, writes `call_real_flag`/`real_impl`/`ret_val`).
+Changing the layout requires updating both.
+
+## The trampoline
+
+One trampoline per intercepted function. The trampoline's job:
+
+1. Save registers into a stack-allocated frame.
+2. Zero the control fields (`call_real_flag = 0`).
+3. Load `x0`/`rdi` with the function name (a string literal).
+4. Load `x1`/`rsi` with a pointer to the frame.
+5. Call `retrace_engine_wrapper`.
+6. After return: if `call_real_flag` is set, restore registers and
+   tail-call `real_impl`. Otherwise, load `ret_val` into the
+   return register and `ret`.
+
+Per-arch assembly:
+
+- **ELF/BSD x86-64** — `src/backends/preload_{elf,bsd}/x86_64/arch_spec_top.S`
+- **Mach-O x86-64** — `src/backends/preload_macho/x86_64/arch_spec_top.S`
+  (Darwin needs `.global _<fn>` prefix and interpose entries.)
+- **ELF AArch64** — `src/backends/preload_elf/aarch64/arch_spec_top.S`
+- **Mach-O AArch64** — `src/backends/preload_macho/aarch64/arch_spec_top.S`
+
+The trampoline's macro `WRAPPER_ENTRY_SYSTEM_V` (or
+`WRAPPER_ENTRY_AARCH64`) emits one trampoline per function. The
+function inventory lives in
+`src/backends/preload_*/<arch>/funcs_symbols.S`, which is now
+generated from the DRY source `src/v2/funcs_symbols.def` via the
+C preprocessor.
+
+## The engine
+
+`src/core/engine.c::retrace_engine_wrapper` is the central dispatch.
+
+```c
+int retrace_engine_wrapper(const char *func_name,
+                           void *arch_spec_ctx)
+{
+    /* 1. Resolve real_impl for this function. */
+    /* 2. If not yet initialized, return early.              */
+    /* 3. Get per-thread context (ThreadContext).            */
+    /* 4. Look up the prototype.                             */
+    /* 5. If filter excludes func_name, return early.        */
+    /* 6. Parse args from the frame into the context.        */
+    /* 7. Find the intercept_script for func_name.           */
+    /* 8. For each action in the script, dispatch to its     */
+    /*    ia_<action>(t_ctx, action_params).                 */
+    /* 9. If call_real_flag is set, signal the trampoline to */
+    /*    invoke real_impl. Otherwise, set ret_val in the    */
+    /*    frame.                                              */
+    /* 10. Return to the trampoline.                          */
+}
+```
+
+The engine itself is thin (~180 lines after the MECE refactor).
+The actual work happens in the actions. Adding a new behavior =
+adding a new action; the engine doesn't need to change.
+
+## Prototypes
+
+A prototype is a `struct FuncPrototype` describing a function's
+calling convention, return type, and parameter types:
+
+```c
+struct FuncPrototype {
+    enum FuncConv conv;          /* SYSCALL_V, etc.           */
+    const char *type_name;       /* "int", "void *", ...      */
+    struct ParamMeta params[];   /* name + type for each arg  */
+};
+```
+
+Prototypes live in `src/core/prototypes/<header>.c`. Each file
+defines an array of prototypes and registers it via
+`retrace_func_define_prototypes(<header>)` into a linker section
+the engine scans at init.
+
+The engine uses prototypes to:
+
+- Walk the frame's int_arg/float_arg arrays in order.
+- For each param, decide whether to read from int_arg (integer
+  types) or fp_arg (float types).
+- Write the parsed values into the per-thread context for actions
+  to consume.
+
+If a prototype is missing, the engine can't parse args for that
+function — `log_params` will emit a call record with no args.
+Adding a prototype = adding a row to the appropriate
+`src/core/prototypes/<header>.c` file.
+
+## Actions
+
+An action is a small C function registered via
+`RETRACE_ACTION_REGISTER`:
+
+```c
+RETRACE_ACTION_REGISTER("memory_fuzz", ia_memory_fuzz, "...");
+
+static int ia_memory_fuzz(struct ThreadContext *t_ctx,
+                          const JSON_Object *action_params) {
+    /* ... */
+    return 0;       /* 0 = continue script           */
+    return -1;      /* negative = abort script       */
+                    /* (call_real_flag is honored)   */
+}
+```
+
+Actions receive:
+
+- `t_ctx` — per-thread context. Holds the parsed params, the
+  real_impl pointer, the frame pointer, the return value slot.
+- `action_params` — the JSON object from the script (may be NULL).
+
+Actions return 0 to continue the script or a negative value to
+abort. The convention is that `call_count_limit`, `memory_fuzz`
+(when it decides to fail), and similar early-exit actions return
+non-zero.
+
+Action registration uses a linker section
+(`__DATA,__retrace_acts` on Darwin; the ELF equivalent on Linux).
+At init, `retrace_actions_init` walks the section and builds the
+registry. No central action table — adding an action is purely
+local to its `.c` file.
+
+## Real-impl indirection
+
+This is the single most important invariant in retrace:
+
+> Every libc call inside retrace itself goes through the
+> `retrace_real_impls` struct. Never call libc directly.
+
+The `retrace_real_impls` struct (defined in
+`src/core/real_impls.h`) holds function pointers for ~35 libc
+symbols that retrace uses internally. At init,
+`retrace_real_impls_init()` resolves them via
+`dlsym(RTLD_NEXT, ...)` (or the platform equivalent).
+
+The indirection serves two purposes:
+
+1. **Reentrancy guard** — when retrace's engine calls e.g.
+   `malloc`, the call goes to the real libc malloc, not to
+   retrace's wrapper. Without this guard, every internal malloc
+   would recurse back into the engine.
+2. **Consistency** — retrace's internal behavior doesn't depend on
+   what the target binary does to libc. If the target has
+   replaced `malloc` with its own allocator, retrace's internal
+   malloc still uses the real libc malloc.
+
+Bypassing the indirection is the single most common cause of
+infinite-recursion crashes. If you're writing code inside
+`src/core/`, grep your code for direct libc calls and route them
+through `retrace_real_impls.*`.
+
+## Config sources
+
+JSON configs come from one of:
+
+1. `RETRACE_JSON_CONFIG` env var (path to a file).
+2. The `--config FILE` CLI flag.
+3. Built-in default: `log_params` + `call_real` for every function.
+
+The config layer (`src/config/json/conf.c`) parses with parson
+(vendored in `src/config/json/parson.{c,h}`). parson supports
+`//` and `/* */` comments — useful for documenting configs.
+
+## Logs
+
+Every intercepted call emits one JSON object to the log stream.
+The log goes to:
+
+- stdout (if `RETRACE_LOGGER_DEF_STDOUT_ENA != 0`)
+- a file (if `RETRACE_LOGGER_DEF_FN` is set, or `--log FILE`)
+- both (default)
+
+Log entries include: timestamp, function name, parsed args, return
+value, `call_duration_us`.
+
+`retrace pp <log.json>` pretty-prints a log as text.
+`retrace html <log.json>` converts it to an interactive HTML page.
+
+## Per-platform backends
+
+Each backend owns exactly one (OS, arch) combination. MECE by
+design.
+
+| Backend | OS | Arch | Mechanism |
+|---|---|---|---|
+| `preload_elf` | Linux, OHOS | x86_64, aarch64 | `LD_PRELOAD` |
+| `preload_bsd` | FreeBSD, OpenBSD, NetBSD | x86_64 | `LD_PRELOAD` |
+| `preload_macho` | macOS | x86_64, arm64 | `DYLD_INSERT_LIBRARIES` |
+| `preload_msvc` | Windows | x86_64, arm64 | Inline hook |
+| `preload_mingw` | Windows | x86_64 | Inline hook |
+| `ptrace` | Linux | x86_64, aarch64 | `ptrace(2)` (for static binaries) |
+
+Each backend implements `retrace_backend_t` from
+`include/retrace/backend.h` and self-registers via the constructor
+section. `retrace_backend_select` walks the registry and picks the
+highest-rank backend whose `probe()` succeeds.
+
+Adding a new backend (e.g., `frida`, `ebpf`) = adding a new
+directory under `src/backends/<name>/` and implementing the
+callback interface. No engine change needed.
+
+## See also
+
+- [Development guide](development.md) — building, testing,
+  contributing.
+- [Configuration reference](configuration.md) — the JSON schema.
+- [CLI reference](cli.md) — every subcommand.
+- [ADRs](adr/README.md) — architecture decision records, including:
+  - ADR-0002 layered architecture
+  - ADR-0003 plugin pattern for backends
+  - ADR-0004 plugin pattern for config sources
+  - ADR-0007 JSON as canonical config
+  - ADR-0008 opaque public types
+  - ADR-0009 from-scratch Windows trampoline
+  - ADR-0010 AArch64 float params from day one
+  - ADR-0013 engine MECE split

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,298 @@
+# Development guide
+
+How to build, test, and contribute to retrace itself. If you're
+looking to *use* retrace, start with the [tutorials](tutorials.md)
+instead.
+
+## Build from source
+
+CMake is the only build system. Ninja is the recommended generator
+(faster, handles the per-arch trampoline objects cleanly).
+
+```sh
+git clone https://github.com/riboseinc/retrace.git
+cd retrace
+cmake -B build -G Ninja -DRETRACE_BUILD_TESTS=ON
+cmake --build build
+```
+
+Output:
+
+```
+build/src/libretrace.so          # the preloadable library
+build/src/cli/retrace            # the CLI launcher
+build/test/...                   # test binaries (with RETRACE_BUILD_TESTS=ON)
+```
+
+### CMake options
+
+| Option | Default | Effect |
+|---|---|---|
+| `RETRACE_BUILD_V2` | `ON` | Build the retrace shared library. |
+| `RETRACE_BUILD_CLI` | `ON` | Build the CLI launcher. |
+| `RETRACE_BUILD_TESTS` | `OFF` | Build the per-feature test binaries in `test/`. |
+| `RETRACE_BUILD_EXAMPLES` | `OFF` | Build the demos under `examples/`. |
+| `RETRACE_ENABLE_RPC` | `OFF` | Build the `rpc/` subtree. |
+| `RETRACE_ENABLE_ASAN` | `OFF` | AddressSanitizer. |
+| `RETRACE_ENABLE_UBSAN` | `OFF` | UndefinedBehaviorSanitizer. |
+| `RETRACE_ENABLE_TSAN` | `OFF` | ThreadSanitizer. |
+| `RETRACE_ENABLE_COVERAGE` | `OFF` | Coverage instrumentation. |
+
+The build does feature probes (`CheckIncludeFile`, `CheckSymbolExists`,
+`CheckCSourceCompiles`) that populate `config.h` from
+`cmake/config.h.cmake.in`. Per-OS selection happens via
+`RETRACE_PLATFORM_{LINUX,DARWIN,FREEBSD,OPENBSD,NETBSD,WINDOWS}`.
+
+### Install
+
+```sh
+sudo cmake --install build
+```
+
+Or use the build output directly via `RETRACE_LIB`:
+
+```sh
+RETRACE_LIB=$PWD/build/src/libretrace.so retrace trace -- ./your-binary
+```
+
+## Run the tests
+
+CTest drives the test pyramid. Labels: `integration`, `unit`,
+`smoke`, `v2`.
+
+```sh
+ctest --test-dir build                 # run all
+ctest --test-dir build -L integration  # only integration
+ctest --test-dir build -L v2           # only v2-targeted
+ctest --test-dir build --output-on-failure
+```
+
+The integration runner is generated from `test/runtests.sh.in` via
+`file(GENERATE)`. It runs each per-feature binary under v2 via
+`LD_PRELOAD`/`DYLD_INSERT_LIBRARIES` and reports pass/fail counts.
+
+Examples under `examples/*/` (dns-fuzz, getenv-fuzzing,
+http-server-overflow, id-redirection, net-fuzzing, stringinject,
+unsafe-system) are self-contained demos.
+
+## Code style
+
+`.clang-format` is Mozilla-based. Format manually if you want
+consistency — there's no enforced pre-commit hook.
+
+```sh
+clang-format -i src/path/to/your-file.c
+```
+
+### checkpatch
+
+GitHub checks via Linux `checkpatch.pl` with a long ignore list in
+`ci/checkpatch.sh`. `typedefs.checkpatch` carries project-specific
+typedefs. `src/config/json/parson.{c,h}` is excluded (vendored
+third-party).
+
+Run locally:
+
+```sh
+./ci/checkpatch.sh
+```
+
+Common gotchas:
+
+- **Commit message**: don't use markdown heading underlines like
+  `---` (three or more dashes on their own line). checkpatch treats
+  these as malformed patch separators. Use `==` instead, or no
+  underline.
+- **Trailing statements**: `if (x) fprintf(...);` triggers a
+  warning. Use braces: `if (x) { fprintf(...); }`.
+- **`*/` on the same line as content**: put `*/` on its own line.
+
+## Contribution workflow
+
+1. **Fork** the repo on GitHub.
+2. **Branch** from `main`: `git checkout -b my-feature`.
+3. **Commit** with a clear message. Format:
+   `<scope>: <imperative summary>` then a blank line then a body
+   that explains the *why*. See `git log` for examples.
+4. **Push** to your fork.
+5. **Open a PR** against `riboseinc/retrace:main`. The CI matrix
+   (~30 jobs across Linux/macOS/Windows/BSD/Android) runs on every
+   PR; wait for green.
+6. **Rebase-merge** when CI is green. Maintainers will do this for
+   you if you don't have write access.
+
+### What gets merged
+
+- Bug fixes — always welcome.
+- New actions — drop a `.c` file in `src/core/actions/`, register
+  via `RETRACE_ACTION_REGISTER`, add a cookbook recipe showing the
+  use case.
+- New backend ports — extend `src/backends/` following the pattern
+  in `src/backends/preload_elf/`. Self-register via the constructor
+  section.
+- New prototypes — add to `src/core/prototypes/<header>.c`, add the
+  function to `src/v2/funcs_symbols.def`, update any per-backend
+  `funcs_symbols.S`.
+- Documentation improvements — cookbook recipes, tutorials,
+  clarifications.
+
+### What probably won't get merged
+
+- Cosmetic refactors with no behavior change.
+- "Spring cleaning" PRs that touch many files.
+- Features without a documented use case.
+- Vendored third-party code (retrace is BSD-2 clean; we want to
+  keep it that way).
+
+## Code of conduct
+
+Ribose's standard community code of conduct applies. Be respectful,
+be technical, be patient. Disagreements about architecture are fine;
+personal attacks are not.
+
+Report conduct issues by emailing the maintainers at
+`opensource@ribose.com`.
+
+## Security disclosures
+
+**Do not open a public issue for security vulnerabilities.**
+
+Email `security@ribose.com` with details. Acknowledgment within
+48 hours. We coordinate disclosure on a timeline that works for
+you.
+
+See [SECURITY.md](https://github.com/riboseinc/retrace/security/policy)
+for the full policy.
+
+## Debugging retrace itself
+
+retrace debugging is tricky because retrace intercepts the libc
+calls that debuggers use. Workarounds:
+
+- **Disable interception while debugging**: set
+  `RETRACE_LOGGER_DEF_ENA=0`. The engine still runs (so you can
+  debug it) but no log output is produced, reducing interference.
+- **Use `gdb`'s `LD_PRELOAD` override**: launch gdb with
+  `gdb -ex 'set environment LD_PRELOAD=' your-binary` to suppress
+  retrace entirely.
+- **AddressSanitizer**: build retrace itself with
+  `-DRETRACE_ENABLE_ASAN=ON` to catch memory errors in retrace's
+  own code.
+- **`retrace_real_impls` struct**: if retrace recurses, the issue
+  is almost always that some libc call inside retrace bypassed the
+  real-impl indirection. Grep for direct libc calls in
+  `src/core/` and route them through `retrace_real_impls.*`.
+
+### Common debugging scenarios
+
+**"My target segfaults under retrace"**
+
+1. Build retrace with ASAN.
+2. Run the target under retrace + ASAN.
+3. The ASAN report will show whether the bug is in retrace or in
+   the target's error path triggered by retrace's interception.
+
+**"retrace hangs at startup"**
+
+Likely a `dlsym` deadlock during `retrace_real_impls_init`. Check
+that `retrace_as_init` ran first (it sets up the section data that
+`dlsym(RTLD_NEXT, ...)` may need on some platforms).
+
+**"My custom action doesn't fire"**
+
+1. Run `retrace list-actions` — does your action show up?
+2. If yes, check that your JSON config's `func_name` matches an
+   intercepted function (run `retrace list-functions | grep <name>`).
+3. If both check out, add a `printf` to your action's `run`
+   callback and confirm the engine is dispatching to it.
+
+## Adding a new backend
+
+Backends live in `src/backends/<name>/`. Each backend:
+
+1. Implements `retrace_backend_t` from
+   `include/retrace/backend.h`.
+2. Self-registers via a constructor in
+   `__attribute__((section("__retrace_backend")))`.
+3. Provides a `probe()` that returns non-zero if the backend can
+   run on the current platform.
+4. Provides `spawn()` that sets up the target process (env vars,
+   ptrace attach, inline hooks — whatever the mechanism needs).
+
+See `src/backends/preload_elf/` for the canonical example. The
+registry walks the constructor section at startup and picks the
+highest-rank backend whose `probe()` succeeds.
+
+## Adding a new action
+
+Drop a `.c` file in `src/core/actions/`. Implement the
+`RETRACE_ACTION_REGISTER` macro call:
+
+```c
+RETRACE_ACTION_REGISTER("my_action", ia_my_action,
+    "Does the thing. action_params:\n"
+    "  foo - required, int. The foo value.\n"
+    "  bar - optional, string. The bar value.\n");
+```
+
+Then implement `ia_my_action`:
+
+```c
+static int ia_my_action(struct ThreadContext *t_ctx,
+                        const JSON_Object *action_params)
+{
+    double foo;
+    const char *bar;
+
+    if (!action_params) {
+        log_err("action_params required for my_action");
+        return -1;
+    }
+
+    if (!json_object_has_value(action_params, "foo")) {
+        log_err("'foo' required for my_action");
+        return -1;
+    }
+    foo = json_object_get_number(action_params, "foo");
+
+    bar = json_object_get_string(action_params, "bar");
+
+    /* ... do the thing ... */
+    return 0;
+}
+```
+
+The build system picks up the new file automatically. Your action
+now appears in `retrace list-actions` and is referenceable from any
+JSON config.
+
+See `src/core/actions/basic.c` for the canonical examples.
+
+## CI
+
+GitHub workflows under `.github/workflows/`:
+
+- `build.yml` — Linux x64+arm64, macOS Intel+arm64, Windows MSVC
+  x64+arm64 (matrix). CMake + ctest.
+- `alpine.yml` — Alpine/musl x64+arm64.
+- `msys.yml` — MinGW64 + UCRT64.
+- `nix.yml` — builds `packages.v2/v2wrapper` from `flake.nix`.
+- `checkpatch.yml` — Linux `checkpatch.pl` against the diff.
+- `coverity.yml` — daily scheduled scan.
+- `release.yml` — tag-triggered source tarball + binary artifacts.
+
+`.cirrus.yml` covers FreeBSD 13/14.
+
+CI runs every PR through the full matrix. To reproduce locally:
+
+```sh
+./ci/main.sh
+```
+
+## See also
+
+- [Architecture](architecture.md) — how the engine, backends, and
+  actions fit together.
+- [Configuration reference](configuration.md) — the JSON schema.
+- [CLI reference](cli.md) — every subcommand.
+- [ADR index](adr/README.md) — architecture decision records.

--- a/website/src/components/Community.astro
+++ b/website/src/components/Community.astro
@@ -14,7 +14,7 @@ const paths = [
     cta: "Browse good first issues",
     href: "https://github.com/riboseinc/retrace/contribute",
     secondary: [
-      { label: "CONTRIBUTING.md", href: "https://github.com/riboseinc/retrace/blob/main/CONTRIBUTING.md" },
+      { label: "Development guide", href: "https://github.com/riboseinc/retrace/blob/main/docs/development.md" },
       { label: "Open a PR", href: "https://github.com/riboseinc/retrace/compare" },
     ],
   },


### PR DESCRIPTION
## Summary

The website's Community section points at "CONTRIBUTING.md" which doesn't exist; the cookbook references engine internals that have no canonical written explanation. This PR closes both gaps.

### docs/development.md

A new top-level doc covering everything a contributor needs to know: build from source, run tests, code style, contribution workflow, code of conduct, security disclosures, debugging retrace itself, adding a new backend, adding a new action, CI overview.

Sections:
- **Build from source** — CMake + Ninja, all `RETRACE_BUILD_*` options
- **Run the tests** — CTest labels: integration, unit, smoke, v2
- **Code style** — clang-format Mozilla-based; format manually
- **checkpatch** — Linux kernel style with project-specific ignore list; common gotchas including the `---` commit separator trap
- **Contribution workflow** — fork, branch, commit message format, PR, rebase-merge when green; what gets merged, what probably won't
- **Code of conduct** — Ribose community standard; conduct issues to `opensource@ribose.com`
- **Security disclosures** — DO NOT open a public issue; email `security@ribose.com`; 48-hour acknowledgement
- **Debugging retrace itself** — ASAN build, `RETRACE_LOGGER_DEF_ENA=0` to disable interference, real-impl indirection as recursion cause, three common debugging scenarios with concrete steps
- **Adding a new backend** — `retrace_backend_t` interface, self-registration via constructor section, `probe`/`spawn` pattern
- **Adding a new action** — `RETRACE_ACTION_REGISTER` macro, `ia_<action>` signature, return-value convention
- **CI overview** — per-workflow breakdown; `ci/main.sh` for local repro

Cross-references to `architecture.md`, `configuration.md`, `cli.md`, and the ADR index throughout.

### docs/architecture.md

A new top-level doc explaining how the engine, backends, and actions fit together. Written for engine developers and backend porters, not end users.

Sections:
- The one-paragraph model
- Layered view (ASCII diagram showing target → backend → engine → action → real libc)
- Init order (the strict 11-step sequence from `src/core/main.c`, with a note that out-of-order init is the most common retrace-internal bug)
- The frame (`WrapperSystemVFrame` and `WrapperAArch64Frame` layouts, with field-by-field explanation)
- The trampoline (per-arch assembly, the `WRAPPER_ENTRY_*` macros, the `funcs_symbols.def` DRY pattern)
- The engine (the 10-step flow in `retrace_engine_wrapper`; thin dispatch, all work in actions)
- Prototypes (`struct FuncPrototype`, how the engine uses them to walk frame args)
- Actions (`RETRACE_ACTION_REGISTER`, the section-based registry, return-value convention)
- **Real-impl indirection** (the most important invariant; every libc call inside retrace goes through `retrace_real_impls`; bypassing = infinite recursion)
- Config sources (the three sources, parson with comments)
- Logs (the JSON-lines stream, where it goes, pp/html viewers)
- Per-platform backends (the MECE matrix of 6 backends)

Cross-references to `development.md`, `configuration.md`, `cli.md`, and the relevant ADRs.

### docs/README.md

Index updated. Two new rows in the "where to go next" table:
- "Contribute, build, test, or debug retrace" → `development.md`
- "Understand the engine, backends, and actions" → `architecture.md`

Documentation map updated to include both new files.

### website/src/components/Community.astro

The Contribute card's secondary link was `CONTRIBUTING.md` (a file that doesn't exist). Updated to "Development guide" pointing at `docs/development.md`, which now exists and is the canonical contributing reference.

## Test plan

- [ ] CI green on this branch.
- [ ] Spot-check `docs/development.md` and `docs/architecture.md` rendering on GitHub.
- [ ] Verify the index in `docs/README.md` links resolve.
- [ ] Verify the Community card "Development guide" link works on the deployed site.
