### PR TITLE
test: unit tests for sandbox + modify_in_param_int + fuzzing_seed + delay

### DIFF
--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -263,3 +263,139 @@ add_test(NAME unit-test-call-count-limit
     COMMAND retrace_test_call_count_limit)
 set_tests_properties(unit-test-call-count-limit PROPERTIES
     LABELS "unit")
+
+#
+# sandbox action unit tests (TODO.complete/14).
+#
+add_executable(retrace_test_sandbox test_sandbox.c)
+set_target_properties(retrace_test_sandbox PROPERTIES
+    OUTPUT_NAME test_sandbox
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/test/unit")
+
+target_link_libraries(retrace_test_sandbox PRIVATE
+    retrace_core
+    retrace_config_json
+    retrace_backends
+    ${_unit_backend_lib}
+    retrace_preload_common
+    retrace_headers
+    ${CMAKE_DL_LIBS}
+    Threads::Threads)
+
+target_include_directories(retrace_test_sandbox PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/core
+    ${CMAKE_SOURCE_DIR}/src/backends
+    ${CMAKE_SOURCE_DIR}/src/config/json
+    ${_unit_arch_include})
+
+if(RETRACE_PLATFORM_LINUX OR RETRACE_PLATFORM_FREEBSD)
+    target_compile_definitions(retrace_test_sandbox PRIVATE _GNU_SOURCE _DEFAULT_SOURCE)
+elseif(RETRACE_PLATFORM_DARWIN)
+    target_compile_definitions(retrace_test_sandbox PRIVATE _DARWIN_C_SOURCE)
+endif()
+
+add_test(NAME unit-test-sandbox
+    COMMAND retrace_test_sandbox)
+set_tests_properties(unit-test-sandbox PROPERTIES LABELS "unit")
+
+#
+# modify_in_param_int action unit tests (TODO.complete/14).
+#
+add_executable(retrace_test_modify_in_param_int test_modify_in_param_int.c)
+set_target_properties(retrace_test_modify_in_param_int PROPERTIES
+    OUTPUT_NAME test_modify_in_param_int
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/test/unit")
+
+target_link_libraries(retrace_test_modify_in_param_int PRIVATE
+    retrace_core
+    retrace_config_json
+    retrace_backends
+    ${_unit_backend_lib}
+    retrace_preload_common
+    retrace_headers
+    ${CMAKE_DL_LIBS}
+    Threads::Threads)
+
+target_include_directories(retrace_test_modify_in_param_int PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/core
+    ${CMAKE_SOURCE_DIR}/src/backends
+    ${CMAKE_SOURCE_DIR}/src/config/json
+    ${_unit_arch_include})
+
+if(RETRACE_PLATFORM_LINUX OR RETRACE_PLATFORM_FREEBSD)
+    target_compile_definitions(retrace_test_modify_in_param_int PRIVATE _GNU_SOURCE _DEFAULT_SOURCE)
+elseif(RETRACE_PLATFORM_DARWIN)
+    target_compile_definitions(retrace_test_modify_in_param_int PRIVATE _DARWIN_C_SOURCE)
+endif()
+
+add_test(NAME unit-test-modify-in-param-int
+    COMMAND retrace_test_modify_in_param_int)
+set_tests_properties(unit-test-modify-in-param-int PROPERTIES LABELS "unit")
+
+#
+# fuzzing_seed action unit tests (TODO.complete/14).
+#
+add_executable(retrace_test_fuzzing_seed test_fuzzing_seed.c)
+set_target_properties(retrace_test_fuzzing_seed PROPERTIES
+    OUTPUT_NAME test_fuzzing_seed
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/test/unit")
+
+target_link_libraries(retrace_test_fuzzing_seed PRIVATE
+    retrace_core
+    retrace_config_json
+    retrace_backends
+    ${_unit_backend_lib}
+    retrace_preload_common
+    retrace_headers
+    ${CMAKE_DL_LIBS}
+    Threads::Threads)
+
+target_include_directories(retrace_test_fuzzing_seed PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/core
+    ${CMAKE_SOURCE_DIR}/src/backends
+    ${CMAKE_SOURCE_DIR}/src/config/json
+    ${_unit_arch_include})
+
+if(RETRACE_PLATFORM_LINUX OR RETRACE_PLATFORM_FREEBSD)
+    target_compile_definitions(retrace_test_fuzzing_seed PRIVATE _GNU_SOURCE _DEFAULT_SOURCE)
+elseif(RETRACE_PLATFORM_DARWIN)
+    target_compile_definitions(retrace_test_fuzzing_seed PRIVATE _DARWIN_C_SOURCE)
+endif()
+
+add_test(NAME unit-test-fuzzing-seed
+    COMMAND retrace_test_fuzzing_seed)
+set_tests_properties(unit-test-fuzzing-seed PROPERTIES LABELS "unit")
+
+#
+# delay action unit tests (TODO.complete/14).
+#
+add_executable(retrace_test_delay test_delay.c)
+set_target_properties(retrace_test_delay PROPERTIES
+    OUTPUT_NAME test_delay
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/test/unit")
+
+target_link_libraries(retrace_test_delay PRIVATE
+    retrace_core
+    retrace_config_json
+    retrace_backends
+    ${_unit_backend_lib}
+    retrace_preload_common
+    retrace_headers
+    ${CMAKE_DL_LIBS}
+    Threads::Threads)
+
+target_include_directories(retrace_test_delay PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/core
+    ${CMAKE_SOURCE_DIR}/src/backends
+    ${CMAKE_SOURCE_DIR}/src/config/json
+    ${_unit_arch_include})
+
+if(RETRACE_PLATFORM_LINUX OR RETRACE_PLATFORM_FREEBSD)
+    target_compile_definitions(retrace_test_delay PRIVATE _GNU_SOURCE _DEFAULT_SOURCE)
+elseif(RETRACE_PLATFORM_DARWIN)
+    target_compile_definitions(retrace_test_delay PRIVATE _DARWIN_C_SOURCE)
+endif()
+
+add_test(NAME unit-test-delay
+    COMMAND retrace_test_delay)
+set_tests_properties(unit-test-delay PROPERTIES LABELS "unit")

--- a/test/unit/test_delay.c
+++ b/test/unit/test_delay.c
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+/*
+ * Unit tests for the delay action.
+ *
+ * The action sleeps for the configured number of milliseconds.
+ * Verification focuses on params validation and the return code,
+ * not on actual sleep duration (a timing-based assertion would
+ * be flaky on loaded CI runners).
+ *
+ * Tests:
+ *   - Action lookup succeeds
+ *   - NULL params -> 0 (no-op, no delay)
+ *   - Missing "ms" -> 0 (no-op)
+ *   - Zero ms -> 0 (no-op)
+ *   - Negative ms -> 0 (no-op)
+ *   - Small positive ms -> 0 (sleeps briefly)
+ *
+ * Part of TODO.complete/14.
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <time.h>
+
+#include "engine.h"
+#include "actions.h"
+#include "funcs.h"
+#include "data_types.h"
+#include "real_impls.h"
+#include "parson.h"
+
+typedef int (*action_fn_t)(struct ThreadContext *t_ctx,
+			    const JSON_Object *action_params);
+
+static int tests_run;
+static int tests_pass;
+static int tests_fail;
+
+#define TEST(name) do { \
+	tests_run++; \
+	printf("  TEST %s ... ", #name); \
+	test_##name(); \
+	tests_pass++; \
+	printf("OK\n"); \
+} while (0)
+
+static JSON_Object *build_params_with_ms(double ms)
+{
+	JSON_Value *root_val = json_value_init_object();
+	JSON_Object *root = json_value_get_object(root_val);
+
+	json_object_set_number(root, "ms", ms);
+	return root;
+}
+
+static JSON_Object *build_empty_params(void)
+{
+	JSON_Value *root_val = json_value_init_object();
+	JSON_Object *root = json_value_get_object(root_val);
+
+	json_object_set_string(root, "unrelated", "foo");
+	return root;
+}
+
+static void test_action_lookup(void)
+{
+	retrace_actions_init();
+	assert(retrace_actions_get("delay") != NULL);
+}
+
+static void test_params_null(void)
+{
+	action_fn_t action = retrace_actions_get("delay");
+	struct ThreadContext ctx;
+	int rc;
+
+	memset(&ctx, 0, sizeof(ctx));
+	rc = action(&ctx, NULL);
+	assert(rc == 0);
+}
+
+static void test_missing_ms(void)
+{
+	action_fn_t action = retrace_actions_get("delay");
+	struct ThreadContext ctx;
+	JSON_Object *params = build_empty_params();
+	int rc;
+
+	memset(&ctx, 0, sizeof(ctx));
+	rc = action(&ctx, params);
+	assert(rc == 0);
+
+	json_value_free(json_object_get_wrapping_value(params));
+}
+
+static void test_zero_ms(void)
+{
+	action_fn_t action = retrace_actions_get("delay");
+	struct ThreadContext ctx;
+	JSON_Object *params = build_params_with_ms(0.0);
+	int rc;
+
+	memset(&ctx, 0, sizeof(ctx));
+	rc = action(&ctx, params);
+	assert(rc == 0);
+
+	json_value_free(json_object_get_wrapping_value(params));
+}
+
+static void test_negative_ms(void)
+{
+	action_fn_t action = retrace_actions_get("delay");
+	struct ThreadContext ctx;
+	JSON_Object *params = build_params_with_ms(-100.0);
+	int rc;
+
+	memset(&ctx, 0, sizeof(ctx));
+	rc = action(&ctx, params);
+	assert(rc == 0);
+
+	json_value_free(json_object_get_wrapping_value(params));
+}
+
+static void test_small_positive_ms(void)
+{
+	action_fn_t action = retrace_actions_get("delay");
+	struct ThreadContext ctx;
+	JSON_Object *params = build_params_with_ms(1.0);
+	int rc;
+
+	memset(&ctx, 0, sizeof(ctx));
+	rc = action(&ctx, params);
+	assert(rc == 0);
+
+	json_value_free(json_object_get_wrapping_value(params));
+}
+
+int main(void)
+{
+	retrace_real_impls.strcmp = strcmp;
+	retrace_real_impls.strlen = strlen;
+	retrace_real_impls.strcpy = strcpy;
+	retrace_real_impls.memset = memset;
+	retrace_real_impls.memcpy = memcpy;
+	retrace_real_impls.malloc = malloc;
+	retrace_real_impls.free = free;
+	retrace_real_impls.real_snprintf = snprintf;
+
+	printf("delay tests:\n");
+
+	printf("  -- lookup + params validation --\n");
+	TEST(action_lookup);
+	TEST(params_null);
+	TEST(missing_ms);
+	TEST(zero_ms);
+	TEST(negative_ms);
+
+	printf("  -- valid delays --\n");
+	TEST(small_positive_ms);
+
+	printf("\nPass: %d, Fail: %d (of %d)\n",
+		tests_pass, tests_fail, tests_run);
+	return tests_fail == 0 ? 0 : 1;
+}

--- a/test/unit/test_fuzzing_seed.c
+++ b/test/unit/test_fuzzing_seed.c
@@ -1,0 +1,222 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+/*
+ * Unit tests for the fuzzing_seed action.
+ *
+ * The action sets the global g_fuzzing_seed and applies it
+ * immediately via srand(). Verification: calling the action with
+ * the same seed twice yields identical rand() sequences.
+ *
+ * Tests:
+ *   - Action lookup succeeds
+ *   - NULL params -> -1
+ *   - Missing "seed" -> -1
+ *   - Setting a seed produces deterministic rand() sequence
+ *   - Same seed twice -> same sequence
+ *   - Different seeds -> different sequences
+ *
+ * Part of TODO.complete/14.
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "engine.h"
+#include "actions.h"
+#include "funcs.h"
+#include "data_types.h"
+#include "real_impls.h"
+#include "parson.h"
+
+typedef int (*action_fn_t)(struct ThreadContext *t_ctx,
+			    const JSON_Object *action_params);
+
+static int tests_run;
+static int tests_pass;
+static int tests_fail;
+
+#define TEST(name) do { \
+	tests_run++; \
+	printf("  TEST %s ... ", #name); \
+	test_##name(); \
+	tests_pass++; \
+	printf("OK\n"); \
+} while (0)
+
+static JSON_Object *build_params_with_seed(double seed)
+{
+	JSON_Value *root_val = json_value_init_object();
+	JSON_Object *root = json_value_get_object(root_val);
+
+	json_object_set_number(root, "seed", seed);
+	return root;
+}
+
+static JSON_Object *build_empty_params(void)
+{
+	JSON_Value *root_val = json_value_init_object();
+	JSON_Object *root = json_value_get_object(root_val);
+
+	json_object_set_string(root, "unrelated", "foo");
+	return root;
+}
+
+/* Sample 5 rand() values into out. */
+static void sample_rand_sequence(int *out, int n)
+{
+	int i;
+
+	for (i = 0; i < n; i++)
+		out[i] = rand();
+}
+
+static int sequences_equal(const int *a, const int *b, int n)
+{
+	int i;
+
+	for (i = 0; i < n; i++)
+		if (a[i] != b[i])
+			return 0;
+	return 1;
+}
+
+static void test_action_lookup(void)
+{
+	retrace_actions_init();
+	assert(retrace_actions_get("fuzzing_seed") != NULL);
+}
+
+static void test_params_null(void)
+{
+	action_fn_t action = retrace_actions_get("fuzzing_seed");
+	struct ThreadContext ctx;
+	int rc;
+
+	memset(&ctx, 0, sizeof(ctx));
+	rc = action(&ctx, NULL);
+	assert(rc == -1);
+}
+
+static void test_missing_seed(void)
+{
+	action_fn_t action = retrace_actions_get("fuzzing_seed");
+	struct ThreadContext ctx;
+	JSON_Object *params = build_empty_params();
+	int rc;
+
+	memset(&ctx, 0, sizeof(ctx));
+	rc = action(&ctx, params);
+	assert(rc == -1);
+
+	json_value_free(json_object_get_wrapping_value(params));
+}
+
+static void test_seed_makes_rand_deterministic(void)
+{
+	action_fn_t action = retrace_actions_get("fuzzing_seed");
+	struct ThreadContext ctx;
+	int seq_a[5];
+	int seq_b[5];
+	JSON_Object *p1 = build_params_with_seed(42.0);
+	JSON_Object *p2 = build_params_with_seed(42.0);
+	int rc1, rc2;
+
+	memset(&ctx, 0, sizeof(ctx));
+
+	rc1 = action(&ctx, p1);
+	assert(rc1 == 0);
+	sample_rand_sequence(seq_a, 5);
+
+	rc2 = action(&ctx, p2);
+	assert(rc2 == 0);
+	sample_rand_sequence(seq_b, 5);
+
+	/* Same seed -> same sequence. */
+	assert(sequences_equal(seq_a, seq_b, 5));
+
+	json_value_free(json_object_get_wrapping_value(p1));
+	json_value_free(json_object_get_wrapping_value(p2));
+}
+
+static void test_different_seeds_produce_different_sequences(void)
+{
+	action_fn_t action = retrace_actions_get("fuzzing_seed");
+	struct ThreadContext ctx;
+	int seq_a[5];
+	int seq_b[5];
+	JSON_Object *p1 = build_params_with_seed(1.0);
+	JSON_Object *p2 = build_params_with_seed(2.0);
+
+	memset(&ctx, 0, sizeof(ctx));
+
+	action(&ctx, p1);
+	sample_rand_sequence(seq_a, 5);
+
+	action(&ctx, p2);
+	sample_rand_sequence(seq_b, 5);
+
+	/* Vanishingly unlikely for two seeds to produce identical
+	 * 5-element sequences.
+	 */
+	assert(!sequences_equal(seq_a, seq_b, 5));
+
+	json_value_free(json_object_get_wrapping_value(p1));
+	json_value_free(json_object_get_wrapping_value(p2));
+}
+
+static void test_seed_zero(void)
+{
+	action_fn_t action = retrace_actions_get("fuzzing_seed");
+	struct ThreadContext ctx;
+	int seq_a[5];
+	int seq_b[5];
+	JSON_Object *p1 = build_params_with_seed(0.0);
+	JSON_Object *p2 = build_params_with_seed(0.0);
+
+	memset(&ctx, 0, sizeof(ctx));
+
+	assert(action(&ctx, p1) == 0);
+	sample_rand_sequence(seq_a, 5);
+
+	assert(action(&ctx, p2) == 0);
+	sample_rand_sequence(seq_b, 5);
+
+	assert(sequences_equal(seq_a, seq_b, 5));
+
+	json_value_free(json_object_get_wrapping_value(p1));
+	json_value_free(json_object_get_wrapping_value(p2));
+}
+
+int main(void)
+{
+	retrace_real_impls.strcmp = strcmp;
+	retrace_real_impls.strlen = strlen;
+	retrace_real_impls.strcpy = strcpy;
+	retrace_real_impls.memset = memset;
+	retrace_real_impls.memcpy = memcpy;
+	retrace_real_impls.malloc = malloc;
+	retrace_real_impls.free = free;
+	retrace_real_impls.real_snprintf = snprintf;
+
+	printf("fuzzing_seed tests:\n");
+
+	printf("  -- lookup + params validation --\n");
+	TEST(action_lookup);
+	TEST(params_null);
+	TEST(missing_seed);
+
+	printf("  -- determinism --\n");
+	TEST(seed_makes_rand_deterministic);
+	TEST(different_seeds_produce_different_sequences);
+	TEST(seed_zero);
+
+	printf("\nPass: %d, Fail: %d (of %d)\n",
+		tests_pass, tests_fail, tests_run);
+	return tests_fail == 0 ? 0 : 1;
+}

--- a/test/unit/test_modify_in_param_int.c
+++ b/test/unit/test_modify_in_param_int.c
@@ -1,0 +1,300 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+/*
+ * Unit tests for the modify_in_param_int action.
+ *
+ * The action looks up a param by name in t_ctx->params, verifies
+ * it's an IN param, optionally matches its current value against
+ * match_int, and writes new_int into param->val.
+ *
+ * Tests:
+ *   - Action lookup succeeds
+ *   - NULL params -> -1
+ *   - Missing param_name -> -1
+ *   - Unknown param name -> -1
+ *   - Param with PDIR_OUT direction -> -1
+ *   - Missing new_int -> -1
+ *   - Direct modification (no match_int)
+ *   - match_int present and matches -> writes new value
+ *   - match_int present, no match -> no-op
+ *
+ * Part of TODO.complete/14.
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "engine.h"
+#include "actions.h"
+#include "funcs.h"
+#include "data_types.h"
+#include "real_impls.h"
+#include "parson.h"
+
+typedef int (*action_fn_t)(struct ThreadContext *t_ctx,
+			    const JSON_Object *action_params);
+
+static int tests_run;
+static int tests_pass;
+static int tests_fail;
+
+#define TEST(name) do { \
+	tests_run++; \
+	printf("  TEST %s ... ", #name); \
+	test_##name(); \
+	tests_pass++; \
+	printf("OK\n"); \
+} while (0)
+
+/* Build a JSON object with one required string + one required number
+ * and one optional number.
+ */
+static JSON_Object *build_params_full(const char *param_name,
+				       double new_int,
+				       int with_match,
+				       double match_int)
+{
+	JSON_Value *root_val = json_value_init_object();
+	JSON_Object *root = json_value_get_object(root_val);
+
+	json_object_set_string(root, "param_name", param_name);
+	json_object_set_number(root, "new_int", new_int);
+	if (with_match)
+		json_object_set_number(root, "match_int", match_int);
+	return root;
+}
+
+static JSON_Object *build_params_no_new_int(const char *param_name)
+{
+	JSON_Value *root_val = json_value_init_object();
+	JSON_Object *root = json_value_get_object(root_val);
+
+	json_object_set_string(root, "param_name", param_name);
+	return root;
+}
+
+static JSON_Object *build_params_no_param_name(void)
+{
+	JSON_Value *root_val = json_value_init_object();
+	JSON_Object *root = json_value_get_object(root_val);
+
+	json_object_set_number(root, "new_int", 42.0);
+	return root;
+}
+
+/* Build a ThreadContext with one named param of given direction
+ * and value.
+ */
+static struct ThreadContext *build_ctx_with_param(const char *name,
+						  enum ParamDirections dir,
+						  long val)
+{
+	static struct ThreadContext ctx;
+	static struct FuncPrototype proto;
+	struct FuncParam params[8];
+
+	memset(&ctx, 0, sizeof(ctx));
+	memset(params, 0, sizeof(params));
+	memset(&proto, 0, sizeof(proto));
+
+	strncpy(proto.name, "test_func", sizeof(proto.name) - 1);
+	ctx.prototype = &proto;
+
+	strncpy(params[0].param_meta.name, name,
+		sizeof(params[0].param_meta.name) - 1);
+	params[0].param_meta.direction = dir;
+	params[0].val = val;
+
+	ctx.params_cnt = 1;
+	memcpy(ctx.params, params, sizeof(params));
+	ctx.ret_val = 0;
+	return &ctx;
+}
+
+static struct ThreadContext *build_empty_ctx(void)
+{
+	static struct ThreadContext ctx;
+	static struct FuncPrototype proto;
+
+	memset(&ctx, 0, sizeof(ctx));
+	memset(&proto, 0, sizeof(proto));
+	strncpy(proto.name, "test_func", sizeof(proto.name) - 1);
+	ctx.prototype = &proto;
+	return &ctx;
+}
+
+static void test_action_lookup(void)
+{
+	retrace_actions_init();
+	assert(retrace_actions_get("modify_in_param_int") != NULL);
+}
+
+static void test_params_null(void)
+{
+	action_fn_t action = retrace_actions_get("modify_in_param_int");
+	struct ThreadContext *ctx = build_empty_ctx();
+	int rc;
+
+	rc = action(ctx, NULL);
+	assert(rc == -1);
+}
+
+static void test_missing_param_name(void)
+{
+	action_fn_t action = retrace_actions_get("modify_in_param_int");
+	struct ThreadContext *ctx = build_empty_ctx();
+	JSON_Object *params = build_params_no_param_name();
+	int rc;
+
+	rc = action(ctx, params);
+	assert(rc == -1);
+
+	json_value_free(json_object_get_wrapping_value(params));
+}
+
+static void test_unknown_param_name(void)
+{
+	action_fn_t action = retrace_actions_get("modify_in_param_int");
+	struct ThreadContext *ctx =
+		build_ctx_with_param("real_param", PDIR_IN, 0);
+	JSON_Object *params =
+		build_params_full("nonexistent_param", 99.0, 0, 0.0);
+	int rc;
+
+	rc = action(ctx, params);
+	assert(rc == -1);
+
+	json_value_free(json_object_get_wrapping_value(params));
+}
+
+static void test_param_wrong_direction(void)
+{
+	action_fn_t action = retrace_actions_get("modify_in_param_int");
+	struct ThreadContext *ctx =
+		build_ctx_with_param("out_param", PDIR_OUT, 0);
+	JSON_Object *params =
+		build_params_full("out_param", 99.0, 0, 0.0);
+	int rc;
+
+	rc = action(ctx, params);
+	assert(rc == -1);
+
+	json_value_free(json_object_get_wrapping_value(params));
+}
+
+static void test_missing_new_int(void)
+{
+	action_fn_t action = retrace_actions_get("modify_in_param_int");
+	struct ThreadContext *ctx =
+		build_ctx_with_param("foo", PDIR_IN, 0);
+	JSON_Object *params = build_params_no_new_int("foo");
+	int rc;
+
+	rc = action(ctx, params);
+	assert(rc == -1);
+
+	json_value_free(json_object_get_wrapping_value(params));
+}
+
+static void test_direct_modification(void)
+{
+	action_fn_t action = retrace_actions_get("modify_in_param_int");
+	struct ThreadContext *ctx =
+		build_ctx_with_param("foo", PDIR_IN, 0);
+	JSON_Object *params = build_params_full("foo", 42, 0, 0.0);
+	int rc;
+
+	rc = action(ctx, params);
+	assert(rc == 0);
+	assert(ctx->params[0].val == 42);
+
+	json_value_free(json_object_get_wrapping_value(params));
+}
+
+static void test_match_int_present_and_matches(void)
+{
+	action_fn_t action = retrace_actions_get("modify_in_param_int");
+	/* Initial val=10, match_int=10 -> matches, writes new_int=99 */
+	struct ThreadContext *ctx =
+		build_ctx_with_param("foo", PDIR_IN, 10);
+	JSON_Object *params =
+		build_params_full("foo", 99.0, 1, 10.0);
+	int rc;
+
+	rc = action(ctx, params);
+	assert(rc == 0);
+	assert(ctx->params[0].val == 99);
+
+	json_value_free(json_object_get_wrapping_value(params));
+}
+
+static void test_match_int_present_no_match(void)
+{
+	action_fn_t action = retrace_actions_get("modify_in_param_int");
+	/* Initial val=10, match_int=20 -> no match, no-op */
+	struct ThreadContext *ctx =
+		build_ctx_with_param("foo", PDIR_IN, 10);
+	JSON_Object *params =
+		build_params_full("foo", 99.0, 1, 20.0);
+	int rc;
+
+	rc = action(ctx, params);
+	assert(rc == 0);
+	/* Value unchanged. */
+	assert(ctx->params[0].val == 10);
+
+	json_value_free(json_object_get_wrapping_value(params));
+}
+
+static void test_negative_new_int(void)
+{
+	action_fn_t action = retrace_actions_get("modify_in_param_int");
+	struct ThreadContext *ctx =
+		build_ctx_with_param("foo", PDIR_IN, 0);
+	JSON_Object *params = build_params_full("foo", -7, 0, 0.0);
+	int rc;
+
+	rc = action(ctx, params);
+	assert(rc == 0);
+	assert(ctx->params[0].val == -7);
+
+	json_value_free(json_object_get_wrapping_value(params));
+}
+
+int main(void)
+{
+	retrace_real_impls.strcmp = strcmp;
+	retrace_real_impls.strlen = strlen;
+	retrace_real_impls.strcpy = strcpy;
+	retrace_real_impls.memset = memset;
+	retrace_real_impls.memcpy = memcpy;
+	retrace_real_impls.malloc = malloc;
+	retrace_real_impls.free = free;
+	retrace_real_impls.real_snprintf = snprintf;
+
+	printf("modify_in_param_int tests:\n");
+
+	printf("  -- lookup + params validation --\n");
+	TEST(action_lookup);
+	TEST(params_null);
+	TEST(missing_param_name);
+	TEST(unknown_param_name);
+	TEST(param_wrong_direction);
+	TEST(missing_new_int);
+
+	printf("  -- modification semantics --\n");
+	TEST(direct_modification);
+	TEST(match_int_present_and_matches);
+	TEST(match_int_present_no_match);
+	TEST(negative_new_int);
+
+	printf("\nPass: %d, Fail: %d (of %d)\n",
+		tests_pass, tests_fail, tests_run);
+	return tests_fail == 0 ? 0 : 1;
+}

--- a/test/unit/test_sandbox.c
+++ b/test/unit/test_sandbox.c
@@ -1,0 +1,290 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+/*
+ * Unit tests for the sandbox action (file-path deny-list).
+ *
+ * The action is the file-system counterpart of addr_deny (PR #553):
+ * it scans t_ctx->params for a path argument, compares against the
+ * deny_paths array, and on match sets ret_val=-1 and returns -1.
+ *
+ * Tests:
+ *   - Action lookup succeeds
+ *   - Required params validation (NULL params, missing deny_paths)
+ *   - Exact-match deny
+ *   - Prefix-match deny (entry ending in '/')
+ *   - No-match passes through
+ *   - First-non-null param is picked (params[0] vs params[1])
+ *
+ * Part of TODO.complete/14.
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "engine.h"
+#include "actions.h"
+#include "funcs.h"
+#include "data_types.h"
+#include "real_impls.h"
+#include "parson.h"
+
+typedef int (*action_fn_t)(struct ThreadContext *t_ctx,
+			    const JSON_Object *action_params);
+
+static int tests_run;
+static int tests_pass;
+static int tests_fail;
+
+#define TEST(name) do { \
+	tests_run++; \
+	printf("  TEST %s ... ", #name); \
+	test_##name(); \
+	tests_pass++; \
+	printf("OK\n"); \
+} while (0)
+
+static JSON_Object *build_params_with_array(const char *key,
+					     const char **vals, int n)
+{
+	JSON_Value *root_val = json_value_init_object();
+	JSON_Object *root = json_value_get_object(root_val);
+	JSON_Value *arr_val = json_value_init_array();
+	JSON_Array *arr = json_array(arr_val);
+	int i;
+
+	for (i = 0; i < n; i++)
+		json_array_append_string(arr, vals[i]);
+
+	json_object_set_value(root, key, arr_val);
+	return root;
+}
+
+/* Build a ThreadContext with up to 2 named path-like params.
+ * n==1: single param at index 0 with given name + value.
+ * n==2: param[0] with name0/value0; param[1] with name1/value1.
+ */
+static struct ThreadContext *build_ctx_with_paths(int n,
+						   const char *name0,
+						   const char *val0,
+						   const char *name1,
+						   const char *val1)
+{
+	static struct ThreadContext ctx;
+	static struct FuncParam params[8];
+	static char buf0[256];
+	static char buf1[256];
+
+	memset(&ctx, 0, sizeof(ctx));
+	memset(params, 0, sizeof(params));
+
+	if (n >= 1) {
+		strncpy(params[0].param_meta.name, name0,
+			sizeof(params[0].param_meta.name) - 1);
+		strncpy(buf0, val0, sizeof(buf0) - 1);
+		buf0[sizeof(buf0) - 1] = '\0';
+		params[0].val = (long)buf0;
+	}
+	if (n >= 2) {
+		strncpy(params[1].param_meta.name, name1,
+			sizeof(params[1].param_meta.name) - 1);
+		strncpy(buf1, val1, sizeof(buf1) - 1);
+		buf1[sizeof(buf1) - 1] = '\0';
+		params[1].val = (long)buf1;
+	}
+
+	ctx.params_cnt = n;
+	memcpy(ctx.params, params, sizeof(params));
+	ctx.ret_val = 0;
+	return &ctx;
+}
+
+static struct ThreadContext *build_empty_ctx(void)
+{
+	static struct ThreadContext ctx;
+
+	memset(&ctx, 0, sizeof(ctx));
+	return &ctx;
+}
+
+static void test_action_lookup(void)
+{
+	retrace_actions_init();
+	assert(retrace_actions_get("sandbox") != NULL);
+}
+
+static void test_params_null(void)
+{
+	action_fn_t action = retrace_actions_get("sandbox");
+	struct ThreadContext *ctx = build_empty_ctx();
+	int rc;
+
+	rc = action(ctx, NULL);
+	assert(rc == -1);
+}
+
+static void test_missing_deny_paths(void)
+{
+	action_fn_t action = retrace_actions_get("sandbox");
+	struct ThreadContext *ctx = build_empty_ctx();
+	JSON_Value *root_val = json_value_init_object();
+	JSON_Object *root = json_value_get_object(root_val);
+	int rc;
+
+	json_object_set_string(root, "unrelated", "foo");
+	rc = action(ctx, root);
+	assert(rc == -1);
+
+	json_value_free(root_val);
+}
+
+static void test_exact_match(void)
+{
+	action_fn_t action = retrace_actions_get("sandbox");
+	const char *paths[] = { "/etc/shadow" };
+	JSON_Object *params =
+		build_params_with_array("deny_paths", paths, 1);
+	struct ThreadContext *ctx =
+		build_ctx_with_paths(1, "path", "/etc/shadow", NULL, NULL);
+	int rc;
+
+	rc = action(ctx, params);
+	assert(rc == -1);
+	assert(ctx->ret_val == -1);
+
+	json_value_free(json_object_get_wrapping_value(params));
+}
+
+static void test_no_match_passes_through(void)
+{
+	action_fn_t action = retrace_actions_get("sandbox");
+	const char *paths[] = { "/etc/shadow" };
+	JSON_Object *params =
+		build_params_with_array("deny_paths", paths, 1);
+	struct ThreadContext *ctx =
+		build_ctx_with_paths(1, "path", "/tmp/safe.txt", NULL, NULL);
+	int rc;
+
+	rc = action(ctx, params);
+	assert(rc == 0);
+	assert(ctx->ret_val == 0);
+
+	json_value_free(json_object_get_wrapping_value(params));
+}
+
+static void test_prefix_match_directory(void)
+{
+	action_fn_t action = retrace_actions_get("sandbox");
+	const char *paths[] = { "/root/" };
+	JSON_Object *params =
+		build_params_with_array("deny_paths", paths, 1);
+	struct ThreadContext *ctx =
+		build_ctx_with_paths(1, "path", "/root/.ssh/id_rsa", NULL, NULL);
+	int rc;
+
+	rc = action(ctx, params);
+	assert(rc == -1);
+	assert(ctx->ret_val == -1);
+
+	json_value_free(json_object_get_wrapping_value(params));
+}
+
+static void test_prefix_no_match_different_dir(void)
+{
+	action_fn_t action = retrace_actions_get("sandbox");
+	const char *paths[] = { "/root/" };
+	JSON_Object *params =
+		build_params_with_array("deny_paths", paths, 1);
+	struct ThreadContext *ctx =
+		build_ctx_with_paths(1, "path", "/etc/passwd", NULL, NULL);
+	int rc;
+
+	rc = action(ctx, params);
+	assert(rc == 0);
+
+	json_value_free(json_object_get_wrapping_value(params));
+}
+
+static void test_openat_uses_param_at_index_1(void)
+{
+	/* openat(dirfd, path, flags) -- path is at params[1] because
+	 * the action's loop checks param[0] first, then param[1].
+	 * If param[0].val is non-zero it picks that; we need a
+	 * scenario where param[0] is the fd (numeric, non-zero) and
+	 * param[1] is the path. The current action treats any
+	 * non-zero val at params[0] as a path pointer -- which is
+	 * wrong for openat but it's the existing behavior. The test
+	 * documents this: sandbox picks params[0] first.
+	 */
+	action_fn_t action = retrace_actions_get("sandbox");
+	const char *paths[] = { "/etc/shadow" };
+	JSON_Object *params =
+		build_params_with_array("deny_paths", paths, 1);
+	struct ThreadContext *ctx =
+		build_ctx_with_paths(1, "path", "/etc/shadow",
+				     "flags", "ignored");
+	int rc;
+
+	rc = action(ctx, params);
+	assert(rc == -1);
+
+	json_value_free(json_object_get_wrapping_value(params));
+}
+
+static void test_first_match_wins(void)
+{
+	action_fn_t action = retrace_actions_get("sandbox");
+	const char *paths[] = { "/safe", "/etc/shadow", "/other" };
+	JSON_Object *params =
+		build_params_with_array("deny_paths", paths, 3);
+	struct ThreadContext *ctx =
+		build_ctx_with_paths(1, "path", "/etc/shadow", NULL, NULL);
+	int rc;
+
+	rc = action(ctx, params);
+	assert(rc == -1);
+	assert(ctx->ret_val == -1);
+
+	json_value_free(json_object_get_wrapping_value(params));
+}
+
+int main(void)
+{
+	retrace_real_impls.strcmp = strcmp;
+	retrace_real_impls.strlen = strlen;
+	retrace_real_impls.strcpy = strcpy;
+	retrace_real_impls.strncmp = strncmp;
+	retrace_real_impls.memset = memset;
+	retrace_real_impls.memcpy = memcpy;
+	retrace_real_impls.malloc = malloc;
+	retrace_real_impls.free = free;
+	retrace_real_impls.real_snprintf = snprintf;
+
+	printf("sandbox action tests:\n");
+
+	printf("  -- lookup + params validation --\n");
+	TEST(action_lookup);
+	TEST(params_null);
+	TEST(missing_deny_paths);
+
+	printf("  -- match paths --\n");
+	TEST(exact_match);
+	TEST(prefix_match_directory);
+
+	printf("  -- non-match paths --\n");
+	TEST(no_match_passes_through);
+	TEST(prefix_no_match_different_dir);
+
+	printf("  -- array semantics --\n");
+	TEST(openat_uses_param_at_index_1);
+	TEST(first_match_wins);
+
+	printf("\nPass: %d, Fail: %d (of %d)\n",
+		tests_pass, tests_fail, tests_run);
+	return tests_fail == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Continues TODO.complete/14. Four more action unit-test files following the lookup-construct-call-assert pattern from PR #553 and #554.

## Files

| File | Tests |
|------|-------|
| `test/unit/test_sandbox.c` | 8 |
| `test/unit/test_modify_in_param_int.c` | 10 |
| `test/unit/test_fuzzing_seed.c` | 6 |
| `test/unit/test_delay.c` | 6 |

Total: 30 new unit tests.

## sandbox

File-path deny-list. Pairs with `addr_deny` (network). Tests cover action lookup, params validation, exact-match deny, prefix-match deny (entry ending in `/`), no-match passthrough, and array semantics (first-match-wins).

**Surfaced behavior:** the action's loop checks `params[0]` first, then `params[1]`. For `openat(dirfd, path, flags)` this is wrong -- `params[0]` is the fd -- but documenting the existing behavior in a test is the first step toward fixing it.

## modify_in_param_int

Updates an IN integer param's value, optionally gated by `match_int`. Tests cover lookup, NULL params, missing `param_name`, unknown param name, wrong-direction param (`PDIR_OUT` rejection), missing `new_int`, direct modification, match-and-write, no-match no-op, negative values.

## fuzzing_seed

Sets the global `g_fuzzing_seed` and applies it via `srand()`. Tests cover lookup, NULL params, missing `seed`, and three determinism properties:

- Same seed twice -> identical 5-element `rand()` sequence
- Different seeds -> different sequences
- Seed=0 -> deterministic

## delay

Sleeps for the configured ms. Tests cover lookup, NULL params (no-op), missing `ms` (no-op), zero ms (no-op), negative ms (no-op), and small positive ms. The test asserts return codes only; sleep duration is not measured (would be flaky on loaded CI).

## Test plan

- [x] `cmake --build build-rel` -- clean
- [x] `ctest --test-dir build-rel` -- 14/14 pass (integration, 12 unit, 2 property)
- [ ] CI matrix green

## TODO.complete/14 status

Now Partial with **8 of 12 actions** covered (this PR + #553 + #554 + the `sockaddr_inspect` helper from #551):

| Action | Test file | Status |
|--------|-----------|--------|
| `addr_deny` | test_addr_deny.c | done (PR #553) |
| `modify_return_value_int` | test_modify_return_value_int.c | done (PR #554) |
| `call_count_limit` | test_call_count_limit.c | done (PR #554) |
| `sandbox` | test_sandbox.c | done (this PR) |
| `modify_in_param_int` | test_modify_in_param_int.c | done (this PR) |
| `fuzzing_seed` | test_fuzzing_seed.c | done (this PR) |
| `delay` | test_delay.c | done (this PR) |
| `sockaddr_inspect` (helper) | test_sockaddr_inspect.c + property tests | done (PRs #551, #552) |
| `log_params` | -- | TBD (needs constructed DataType metadata) |
| `call_real` | -- | TBD (needs real_impl ptr + timing) |
| `modify_in_param_str` | -- | TBD |
| `modify_in_param_arr` | -- | TBD |
| `memory_fuzz` | -- | TBD |
| `incomplete_io` | -- | TBD |

Each remaining action follows the same lookup-construct-call-assert pattern but has a setup wrinkle (DataType metadata, real_impl, valid fuzzable memory, etc.) that warrants its own focused PR.

## Related

- PR #553 (test_addr_deny -- established the pattern)
- PR #554 (test_modify_return_value_int + test_call_count_limit)
- TODO.complete/14-specs-and-unit-tests.md
