### PR TITLE
test: unit tests for log_params + call_real (TODO 14)

### DIFF
--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -399,3 +399,71 @@ endif()
 add_test(NAME unit-test-delay
     COMMAND retrace_test_delay)
 set_tests_properties(unit-test-delay PROPERTIES LABELS "unit")
+
+#
+# log_params action unit tests (TODO.complete/14).
+#
+add_executable(retrace_test_log_params test_log_params.c)
+set_target_properties(retrace_test_log_params PROPERTIES
+    OUTPUT_NAME test_log_params
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/test/unit")
+
+target_link_libraries(retrace_test_log_params PRIVATE
+    retrace_core
+    retrace_config_json
+    retrace_backends
+    ${_unit_backend_lib}
+    retrace_preload_common
+    retrace_headers
+    ${CMAKE_DL_LIBS}
+    Threads::Threads)
+
+target_include_directories(retrace_test_log_params PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/core
+    ${CMAKE_SOURCE_DIR}/src/backends
+    ${CMAKE_SOURCE_DIR}/src/config/json
+    ${_unit_arch_include})
+
+if(RETRACE_PLATFORM_LINUX OR RETRACE_PLATFORM_FREEBSD)
+    target_compile_definitions(retrace_test_log_params PRIVATE _GNU_SOURCE _DEFAULT_SOURCE)
+elseif(RETRACE_PLATFORM_DARWIN)
+    target_compile_definitions(retrace_test_log_params PRIVATE _DARWIN_C_SOURCE)
+endif()
+
+add_test(NAME unit-test-log-params
+    COMMAND retrace_test_log_params)
+set_tests_properties(unit-test-log-params PROPERTIES LABELS "unit")
+
+#
+# call_real action unit tests (TODO.complete/14).
+#
+add_executable(retrace_test_call_real test_call_real.c)
+set_target_properties(retrace_test_call_real PROPERTIES
+    OUTPUT_NAME test_call_real
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/test/unit")
+
+target_link_libraries(retrace_test_call_real PRIVATE
+    retrace_core
+    retrace_config_json
+    retrace_backends
+    ${_unit_backend_lib}
+    retrace_preload_common
+    retrace_headers
+    ${CMAKE_DL_LIBS}
+    Threads::Threads)
+
+target_include_directories(retrace_test_call_real PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/core
+    ${CMAKE_SOURCE_DIR}/src/backends
+    ${CMAKE_SOURCE_DIR}/src/config/json
+    ${_unit_arch_include})
+
+if(RETRACE_PLATFORM_LINUX OR RETRACE_PLATFORM_FREEBSD)
+    target_compile_definitions(retrace_test_call_real PRIVATE _GNU_SOURCE _DEFAULT_SOURCE)
+elseif(RETRACE_PLATFORM_DARWIN)
+    target_compile_definitions(retrace_test_call_real PRIVATE _DARWIN_C_SOURCE)
+endif()
+
+add_test(NAME unit-test-call-real
+    COMMAND retrace_test_call_real)
+set_tests_properties(unit-test-call-real PROPERTIES LABELS "unit")

--- a/test/unit/test_call_real.c
+++ b/test/unit/test_call_real.c
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+/*
+ * Unit tests for the call_real action.
+ *
+ * call_real invokes t_ctx->real_impl via retrace_as_call_real /
+ * retrace_as_call_real_variadic. It also measures call duration
+ * via clock_gettime and logs the timing as a JSON entry.
+ *
+ * The test installs a stub function as real_impl so we can verify
+ * the call mechanics without depending on libc internals.
+ *
+ * Tests:
+ *   - Action lookup succeeds
+ *   - Zero-arg stub: called exactly once; ret_val matches stub return
+ *   - One-arg stub: arg comes from params[0].val
+ *   - Action returns 0 (success) on every path
+ *
+ * Note: the timing JSON is logged via retrace_logger_log_json; the
+ * test does not capture it. The clock_gettime call itself is the
+ * only libc dependency, which is always available.
+ *
+ * Part of TODO.complete/14.
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "engine.h"
+#include "actions.h"
+#include "arch_spec.h"
+#include "funcs.h"
+#include "data_types.h"
+#include "real_impls.h"
+#include "parson.h"
+
+typedef int (*action_fn_t)(struct ThreadContext *t_ctx,
+			    const JSON_Object *action_params);
+
+static int tests_run;
+static int tests_pass;
+static int tests_fail;
+
+#define TEST(name) do { \
+	tests_run++; \
+	printf("  TEST %s ... ", #name); \
+	test_##name(); \
+	tests_pass++; \
+	printf("OK\n"); \
+} while (0)
+
+/* Stub functions used as real_impl. Their signatures match what
+ * retrace_as_call_real_dispatch expects for each params_cnt case.
+ */
+static long g_zero_arg_call_count;
+static long g_one_arg_last_val;
+
+static long stub_zero_arg(void)
+{
+	g_zero_arg_call_count++;
+	return 0x4242;
+}
+
+static long stub_one_arg(long a)
+{
+	g_one_arg_last_val = a;
+	return a + 1;
+}
+
+static struct ThreadContext *build_ctx_for_call_real(void *real_impl,
+						     int params_cnt,
+						     const long *vals)
+{
+	static struct ThreadContext ctx;
+	static struct FuncPrototype proto;
+	struct FuncParam params[8];
+	const struct DataType *int_dt;
+	int i;
+
+	memset(&ctx, 0, sizeof(ctx));
+	memset(params, 0, sizeof(params));
+	memset(&proto, 0, sizeof(proto));
+
+	int_dt = retrace_datatype_get("int");
+	assert(int_dt != NULL);
+
+	strncpy(proto.name, "stub_func", sizeof(proto.name) - 1);
+	proto.fmt = FAT_NOVARARGS;
+	ctx.prototype = &proto;
+	ctx.real_impl = real_impl;
+
+	for (i = 0; i < params_cnt && i < 8; i++) {
+		snprintf(params[i].param_meta.name,
+			sizeof(params[i].param_meta.name), "p%d", i);
+		params[i].param_meta.modifiers = CDM_NOMOD;
+		params[i].param_meta.direction = PDIR_IN;
+		params[i].data_type = int_dt;
+		params[i].val = vals[i];
+	}
+
+	ctx.params_cnt = params_cnt;
+	memcpy(ctx.params, params, sizeof(params));
+	ctx.ret_val = 0;
+	return &ctx;
+}
+
+static void test_action_lookup(void)
+{
+	retrace_actions_init();
+	retrace_datatypes_init();
+	assert(retrace_actions_get("call_real") != NULL);
+}
+
+static void test_zero_arg_stub(void)
+{
+	action_fn_t action = retrace_actions_get("call_real");
+	struct ThreadContext *ctx;
+	int rc;
+
+	g_zero_arg_call_count = 0;
+	ctx = build_ctx_for_call_real(stub_zero_arg, 0, NULL);
+
+	rc = action(ctx, NULL);
+	assert(rc == 0);
+	assert(g_zero_arg_call_count == 1);
+	/* retrace_as_call_real_dispatch returns the stub's return value;
+	 * call_real stores it in t_ctx->ret_val.
+	 */
+	assert(ctx->ret_val == 0x4242);
+}
+
+static void test_one_arg_stub(void)
+{
+	action_fn_t action = retrace_actions_get("call_real");
+	long vals[] = { 99 };
+	struct ThreadContext *ctx;
+	int rc;
+
+	g_one_arg_last_val = -1;
+	ctx = build_ctx_for_call_real(stub_one_arg, 1, vals);
+
+	rc = action(ctx, NULL);
+	assert(rc == 0);
+	assert(g_one_arg_last_val == 99);
+	/* stub returns a+1 = 100. */
+	assert(ctx->ret_val == 100);
+}
+
+static void test_action_params_ignored(void)
+{
+	action_fn_t action = retrace_actions_get("call_real");
+	struct ThreadContext *ctx;
+	JSON_Value *root_val;
+	JSON_Object *root;
+	int rc;
+
+	/* action_params is ignored by call_real. Pass a non-NULL object
+	 * to verify it doesn't cause issues.
+	 */
+	root_val = json_value_init_object();
+	root = json_value_get_object(root_val);
+	json_object_set_string(root, "anything", "value");
+
+	g_zero_arg_call_count = 0;
+	ctx = build_ctx_for_call_real(stub_zero_arg, 0, NULL);
+
+	rc = action(ctx, root);
+	assert(rc == 0);
+	assert(g_zero_arg_call_count == 1);
+
+	json_value_free(root_val);
+}
+
+int main(void)
+{
+	retrace_real_impls.strcmp = strcmp;
+	retrace_real_impls.strlen = strlen;
+	retrace_real_impls.strcpy = strcpy;
+	retrace_real_impls.memset = memset;
+	retrace_real_impls.memcpy = memcpy;
+	retrace_real_impls.malloc = malloc;
+	retrace_real_impls.free = free;
+	retrace_real_impls.real_snprintf = snprintf;
+	retrace_real_impls.real_sprintf = sprintf;
+	retrace_real_impls.real_vsnprintf = vsnprintf;
+
+	printf("call_real tests:\n");
+
+	printf("  -- lookup --\n");
+	TEST(action_lookup);
+
+	printf("  -- stub invocations --\n");
+	TEST(zero_arg_stub);
+	TEST(one_arg_stub);
+
+	printf("  -- action_params handling --\n");
+	TEST(action_params_ignored);
+
+	printf("\nPass: %d, Fail: %d (of %d)\n",
+		tests_pass, tests_fail, tests_run);
+	return tests_fail == 0 ? 0 : 1;
+}

--- a/test/unit/test_log_params.c
+++ b/test/unit/test_log_params.c
@@ -1,0 +1,233 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+/*
+ * Unit tests for the log_params action.
+ *
+ * log_params is the most-used action (the default config runs it
+ * for every intercepted call). It walks each param, looks up its
+ * DataType, and serializes the value to a JSON log entry.
+ *
+ * The action's contract:
+ *   - Returns 0 on success
+ *   - For each param, param->data_type must be non-NULL (set by
+ *     the engine from the prototype metadata)
+ *   - omit_params (optional JSON array) skips named params
+ *
+ * Tests:
+ *   - Action lookup succeeds
+ *   - Single int param: doesn't crash, returns 0
+ *   - Multiple int params: all walked without crash
+ *   - omit_params excludes a named param (still returns 0)
+ *   - NULL params arg: still walks the ThreadContext
+ *   - Zero-param ctx: returns 0 immediately
+ *
+ * Note: the JSON output is logged via retrace_logger_log_json,
+ * which goes to stdout/file. The test asserts only the return
+ * code and absence of crash. Capturing the JSON output would
+ * require log redirection plumbing (deferred to a future test
+ * infrastructure PR).
+ *
+ * Part of TODO.complete/14.
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "engine.h"
+#include "actions.h"
+#include "funcs.h"
+#include "data_types.h"
+#include "real_impls.h"
+#include "parson.h"
+
+typedef int (*action_fn_t)(struct ThreadContext *t_ctx,
+			    const JSON_Object *action_params);
+
+static int tests_run;
+static int tests_pass;
+static int tests_fail;
+
+#define TEST(name) do { \
+	tests_run++; \
+	printf("  TEST %s ... ", #name); \
+	test_##name(); \
+	tests_pass++; \
+	printf("OK\n"); \
+} while (0)
+
+/* Build a ThreadContext with N integer params of the given values.
+ * Each param's data_type is set to the registered "int" DataType.
+ */
+static struct ThreadContext *build_ctx_int_params(int n, const long *vals)
+{
+	static struct ThreadContext ctx;
+	static struct FuncPrototype proto;
+	struct FuncParam params[8];
+	const struct DataType *int_dt;
+	int i;
+
+	memset(&ctx, 0, sizeof(ctx));
+	memset(params, 0, sizeof(params));
+	memset(&proto, 0, sizeof(proto));
+
+	int_dt = retrace_datatype_get("int");
+	assert(int_dt != NULL);
+
+	strncpy(proto.name, "test_func", sizeof(proto.name) - 1);
+	proto.fmt = FAT_NOVARARGS;
+	ctx.prototype = &proto;
+
+	for (i = 0; i < n && i < 8; i++) {
+		char nm[4];
+
+		snprintf(nm, sizeof(nm), "p%d", i);
+		strncpy(params[i].param_meta.name, nm,
+			sizeof(params[i].param_meta.name) - 1);
+		params[i].param_meta.type_name[0] = 'i';
+		params[i].param_meta.type_name[1] = 'n';
+		params[i].param_meta.type_name[2] = 't';
+		params[i].param_meta.type_name[3] = '\0';
+		params[i].param_meta.modifiers = CDM_NOMOD;
+		params[i].param_meta.direction = PDIR_IN;
+		params[i].data_type = int_dt;
+		params[i].val = vals[i];
+	}
+
+	ctx.params_cnt = n;
+	memcpy(ctx.params, params, sizeof(params));
+	ctx.ret_val = 0;
+	return &ctx;
+}
+
+static JSON_Object *build_omit_params(const char *name)
+{
+	JSON_Value *root_val = json_value_init_object();
+	JSON_Object *root = json_value_get_object(root_val);
+	JSON_Value *arr_val = json_value_init_array();
+	JSON_Array *arr = json_array(arr_val);
+
+	json_array_append_string(arr, name);
+	json_object_set_value(root, "omit_params", arr_val);
+	return root;
+}
+
+static void test_action_lookup(void)
+{
+	retrace_actions_init();
+	retrace_datatypes_init();
+	assert(retrace_actions_get("log_params") != NULL);
+}
+
+static void test_zero_params(void)
+{
+	action_fn_t action = retrace_actions_get("log_params");
+	struct ThreadContext ctx;
+	int rc;
+
+	memset(&ctx, 0, sizeof(ctx));
+	ctx.params_cnt = 0;
+
+	rc = action(&ctx, NULL);
+	assert(rc == 0);
+}
+
+static void test_single_int_param(void)
+{
+	action_fn_t action = retrace_actions_get("log_params");
+	long vals[] = { 42 };
+	struct ThreadContext *ctx = build_ctx_int_params(1, vals);
+	int rc;
+
+	rc = action(ctx, NULL);
+	assert(rc == 0);
+}
+
+static void test_multiple_int_params(void)
+{
+	action_fn_t action = retrace_actions_get("log_params");
+	long vals[] = { 1, 2, 3, 4 };
+	struct ThreadContext *ctx = build_ctx_int_params(4, vals);
+	int rc;
+
+	rc = action(ctx, NULL);
+	assert(rc == 0);
+}
+
+static void test_omit_one_param(void)
+{
+	action_fn_t action = retrace_actions_get("log_params");
+	long vals[] = { 10, 20, 30 };
+	struct ThreadContext *ctx = build_ctx_int_params(3, vals);
+	JSON_Object *params = build_omit_params("p1");
+	int rc;
+
+	/* omit p1, walk p0 and p2. */
+	rc = action(ctx, params);
+	assert(rc == 0);
+
+	json_value_free(json_object_get_wrapping_value(params));
+}
+
+static void test_null_params_arg(void)
+{
+	action_fn_t action = retrace_actions_get("log_params");
+	long vals[] = { 7 };
+	struct ThreadContext *ctx = build_ctx_int_params(1, vals);
+	int rc;
+
+	/* NULL action_params is allowed (omit_params defaults to NULL). */
+	rc = action(ctx, NULL);
+	assert(rc == 0);
+}
+
+static void test_negative_int_param(void)
+{
+	action_fn_t action = retrace_actions_get("log_params");
+	long vals[] = { -123 };
+	struct ThreadContext *ctx = build_ctx_int_params(1, vals);
+	int rc;
+
+	rc = action(ctx, NULL);
+	assert(rc == 0);
+}
+
+int main(void)
+{
+	retrace_real_impls.strcmp = strcmp;
+	retrace_real_impls.strlen = strlen;
+	retrace_real_impls.strcpy = strcpy;
+	retrace_real_impls.memset = memset;
+	retrace_real_impls.memcpy = memcpy;
+	retrace_real_impls.malloc = malloc;
+	retrace_real_impls.free = free;
+	retrace_real_impls.real_snprintf = snprintf;
+	retrace_real_impls.real_sprintf = sprintf;
+	retrace_real_impls.real_vsnprintf = vsnprintf;
+
+	printf("log_params tests:\n");
+
+	printf("  -- lookup + zero-param --\n");
+	TEST(action_lookup);
+	TEST(zero_params);
+
+	printf("  -- int param walks --\n");
+	TEST(single_int_param);
+	TEST(multiple_int_params);
+	TEST(negative_int_param);
+
+	printf("  -- omit_params --\n");
+	TEST(omit_one_param);
+
+	printf("  -- NULL action_params --\n");
+	TEST(null_params_arg);
+
+	printf("\nPass: %d, Fail: %d (of %d)\n",
+		tests_pass, tests_fail, tests_run);
+	return tests_fail == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Continues TODO.complete/14. The two most-used actions get coverage:

- `log_params` — default config runs it for every call
- `call_real` — every script that needs the real call uses it

## test_log_params.c (6 tests)

- `action_lookup` — `retrace_actions_get("log_params")` returns non-NULL
- `zero_params` — `params_cnt=0` -> 0, no crash
- `single_int_param` — `params_cnt=1`, val=42 -> 0, no crash
- `multiple_int_params` — `params_cnt=4` (1,2,3,4) -> 0, no crash
- `negative_int_param` — `params_cnt=1`, val=-123 -> 0, no crash
- `omit_one_param` — `omit_params=["p1"]` skips middle param
- `null_params_arg` — NULL `action_params` is allowed

**Setup:** each param's `data_type` is populated from `retrace_datatype_get("int")` after `retrace_datatypes_init()`. Without this, `log_params` dereferences a NULL `DataType*` and crashes.

**Note:** the JSON output is logged via `retrace_logger_log_json` which writes to stdout/file. The test asserts only return code and absence of crash. Capturing JSON output requires log redirection plumbing (future test infrastructure PR).

## test_call_real.c (4 tests)

- `action_lookup` — `retrace_actions_get("call_real")` returns non-NULL
- `zero_arg_stub` — `real_impl=stub_zero_arg`; called once; `ret_val` matches stub return (0x4242)
- `one_arg_stub` — `real_impl=stub_one_arg(val)`; stub receives `params[0].val=99`, returns 100
- `action_params_ignored` — non-NULL `action_params` is accepted, no effect on behavior

**Setup:** `t_ctx->real_impl` is set to a stub function matching the signature `retrace_as_call_real_dispatch` expects. The stub records call count + last arg so the test can verify the mechanics without depending on libc internals.

The action's `clock_gettime`-based timing is exercised but its JSON output (`call_duration_us`, `ret_val`) is logged, not captured.

## Files

| File | Tests |
|------|-------|
| `test/unit/test_log_params.c` | 6 |
| `test/unit/test_call_real.c` | 4 |
| `test/unit/CMakeLists.txt` | register both |

## Test plan

- [x] `cmake --build build-rel` -- clean
- [x] `ctest --test-dir build-rel` -- 16/16 pass (integration, 14 unit, 2 property)
- [ ] CI matrix green

## TODO.complete/14 status

Now Partial with **10 of 12 actions** covered (this PR + #553 + #554 + #555 + the `sockaddr_inspect` helper from #551/#552):

| Action | Test file | Status |
|--------|-----------|--------|
| `addr_deny` | test_addr_deny.c | done (PR #553) |
| `modify_return_value_int` | test_modify_return_value_int.c | done (PR #554) |
| `call_count_limit` | test_call_count_limit.c | done (PR #554) |
| `sandbox` | test_sandbox.c | done (PR #555) |
| `modify_in_param_int` | test_modify_in_param_int.c | done (PR #555) |
| `fuzzing_seed` | test_fuzzing_seed.c | done (PR #555) |
| `delay` | test_delay.c | done (PR #555) |
| `log_params` | test_log_params.c | done (this PR) |
| `call_real` | test_call_real.c | done (this PR) |
| `sockaddr_inspect` (helper) | test_sockaddr_inspect.c + property tests | done (PRs #551, #552) |
| `modify_in_param_str` | -- | TBD |
| `modify_in_param_arr` | -- | TBD |
| `memory_fuzz` | -- | TBD |
| `incomplete_io` | -- | TBD |

Remaining 4 each have a setup wrinkle (string/array param semantics, fuzzable memory, I/O fault injection) that warrants its own focused PR.

## Related

- PR #553 (test_addr_deny -- established the pattern)
- PR #554 (test_modify_return_value_int + test_call_count_limit)
- PR #555 (test_sandbox + test_modify_in_param_int + test_fuzzing_seed + test_delay)
- TODO.complete/14-specs-and-unit-tests.md
