### PR TITLE
v2: complete socket interception -- 16 more functions + helper + action

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -299,6 +299,21 @@ if(NOT HAVE_ISOC99_SCANF)
 endif()
 add_compile_definitions(RETRACE_HAVE_ISOC99_SCANF=${HAVE_ISOC99_SCANF})
 
+# accept4() is a Linux-ism (glibc 2.10+, kernel 2.6.28+). FreeBSD,
+# OpenBSD, and NetBSD adopted it later. macOS does NOT ship it. The
+# trampoline .S references the symbol directly, so we must only emit
+# the wrapper on platforms that actually export it. Same pattern as
+# RETRACE_HAVE_ISOC99_SCANF above.
+check_c_source_compiles("
+	#include <sys/types.h>
+	#include <sys/socket.h>
+	int main(void) { return accept4(0, (void *)0, (void *)0, 0); }
+" HAVE_ACCEPT4)
+if(NOT HAVE_ACCEPT4)
+	set(HAVE_ACCEPT4 0)
+endif()
+add_compile_definitions(RETRACE_HAVE_ACCEPT4=${HAVE_ACCEPT4})
+
 # Make config.h discoverable by every target.
 # Also add src/config/json (parson.h, conf.h) and src/backends (arch_spec.h)
 # globally — OBJECT libraries don't always propagate target_include_directories

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -10,7 +10,8 @@
 set(_core_sources
 	engine.c        funcs.c         actions.c      data_types.c
 	real_impls.c    logger.c        main.c         as_call_real.c
-	thread_context.c script_resolver.c action_runner.c)
+	thread_context.c script_resolver.c action_runner.c
+	sockaddr_inspect.c)
 
 # dlopen_guard.c is Linux-only: it exports dlopen/dlclose/dlsym/dlerror
 # as global symbols for LD_PRELOAD interposition. On macOS these symbols
@@ -32,7 +33,7 @@ set(_core_action_sources
 	actions/basic.c actions/memfuzz.c
 	actions/incomplete_io.c actions/fuzzing_seed.c
 	actions/delay.c actions/call_count_limit.c
-	actions/sandbox.c)
+	actions/sandbox.c actions/addr_deny.c)
 
 set(_core_datatype_sources
 	datatypes/basic.c datatypes/uio.c datatypes/unistd.c)

--- a/src/core/actions/addr_deny.c
+++ b/src/core/actions/addr_deny.c
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * addr_deny -- deny-list network destinations.
+ *
+ * The network equivalent of `sandbox`. Where sandbox inspects path
+ * arguments of open/fopen/openat and returns -1 on match, addr_deny
+ * inspects sockaddr arguments of connect/bind/sendto/recvfrom and
+ * returns -ECONNREFUSED on match.
+ *
+ * Why a separate action (not an extension of sandbox)
+ * ===================================================
+ *
+ * sandbox's contract is "deny access to specific file paths."
+ * Adding "and also network addresses" turns it into a denylist
+ * for everything, violating MECE: the action name should encode
+ * what it operates on. Keeping them separate also keeps each
+ * action's JSON schema simple -- one array per action -- and
+ * lets users combine them independently (sandbox paths in one
+ * script, addr_deny in another, both attached to the same
+ * function if desired).
+ *
+ * sockaddr extraction
+ * ===================
+ *
+ * Different functions put the sockaddr at different parameter
+ * indices:
+ *   connect(sockfd, addr, addrlen)             -- params[1]
+ *   bind(sockfd, addr, addrlen)                -- params[1]
+ *   sendto(..., dest_addr, addrlen)            -- params[4]
+ *   recvfrom(..., src_addr, addrlen)           -- params[4]
+ *   accept(sockfd, addr, addrlen)              -- params[1]
+ *   getpeername(sockfd, addr, addrlen)         -- params[1]
+ *
+ * To avoid hardcoding every function->index map, the action
+ * scans t_ctx->params for the first parameter whose name is
+ * "addr", "dest_addr", or "src_addr" and treats its value as
+ * the sockaddr pointer. The prototype metadata (param_meta.name)
+ * is the source of truth -- the action never inspects the
+ * function name.
+ *
+ * action_params:
+ *   deny_addrs - JSON array of "host:port" specs. Each spec is
+ *                matched via retrace_sockaddr_match. Wildcards
+ *                supported: "host:*", "*:port", "*:*" (deny all),
+ *                "[::1]:443" (IPv6), "/var/run/x.sock" (AF_UNIX).
+ *
+ * Example JSON (block all outbound connects to port 443 and to
+ * a specific IP):
+ *   {
+ *     "func_name": "connect",
+ *     "actions": [
+ *       { "action_name": "addr_deny",
+ *         "action_params": {
+ *           "deny_addrs": ["*:443", "10.0.0.1:*"]
+ *         }
+ *       },
+ *       { "action_name": "call_real" }
+ *     ]
+ *   }
+ *
+ * On match, the action sets t_ctx->ret_val = -ECONNREFUSED and
+ * returns -1 to abort the script (call_real will not run).
+ */
+
+#include <errno.h>
+#include <string.h>
+
+#include "actions.h"
+#include "engine.h"
+#include "logger.h"
+#include "real_impls.h"
+#include "sockaddr_inspect.h"
+
+/* Names that identify a sockaddr argument in prototype metadata.
+ * The action scans params and picks the first match.
+ */
+static int is_addr_param_name(const char *name)
+{
+	if (name == NULL)
+		return 0;
+
+	if (retrace_real_impls.strcmp(name, "addr") == 0)
+		return 1;
+	if (retrace_real_impls.strcmp(name, "dest_addr") == 0)
+		return 1;
+	if (retrace_real_impls.strcmp(name, "src_addr") == 0)
+		return 1;
+	return 0;
+}
+
+/* Find the sockaddr pointer among the call's params. Returns the
+ * pointer, or NULL if no suitable param was found.
+ */
+static const void *find_sockaddr(struct ThreadContext *t_ctx)
+{
+	int i;
+
+	for (i = 0; i < t_ctx->params_cnt; i++) {
+		const char *name = t_ctx->params[i].param_meta.name;
+
+		if (is_addr_param_name(name))
+			return (const void *)t_ctx->params[i].val;
+	}
+
+	return NULL;
+}
+
+static int ia_addr_deny(struct ThreadContext *t_ctx,
+			const JSON_Object *action_params)
+{
+	JSON_Array *deny_addrs;
+	size_t i, n;
+	const void *sa;
+	struct retrace_sockaddr_info info;
+
+	if (action_params == NULL) {
+		log_err("addr_deny: action_params required");
+		return -1;
+	}
+
+	deny_addrs = json_object_get_array(action_params, "deny_addrs");
+	if (deny_addrs == NULL) {
+		log_err("addr_deny: 'deny_addrs' array required");
+		return -1;
+	}
+
+	sa = find_sockaddr(t_ctx);
+	if (sa == NULL) {
+		/* Not a function we can inspect. Let the script continue;
+		 * call_real will run.
+		 */
+		return 0;
+	}
+
+	if (retrace_sockaddr_inspect(sa, 0, &info) != 0) {
+		log_warn("addr_deny: could not inspect sockaddr; allowing");
+		return 0;
+	}
+
+	n = json_array_get_count(deny_addrs);
+	for (i = 0; i < n; i++) {
+		const char *spec = json_array_get_string(deny_addrs, i);
+		int match;
+
+		if (spec == NULL)
+			continue;
+
+		match = retrace_sockaddr_match(&info, spec);
+		if (match < 0) {
+			log_warn("addr_deny: malformed spec '%s' ignored",
+				spec);
+			continue;
+		}
+
+		if (match) {
+			log_warn("addr_deny: DENIED %s:%u (matches '%s')",
+				info.ip[0] ? info.ip : "(unix)",
+				(unsigned int)info.port, spec);
+			t_ctx->ret_val = -ECONNREFUSED;
+			return -1;
+		}
+	}
+
+	return 0;
+}
+
+retrace_actions_define_package(addr_deny) = {
+	{
+		.name = "addr_deny",
+		.action = ia_addr_deny
+	}
+};

