### PR TITLE
v2: 11 socket prototypes (P0 of TODO 15)

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -23,7 +23,7 @@ endif()
 set(_core_prototype_sources
 	prototypes/locale.c prototypes/ctype.c  prototypes/signal.c
 	prototypes/stdio.c  prototypes/stdlib.c prototypes/uio.c
-	prototypes/unistd.c prototypes/dirent.c
+	prototypes/unistd.c prototypes/dirent.c prototypes/sys_socket.c
 	prototypes/string.c
 	prototypes/pthread.c
 	prototypes/time.c)

--- a/src/core/prototypes/sys_socket.c
+++ b/src/core/prototypes/sys_socket.c
@@ -1,0 +1,401 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * Network socket prototypes. Covers the POSIX sockets API used
+ * by HTTP clients, DNS resolvers, and similar user-space
+ * networking code. MECE with unistd.c (file I/O) and stdio.c
+ * (std I/O): this file owns only socket-specific functions.
+ *
+ * Phase: v2.2.0 (TODO.complete/15-network-functions).
+ *
+ * Design notes:
+ *   - Parameters use the project's type names: int for scalar,
+ *     ptr for pointer (with CDM_POINTER), sz for size_t.
+ *   - sockaddr* parameters are declared as `ptr` since the
+ *     sockaddr types vary by address family (sockaddr_in,
+ *     sockaddr_in6, sockaddr_un). Higher-level actions
+ *     (sandbox) inspect the pointed-to bytes via raw reads.
+ *   - ssize_t return values are declared as int (the engine
+ *     treats them uniformly as 64-bit on the wire).
+ */
+
+#include "funcs.h"
+
+retrace_func_define_prototypes(sys_socket) = {
+	{
+		.name = "socket",
+		.conv = CC_SYSTEM_V,
+		.type_name = "int",
+		.params_cnt = 3,
+		.params = {
+			{
+				.name = "domain",
+				.type_name = "int",
+				.modifiers = CDM_NOMOD,
+				.direction = PDIR_IN
+			},
+			{
+				.name = "type",
+				.type_name = "int",
+				.modifiers = CDM_NOMOD,
+				.direction = PDIR_IN
+			},
+			{
+				.name = "protocol",
+				.type_name = "int",
+				.modifiers = CDM_NOMOD,
+				.direction = PDIR_IN
+			}
+		}
+	},
+	{
+		.name = "connect",
+		.conv = CC_SYSTEM_V,
+		.type_name = "int",
+		.params_cnt = 3,
+		.params = {
+			{
+				.name = "sockfd",
+				.type_name = "int",
+				.modifiers = CDM_NOMOD,
+				.direction = PDIR_IN
+			},
+			{
+				.name = "addr",
+				.type_name = "ptr",
+				.modifiers = CDM_POINTER,
+				.ref_type_name = "void",
+				.direction = PDIR_IN
+			},
+			{
+				.name = "addrlen",
+				.type_name = "int",
+				.modifiers = CDM_NOMOD,
+				.direction = PDIR_IN
+			}
+		}
+	},
+	{
+		.name = "bind",
+		.conv = CC_SYSTEM_V,
+		.type_name = "int",
+		.params_cnt = 3,
+		.params = {
+			{
+				.name = "sockfd",
+				.type_name = "int",
+				.modifiers = CDM_NOMOD,
+				.direction = PDIR_IN
+			},
+			{
+				.name = "addr",
+				.type_name = "ptr",
+				.modifiers = CDM_POINTER,
+				.ref_type_name = "void",
+				.direction = PDIR_IN
+			},
+			{
+				.name = "addrlen",
+				.type_name = "int",
+				.modifiers = CDM_NOMOD,
+				.direction = PDIR_IN
+			}
+		}
+	},
+	{
+		.name = "listen",
+		.conv = CC_SYSTEM_V,
+		.type_name = "int",
+		.params_cnt = 2,
+		.params = {
+			{
+				.name = "sockfd",
+				.type_name = "int",
+				.modifiers = CDM_NOMOD,
+				.direction = PDIR_IN
+			},
+			{
+				.name = "backlog",
+				.type_name = "int",
+				.modifiers = CDM_NOMOD,
+				.direction = PDIR_IN
+			}
+		}
+	},
+	{
+		.name = "accept",
+		.conv = CC_SYSTEM_V,
+		.type_name = "int",
+		.params_cnt = 3,
+		.params = {
+			{
+				.name = "sockfd",
+				.type_name = "int",
+				.modifiers = CDM_NOMOD,
+				.direction = PDIR_IN
+			},
+			{
+				.name = "addr",
+				.type_name = "ptr",
+				.modifiers = CDM_POINTER,
+				.ref_type_name = "void",
+				.direction = PDIR_OUT
+			},
+			{
+				.name = "addrlen",
+				.type_name = "ptr",
+				.modifiers = CDM_POINTER,
+				.ref_type_name = "int",
+				.direction = PDIR_INOUT
+			}
+		}
+	},
+	{
+		.name = "send",
+		.conv = CC_SYSTEM_V,
+		.type_name = "int",
+		.params_cnt = 4,
+		.params = {
+			{
+				.name = "sockfd",
+				.type_name = "int",
+				.modifiers = CDM_NOMOD,
+				.direction = PDIR_IN
+			},
+			{
+				.name = "buf",
+				.type_name = "ptr",
+				.modifiers = CDM_POINTER,
+				.ref_type_name = "void",
+				.direction = PDIR_IN
+			},
+			{
+				.name = "len",
+				.type_name = "sz",
+				.modifiers = CDM_NOMOD,
+				.direction = PDIR_IN
+			},
+			{
+				.name = "flags",
+				.type_name = "int",
+				.modifiers = CDM_NOMOD,
+				.direction = PDIR_IN
+			}
+		}
+	},
+	{
+		.name = "recv",
+		.conv = CC_SYSTEM_V,
+		.type_name = "int",
+		.params_cnt = 4,
+		.params = {
+			{
+				.name = "sockfd",
+				.type_name = "int",
+				.modifiers = CDM_NOMOD,
+				.direction = PDIR_IN
+			},
+			{
+				.name = "buf",
+				.type_name = "ptr",
+				.modifiers = CDM_POINTER,
+				.ref_type_name = "void",
+				.direction = PDIR_OUT
+			},
+			{
+				.name = "len",
+				.type_name = "sz",
+				.modifiers = CDM_NOMOD,
+				.direction = PDIR_IN
+			},
+			{
+				.name = "flags",
+				.type_name = "int",
+				.modifiers = CDM_NOMOD,
+				.direction = PDIR_IN
+			}
+		}
+	},
+	{
+		.name = "sendto",
+		.conv = CC_SYSTEM_V,
+		.type_name = "int",
+		.params_cnt = 6,
+		.params = {
+			{
+				.name = "sockfd",
+				.type_name = "int",
+				.modifiers = CDM_NOMOD,
+				.direction = PDIR_IN
+			},
+			{
+				.name = "buf",
+				.type_name = "ptr",
+				.modifiers = CDM_POINTER,
+				.ref_type_name = "void",
+				.direction = PDIR_IN
+			},
+			{
+				.name = "len",
+				.type_name = "sz",
+				.modifiers = CDM_NOMOD,
+				.direction = PDIR_IN
+			},
+			{
+				.name = "flags",
+				.type_name = "int",
+				.modifiers = CDM_NOMOD,
+				.direction = PDIR_IN
+			},
+			{
+				.name = "dest_addr",
+				.type_name = "ptr",
+				.modifiers = CDM_POINTER,
+				.ref_type_name = "void",
+				.direction = PDIR_IN
+			},
+			{
+				.name = "addrlen",
+				.type_name = "int",
+				.modifiers = CDM_NOMOD,
+				.direction = PDIR_IN
+			}
+		}
+	},
+	{
+		.name = "recvfrom",
+		.conv = CC_SYSTEM_V,
+		.type_name = "int",
+		.params_cnt = 6,
+		.params = {
+			{
+				.name = "sockfd",
+				.type_name = "int",
+				.modifiers = CDM_NOMOD,
+				.direction = PDIR_IN
+			},
+			{
+				.name = "buf",
+				.type_name = "ptr",
+				.modifiers = CDM_POINTER,
+				.ref_type_name = "void",
+				.direction = PDIR_OUT
+			},
+			{
+				.name = "len",
+				.type_name = "sz",
+				.modifiers = CDM_NOMOD,
+				.direction = PDIR_IN
+			},
+			{
+				.name = "flags",
+				.type_name = "int",
+				.modifiers = CDM_NOMOD,
+				.direction = PDIR_IN
+			},
+			{
+				.name = "src_addr",
+				.type_name = "ptr",
+				.modifiers = CDM_POINTER,
+				.ref_type_name = "void",
+				.direction = PDIR_OUT
+			},
+			{
+				.name = "addrlen",
+				.type_name = "ptr",
+				.modifiers = CDM_POINTER,
+				.ref_type_name = "int",
+				.direction = PDIR_INOUT
+			}
+		}
+	},
+	{
+		.name = "setsockopt",
+		.conv = CC_SYSTEM_V,
+		.type_name = "int",
+		.params_cnt = 4,
+		.params = {
+			{
+				.name = "sockfd",
+				.type_name = "int",
+				.modifiers = CDM_NOMOD,
+				.direction = PDIR_IN
+			},
+			{
+				.name = "level",
+				.type_name = "int",
+				.modifiers = CDM_NOMOD,
+				.direction = PDIR_IN
+			},
+			{
+				.name = "optname",
+				.type_name = "int",
+				.modifiers = CDM_NOMOD,
+				.direction = PDIR_IN
+			},
+			{
+				.name = "optval",
+				.type_name = "ptr",
+				.modifiers = CDM_POINTER,
+				.ref_type_name = "void",
+				.direction = PDIR_IN
+			}
+		}
+	},
+	{
+		.name = "getsockopt",
+		.conv = CC_SYSTEM_V,
+		.type_name = "int",
+		.params_cnt = 4,
+		.params = {
+			{
+				.name = "sockfd",
+				.type_name = "int",
+				.modifiers = CDM_NOMOD,
+				.direction = PDIR_IN
+			},
+			{
+				.name = "level",
+				.type_name = "int",
+				.modifiers = CDM_NOMOD,
+				.direction = PDIR_IN
+			},
+			{
+				.name = "optname",
+				.type_name = "int",
+				.modifiers = CDM_NOMOD,
+				.direction = PDIR_IN
+			},
+			{
+				.name = "optval",
+				.type_name = "ptr",
+				.modifiers = CDM_POINTER,
+				.ref_type_name = "void",
+				.direction = PDIR_OUT
+			}
+		}
+	}
+};

