### PR TITLE
test: unit tests for incomplete_io + memory_fuzz + modify_in_param_str

### DIFF
--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -467,3 +467,105 @@ endif()
 add_test(NAME unit-test-call-real
     COMMAND retrace_test_call_real)
 set_tests_properties(unit-test-call-real PROPERTIES LABELS "unit")
+
+#
+# incomplete_io action unit tests (TODO.complete/14).
+#
+add_executable(retrace_test_incomplete_io test_incomplete_io.c)
+set_target_properties(retrace_test_incomplete_io PROPERTIES
+    OUTPUT_NAME test_incomplete_io
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/test/unit")
+
+target_link_libraries(retrace_test_incomplete_io PRIVATE
+    retrace_core
+    retrace_config_json
+    retrace_backends
+    ${_unit_backend_lib}
+    retrace_preload_common
+    retrace_headers
+    ${CMAKE_DL_LIBS}
+    Threads::Threads)
+
+target_include_directories(retrace_test_incomplete_io PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/core
+    ${CMAKE_SOURCE_DIR}/src/backends
+    ${CMAKE_SOURCE_DIR}/src/config/json
+    ${_unit_arch_include})
+
+if(RETRACE_PLATFORM_LINUX OR RETRACE_PLATFORM_FREEBSD)
+    target_compile_definitions(retrace_test_incomplete_io PRIVATE _GNU_SOURCE _DEFAULT_SOURCE)
+elseif(RETRACE_PLATFORM_DARWIN)
+    target_compile_definitions(retrace_test_incomplete_io PRIVATE _DARWIN_C_SOURCE)
+endif()
+
+add_test(NAME unit-test-incomplete-io
+    COMMAND retrace_test_incomplete_io)
+set_tests_properties(unit-test-incomplete-io PROPERTIES LABELS "unit")
+
+#
+# memory_fuzz action unit tests (TODO.complete/14).
+#
+add_executable(retrace_test_memory_fuzz test_memory_fuzz.c)
+set_target_properties(retrace_test_memory_fuzz PROPERTIES
+    OUTPUT_NAME test_memory_fuzz
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/test/unit")
+
+target_link_libraries(retrace_test_memory_fuzz PRIVATE
+    retrace_core
+    retrace_config_json
+    retrace_backends
+    ${_unit_backend_lib}
+    retrace_preload_common
+    retrace_headers
+    ${CMAKE_DL_LIBS}
+    Threads::Threads)
+
+target_include_directories(retrace_test_memory_fuzz PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/core
+    ${CMAKE_SOURCE_DIR}/src/backends
+    ${CMAKE_SOURCE_DIR}/src/config/json
+    ${_unit_arch_include})
+
+if(RETRACE_PLATFORM_LINUX OR RETRACE_PLATFORM_FREEBSD)
+    target_compile_definitions(retrace_test_memory_fuzz PRIVATE _GNU_SOURCE _DEFAULT_SOURCE)
+elseif(RETRACE_PLATFORM_DARWIN)
+    target_compile_definitions(retrace_test_memory_fuzz PRIVATE _DARWIN_C_SOURCE)
+endif()
+
+add_test(NAME unit-test-memory-fuzz
+    COMMAND retrace_test_memory_fuzz)
+set_tests_properties(unit-test-memory-fuzz PROPERTIES LABELS "unit")
+
+#
+# modify_in_param_str action unit tests (TODO.complete/14).
+#
+add_executable(retrace_test_modify_in_param_str test_modify_in_param_str.c)
+set_target_properties(retrace_test_modify_in_param_str PROPERTIES
+    OUTPUT_NAME test_modify_in_param_str
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/test/unit")
+
+target_link_libraries(retrace_test_modify_in_param_str PRIVATE
+    retrace_core
+    retrace_config_json
+    retrace_backends
+    ${_unit_backend_lib}
+    retrace_preload_common
+    retrace_headers
+    ${CMAKE_DL_LIBS}
+    Threads::Threads)
+
+target_include_directories(retrace_test_modify_in_param_str PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/core
+    ${CMAKE_SOURCE_DIR}/src/backends
+    ${CMAKE_SOURCE_DIR}/src/config/json
+    ${_unit_arch_include})
+
+if(RETRACE_PLATFORM_LINUX OR RETRACE_PLATFORM_FREEBSD)
+    target_compile_definitions(retrace_test_modify_in_param_str PRIVATE _GNU_SOURCE _DEFAULT_SOURCE)
+elseif(RETRACE_PLATFORM_DARWIN)
+    target_compile_definitions(retrace_test_modify_in_param_str PRIVATE _DARWIN_C_SOURCE)
+endif()
+
+add_test(NAME unit-test-modify-in-param-str
+    COMMAND retrace_test_modify_in_param_str)
+set_tests_properties(unit-test-modify-in-param-str PROPERTIES LABELS "unit")

--- a/test/unit/test_incomplete_io.c
+++ b/test/unit/test_incomplete_io.c
@@ -1,0 +1,243 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+/*
+ * Unit tests for the incomplete_io action.
+ *
+ * The action truncates t_ctx->ret_val to (real_ret * rate), where
+ * rate is clamped to [0.0, 1.0]. Negative or zero ret_vals pass
+ * through untouched.
+ *
+ * Tests:
+ *   - Action lookup succeeds
+ *   - NULL params -> -1
+ *   - Missing rate -> -1
+ *   - rate=1.0 -> ret_val unchanged
+ *   - rate=0.0 -> ret_val = 0
+ *   - rate=0.5 -> ret_val halved (rounded down)
+ *   - rate<0 clamped to 0
+ *   - rate>1 clamped to 1
+ *   - Negative ret_val passes through
+ *   - Zero ret_val passes through
+ *
+ * Part of TODO.complete/14.
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "engine.h"
+#include "actions.h"
+#include "funcs.h"
+#include "data_types.h"
+#include "real_impls.h"
+#include "parson.h"
+
+typedef int (*action_fn_t)(struct ThreadContext *t_ctx,
+			    const JSON_Object *action_params);
+
+static int tests_run;
+static int tests_pass;
+static int tests_fail;
+
+#define TEST(name) do { \
+	tests_run++; \
+	printf("  TEST %s ... ", #name); \
+	test_##name(); \
+	tests_pass++; \
+	printf("OK\n"); \
+} while (0)
+
+static JSON_Object *build_params_with_rate(double rate)
+{
+	JSON_Value *root_val = json_value_init_object();
+	JSON_Object *root = json_value_get_object(root_val);
+
+	json_object_set_number(root, "rate", rate);
+	return root;
+}
+
+static JSON_Object *build_empty_params(void)
+{
+	JSON_Value *root_val = json_value_init_object();
+	JSON_Object *root = json_value_get_object(root_val);
+
+	json_object_set_string(root, "unrelated", "foo");
+	return root;
+}
+
+static struct ThreadContext *build_ctx_with_retval(long ret_val)
+{
+	static struct ThreadContext ctx;
+
+	memset(&ctx, 0, sizeof(ctx));
+	ctx.ret_val = ret_val;
+	return &ctx;
+}
+
+static void test_action_lookup(void)
+{
+	retrace_actions_init();
+	assert(retrace_actions_get("incomplete_io") != NULL);
+}
+
+static void test_params_null(void)
+{
+	action_fn_t action = retrace_actions_get("incomplete_io");
+	struct ThreadContext *ctx = build_ctx_with_retval(100);
+	int rc;
+
+	rc = action(ctx, NULL);
+	assert(rc == -1);
+}
+
+static void test_missing_rate(void)
+{
+	action_fn_t action = retrace_actions_get("incomplete_io");
+	struct ThreadContext *ctx = build_ctx_with_retval(100);
+	JSON_Object *params = build_empty_params();
+	int rc;
+
+	rc = action(ctx, params);
+	assert(rc == -1);
+
+	json_value_free(json_object_get_wrapping_value(params));
+}
+
+static void test_rate_one_full(void)
+{
+	action_fn_t action = retrace_actions_get("incomplete_io");
+	struct ThreadContext *ctx = build_ctx_with_retval(100);
+	JSON_Object *params = build_params_with_rate(1.0);
+	int rc;
+
+	rc = action(ctx, params);
+	assert(rc == 0);
+	assert(ctx->ret_val == 100);
+
+	json_value_free(json_object_get_wrapping_value(params));
+}
+
+static void test_rate_zero_eof(void)
+{
+	action_fn_t action = retrace_actions_get("incomplete_io");
+	struct ThreadContext *ctx = build_ctx_with_retval(100);
+	JSON_Object *params = build_params_with_rate(0.0);
+	int rc;
+
+	rc = action(ctx, params);
+	assert(rc == 0);
+	assert(ctx->ret_val == 0);
+
+	json_value_free(json_object_get_wrapping_value(params));
+}
+
+static void test_rate_half_truncates(void)
+{
+	action_fn_t action = retrace_actions_get("incomplete_io");
+	struct ThreadContext *ctx = build_ctx_with_retval(100);
+	JSON_Object *params = build_params_with_rate(0.5);
+	int rc;
+
+	rc = action(ctx, params);
+	assert(rc == 0);
+	assert(ctx->ret_val == 50);
+
+	json_value_free(json_object_get_wrapping_value(params));
+}
+
+static void test_rate_negative_clamped(void)
+{
+	action_fn_t action = retrace_actions_get("incomplete_io");
+	struct ThreadContext *ctx = build_ctx_with_retval(100);
+	JSON_Object *params = build_params_with_rate(-0.5);
+	int rc;
+
+	rc = action(ctx, params);
+	assert(rc == 0);
+	assert(ctx->ret_val == 0);
+
+	json_value_free(json_object_get_wrapping_value(params));
+}
+
+static void test_rate_above_one_clamped(void)
+{
+	action_fn_t action = retrace_actions_get("incomplete_io");
+	struct ThreadContext *ctx = build_ctx_with_retval(100);
+	JSON_Object *params = build_params_with_rate(2.5);
+	int rc;
+
+	rc = action(ctx, params);
+	assert(rc == 0);
+	assert(ctx->ret_val == 100);
+
+	json_value_free(json_object_get_wrapping_value(params));
+}
+
+static void test_negative_retval_passes_through(void)
+{
+	action_fn_t action = retrace_actions_get("incomplete_io");
+	struct ThreadContext *ctx = build_ctx_with_retval(-1);
+	JSON_Object *params = build_params_with_rate(0.5);
+	int rc;
+
+	rc = action(ctx, params);
+	assert(rc == 0);
+	assert(ctx->ret_val == -1);
+
+	json_value_free(json_object_get_wrapping_value(params));
+}
+
+static void test_zero_retval_passes_through(void)
+{
+	action_fn_t action = retrace_actions_get("incomplete_io");
+	struct ThreadContext *ctx = build_ctx_with_retval(0);
+	JSON_Object *params = build_params_with_rate(0.5);
+	int rc;
+
+	rc = action(ctx, params);
+	assert(rc == 0);
+	assert(ctx->ret_val == 0);
+
+	json_value_free(json_object_get_wrapping_value(params));
+}
+
+int main(void)
+{
+	retrace_real_impls.strcmp = strcmp;
+	retrace_real_impls.strlen = strlen;
+	retrace_real_impls.strcpy = strcpy;
+	retrace_real_impls.memset = memset;
+	retrace_real_impls.memcpy = memcpy;
+	retrace_real_impls.malloc = malloc;
+	retrace_real_impls.free = free;
+	retrace_real_impls.real_snprintf = snprintf;
+	retrace_real_impls.time = time;
+
+	printf("incomplete_io tests:\n");
+
+	printf("  -- lookup + params validation --\n");
+	TEST(action_lookup);
+	TEST(params_null);
+	TEST(missing_rate);
+
+	printf("  -- rate semantics --\n");
+	TEST(rate_one_full);
+	TEST(rate_zero_eof);
+	TEST(rate_half_truncates);
+	TEST(rate_negative_clamped);
+	TEST(rate_above_one_clamped);
+
+	printf("  -- ret_val edge cases --\n");
+	TEST(negative_retval_passes_through);
+	TEST(zero_retval_passes_through);
+
+	printf("\nPass: %d, Fail: %d (of %d)\n",
+		tests_pass, tests_fail, tests_run);
+	return tests_fail == 0 ? 0 : 1;
+}

--- a/test/unit/test_memory_fuzz.c
+++ b/test/unit/test_memory_fuzz.c
@@ -1,0 +1,238 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+/*
+ * Unit tests for the memory_fuzz action.
+ *
+ * The action fuzzes memory-allocation return values: with
+ * probability fail_rate, sets ret_val=NULL + errno=ENOMEM
+ * (simulating malloc failure).
+ *
+ * Tests:
+ *   - Action lookup succeeds
+ *   - NULL params -> -1
+ *   - Missing fail_rate -> -1
+ *   - fail_rate=0.0 -> never fuzzes (ret_val unchanged across many
+ *     invocations)
+ *   - fail_rate=1.0 -> always fuzzes (ret_val=NULL, errno=ENOMEM)
+ *   - Deterministic with fuzz_seed (same seed -> same decision
+ *     sequence)
+ *
+ * Note: memory_fuzz's `initialized` static flag persists across
+ * tests in this binary. Tests order matters: seed-bearing tests
+ * must run before no-seed tests, or the seed must be set fresh
+ * each time. We use the action_params' fuzz_seed field which the
+ * action honors on first call only.
+ *
+ * Part of TODO.complete/14.
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <errno.h>
+
+#include "engine.h"
+#include "actions.h"
+#include "funcs.h"
+#include "data_types.h"
+#include "real_impls.h"
+#include "parson.h"
+
+typedef int (*action_fn_t)(struct ThreadContext *t_ctx,
+			    const JSON_Object *action_params);
+
+static int tests_run;
+static int tests_pass;
+static int tests_fail;
+
+#define TEST(name) do { \
+	tests_run++; \
+	printf("  TEST %s ... ", #name); \
+	test_##name(); \
+	tests_pass++; \
+	printf("OK\n"); \
+} while (0)
+
+static JSON_Object *build_params(double fail_rate, int with_seed,
+				  double fuzz_seed)
+{
+	JSON_Value *root_val = json_value_init_object();
+	JSON_Object *root = json_value_get_object(root_val);
+
+	json_object_set_number(root, "fail_rate", fail_rate);
+	if (with_seed)
+		json_object_set_number(root, "fuzz_seed", fuzz_seed);
+	return root;
+}
+
+static struct ThreadContext *build_ctx_with_retval(long ret_val)
+{
+	static struct ThreadContext ctx;
+
+	memset(&ctx, 0, sizeof(ctx));
+	ctx.ret_val = ret_val;
+	return &ctx;
+}
+
+static void test_action_lookup(void)
+{
+	retrace_actions_init();
+	assert(retrace_actions_get("memory_fuzz") != NULL);
+}
+
+static void test_params_null(void)
+{
+	action_fn_t action = retrace_actions_get("memory_fuzz");
+	struct ThreadContext *ctx = build_ctx_with_retval(0x1000);
+	int rc;
+
+	rc = action(ctx, NULL);
+	assert(rc == -1);
+}
+
+static void test_missing_fail_rate(void)
+{
+	action_fn_t action = retrace_actions_get("memory_fuzz");
+	struct ThreadContext *ctx = build_ctx_with_retval(0x1000);
+	JSON_Value *root_val = json_value_init_object();
+	JSON_Object *root = json_value_get_object(root_val);
+	int rc;
+
+	json_object_set_string(root, "unrelated", "foo");
+
+	/* First call seeds srand but then errors on missing fail_rate.
+	 * The init flag persists for the rest of the binary; that's
+	 * fine, subsequent tests provide explicit fail_rate.
+	 */
+	rc = action(ctx, root);
+	assert(rc == -1);
+
+	json_value_free(root_val);
+}
+
+static void test_fail_rate_zero_never_fuzzes(void)
+{
+	action_fn_t action = retrace_actions_get("memory_fuzz");
+	struct ThreadContext *ctx;
+	JSON_Object *params = build_params(0.0, 1, 42.0);
+	int rc;
+	int i;
+
+	/* fail_rate=0.0 means random_value <= 0 never holds. Verify
+	 * across 50 invocations that ret_val is never touched.
+	 */
+	for (i = 0; i < 50; i++) {
+		ctx = build_ctx_with_retval(0xDEAD);
+		rc = action(ctx, params);
+		assert(rc == 0);
+		assert(ctx->ret_val == 0xDEAD);
+	}
+
+	json_value_free(json_object_get_wrapping_value(params));
+}
+
+static void test_fail_rate_one_always_fuzzes(void)
+{
+	action_fn_t action = retrace_actions_get("memory_fuzz");
+	struct ThreadContext *ctx;
+	JSON_Object *params = build_params(1.0, 1, 99.0);
+	int rc;
+	int i;
+
+	/* fail_rate=1.0 means random_value <= RAND_MAX always holds. */
+	for (i = 0; i < 50; i++) {
+		ctx = build_ctx_with_retval(0xDEAD);
+		errno = 0;
+		rc = action(ctx, params);
+		assert(rc == 0);
+		assert(ctx->ret_val == (long)NULL);
+		assert(errno == ENOMEM);
+	}
+
+	json_value_free(json_object_get_wrapping_value(params));
+}
+
+static void test_deterministic_with_seed(void)
+{
+	action_fn_t action = retrace_actions_get("memory_fuzz");
+
+	/* Same seed + same fail_rate should produce the same decision
+	 * sequence. The action's `initialized` flag persists, so we
+	 * can't re-seed via fuzz_seed in this test. Instead, we use
+	 * the fuzzing_seed action (which sets a global) and verify
+	 * determinism that way.
+	 *
+	 * Setup: invoke fuzzing_seed with seed=42, then sample 20
+	 * decisions at fail_rate=0.5. Reset and repeat. The two
+	 * sequences should be identical.
+	 */
+	action_fn_t seed_action = retrace_actions_get("fuzzing_seed");
+	JSON_Object *seed_params;
+	JSON_Object *fuzz_params;
+	int seq_a[20];
+	int seq_b[20];
+	int i;
+
+	seed_params = json_value_get_object(json_value_init_object());
+	json_object_set_number(seed_params, "seed", 42.0);
+	(void)seed_action(build_ctx_with_retval(0), seed_params);
+
+	fuzz_params = build_params(0.5, 0, 0.0);
+	for (i = 0; i < 20; i++) {
+		struct ThreadContext *ctx = build_ctx_with_retval(0xCAFE);
+
+		action(ctx, fuzz_params);
+		seq_a[i] = (ctx->ret_val == 0) ? 1 : 0;
+	}
+
+	/* Re-seed and re-sample. */
+	(void)seed_action(build_ctx_with_retval(0), seed_params);
+	for (i = 0; i < 20; i++) {
+		struct ThreadContext *ctx = build_ctx_with_retval(0xCAFE);
+
+		action(ctx, fuzz_params);
+		seq_b[i] = (ctx->ret_val == 0) ? 1 : 0;
+	}
+
+	for (i = 0; i < 20; i++)
+		assert(seq_a[i] == seq_b[i]);
+
+	json_value_free(json_object_get_wrapping_value(seed_params));
+	json_value_free(json_object_get_wrapping_value(fuzz_params));
+}
+
+int main(void)
+{
+	retrace_real_impls.strcmp = strcmp;
+	retrace_real_impls.strlen = strlen;
+	retrace_real_impls.strcpy = strcpy;
+	retrace_real_impls.memset = memset;
+	retrace_real_impls.memcpy = memcpy;
+	retrace_real_impls.malloc = malloc;
+	retrace_real_impls.free = free;
+	retrace_real_impls.real_snprintf = snprintf;
+	retrace_real_impls.time = time;
+
+	printf("memory_fuzz tests:\n");
+
+	printf("  -- lookup + params validation --\n");
+	TEST(action_lookup);
+	TEST(params_null);
+	TEST(missing_fail_rate);
+
+	printf("  -- boundary fail_rates --\n");
+	TEST(fail_rate_zero_never_fuzzes);
+	TEST(fail_rate_one_always_fuzzes);
+
+	printf("  -- determinism --\n");
+	TEST(deterministic_with_seed);
+
+	printf("\nPass: %d, Fail: %d (of %d)\n",
+		tests_pass, tests_fail, tests_run);
+	return tests_fail == 0 ? 0 : 1;
+}

--- a/test/unit/test_modify_in_param_str.c
+++ b/test/unit/test_modify_in_param_str.c
@@ -1,0 +1,300 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+/*
+ * Unit tests for the modify_in_param_str action.
+ *
+ * The action swaps a string param's value:
+ *   - Allocates a new buffer (free_val=1 so the engine frees it)
+ *   - strcpy's new_str into the new buffer
+ *   - Optional match_str gates the modification (no match = no-op)
+ *
+ * Tests:
+ *   - Action lookup succeeds
+ *   - NULL params -> -1
+ *   - Missing param_name -> -1
+ *   - Unknown param name -> -1
+ *   - Missing new_str -> -1
+ *   - Direct modification (no match_str)
+ *   - match_str present and matches -> writes new value
+ *   - match_str present, no match -> no-op
+ *   - Repeated modification frees the prior buffer (free_val flag)
+ *
+ * Part of TODO.complete/14.
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "engine.h"
+#include "actions.h"
+#include "funcs.h"
+#include "data_types.h"
+#include "real_impls.h"
+#include "parson.h"
+
+typedef int (*action_fn_t)(struct ThreadContext *t_ctx,
+			    const JSON_Object *action_params);
+
+static int tests_run;
+static int tests_pass;
+static int tests_fail;
+
+#define TEST(name) do { \
+	tests_run++; \
+	printf("  TEST %s ... ", #name); \
+	test_##name(); \
+	tests_pass++; \
+	printf("OK\n"); \
+} while (0)
+
+static JSON_Object *build_params_full(const char *param_name,
+				       const char *new_str,
+				       int with_match,
+				       const char *match_str)
+{
+	JSON_Value *root_val = json_value_init_object();
+	JSON_Object *root = json_value_get_object(root_val);
+
+	json_object_set_string(root, "param_name", param_name);
+	json_object_set_string(root, "new_str", new_str);
+	if (with_match)
+		json_object_set_string(root, "match_str", match_str);
+	return root;
+}
+
+static JSON_Object *build_params_no_new_str(const char *param_name)
+{
+	JSON_Value *root_val = json_value_init_object();
+	JSON_Object *root = json_value_get_object(root_val);
+
+	json_object_set_string(root, "param_name", param_name);
+	return root;
+}
+
+static JSON_Object *build_params_no_param_name(void)
+{
+	JSON_Value *root_val = json_value_init_object();
+	JSON_Object *root = json_value_get_object(root_val);
+
+	json_object_set_string(root, "new_str", "ignored");
+	return root;
+}
+
+static struct ThreadContext *build_ctx_with_str_param(const char *name,
+						       const char *val)
+{
+	static struct ThreadContext ctx;
+	static struct FuncPrototype proto;
+	static char buf[256];
+	struct FuncParam params[8];
+
+	memset(&ctx, 0, sizeof(ctx));
+	memset(params, 0, sizeof(params));
+	memset(&proto, 0, sizeof(proto));
+
+	strncpy(proto.name, "test_func", sizeof(proto.name) - 1);
+	ctx.prototype = &proto;
+
+	strncpy(buf, val, sizeof(buf) - 1);
+	buf[sizeof(buf) - 1] = '\0';
+
+	strncpy(params[0].param_meta.name, name,
+		sizeof(params[0].param_meta.name) - 1);
+	params[0].param_meta.modifiers = CDM_POINTER;
+	params[0].param_meta.direction = PDIR_IN;
+	strcpy(params[0].param_meta.ref_type_name, "sz");
+	params[0].val = (long)buf;
+	params[0].free_val = 0;
+
+	ctx.params_cnt = 1;
+	memcpy(ctx.params, params, sizeof(params));
+	ctx.ret_val = 0;
+	return &ctx;
+}
+
+static struct ThreadContext *build_empty_ctx(void)
+{
+	static struct ThreadContext ctx;
+	static struct FuncPrototype proto;
+
+	memset(&ctx, 0, sizeof(ctx));
+	memset(&proto, 0, sizeof(proto));
+	strncpy(proto.name, "test_func", sizeof(proto.name) - 1);
+	ctx.prototype = &proto;
+	return &ctx;
+}
+
+static void test_action_lookup(void)
+{
+	retrace_actions_init();
+	assert(retrace_actions_get("modify_in_param_str") != NULL);
+}
+
+static void test_params_null(void)
+{
+	action_fn_t action = retrace_actions_get("modify_in_param_str");
+	struct ThreadContext *ctx = build_empty_ctx();
+	int rc;
+
+	rc = action(ctx, NULL);
+	assert(rc == -1);
+}
+
+static void test_missing_param_name(void)
+{
+	action_fn_t action = retrace_actions_get("modify_in_param_str");
+	struct ThreadContext *ctx = build_empty_ctx();
+	JSON_Object *params = build_params_no_param_name();
+	int rc;
+
+	rc = action(ctx, params);
+	assert(rc == -1);
+
+	json_value_free(json_object_get_wrapping_value(params));
+}
+
+static void test_unknown_param_name(void)
+{
+	action_fn_t action = retrace_actions_get("modify_in_param_str");
+	struct ThreadContext *ctx =
+		build_ctx_with_str_param("real_param", "value");
+	JSON_Object *params =
+		build_params_full("nonexistent", "new", 0, NULL);
+	int rc;
+
+	rc = action(ctx, params);
+	assert(rc == -1);
+
+	json_value_free(json_object_get_wrapping_value(params));
+}
+
+static void test_missing_new_str(void)
+{
+	action_fn_t action = retrace_actions_get("modify_in_param_str");
+	struct ThreadContext *ctx =
+		build_ctx_with_str_param("foo", "value");
+	JSON_Object *params = build_params_no_new_str("foo");
+	int rc;
+
+	rc = action(ctx, params);
+	assert(rc == -1);
+
+	json_value_free(json_object_get_wrapping_value(params));
+}
+
+static void test_direct_modification(void)
+{
+	action_fn_t action = retrace_actions_get("modify_in_param_str");
+	struct ThreadContext *ctx =
+		build_ctx_with_str_param("foo", "original");
+	JSON_Object *params =
+		build_params_full("foo", "replacement", 0, NULL);
+	int rc;
+
+	rc = action(ctx, params);
+	assert(rc == 0);
+	assert(strcmp((char *)ctx->params[0].val, "replacement") == 0);
+	assert(ctx->params[0].free_val == 1);
+
+	json_value_free(json_object_get_wrapping_value(params));
+}
+
+static void test_match_str_present_and_matches(void)
+{
+	action_fn_t action = retrace_actions_get("modify_in_param_str");
+	struct ThreadContext *ctx =
+		build_ctx_with_str_param("foo", "old_value");
+	JSON_Object *params =
+		build_params_full("foo", "new_value", 1, "old_value");
+	int rc;
+
+	rc = action(ctx, params);
+	assert(rc == 0);
+	assert(strcmp((char *)ctx->params[0].val, "new_value") == 0);
+
+	json_value_free(json_object_get_wrapping_value(params));
+}
+
+static void test_match_str_present_no_match(void)
+{
+	action_fn_t action = retrace_actions_get("modify_in_param_str");
+	struct ThreadContext *ctx =
+		build_ctx_with_str_param("foo", "actual_value");
+	JSON_Object *params =
+		build_params_full("foo", "new_value", 1, "different_value");
+	int rc;
+
+	rc = action(ctx, params);
+	assert(rc == 0);
+	/* Original value unchanged. */
+	assert(strcmp((char *)ctx->params[0].val, "actual_value") == 0);
+
+	json_value_free(json_object_get_wrapping_value(params));
+}
+
+static void test_repeated_modification_frees_prior_buffer(void)
+{
+	action_fn_t action = retrace_actions_get("modify_in_param_str");
+	struct ThreadContext *ctx =
+		build_ctx_with_str_param("foo", "initial");
+	JSON_Object *p1 = build_params_full("foo", "first", 0, NULL);
+	JSON_Object *p2 = build_params_full("foo", "second", 0, NULL);
+	int rc;
+
+	/* First modification allocates a new buffer; free_val=1. */
+	rc = action(ctx, p1);
+	assert(rc == 0);
+	assert(ctx->params[0].free_val == 1);
+	assert(strcmp((char *)ctx->params[0].val, "first") == 0);
+
+	/* Second modification should free the first buffer before
+	 * allocating the second.
+	 */
+	rc = action(ctx, p2);
+	assert(rc == 0);
+	assert(ctx->params[0].free_val == 1);
+	assert(strcmp((char *)ctx->params[0].val, "second") == 0);
+
+	/* Manual cleanup: the engine would free this. */
+	free((void *)ctx->params[0].val);
+
+	json_value_free(json_object_get_wrapping_value(p1));
+	json_value_free(json_object_get_wrapping_value(p2));
+}
+
+int main(void)
+{
+	retrace_real_impls.strcmp = strcmp;
+	retrace_real_impls.strlen = strlen;
+	retrace_real_impls.strcpy = strcpy;
+	retrace_real_impls.memset = memset;
+	retrace_real_impls.memcpy = memcpy;
+	retrace_real_impls.malloc = malloc;
+	retrace_real_impls.free = free;
+	retrace_real_impls.real_snprintf = snprintf;
+
+	printf("modify_in_param_str tests:\n");
+
+	printf("  -- lookup + params validation --\n");
+	TEST(action_lookup);
+	TEST(params_null);
+	TEST(missing_param_name);
+	TEST(unknown_param_name);
+	TEST(missing_new_str);
+
+	printf("  -- modification semantics --\n");
+	TEST(direct_modification);
+	TEST(match_str_present_and_matches);
+	TEST(match_str_present_no_match);
+	TEST(repeated_modification_frees_prior_buffer);
+
+	printf("\nPass: %d, Fail: %d (of %d)\n",
+		tests_pass, tests_fail, tests_run);
+	return tests_fail == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Continues TODO.complete/14. Three more action unit-test files:

- `test/unit/test_incomplete_io.c` -- 9 tests
- `test/unit/test_memory_fuzz.c` -- 6 tests
- `test/unit/test_modify_in_param_str.c` -- 9 tests

## incomplete_io

Truncates `t_ctx->ret_val` to `(real * rate)`. Rate is clamped to `[0.0, 1.0]`. Negative or zero ret_vals pass through untouched.

Tests cover lookup, NULL params, missing rate, rate=1.0 (no-op), rate=0.0 (zero), rate=0.5 (halved), rate<0 (clamped), rate>1 (clamped), negative ret_val passes through, zero ret_val passes through.

## memory_fuzz

With probability `fail_rate`, sets `ret_val=NULL` + `errno=ENOMEM` (simulating malloc failure).

Tests cover lookup, NULL params, missing fail_rate, fail_rate=0.0 (never fuzzes, verified across 50 invocations), fail_rate=1.0 (always fuzzes, errno=ENOMEM each time across 50 invocations), and determinism (same seed -> same 20-element decision sequence across two samplings, using the `fuzzing_seed` action to reset the global seed).

## modify_in_param_str

Swaps a string param's value: allocates new buffer (`free_val=1`), strcpy's `new_str`, optional `match_str` gates (no match = no-op).

Tests cover lookup, NULL params, missing param_name, unknown param name, missing new_str, direct modification, match-and-write, no-match no-op, and repeated modification (verifies prior buffer is freed before allocating the new one).

**Setup:** param must be marked `CDM_POINTER` with `ref_type_name="sz"` and `direction=PDIR_IN`. Without these the action rejects with "param 'foo' is not a pointer to string".

## Test plan

- [x] `cmake --build build-rel` -- clean
- [x] `ctest --test-dir build-rel` -- 19/19 pass (integration, 17 unit, 2 property)
- [ ] CI matrix green

## TODO.complete/14 status

Now Partial with **13 of 14 actions** covered (this PR + #553 + #554 + #555 + #556 + the `sockaddr_inspect` helper from #551/#552):

| Action | Test file | Status |
|--------|-----------|--------|
| `addr_deny` | test_addr_deny.c | done (PR #553) |
| `modify_return_value_int` | test_modify_return_value_int.c | done (PR #554) |
| `call_count_limit` | test_call_count_limit.c | done (PR #554) |
| `sandbox` | test_sandbox.c | done (PR #555) |
| `modify_in_param_int` | test_modify_in_param_int.c | done (PR #555) |
| `fuzzing_seed` | test_fuzzing_seed.c | done (PR #555) |
| `delay` | test_delay.c | done (PR #555) |
| `log_params` | test_log_params.c | done (PR #556) |
| `call_real` | test_call_real.c | done (PR #556) |
| `incomplete_io` | test_incomplete_io.c | done (this PR) |
| `memory_fuzz` | test_memory_fuzz.c | done (this PR) |
| `modify_in_param_str` | test_modify_in_param_str.c | done (this PR) |
| `sockaddr_inspect` (helper) | test_sockaddr_inspect.c + property tests | done (PRs #551, #552) |
| `modify_in_param_arr` | -- | TBD (array semantics + JSON array input) |

Only `modify_in_param_arr` remains. It involves JSON array parsing, multi-buffer allocation, and the `array_cnt_param` lookup -- complex enough to warrant its own focused PR.

## Related

- PR #553 (test_addr_deny -- established the pattern)
- PR #554, #555, #556 (more action tests)
- TODO.complete/14-specs-and-unit-tests.md