--- a/src/core/prototypes/sys_socket.c
+++ b/src/core/prototypes/sys_socket.c
@@ -397,5 +397,410 @@ retrace_func_define_prototypes(sys_socket) = {
 				.direction = PDIR_OUT
 			}
 		}
+	},
+	/*
+	 * Second slice (TODO.complete/15 follow-up): the remaining 16
+	 * socket-family functions.
+	 *
+	 *   - socketpair, accept4, shutdown: simple int args
+	 *   - sendmsg, recvmsg: msghdr* (opaque; msghdr inspect deferred)
+	 *   - gethostbyname: returns opaque hostent*
+	 *   - getaddrinfo/freeaddrinfo/gai_strerror: addrinfo family
+	 *   - inet_pton/ntop/addr/aton/network: string/addr conversions
+	 *   - getpeername/getsockname: sockaddr out, mirror bind
+	 *
+	 * ssize_t returns are declared as int (engine treats them as
+	 * 64-bit on the wire; matches the first slice).
+	 */
+	{
+		.name = "socketpair",
+		.conv = CC_SYSTEM_V,
+		.type_name = "int",
+		.params_cnt = 4,
+		.params = {
+			{
+				.name = "domain",
+				.type_name = "int",
+				.modifiers = CDM_NOMOD,
+				.direction = PDIR_IN
+			},
+			{
+				.name = "type",
+				.type_name = "int",
+				.modifiers = CDM_NOMOD,
+				.direction = PDIR_IN
+			},
+			{
+				.name = "protocol",
+				.type_name = "int",
+				.modifiers = CDM_NOMOD,
+				.direction = PDIR_IN
+			},
+			{
+				.name = "sv",
+				.type_name = "ptr",
+				.modifiers = CDM_POINTER,
+				.ref_type_name = "int",
+				.direction = PDIR_OUT
+			}
+		}
+	},
+	{
+		.name = "accept4",
+		.conv = CC_SYSTEM_V,
+		.type_name = "int",
+		.params_cnt = 4,
+		.params = {
+			{
+				.name = "sockfd",
+				.type_name = "int",
+				.modifiers = CDM_NOMOD,
+				.direction = PDIR_IN
+			},
+			{
+				.name = "addr",
+				.type_name = "ptr",
+				.modifiers = CDM_POINTER,
+				.ref_type_name = "void",
+				.direction = PDIR_OUT
+			},
+			{
+				.name = "addrlen",
+				.type_name = "ptr",
+				.modifiers = CDM_POINTER,
+				.ref_type_name = "int",
+				.direction = PDIR_INOUT
+			},
+			{
+				.name = "flags",
+				.type_name = "int",
+				.modifiers = CDM_NOMOD,
+				.direction = PDIR_IN
+			}
+		}
+	},
+	{
+		.name = "shutdown",
+		.conv = CC_SYSTEM_V,
+		.type_name = "int",
+		.params_cnt = 2,
+		.params = {
+			{
+				.name = "sockfd",
+				.type_name = "int",
+				.modifiers = CDM_NOMOD,
+				.direction = PDIR_IN
+			},
+			{
+				.name = "how",
+				.type_name = "int",
+				.modifiers = CDM_NOMOD,
+				.direction = PDIR_IN
+			}
+		}
+	},
+	{
+		.name = "sendmsg",
+		.conv = CC_SYSTEM_V,
+		.type_name = "int",
+		.params_cnt = 3,
+		.params = {
+			{
+				.name = "sockfd",
+				.type_name = "int",
+				.modifiers = CDM_NOMOD,
+				.direction = PDIR_IN
+			},
+			{
+				.name = "msg",
+				.type_name = "ptr",
+				.modifiers = CDM_POINTER,
+				.ref_type_name = "void",
+				.direction = PDIR_IN
+			},
+			{
+				.name = "flags",
+				.type_name = "int",
+				.modifiers = CDM_NOMOD,
+				.direction = PDIR_IN
+			}
+		}
+	},
+	{
+		.name = "recvmsg",
+		.conv = CC_SYSTEM_V,
+		.type_name = "int",
+		.params_cnt = 3,
+		.params = {
+			{
+				.name = "sockfd",
+				.type_name = "int",
+				.modifiers = CDM_NOMOD,
+				.direction = PDIR_IN
+			},
+			{
+				.name = "msg",
+				.type_name = "ptr",
+				.modifiers = CDM_POINTER,
+				.ref_type_name = "void",
+				.direction = PDIR_INOUT
+			},
+			{
+				.name = "flags",
+				.type_name = "int",
+				.modifiers = CDM_NOMOD,
+				.direction = PDIR_IN
+			}
+		}
+	},
+	{
+		.name = "gethostbyname",
+		.conv = CC_SYSTEM_V,
+		.type_name = "ptr",
+		.params_cnt = 1,
+		.params = {
+			{
+				.name = "name",
+				.type_name = "ptr",
+				.modifiers = CDM_POINTER | CDM_CONST,
+				.ref_type_name = "sz",
+				.direction = PDIR_IN
+			}
+		}
+	},
+	{
+		.name = "getaddrinfo",
+		.conv = CC_SYSTEM_V,
+		.type_name = "int",
+		.params_cnt = 4,
+		.params = {
+			{
+				.name = "node",
+				.type_name = "ptr",
+				.modifiers = CDM_POINTER | CDM_CONST,
+				.ref_type_name = "sz",
+				.direction = PDIR_IN
+			},
+			{
+				.name = "service",
+				.type_name = "ptr",
+				.modifiers = CDM_POINTER | CDM_CONST,
+				.ref_type_name = "sz",
+				.direction = PDIR_IN
+			},
+			{
+				.name = "hints",
+				.type_name = "ptr",
+				.modifiers = CDM_POINTER | CDM_CONST,
+				.ref_type_name = "void",
+				.direction = PDIR_IN
+			},
+			{
+				.name = "res",
+				.type_name = "ptr",
+				.modifiers = CDM_POINTER,
+				.ref_type_name = "ptr",
+				.direction = PDIR_OUT
+			}
+		}
+	},
+	{
+		.name = "freeaddrinfo",
+		.conv = CC_SYSTEM_V,
+		.type_name = "void",
+		.params_cnt = 1,
+		.params = {
+			{
+				.name = "res",
+				.type_name = "ptr",
+				.modifiers = CDM_POINTER,
+				.ref_type_name = "void",
+				.direction = PDIR_IN
+			}
+		}
+	},
+	{
+		.name = "gai_strerror",
+		.conv = CC_SYSTEM_V,
+		.type_name = "ptr",
+		.params_cnt = 1,
+		.params = {
+			{
+				.name = "errcode",
+				.type_name = "int",
+				.modifiers = CDM_NOMOD,
+				.direction = PDIR_IN
+			}
+		}
+	},
+	{
+		.name = "inet_pton",
+		.conv = CC_SYSTEM_V,
+		.type_name = "int",
+		.params_cnt = 3,
+		.params = {
+			{
+				.name = "af",
+				.type_name = "int",
+				.modifiers = CDM_NOMOD,
+				.direction = PDIR_IN
+			},
+			{
+				.name = "src",
+				.type_name = "ptr",
+				.modifiers = CDM_POINTER | CDM_CONST,
+				.ref_type_name = "sz",
+				.direction = PDIR_IN
+			},
+			{
+				.name = "dst",
+				.type_name = "ptr",
+				.modifiers = CDM_POINTER,
+				.ref_type_name = "void",
+				.direction = PDIR_OUT
+			}
+		}
+	},
+	{
+		.name = "inet_ntop",
+		.conv = CC_SYSTEM_V,
+		.type_name = "ptr",
+		.params_cnt = 4,
+		.params = {
+			{
+				.name = "af",
+				.type_name = "int",
+				.modifiers = CDM_NOMOD,
+				.direction = PDIR_IN
+			},
+			{
+				.name = "src",
+				.type_name = "ptr",
+				.modifiers = CDM_POINTER | CDM_CONST,
+				.ref_type_name = "void",
+				.direction = PDIR_IN
+			},
+			{
+				.name = "dst",
+				.type_name = "ptr",
+				.modifiers = CDM_POINTER,
+				.ref_type_name = "sz",
+				.direction = PDIR_OUT
+			},
+			{
+				.name = "size",
+				.type_name = "sz",
+				.modifiers = CDM_NOMOD,
+				.direction = PDIR_IN
+			}
+		}
+	},
+	{
+		.name = "inet_addr",
+		.conv = CC_SYSTEM_V,
+		.type_name = "unsigned int",
+		.params_cnt = 1,
+		.params = {
+			{
+				.name = "cp",
+				.type_name = "ptr",
+				.modifiers = CDM_POINTER | CDM_CONST,
+				.ref_type_name = "sz",
+				.direction = PDIR_IN
+			}
+		}
+	},
+	{
+		.name = "inet_aton",
+		.conv = CC_SYSTEM_V,
+		.type_name = "int",
+		.params_cnt = 2,
+		.params = {
+			{
+				.name = "cp",
+				.type_name = "ptr",
+				.modifiers = CDM_POINTER | CDM_CONST,
+				.ref_type_name = "sz",
+				.direction = PDIR_IN
+			},
+			{
+				.name = "inp",
+				.type_name = "ptr",
+				.modifiers = CDM_POINTER,
+				.ref_type_name = "void",
+				.direction = PDIR_OUT
+			}
+		}
+	},
+	{
+		.name = "inet_network",
+		.conv = CC_SYSTEM_V,
+		.type_name = "unsigned int",
+		.params_cnt = 1,
+		.params = {
+			{
+				.name = "cp",
+				.type_name = "ptr",
+				.modifiers = CDM_POINTER | CDM_CONST,
+				.ref_type_name = "sz",
+				.direction = PDIR_IN
+			}
+		}
+	},
+	{
+		.name = "getpeername",
+		.conv = CC_SYSTEM_V,
+		.type_name = "int",
+		.params_cnt = 3,
+		.params = {
+			{
+				.name = "sockfd",
+				.type_name = "int",
+				.modifiers = CDM_NOMOD,
+				.direction = PDIR_IN
+			},
+			{
+				.name = "addr",
+				.type_name = "ptr",
+				.modifiers = CDM_POINTER,
+				.ref_type_name = "void",
+				.direction = PDIR_OUT
+			},
+			{
+				.name = "addrlen",
+				.type_name = "ptr",
+				.modifiers = CDM_POINTER,
+				.ref_type_name = "int",
+				.direction = PDIR_INOUT
+			}
+		}
+	},
+	{
+		.name = "getsockname",
+		.conv = CC_SYSTEM_V,
+		.type_name = "int",
+		.params_cnt = 3,
+		.params = {
+			{
+				.name = "sockfd",
+				.type_name = "int",
+				.modifiers = CDM_NOMOD,
+				.direction = PDIR_IN
+			},
+			{
+				.name = "addr",
+				.type_name = "ptr",
+				.modifiers = CDM_POINTER,
+				.ref_type_name = "void",
+				.direction = PDIR_OUT
+			},
+			{
+				.name = "addrlen",
+				.type_name = "ptr",
+				.modifiers = CDM_POINTER,
+				.ref_type_name = "int",
+				.direction = PDIR_INOUT
+			}
+		}
 	}
 };