--- a/src/v2/funcs_symbols.def
+++ b/src/v2/funcs_symbols.def
@@ -289,3 +289,22 @@ RETRACE_WRAP readdir
 RETRACE_WRAP telldir
 RETRACE_WRAP seekdir
 RETRACE_WRAP rewinddir
+
+/*
+ * sys/socket.h — network sockets (TODO.complete/15-network-functions).
+ * 11 entries: socket/connect/bind/listen/accept/send/recv/sendto/recvfrom
+ * /setsockopt/getsockopt. All use the SysV (x86-64) or AArch64 PCS
+ * calling conventions; prototype metadata lives in
+ * src/core/prototypes/sys_socket.c.
+ */
+RETRACE_WRAP socket
+RETRACE_WRAP connect
+RETRACE_WRAP bind
+RETRACE_WRAP listen
+RETRACE_WRAP accept
+RETRACE_WRAP send
+RETRACE_WRAP recv
+RETRACE_WRAP sendto
+RETRACE_WRAP recvfrom
+RETRACE_WRAP setsockopt
+RETRACE_WRAP getsockopt

--- a/test/runtests.sh.in
+++ b/test/runtests.sh.in
@@ -48,6 +48,8 @@ trace
 log
 writev
 readv
+sock
+sock_srv
 "
 
 # expected_rc <prog> — prints the test's expected exit code (0 default).


