### PR TITLE
test: unit tests for modify_return_value_int + call_count_limit

### DIFF
--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -188,3 +188,78 @@ endif()
 add_test(NAME unit-test-addr-deny
     COMMAND retrace_test_addr_deny)
 set_tests_properties(unit-test-addr-deny PROPERTIES LABELS "unit")
+
+#
+# modify_return_value_int action unit tests (TODO.complete/14).
+#
+add_executable(retrace_test_modify_return_value_int
+    test_modify_return_value_int.c)
+set_target_properties(retrace_test_modify_return_value_int PROPERTIES
+    OUTPUT_NAME test_modify_return_value_int
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/test/unit")
+
+target_link_libraries(retrace_test_modify_return_value_int PRIVATE
+    retrace_core
+    retrace_config_json
+    retrace_backends
+    ${_unit_backend_lib}
+    retrace_preload_common
+    retrace_headers
+    ${CMAKE_DL_LIBS}
+    Threads::Threads)
+
+target_include_directories(retrace_test_modify_return_value_int PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/core
+    ${CMAKE_SOURCE_DIR}/src/backends
+    ${CMAKE_SOURCE_DIR}/src/config/json
+    ${_unit_arch_include})
+
+if(RETRACE_PLATFORM_LINUX OR RETRACE_PLATFORM_FREEBSD)
+    target_compile_definitions(retrace_test_modify_return_value_int PRIVATE
+        _GNU_SOURCE _DEFAULT_SOURCE)
+elseif(RETRACE_PLATFORM_DARWIN)
+    target_compile_definitions(retrace_test_modify_return_value_int PRIVATE
+        _DARWIN_C_SOURCE)
+endif()
+
+add_test(NAME unit-test-modify-return-value-int
+    COMMAND retrace_test_modify_return_value_int)
+set_tests_properties(unit-test-modify-return-value-int PROPERTIES
+    LABELS "unit")
+
+#
+# call_count_limit action unit tests (TODO.complete/14).
+#
+add_executable(retrace_test_call_count_limit test_call_count_limit.c)
+set_target_properties(retrace_test_call_count_limit PROPERTIES
+    OUTPUT_NAME test_call_count_limit
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/test/unit")
+
+target_link_libraries(retrace_test_call_count_limit PRIVATE
+    retrace_core
+    retrace_config_json
+    retrace_backends
+    ${_unit_backend_lib}
+    retrace_preload_common
+    retrace_headers
+    ${CMAKE_DL_LIBS}
+    Threads::Threads)
+
+target_include_directories(retrace_test_call_count_limit PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/core
+    ${CMAKE_SOURCE_DIR}/src/backends
+    ${CMAKE_SOURCE_DIR}/src/config/json
+    ${_unit_arch_include})
+
+if(RETRACE_PLATFORM_LINUX OR RETRACE_PLATFORM_FREEBSD)
+    target_compile_definitions(retrace_test_call_count_limit PRIVATE
+        _GNU_SOURCE _DEFAULT_SOURCE)
+elseif(RETRACE_PLATFORM_DARWIN)
+    target_compile_definitions(retrace_test_call_count_limit PRIVATE
+        _DARWIN_C_SOURCE)
+endif()
+
+add_test(NAME unit-test-call-count-limit
+    COMMAND retrace_test_call_count_limit)
+set_tests_properties(unit-test-call-count-limit PROPERTIES
+    LABELS "unit")

--- a/test/unit/test_call_count_limit.c
+++ b/test/unit/test_call_count_limit.c
@@ -1,0 +1,270 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+/*
+ * Unit tests for the call_count_limit action.
+ *
+ * The action maintains a per-function-name counter. The first N
+ * invocations return 0; the (N+1)th returns -1, aborting the rest
+ * of the intercept script.
+ *
+ * Verifies:
+ *   - Action lookup succeeds
+ *   - NULL params -> -1
+ *   - Missing limit -> -1
+ *   - First N calls return 0; (N+1)th returns -1
+ *   - Independent functions tracked separately
+ *   - Re-claiming an existing name with a different limit warns but
+ *     keeps the original limit
+ *
+ * Note: the global counter table (g_entries in call_count_limit.c)
+ * persists across tests in this binary. Tests use unique function
+ * names to avoid collisions.
+ *
+ * Part of TODO.complete/14.
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "engine.h"
+#include "actions.h"
+#include "funcs.h"
+#include "data_types.h"
+#include "real_impls.h"
+#include "parson.h"
+
+typedef int (*action_fn_t)(struct ThreadContext *t_ctx,
+			    const JSON_Object *action_params);
+
+static int tests_run;
+static int tests_pass;
+static int tests_fail;
+
+#define TEST(name) do { \
+	tests_run++; \
+	printf("  TEST %s ... ", #name); \
+	test_##name(); \
+	tests_pass++; \
+	printf("OK\n"); \
+} while (0)
+
+static JSON_Object *build_params_with_number(const char *key, double val)
+{
+	JSON_Value *root_val = json_value_init_object();
+	JSON_Object *root = json_value_get_object(root_val);
+
+	json_object_set_number(root, key, val);
+	return root;
+}
+
+/* Build a ThreadContext with a prototype name. call_count_limit
+ * keys its counter table on prototype->name.
+ */
+static struct ThreadContext *build_ctx_for_func(const char *func_name)
+{
+	static struct ThreadContext ctx;
+	static struct FuncPrototype proto;
+
+	memset(&ctx, 0, sizeof(ctx));
+	memset(&proto, 0, sizeof(proto));
+
+	strncpy(proto.name, func_name, sizeof(proto.name) - 1);
+	proto.name[sizeof(proto.name) - 1] = '\0';
+	ctx.prototype = &proto;
+
+	return &ctx;
+}
+
+static void test_action_lookup(void)
+{
+	retrace_actions_init();
+	assert(retrace_actions_get("call_count_limit") != NULL);
+}
+
+static void test_params_null(void)
+{
+	action_fn_t action = retrace_actions_get("call_count_limit");
+	struct ThreadContext *ctx = build_ctx_for_func("test_null_params");
+	int rc;
+
+	rc = action(ctx, NULL);
+	assert(rc == -1);
+}
+
+static void test_missing_limit(void)
+{
+	action_fn_t action = retrace_actions_get("call_count_limit");
+	struct ThreadContext *ctx = build_ctx_for_func("test_missing_limit");
+	JSON_Value *root_val = json_value_init_object();
+	JSON_Object *root = json_value_get_object(root_val);
+	int rc;
+
+	json_object_set_string(root, "unrelated", "foo");
+
+	rc = action(ctx, root);
+	assert(rc == -1);
+
+	json_value_free(root_val);
+}
+
+static void test_limit_three_first_three_pass(void)
+{
+	action_fn_t action = retrace_actions_get("call_count_limit");
+	struct ThreadContext *ctx = build_ctx_for_func("test_limit_3_pass");
+	JSON_Object *params = build_params_with_number("limit", 3.0);
+	int rc;
+	int i;
+
+	/* First 3 calls (count goes 1, 2, 3) should pass. */
+	for (i = 0; i < 3; i++) {
+		rc = action(ctx, params);
+		assert(rc == 0);
+	}
+
+	json_value_free(json_object_get_wrapping_value(params));
+}
+
+static void test_limit_three_fourth_aborts(void)
+{
+	action_fn_t action = retrace_actions_get("call_count_limit");
+	struct ThreadContext *ctx =
+		build_ctx_for_func("test_limit_3_abort");
+	JSON_Object *params = build_params_with_number("limit", 3.0);
+	int rc;
+	int i;
+
+	for (i = 0; i < 3; i++)
+		action(ctx, params);
+
+	/* 4th call (count=4) should abort. */
+	rc = action(ctx, params);
+	assert(rc == -1);
+
+	json_value_free(json_object_get_wrapping_value(params));
+}
+
+static void test_limit_one_first_passes(void)
+{
+	action_fn_t action = retrace_actions_get("call_count_limit");
+	struct ThreadContext *ctx = build_ctx_for_func("test_limit_1_pass");
+	JSON_Object *params = build_params_with_number("limit", 1.0);
+	int rc;
+
+	rc = action(ctx, params);
+	assert(rc == 0);
+
+	json_value_free(json_object_get_wrapping_value(params));
+}
+
+static void test_limit_one_second_aborts(void)
+{
+	action_fn_t action = retrace_actions_get("call_count_limit");
+	struct ThreadContext *ctx = build_ctx_for_func("test_limit_1_abort");
+	JSON_Object *params = build_params_with_number("limit", 1.0);
+	int rc;
+
+	action(ctx, params);
+	rc = action(ctx, params);
+	assert(rc == -1);
+
+	json_value_free(json_object_get_wrapping_value(params));
+}
+
+static void test_independent_functions(void)
+{
+	action_fn_t action = retrace_actions_get("call_count_limit");
+	struct ThreadContext *ctx_a = build_ctx_for_func("indep_func_a");
+	struct ThreadContext *ctx_b = build_ctx_for_func("indep_func_b");
+	JSON_Object *params = build_params_with_number("limit", 2.0);
+	int rc;
+
+	/* A: 2 calls pass */
+	rc = action(ctx_a, params);
+	assert(rc == 0);
+	rc = action(ctx_a, params);
+	assert(rc == 0);
+
+	/* B: independent counter, 2 calls pass */
+	rc = action(ctx_b, params);
+	assert(rc == 0);
+	rc = action(ctx_b, params);
+	assert(rc == 0);
+
+	/* A: 3rd call now aborts */
+	rc = action(ctx_a, params);
+	assert(rc == -1);
+
+	/* B: 3rd call also aborts (independent count, same limit) */
+	rc = action(ctx_b, params);
+	assert(rc == -1);
+
+	json_value_free(json_object_get_wrapping_value(params));
+}
+
+static void test_reclaim_with_different_limit_keeps_original(void)
+{
+	action_fn_t action = retrace_actions_get("call_count_limit");
+	struct ThreadContext *ctx =
+		build_ctx_for_func("reclaim_func");
+	JSON_Object *p1 = build_params_with_number("limit", 5.0);
+	JSON_Object *p2 = build_params_with_number("limit", 100.0);
+	int rc;
+	int i;
+
+	/* Claim with limit=5, run 3 calls. */
+	assert(action(ctx, p1) == 0);
+	assert(action(ctx, p1) == 0);
+	assert(action(ctx, p1) == 0);
+
+	/* Re-claim same name with limit=100. Original limit (5) is kept. */
+	for (i = 0; i < 2; i++)
+		assert(action(ctx, p2) == 0);  /* count=4, 5; still under 5 */
+
+	/* count=6: now aborts because original limit was 5. */
+	rc = action(ctx, p2);
+	assert(rc == -1);
+
+	json_value_free(json_object_get_wrapping_value(p1));
+	json_value_free(json_object_get_wrapping_value(p2));
+}
+
+int main(void)
+{
+	retrace_real_impls.strcmp = strcmp;
+	retrace_real_impls.strlen = strlen;
+	retrace_real_impls.strcpy = strcpy;
+	retrace_real_impls.memset = memset;
+	retrace_real_impls.memcpy = memcpy;
+	retrace_real_impls.malloc = malloc;
+	retrace_real_impls.free = free;
+	retrace_real_impls.real_snprintf = snprintf;
+
+	printf("call_count_limit tests:\n");
+
+	printf("  -- lookup + params validation --\n");
+	TEST(action_lookup);
+	TEST(params_null);
+	TEST(missing_limit);
+
+	printf("  -- count semantics --\n");
+	TEST(limit_three_first_three_pass);
+	TEST(limit_three_fourth_aborts);
+	TEST(limit_one_first_passes);
+	TEST(limit_one_second_aborts);
+
+	printf("  -- per-function isolation --\n");
+	TEST(independent_functions);
+
+	printf("  -- reclaim semantics --\n");
+	TEST(reclaim_with_different_limit_keeps_original);
+
+	printf("\nPass: %d, Fail: %d (of %d)\n",
+		tests_pass, tests_fail, tests_run);
+	return tests_fail == 0 ? 0 : 1;
+}

--- a/test/unit/test_modify_return_value_int.c
+++ b/test/unit/test_modify_return_value_int.c
@@ -1,0 +1,206 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+/*
+ * Unit tests for the modify_return_value_int action.
+ *
+ * The action is the simplest of the built-ins: it reads retval_int
+ * from action_params and writes it to t_ctx->ret_val. Verifies:
+ *   - Action lookup succeeds
+ *   - NULL params -> -1
+ *   - Missing retval_int -> -1
+ *   - Numeric value (zero, positive, negative, large) is set verbatim
+ *   - Repeated calls overwrite (no accumulate)
+ *
+ * Part of TODO.complete/14.
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <limits.h>
+
+#include "engine.h"
+#include "actions.h"
+#include "funcs.h"
+#include "data_types.h"
+#include "real_impls.h"
+#include "parson.h"
+
+typedef int (*action_fn_t)(struct ThreadContext *t_ctx,
+			    const JSON_Object *action_params);
+
+static int tests_run;
+static int tests_pass;
+static int tests_fail;
+
+#define TEST(name) do { \
+	tests_run++; \
+	printf("  TEST %s ... ", #name); \
+	test_##name(); \
+	tests_pass++; \
+	printf("OK\n"); \
+} while (0)
+
+static JSON_Object *build_params_with_number(const char *key, double val)
+{
+	JSON_Value *root_val = json_value_init_object();
+	JSON_Object *root = json_value_get_object(root_val);
+
+	json_object_set_number(root, key, val);
+	return root;
+}
+
+static struct ThreadContext *build_empty_ctx(void)
+{
+	static struct ThreadContext ctx;
+
+	memset(&ctx, 0, sizeof(ctx));
+	ctx.ret_val = 0;
+	return &ctx;
+}
+
+static void test_action_lookup(void)
+{
+	retrace_actions_init();
+	assert(retrace_actions_get("modify_return_value_int") != NULL);
+}
+
+static void test_params_null(void)
+{
+	action_fn_t action = retrace_actions_get("modify_return_value_int");
+	struct ThreadContext *ctx = build_empty_ctx();
+	int rc;
+
+	rc = action(ctx, NULL);
+	assert(rc == -1);
+}
+
+static void test_missing_retval_int(void)
+{
+	action_fn_t action = retrace_actions_get("modify_return_value_int");
+	struct ThreadContext *ctx = build_empty_ctx();
+	JSON_Value *root_val = json_value_init_object();
+	JSON_Object *root = json_value_get_object(root_val);
+	int rc;
+
+	/* Object with unrelated key, no retval_int. */
+	json_object_set_string(root, "unrelated", "foo");
+
+	rc = action(ctx, root);
+	assert(rc == -1);
+
+	json_value_free(root_val);
+}
+
+static void test_set_zero(void)
+{
+	action_fn_t action = retrace_actions_get("modify_return_value_int");
+	struct ThreadContext *ctx = build_empty_ctx();
+	JSON_Object *params = build_params_with_number("retval_int", 0.0);
+	int rc;
+
+	rc = action(ctx, params);
+	assert(rc == 0);
+	assert(ctx->ret_val == 0);
+
+	json_value_free(json_object_get_wrapping_value(params));
+}
+
+static void test_set_positive(void)
+{
+	action_fn_t action = retrace_actions_get("modify_return_value_int");
+	struct ThreadContext *ctx = build_empty_ctx();
+	JSON_Object *params = build_params_with_number("retval_int", 42.0);
+	int rc;
+
+	rc = action(ctx, params);
+	assert(rc == 0);
+	assert(ctx->ret_val == 42);
+
+	json_value_free(json_object_get_wrapping_value(params));
+}
+
+static void test_set_negative(void)
+{
+	action_fn_t action = retrace_actions_get("modify_return_value_int");
+	struct ThreadContext *ctx = build_empty_ctx();
+	JSON_Object *params = build_params_with_number("retval_int", -13.0);
+	int rc;
+
+	rc = action(ctx, params);
+	assert(rc == 0);
+	assert(ctx->ret_val == -13);
+
+	json_value_free(json_object_get_wrapping_value(params));
+}
+
+static void test_set_large(void)
+{
+	action_fn_t action = retrace_actions_get("modify_return_value_int");
+	struct ThreadContext *ctx = build_empty_ctx();
+	JSON_Object *params;
+	int rc;
+
+	/* Near long max. parson stores as double; for values < 2^53
+	 * this is exact.
+	 */
+	params = build_params_with_number("retval_int", 9007199254740992.0);
+
+	rc = action(ctx, params);
+	assert(rc == 0);
+	assert(ctx->ret_val == 9007199254740992L);
+
+	json_value_free(json_object_get_wrapping_value(params));
+}
+
+static void test_overwrites_each_call(void)
+{
+	action_fn_t action = retrace_actions_get("modify_return_value_int");
+	struct ThreadContext *ctx = build_empty_ctx();
+	JSON_Object *p1 = build_params_with_number("retval_int", 100.0);
+	JSON_Object *p2 = build_params_with_number("retval_int", 200.0);
+
+	assert(action(ctx, p1) == 0);
+	assert(ctx->ret_val == 100);
+
+	assert(action(ctx, p2) == 0);
+	assert(ctx->ret_val == 200);
+
+	json_value_free(json_object_get_wrapping_value(p1));
+	json_value_free(json_object_get_wrapping_value(p2));
+}
+
+int main(void)
+{
+	retrace_real_impls.strcmp = strcmp;
+	retrace_real_impls.strlen = strlen;
+	retrace_real_impls.strcpy = strcpy;
+	retrace_real_impls.memset = memset;
+	retrace_real_impls.memcpy = memcpy;
+	retrace_real_impls.malloc = malloc;
+	retrace_real_impls.free = free;
+	retrace_real_impls.real_snprintf = snprintf;
+
+	printf("modify_return_value_int tests:\n");
+
+	printf("  -- lookup + params validation --\n");
+	TEST(action_lookup);
+	TEST(params_null);
+	TEST(missing_retval_int);
+
+	printf("  -- value semantics --\n");
+	TEST(set_zero);
+	TEST(set_positive);
+	TEST(set_negative);
+	TEST(set_large);
+	TEST(overwrites_each_call);
+
+	printf("\nPass: %d, Fail: %d (of %d)\n",
+		tests_pass, tests_fail, tests_run);
+	return tests_fail == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Continues TODO.complete/14. Two more action unit-test files following the pattern established by `test_addr_deny` (PR #553):

- `test/unit/test_modify_return_value_int.c` -- 8 tests
- `test/unit/test_call_count_limit.c` -- 9 tests

## modify_return_value_int

Simplest action: reads `retval_int` from JSON, writes to `t_ctx->ret_val`.

Tests:
- `action_lookup`
- `params_null` -- NULL params returns -1
- `missing_retval_int` -- object without `retval_int` returns -1
- `set_zero`
- `set_positive` (42)
- `set_negative` (-13)
- `set_large` (2^53, exact in double)
- `overwrites_each_call` (100 then 200; no accumulate)

**Note:** the action's own `log_info` uses `(int)` cast, which truncates large values for display. The actual `t_ctx->ret_val` is stored as `long`, which is what the test asserts. The display is a separate bug worth fixing in a follow-up.

## call_count_limit

Per-function-name counter. First N calls return 0; (N+1)th returns -1, aborting the rest of the script.

Tests:
- `action_lookup`
- `params_null` -- returns -1
- `missing_limit` -- returns -1
- `limit_three_first_three_pass`
- `limit_three_fourth_aborts`
- `limit_one_first_passes`
- `limit_one_second_aborts`
- `independent_functions` -- two funcs tracked separately, same limit
- `reclaim_with_different_limit_keeps_original` -- re-claiming warns, original limit stays

Each test uses a unique prototype name to avoid collisions in the action's global counter table (`g_entries`).

## Pattern

Same as PR #553: lookup via `retrace_actions_get`, construct `ThreadContext` inline, build JSON params via parson, call, assert. The typedef `action_fn_t` is repeated per-file because each file is a standalone translation unit (DRY across files would require a shared test header, deferred).

## Test plan

- [x] `cmake --build build-rel` -- clean
- [x] `ctest --test-dir build-rel` -- 10/10 pass (integration, 8 unit, 2 property)
- [ ] CI matrix green

## TODO.complete/14 status

Now Partial with 4 of 12 actions covered (this PR + `addr_deny` from PR #553 + `sockaddr_inspect` helper from PR #551):

| Action | Test file | Status |
|--------|-----------|--------|
| `addr_deny` | test_addr_deny.c | done (PR #553) |
| `modify_return_value_int` | test_modify_return_value_int.c | done (this PR) |
| `call_count_limit` | test_call_count_limit.c | done (this PR) |
| `log_params` | -- | TBD (needs constructed DataType metadata) |
| `call_real` | -- | TBD (needs real_impl ptr) |
| `modify_in_param_str` | -- | TBD |
| `modify_in_param_int` | -- | TBD |
| `modify_in_param_arr` | -- | TBD |
| `memory_fuzz` | -- | TBD (needs valid memory to fuzz) |
| `fuzzing_seed` | -- | TBD |
| `delay` | -- | TBD (uses nanosleep; needs timing assertions) |
| `incomplete_io` | -- | TBD |
| `sandbox` | -- | TBD (similar pattern to addr_deny) |

Each remaining action follows the same lookup-construct-call-assert pattern; future PRs can knock them out one at a time.

## Related

- PR #553 (test_addr_deny -- established the pattern)
- PR #552 (property tests for sockaddr_inspect)
- TODO.complete/14-specs-and-unit-tests.md