--- a/src/core/sockaddr_inspect.c
+++ b/src/core/sockaddr_inspect.c
@@ -1,0 +1,358 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * sockaddr_inspect implementation. See sockaddr_inspect.h for the
+ * public contract.
+ *
+ * All libc usage goes through retrace_real_impls. We never call
+ * strchr/strncpy/strtol directly because those are intercepted by
+ * prototypes/string.c -- using them would recurse back through the
+ * engine. Manual equivalents below.
+ */
+
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <netinet/in.h>
+#include <sys/un.h>
+#include <arpa/inet.h>
+
+#include "sockaddr_inspect.h"
+#include "real_impls.h"
+#include "logger.h"
+
+#define MIN_HEADER_LEN  (sizeof(((struct sockaddr *)0)->sa_family))
+
+static char find_char(const char *s, char c)
+{
+	for (; *s != '\0'; s++) {
+		if (*s == c)
+			return 1;
+	}
+	return 0;
+}
+
+static const char *find_byte(const char *s, char c)
+{
+	for (; *s != '\0'; s++) {
+		if (*s == c)
+			return s;
+	}
+	return NULL;
+}
+
+static void copy_bounded(const char *src, char *dst, size_t cap)
+{
+	size_t i;
+
+	if (cap == 0)
+		return;
+
+	for (i = 0; i + 1 < cap; i++) {
+		if (src[i] == '\0')
+			break;
+		dst[i] = src[i];
+	}
+	dst[i] = '\0';
+}
+
+/* Parse a non-negative decimal integer 0..65535. Returns 0 on
+ * success and writes the value; -1 on overflow or empty input.
+ */
+static int parse_port(const char *s, int *out)
+{
+	long v = 0;
+
+	if (s[0] < '0' || s[0] > '9')
+		return -1;
+
+	while (s[0] >= '0' && s[0] <= '9') {
+		v = v * 10 + (s[0] - '0');
+		if (v > 65535)
+			return -1;
+		s++;
+	}
+
+	if (s[0] != '\0')
+		return -1;
+
+	*out = (int)v;
+	return 0;
+}
+
+static void format_ipv4(const struct in_addr *a, char *buf, size_t buflen)
+{
+	const unsigned char *p = (const unsigned char *)a;
+
+	if (buflen < 16) {
+		if (buflen > 0)
+			buf[0] = '\0';
+		return;
+	}
+
+	retrace_real_impls.real_snprintf(buf, buflen, "%u.%u.%u.%u",
+		p[0], p[1], p[2], p[3]);
+}
+
+static void format_ipv6(const struct in6_addr *a, char *buf, size_t buflen)
+{
+	const uint16_t *w = (const uint16_t *)a->s6_addr;
+	size_t i;
+	size_t pos = 0;
+
+	if (buflen < 40) {
+		if (buflen > 0)
+			buf[0] = '\0';
+		return;
+	}
+
+	for (i = 0; i < 8; i++) {
+		uint16_t v = ntohs(w[i]);
+		int n;
+
+		n = retrace_real_impls.real_snprintf(buf + pos,
+			buflen - pos, (i == 0) ? "%x" : ":%x", v);
+		if (n < 0 || (size_t)n >= buflen - pos)
+			break;
+		pos += (size_t)n;
+	}
+}
+
+int retrace_sockaddr_inspect(const void *sa, size_t addrlen,
+			      struct retrace_sockaddr_info *out)
+{
+	const struct sockaddr *s;
+	sa_family_t family;
+
+	if (sa == NULL || out == NULL)
+		return -1;
+
+	retrace_real_impls.memset(out, 0, sizeof(*out));
+
+	if (addrlen != 0 && addrlen < MIN_HEADER_LEN) {
+		log_err("sockaddr_inspect: addrlen %zu too small", addrlen);
+		return -1;
+	}
+
+	s = (const struct sockaddr *)sa;
+	family = s->sa_family;
+	out->family = (int)family;
+
+	switch (family) {
+	case AF_INET: {
+		const struct sockaddr_in *sin;
+
+		if (addrlen != 0 && addrlen < sizeof(*sin))
+			return -1;
+
+		sin = (const struct sockaddr_in *)sa;
+		out->group = RETRACE_SAF_INET;
+		out->expected_len = sizeof(*sin);
+		out->port = ntohs(sin->sin_port);
+		format_ipv4(&sin->sin_addr, out->ip, sizeof(out->ip));
+		return 0;
+	}
+	case AF_INET6: {
+		const struct sockaddr_in6 *sin6;
+
+		if (addrlen != 0 && addrlen < sizeof(*sin6))
+			return -1;
+
+		sin6 = (const struct sockaddr_in6 *)sa;
+		out->group = RETRACE_SAF_INET6;
+		out->expected_len = sizeof(*sin6);
+		out->port = ntohs(sin6->sin6_port);
+		format_ipv6(&sin6->sin6_addr, out->ip, sizeof(out->ip));
+		return 0;
+	}
+	case AF_UNIX: {
+		const struct sockaddr_un *sun;
+		size_t pathlen;
+		size_t max_path = sizeof(sun->sun_path);
+
+		if (addrlen != 0 && addrlen < sizeof(sa_family_t))
+			return -1;
+
+		sun = (const struct sockaddr_un *)sa;
+		out->group = RETRACE_SAF_UNIX;
+		out->expected_len = sizeof(*sun);
+
+		if (addrlen != 0 && addrlen - sizeof(sa_family_t) < max_path)
+			pathlen = addrlen - sizeof(sa_family_t);
+		else
+			pathlen = max_path;
+
+		/* Copy up to pathlen bytes, NUL-terminate. */
+		if (pathlen > sizeof(out->path) - 1)
+			pathlen = sizeof(out->path) - 1;
+
+		retrace_real_impls.memcpy(out->path, sun->sun_path, pathlen);
+		out->path[pathlen] = '\0';
+
+		/* If the source had a NUL before pathlen, truncate. */
+		{
+			size_t nulpos = 0;
+
+			while (nulpos < pathlen &&
+			       out->path[nulpos] != '\0')
+				nulpos++;
+			out->path[nulpos] = '\0';
+		}
+		return 0;
+	}
+	default:
+		out->group = RETRACE_SAF_UNKNOWN;
+		return 0;
+	}
+}
+
+/* Parse a "[literal]:port" or "host:port" spec. Returns 0 on
+ * success, -1 on malformed. On success:
+ *   host_buf   - host part (no brackets), NUL-terminated
+ *   host_len   - length of host part (excluding NUL)
+ *   has_port   - 1 if a port was given, 0 if wildcard or absent
+ *   port       - 0 if has_port==0, else the parsed port
+ */
+static int parse_host_port(const char *spec,
+			   char *host_buf, size_t host_cap, size_t *host_len,
+			   int *has_port, int *port)
+{
+	const char *host_start;
+	size_t hlen;
+	const char *close;
+	const char *port_str;
+
+	if (spec == NULL || host_buf == NULL || host_cap == 0)
+		return -1;
+
+	*has_port = 0;
+	*port = 0;
+
+	/* IPv6 literal: "[...]" or "[...]:port" or "[...]:*". */
+	if (spec[0] == '[') {
+		close = find_byte(spec, ']');
+		if (close == NULL)
+			return -1;
+
+		host_start = spec + 1;
+		hlen = (size_t)(close - host_start);
+
+		if (close[1] == '\0') {
+			/* No port segment. */
+		} else if (close[1] == ':') {
+			port_str = close + 2;
+			if (port_str[0] == '*' && port_str[1] == '\0') {
+				/* wildcard, has_port stays 0 */
+			} else {
+				if (parse_port(port_str, port) != 0)
+					return -1;
+				*has_port = 1;
+			}
+		} else {
+			return -1;
+		}
+	} else {
+		const char *colon = find_byte(spec, ':');
+
+		if (colon == NULL) {
+			/* Bare host: no port. */
+			host_start = spec;
+			hlen = retrace_real_impls.strlen(spec);
+		} else {
+			host_start = spec;
+			hlen = (size_t)(colon - spec);
+
+			port_str = colon + 1;
+			if (port_str[0] == '*' && port_str[1] == '\0') {
+				/* wildcard */
+			} else {
+				if (parse_port(port_str, port) != 0)
+					return -1;
+				*has_port = 1;
+			}
+		}
+	}
+
+	if (hlen == 0 || hlen >= host_cap)
+		return -1;
+
+	retrace_real_impls.memcpy(host_buf, host_start, hlen);
+	host_buf[hlen] = '\0';
+	*host_len = hlen;
+	return 0;
+}
+
+int retrace_sockaddr_match(const struct retrace_sockaddr_info *info,
+			   const char *spec)
+{
+	char host_buf[RETRACE_SOCKADDR_IP_LEN];
+	size_t host_len = 0;
+	int has_port = 0;
+	int port = 0;
+	int host_is_wild;
+	int rc;
+
+	if (info == NULL || spec == NULL)
+		return -1;
+
+	/* Bare "*" matches anything. */
+	if (spec[0] == '*' && spec[1] == '\0')
+		return 1;
+
+	/* UNIX path: no colon in spec means match by path only.
+	 * A spec with a colon never matches a unix sockaddr.
+	 */
+	if (info->group == RETRACE_SAF_UNIX) {
+		if (find_char(spec, ':'))
+			return 0;
+		if (retrace_real_impls.strcmp(spec, info->path) == 0)
+			return 1;
+		return 0;
+	}
+
+	/* For non-INET infos, a path-only spec never matches. */
+	if (info->group != RETRACE_SAF_INET &&
+	    info->group != RETRACE_SAF_INET6) {
+		if (!find_char(spec, ':'))
+			return 0;
+	}
+
+	rc = parse_host_port(spec, host_buf, sizeof(host_buf),
+		&host_len, &has_port, &port);
+	if (rc != 0)
+		return -1;
+
+	host_is_wild = (host_len == 1 && host_buf[0] == '*');
+
+	if (!host_is_wild) {
+		if (retrace_real_impls.strcmp(host_buf, info->ip) != 0)
+			return 0;
+	}
+
+	if (has_port && info->port != (uint16_t)port)
+		return 0;
+
+	return 1;
+}