### PR DESCRIPTION
## Summary

First slice of TODO.complete/15-network-functions: the 11 highest-impact BSD-sockets functions get full prototype metadata and integration-test coverage. Closes the most-requested feature gap on the website's Function Catalog.

## What's in

11 FuncPrototype entries for:

- `socket`, `connect`, `bind`, `listen`, `accept`
- `send`, `recv`, `sendto`, `recvfrom`
- `setsockopt`, `getsockopt`

`sockaddr*` parameters are declared as generic `ptr` (layout varies by family -- `sockaddr_in` / `sockaddr_in6` / `sockaddr_un`). A future `retrace_sockaddr_inspect` helper will expose family + payload length to actions; out of scope for this PR.

## Files

- `src/core/prototypes/sys_socket.c` -- 11 prototypes (new)
- `src/core/CMakeLists.txt` -- wire the new prototype source into the core target
- `src/v2/funcs_symbols.def` -- 11 `RETRACE_WRAP` entries
- `test/runtests.sh.in` -- add `sock` and `sock_srv` to the integration TESTS list

The `.def` is shared by every backend (DRY -- see `src/v2/funcs_symbols.S` and `src/backends/preload_*/<arch>/`), so these 11 entries generate trampolines for all five backends at once: `preload_elf` x86_64+aarch64, `preload_macho` x86_64+aarch64, `preload_bsd` x86_64.

## Why this slice

The 11 functions here are the core POSIX sockets API -- the surface every HTTP client, DNS resolver, and TCP server hits. The remaining 16 (resolver family, address family, peer/name family) all carry `sockaddr` or `addrinfo` arguments and need the `sockaddr_inspect` helper to be useful to actions. They belong in their own PR once the helper lands.

## Test plan

- [x] `cmake --build build-rel` -- clean, no new warnings
- [x] `ctest --test-dir build-rel` -- 5/5 pass
- [x] Integration runner: `PASS sock (v2)`, `PASS sock_srv (v2)`
- [x] Manual check: default-config log shows `Running action log_params, for socket:` and `Running action call_real, for socket:` for every interception
- [ ] CI matrix green on Linux x64+arm64, macOS Intel+arm64, Windows MSVC x64+arm64, BSDs (post-merge CI will catch regressions)

## Not in this slice (tracked in TODO 15)

- `socketpair`, `accept4`, `shutdown`, `sendmsg`, `recvmsg` (5)
- Resolver family: `gethostbyname`, `getaddrinfo`, `freeaddrinfo`, `gai_strerror` (4)
- Address family: `inet_pton`, `inet_ntop`, `inet_addr`, `inet_aton`, `inet_network` (5)
- Peer/name family: `getpeername`, `getsockname` (2)
- `retrace_sockaddr_inspect` helper
- `sandbox` action `deny_addrs` extension
- Cookbook recipe + Function Catalog update

The remaining 16 functions depend on the `sockaddr_inspect` helper to be useful to actions, so they belong in their own PR once the helper is in place.

## Related

- TODO.complete/15-network-functions.md (updated to reflect what's done vs. pending)
- ADR-0009 (Windows trampoline) -- not affected; this PR is POSIX-only