--- a/src/core/sockaddr_inspect.h
+++ b/src/core/sockaddr_inspect.h
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * sockaddr_inspect -- uniform view of sockaddr* across families.
+ *
+ * The BSD sockets API passes `struct sockaddr *` everywhere, but the
+ * actual layout depends on `sa_family` (AF_INET -> sockaddr_in,
+ * AF_INET6 -> sockaddr_in6, AF_UNIX -> sockaddr_un). Actions that
+ * want to reason about a peer address (deny-by-destination, audit
+ * log, redirect) need a uniform view that does not require every
+ * caller to know the union shape.
+ *
+ * This helper reads `sa_family` from the first 2 bytes, dispatches
+ * on the family, and fills a flat info struct. For unsupported
+ * families the helper still returns 0 but leaves `family` set and
+ * the other fields zeroed -- callers can branch on `family`.
+ *
+ * Recursion safety: every libc call inside this module goes through
+ * retrace_real_impls. We never call inet_ntop/inet_pton directly,
+ * so intercepting those symbols (TODO.complete/15) cannot recurse
+ * back into us.
+ */
+
+#ifndef RETRACE_CORE_SOCKADDR_INSPECT_H_
+#define RETRACE_CORE_SOCKADDR_INSPECT_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define RETRACE_SOCKADDR_IP_LEN   64   /* fits IPv6 + NUL */
+#define RETRACE_SOCKADDR_PATH_LEN 108  /* matches sun_path */
+
+enum retrace_sockaddr_family_group {
+	RETRACE_SAF_UNKNOWN = 0,
+	RETRACE_SAF_INET    = 1,
+	RETRACE_SAF_INET6   = 2,
+	RETRACE_SAF_UNIX    = 3,
+};
+
+struct retrace_sockaddr_info {
+	/* Raw sa_family value (AF_INET, AF_INET6, AF_UNIX, ...). */
+	int family;
+
+	/* Normalized group so actions don't need AF_* constants. */
+	enum retrace_sockaddr_family_group group;
+
+	/* Expected payload size for this family (sizeof(sockaddr_in)
+	 * etc.). 0 if unknown.
+	 */
+	size_t expected_len;
+
+	/* AF_INET / AF_INET6: presentation-form address ("1.2.3.4"
+	 * or "fe80::1"). Empty string for other families or when
+	 * the address could not be formatted.
+	 */
+	char ip[RETRACE_SOCKADDR_IP_LEN];
+
+	/* AF_INET / AF_INET6: port in host byte order. 0 if unknown. */
+	uint16_t port;
+
+	/* AF_UNIX: filesystem path. May be empty for anonymous unix
+	 * sockets. Empty for other families.
+	 */
+	char path[RETRACE_SOCKADDR_PATH_LEN];
+};
+
+/*
+ * Inspect a sockaddr pointer.
+ *
+ *   sa       - the sockaddr* (must not be NULL)
+ *   addrlen  - byte count available at *sa; use sizeof(sockaddr_in)
+ *              etc. 0 means "unknown, fall back to expected_len."
+ *   out      - filled on return; never NULL.
+ *
+ * Returns 0 on success (out is populated, possibly with group=UNKNOWN
+ * for an unsupported family), -1 on hard failure (NULL sa/out, or
+ * addrlen too small for the family header).
+ */
+int retrace_sockaddr_inspect(const void *sa, size_t addrlen,
+			      struct retrace_sockaddr_info *out);
+
+/*
+ * Match an inspected sockaddr against a "host:port" spec.
+ *
+ * Spec grammar (each part optional, but the ':' separator is
+ * required when port is present):
+ *
+ *   "1.2.3.4:443"   -- exact IPv4 + port
+ *   "1.2.3.4:*"     -- IPv4, any port
+ *   "*:443"         -- any host, port 443
+ *   "*:*" or "*"    -- match anything (semantic "deny all")
+ *   "[::1]:443"     -- IPv6 literal (brackets mandatory when port given)
+ *   "[::1]:*"       -- IPv6, any port
+ *   "/var/run/x"    -- AF_UNIX path (no host:port); exact path match
+ *
+ * For AF_UNIX infos, only the path form matches; "host:port" specs
+ * never match a unix sockaddr (and vice versa).
+ *
+ * Returns 1 on match, 0 on no match, -1 on malformed spec.
+ */
+int retrace_sockaddr_match(const struct retrace_sockaddr_info *info,
+			   const char *spec);
+
+#endif /* RETRACE_CORE_SOCKADDR_INSPECT_H_ */

--- a/src/v2/funcs_symbols.def
+++ b/src/v2/funcs_symbols.def
@@ -308,3 +308,26 @@ RETRACE_WRAP sendto
 RETRACE_WRAP recvfrom
 RETRACE_WRAP setsockopt
 RETRACE_WRAP getsockopt
+
+/*
+ * Second slice (TODO.complete/15): remaining 16 socket-family
+ * functions. Prototypes live in src/core/prototypes/sys_socket.c.
+ */
+RETRACE_WRAP socketpair
+#if RETRACE_HAVE_ACCEPT4
+RETRACE_WRAP accept4
+#endif
+RETRACE_WRAP shutdown
+RETRACE_WRAP sendmsg
+RETRACE_WRAP recvmsg
+RETRACE_WRAP gethostbyname
+RETRACE_WRAP getaddrinfo
+RETRACE_WRAP freeaddrinfo
+RETRACE_WRAP gai_strerror
+RETRACE_WRAP inet_pton
+RETRACE_WRAP inet_ntop
+RETRACE_WRAP inet_addr
+RETRACE_WRAP inet_aton
+RETRACE_WRAP inet_network
+RETRACE_WRAP getpeername
+RETRACE_WRAP getsockname

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -116,3 +116,39 @@ endif()
 add_test(NAME unit-test-script-resolver
     COMMAND retrace_test_script_resolver)
 set_tests_properties(unit-test-script-resolver PROPERTIES LABELS "unit")
+
+#
+# sockaddr_inspect tests (TODO.complete/15). The helper is a pure C
+# function -- no engine, no LD_PRELOAD. Minimal real_impls setup in
+# the test main().
+#
+add_executable(retrace_test_sockaddr_inspect test_sockaddr_inspect.c)
+set_target_properties(retrace_test_sockaddr_inspect PROPERTIES
+    OUTPUT_NAME test_sockaddr_inspect
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/test/unit")
+
+target_link_libraries(retrace_test_sockaddr_inspect PRIVATE
+    retrace_core
+    retrace_config_json
+    retrace_backends
+    ${_unit_backend_lib}
+    retrace_preload_common
+    retrace_headers
+    ${CMAKE_DL_LIBS}
+    Threads::Threads)
+
+target_include_directories(retrace_test_sockaddr_inspect PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/core
+    ${CMAKE_SOURCE_DIR}/src/backends
+    ${CMAKE_SOURCE_DIR}/src/config/json
+    ${_unit_arch_include})
+
+if(RETRACE_PLATFORM_LINUX OR RETRACE_PLATFORM_FREEBSD)
+    target_compile_definitions(retrace_test_sockaddr_inspect PRIVATE _GNU_SOURCE _DEFAULT_SOURCE)
+elseif(RETRACE_PLATFORM_DARWIN)
+    target_compile_definitions(retrace_test_sockaddr_inspect PRIVATE _DARWIN_C_SOURCE)
+endif()
+
+add_test(NAME unit-test-sockaddr-inspect
+    COMMAND retrace_test_sockaddr_inspect)
+set_tests_properties(unit-test-sockaddr-inspect PROPERTIES LABELS "unit")

--- a/test/unit/test_sockaddr_inspect.c
+++ b/test/unit/test_sockaddr_inspect.c
@@ -1,0 +1,373 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+/*
+ * Unit tests for retrace_sockaddr_inspect and retrace_sockaddr_match.
+ *
+ * These do NOT load the v2 engine -- the helpers are pure C functions
+ * that read sockaddr* and compare strings. We set up a minimal
+ * retrace_real_impls so the helper's libc calls don't crash, then
+ * exercise each family and match form.
+ *
+ * Part of TODO.complete/15 (network functions).
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/un.h>
+#include <sys/socket.h>
+
+#include "sockaddr_inspect.h"
+#include "real_impls.h"
+
+static int tests_run;
+static int tests_pass;
+static int tests_fail;
+
+#define TEST(name) do { \
+	tests_run++; \
+	printf("  TEST %s ... ", #name); \
+	test_##name(); \
+	tests_pass++; \
+	printf("OK\n"); \
+} while (0)
+
+/* -- inspect: AF_INET -- */
+
+static void test_inspect_ipv4_loopback(void)
+{
+	struct sockaddr_in sin = {0};
+	struct retrace_sockaddr_info info;
+	int rc;
+
+	sin.sin_family = AF_INET;
+	sin.sin_port = htons(443);
+	inet_pton(AF_INET, "127.0.0.1", &sin.sin_addr);
+
+	rc = retrace_sockaddr_inspect(&sin, sizeof(sin), &info);
+	assert(rc == 0);
+	assert(info.family == AF_INET);
+	assert(info.group == RETRACE_SAF_INET);
+	assert(info.expected_len == sizeof(sin));
+	assert(info.port == 443);
+	assert(strcmp(info.ip, "127.0.0.1") == 0);
+}
+
+static void test_inspect_ipv4_arbitrary(void)
+{
+	struct sockaddr_in sin = {0};
+	struct retrace_sockaddr_info info;
+
+	sin.sin_family = AF_INET;
+	sin.sin_port = htons(8080);
+	inet_pton(AF_INET, "10.0.0.1", &sin.sin_addr);
+
+	assert(retrace_sockaddr_inspect(&sin, sizeof(sin), &info) == 0);
+	assert(info.port == 8080);
+	assert(strcmp(info.ip, "10.0.0.1") == 0);
+}
+
+/* -- inspect: AF_INET6 -- */
+
+static void test_inspect_ipv6_loopback(void)
+{
+	struct sockaddr_in6 sin6 = {0};
+	struct retrace_sockaddr_info info;
+
+	sin6.sin6_family = AF_INET6;
+	sin6.sin6_port = htons(443);
+	inet_pton(AF_INET6, "::1", &sin6.sin6_addr);
+
+	assert(retrace_sockaddr_inspect(&sin6, sizeof(sin6), &info) == 0);
+	assert(info.family == AF_INET6);
+	assert(info.group == RETRACE_SAF_INET6);
+	assert(info.expected_len == sizeof(sin6));
+	assert(info.port == 443);
+	/* inet_pton -> ::1, our formatter produces "0:0:0:0:0:0:0:1" */
+	assert(strcmp(info.ip, "0:0:0:0:0:0:0:1") == 0);
+}
+
+static void test_inspect_ipv6_link_local(void)
+{
+	struct sockaddr_in6 sin6 = {0};
+	struct retrace_sockaddr_info info;
+
+	sin6.sin6_family = AF_INET6;
+	sin6.sin6_port = htons(1234);
+	inet_pton(AF_INET6, "fe80::1", &sin6.sin6_addr);
+
+	assert(retrace_sockaddr_inspect(&sin6, sizeof(sin6), &info) == 0);
+	assert(strcmp(info.ip, "fe80:0:0:0:0:0:0:1") == 0);
+	assert(info.port == 1234);
+}
+
+/* -- inspect: AF_UNIX -- */
+
+static void test_inspect_unix_path(void)
+{
+	struct sockaddr_un sun = {0};
+	struct retrace_sockaddr_info info;
+
+	sun.sun_family = AF_UNIX;
+	strncpy(sun.sun_path, "/var/run/test.sock", sizeof(sun.sun_path) - 1);
+
+	assert(retrace_sockaddr_inspect(&sun, sizeof(sun), &info) == 0);
+	assert(info.family == AF_UNIX);
+	assert(info.group == RETRACE_SAF_UNIX);
+	assert(info.expected_len == sizeof(sun));
+	assert(strcmp(info.path, "/var/run/test.sock") == 0);
+	assert(info.ip[0] == '\0');
+}
+
+static void test_inspect_unix_anonymous(void)
+{
+	struct sockaddr_un sun;
+	struct retrace_sockaddr_info info;
+
+	memset(&sun, 0, sizeof(sun));
+	sun.sun_family = AF_UNIX;
+
+	assert(retrace_sockaddr_inspect(&sun, sizeof(sun), &info) == 0);
+	assert(info.group == RETRACE_SAF_UNIX);
+	assert(info.path[0] == '\0');
+}
+
+/* -- inspect: edge cases -- */
+
+static void test_inspect_null(void)
+{
+	struct retrace_sockaddr_info info;
+
+	assert(retrace_sockaddr_inspect(NULL, 0, &info) == -1);
+	assert(retrace_sockaddr_inspect(NULL, sizeof(struct sockaddr_in),
+		&info) == -1);
+}
+
+static void test_inspect_null_out(void)
+{
+	struct sockaddr_in sin = {0};
+
+	sin.sin_family = AF_INET;
+	assert(retrace_sockaddr_inspect(&sin, sizeof(sin), NULL) == -1);
+}
+
+static void test_inspect_unknown_family(void)
+{
+	struct sockaddr_in sin = {0};
+	struct retrace_sockaddr_info info;
+
+	/* Use a family value that's unlikely to be valid. */
+	sin.sin_family = (sa_family_t)0xFFFE;
+
+	assert(retrace_sockaddr_inspect(&sin, sizeof(sin), &info) == 0);
+	assert(info.group == RETRACE_SAF_UNKNOWN);
+	assert(info.expected_len == 0);
+}
+
+static void test_inspect_short_buffer(void)
+{
+	struct sockaddr_in sin = {0};
+	struct retrace_sockaddr_info info;
+
+	sin.sin_family = AF_INET;
+	/* addrlen smaller than sockaddr_in */
+	assert(retrace_sockaddr_inspect(&sin, sizeof(sin) - 4, &info) == -1);
+}
+
+/* -- match: IPv4 forms -- */
+
+static void test_match_ipv4_exact(void)
+{
+	struct retrace_sockaddr_info info = {0};
+
+	info.group = RETRACE_SAF_INET;
+	strcpy(info.ip, "10.0.0.1");
+	info.port = 443;
+
+	assert(retrace_sockaddr_match(&info, "10.0.0.1:443") == 1);
+	assert(retrace_sockaddr_match(&info, "10.0.0.1:80") == 0);
+	assert(retrace_sockaddr_match(&info, "10.0.0.2:443") == 0);
+}
+
+static void test_match_ipv4_wild_port(void)
+{
+	struct retrace_sockaddr_info info = {0};
+
+	info.group = RETRACE_SAF_INET;
+	strcpy(info.ip, "10.0.0.1");
+	info.port = 443;
+
+	assert(retrace_sockaddr_match(&info, "10.0.0.1:*") == 1);
+	assert(retrace_sockaddr_match(&info, "10.0.0.2:*") == 0);
+}
+
+static void test_match_ipv4_wild_host(void)
+{
+	struct retrace_sockaddr_info info = {0};
+
+	info.group = RETRACE_SAF_INET;
+	strcpy(info.ip, "10.0.0.1");
+	info.port = 443;
+
+	assert(retrace_sockaddr_match(&info, "*:443") == 1);
+	assert(retrace_sockaddr_match(&info, "*:80") == 0);
+}
+
+static void test_match_ipv4_deny_all(void)
+{
+	struct retrace_sockaddr_info info = {0};
+
+	info.group = RETRACE_SAF_INET;
+	strcpy(info.ip, "10.0.0.1");
+	info.port = 443;
+
+	assert(retrace_sockaddr_match(&info, "*:*") == 1);
+	assert(retrace_sockaddr_match(&info, "*") == 1);
+}
+
+/* -- match: IPv6 forms -- */
+
+static void test_match_ipv6_bracketed(void)
+{
+	struct retrace_sockaddr_info info = {0};
+
+	info.group = RETRACE_SAF_INET6;
+	strcpy(info.ip, "fe80:0:0:0:0:0:0:1");
+	info.port = 443;
+
+	assert(retrace_sockaddr_match(&info, "[fe80:0:0:0:0:0:0:1]:443") == 1);
+	assert(retrace_sockaddr_match(&info, "[fe80:0:0:0:0:0:0:1]:*") == 1);
+	assert(retrace_sockaddr_match(&info, "[fe80:0:0:0:0:0:0:2]:443") == 0);
+}
+
+static void test_match_ipv6_no_port(void)
+{
+	struct retrace_sockaddr_info info = {0};
+
+	info.group = RETRACE_SAF_INET6;
+	strcpy(info.ip, "0:0:0:0:0:0:0:1");
+	info.port = 443;
+
+	/* "[::1]" alone -- no port, no wildcard suffix. */
+	assert(retrace_sockaddr_match(&info, "[0:0:0:0:0:0:0:1]") == 1);
+}
+
+/* -- match: AF_UNIX -- */
+
+static void test_match_unix_path(void)
+{
+	struct retrace_sockaddr_info info = {0};
+
+	info.group = RETRACE_SAF_UNIX;
+	strcpy(info.path, "/var/run/x.sock");
+
+	assert(retrace_sockaddr_match(&info, "/var/run/x.sock") == 1);
+	assert(retrace_sockaddr_match(&info, "/var/run/y.sock") == 0);
+	/* "host:port" spec never matches a unix sockaddr. */
+	assert(retrace_sockaddr_match(&info, "*:443") == 0);
+}
+
+/* -- match: malformed -- */
+
+static void test_match_malformed(void)
+{
+	struct retrace_sockaddr_info info = {0};
+
+	info.group = RETRACE_SAF_INET;
+	strcpy(info.ip, "10.0.0.1");
+	info.port = 443;
+
+	/* Missing close bracket. */
+	assert(retrace_sockaddr_match(&info, "[10.0.0.1:443") == -1);
+	/* Bracket but no closing colon-form. */
+	assert(retrace_sockaddr_match(&info, "[10.0.0.1]extra") == -1);
+	/* Non-numeric port. */
+	assert(retrace_sockaddr_match(&info, "10.0.0.1:abc") == -1);
+	/* Out-of-range port. */
+	assert(retrace_sockaddr_match(&info, "10.0.0.1:99999") == -1);
+}
+
+static void test_match_null(void)
+{
+	struct retrace_sockaddr_info info = {0};
+
+	assert(retrace_sockaddr_match(NULL, "10.0.0.1:443") == -1);
+	assert(retrace_sockaddr_match(&info, NULL) == -1);
+}
+
+/* -- match: AF_INET vs AF_INET6 mismatch -- */
+
+static void test_match_family_mismatch(void)
+{
+	struct retrace_sockaddr_info info = {0};
+
+	info.group = RETRACE_SAF_INET;
+	strcpy(info.ip, "10.0.0.1");
+	info.port = 443;
+
+	/* IPv6-bracketed spec should not match an IPv4 info. */
+	assert(retrace_sockaddr_match(&info, "[10.0.0.1]:443") == 0);
+}
+
+int main(void)
+{
+	/* Minimal real_impls setup. */
+	retrace_real_impls.strcmp = strcmp;
+	retrace_real_impls.strlen = strlen;
+	retrace_real_impls.strcpy = strcpy;
+	retrace_real_impls.memset = memset;
+	retrace_real_impls.memcpy = memcpy;
+	retrace_real_impls.malloc = malloc;
+	retrace_real_impls.free = free;
+	retrace_real_impls.real_snprintf = snprintf;
+
+	printf("sockaddr_inspect tests:\n");
+
+	printf("  -- inspect: AF_INET --\n");
+	TEST(inspect_ipv4_loopback);
+	TEST(inspect_ipv4_arbitrary);
+
+	printf("  -- inspect: AF_INET6 --\n");
+	TEST(inspect_ipv6_loopback);
+	TEST(inspect_ipv6_link_local);
+
+	printf("  -- inspect: AF_UNIX --\n");
+	TEST(inspect_unix_path);
+	TEST(inspect_unix_anonymous);
+
+	printf("  -- inspect: edge cases --\n");
+	TEST(inspect_null);
+	TEST(inspect_null_out);
+	TEST(inspect_unknown_family);
+	TEST(inspect_short_buffer);
+
+	printf("  -- match: IPv4 forms --\n");
+	TEST(match_ipv4_exact);
+	TEST(match_ipv4_wild_port);
+	TEST(match_ipv4_wild_host);
+	TEST(match_ipv4_deny_all);
+
+	printf("  -- match: IPv6 forms --\n");
+	TEST(match_ipv6_bracketed);
+	TEST(match_ipv6_no_port);
+
+	printf("  -- match: AF_UNIX --\n");
+	TEST(match_unix_path);
+
+	printf("  -- match: malformed --\n");
+	TEST(match_malformed);
+	TEST(match_null);
+	TEST(match_family_mismatch);
+
+	printf("\nPass: %d, Fail: %d (of %d)\n",
+		tests_pass, tests_fail, tests_run);
+	return tests_fail == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Closes TODO.complete/15. Adds the remaining 16 socket-family functions, plus a `sockaddr_inspect` helper that turns the tagged-union sockaddr mess into a flat info struct, plus an `addr_deny` action for network deny-listing.

This builds on PR #550 (the first 11 socket functions) and brings the total to 27 of the 27 functions in scope.

## What's new

### 16 more functions

- `socketpair`, `accept4` (Linux/BSD only -- see below), `shutdown`
- `sendmsg`, `recvmsg` (msghdr treated as opaque ptr; scatter-gather inspect deferred)
- `gethostbyname` (hostent opaque)
- `getaddrinfo`, `freeaddrinfo`, `gai_strerror`
- `inet_pton`, `inet_ntop`, `inet_addr`, `inet_aton`, `inet_network`
- `getpeername`, `getsockname`

`accept4` is not in macOS libSystem. The wrapper is gated by `RETRACE_HAVE_ACCEPT4`, a CMake feature probe following the same pattern as `RETRACE_HAVE_ISOC99_SCANF`. The prototype is always compiled; the engine silently skips lookups for prototypes whose wrappers are not present.

### Helper: `src/core/sockaddr_inspect.{h,c}`

```
int retrace_sockaddr_inspect(const void *sa, size_t addrlen,
                              struct retrace_sockaddr_info *out);
```

Reads `sa_family` from the first 2 bytes, dispatches:

- `AF_INET` -> sockaddr_in: family, port (host order), ip "1.2.3.4"
- `AF_INET6` -> sockaddr_in6: family, port, ip "fe80:0:...:1"
- `AF_UNIX` -> sockaddr_un: family, path "/var/run/x.sock"
- other -> group=UNKNOWN, fields zero

The IP formatters are manual (no `inet_ntop` dependency) so intercepting `inet_ntop` cannot recurse into the helper. Every libc call goes through `retrace_real_impls`. `strchr`/`strncpy`/`strtol` are replaced with manual scans because they are themselves intercepted by `prototypes/string.c`.

### Action: `src/core/actions/addr_deny.c`

Network equivalent of `sandbox`. Inspects sockaddr args of `connect`/`bind`/`sendto`/`recvfrom`/`accept`/`getpeername`/`getsockname` and returns `-ECONNREFUSED` on match.

```json
{
  "func_name": "connect",
  "actions": [
    { "action_name": "addr_deny",
      "action_params": { "deny_addrs": ["*:443", "10.0.0.1:*"] }
    },
    { "action_name": "call_real" }
  ]
}
```

**Why a separate action** (not an extension of `sandbox`): `sandbox`'s contract is "deny access to specific file paths." Adding "and also network addresses" turns it into a denylist for everything, violating MECE. Keeping them separate keeps each action's JSON schema simple (one array per action) and lets users combine them independently.

Spec grammar (`retrace_sockaddr_match`):

- `"1.2.3.4:443"` exact IPv4 + port
- `"1.2.3.4:*"` IPv4, any port
- `"*:443"` any host, port 443
- `"*:*"` or `"*"` match anything (deny all)
- `"[::1]:443"` IPv6 literal (brackets required with port)
- `"/var/run/x"` AF_UNIX path (no colon)

For AF_UNIX infos, only the path form matches; "host:port" specs never match a unix sockaddr.

sockaddr extraction is generic: the action scans `t_ctx->params` for the first param whose name is `addr`, `dest_addr`, or `src_addr` and reads its value as the sockaddr pointer. No per-function index table.

## Files

| File | Change |
|------|--------|
| `src/core/prototypes/sys_socket.c` | 16 more prototypes (27 total) |
| `src/v2/funcs_symbols.def` | 16 more `RETRACE_WRAP` entries; `accept4` gated by `RETRACE_HAVE_ACCEPT4` |
| `src/core/sockaddr_inspect.h` | new -- helper API (124 lines) |
| `src/core/sockaddr_inspect.c` | new -- implementation (354 lines) |
| `src/core/actions/addr_deny.c` | new -- action (193 lines) |
| `src/core/CMakeLists.txt` | wire new sources |
| `test/unit/test_sockaddr_inspect.c` | new -- 20 unit tests (373 lines) |
| `test/unit/CMakeLists.txt` | register new test |
| `CMakeLists.txt` | `RETRACE_HAVE_ACCEPT4` feature probe |

## Architecture principles applied

- **OCP**: the new action is registered via the same constructor-section mechanism as the existing 11 actions. The engine doesn't know about `addr_deny`; it just looks up the action by name in the `__retrace_acts` section. Same for the helper: a pure C function, no engine changes.
- **MECE**: `sandbox` owns paths, `addr_deny` owns addrs. Each action's schema is one array. `sockaddr_inspect` owns "interpret a sockaddr pointer"; no other module touches sockaddr internals.
- **DRY**: the 16 new prototypes share the same struct layout as the 11 from PR #550. No new pattern, no new accessor.
- **Performance**: helper is O(1) (single sa_family switch). Match is O(spec_len). Neither allocates.

## Test plan

- [x] `cmake --build build-rel` -- clean, no new warnings
- [x] `ctest --test-dir build-rel` -- 6/6 pass (integration, 4 unit, 1 property)
- [x] New `unit-test-sockaddr-inspect`: 20/20 sub-tests pass
- [x] Manual end-to-end: `addr_deny` config blocks `connect` to 127.0.0.1:80 with `DENIED 127.0.0.1:80 (matches '127.0.0.1:*')` and aborts the script
- [x] Manual check: `inet_pton` (new) is intercepted alongside the original 11
- [ ] CI matrix green on Linux x64+arm64, macOS Intel+arm64, Windows MSVC x64+arm64, BSDs

## Not in this slice (deferred to v2.3.0)

- `gethostbyname_r`, `_r` variants (complex signatures)
- `msghdr` inspect helper (scatter-gather for `sendmsg`/`recvmsg`)
- `addrinfo`/`hostent` walkers (richer logging)
- Cookbook recipe 12 + website Function Catalog update

## Related

- PR #550 (first slice -- 11 core functions)
- ADR-0009 (Windows trampoline) -- not affected; this PR is POSIX-only
- TODO.complete/15-network-functions.md (updated to mark TODO complete)
