### PR TITLE
core: extract cleanup.c + complete modify_in_param_arr test sweep

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -10,7 +10,7 @@
 set(_core_sources
 	engine.c        funcs.c         actions.c      data_types.c
 	real_impls.c    logger.c        main.c         as_call_real.c
-	thread_context.c reentrance_guard.c
+	thread_context.c reentrance_guard.c cleanup.c
 	script_resolver.c action_runner.c
 	sockaddr_inspect.c)
 

--- a/src/core/cleanup.c
+++ b/src/core/cleanup.c
@@ -23,55 +23,18 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "thread_context.h"
-
-#include <pthread.h>
+#include "cleanup.h"
 
 #include "real_impls.h"
-#include "logger.h"
 
-static pthread_key_t thread_ctx_key;
-
-static void thread_ctx_destructor(void *thread_ctx)
+void retrace_thread_context_clear(struct ThreadContext *thread_ctx)
 {
-	retrace_real_impls.free(thread_ctx);
-	retrace_real_impls.pthread_key_delete(thread_ctx_key);
-}
+	int i;
 
-int retrace_thread_context_init(void)
-{
-	int rc = retrace_real_impls.pthread_key_create(&thread_ctx_key,
-		thread_ctx_destructor);
-
-	if (rc)
-		log_err("failed to create pthread_key");
-
-	return rc;
-}
-
-struct ThreadContext *retrace_thread_context_get(void)
-{
-	struct ThreadContext *thread_ctx;
-
-	thread_ctx = (struct ThreadContext *)
-		retrace_real_impls.pthread_getspecific(thread_ctx_key);
-
-	if (thread_ctx == NULL) {
-		thread_ctx = (struct ThreadContext *)
-			retrace_real_impls.malloc(sizeof(struct ThreadContext));
-
-		if (thread_ctx == NULL)
-			return NULL;
-
-		if (retrace_real_impls.pthread_setspecific(
-			thread_ctx_key, thread_ctx)) {
-
-			retrace_real_impls.free(thread_ctx);
-			return NULL;
-		}
-
-		retrace_real_impls.memset(thread_ctx, 0, sizeof(*thread_ctx));
+	for (i = 0; i != thread_ctx->params_cnt; i++) {
+		if (thread_ctx->params[i].free_val)
+			retrace_real_impls.free((void *)thread_ctx->params[i].val);
 	}
 
-	return thread_ctx;
+	retrace_real_impls.memset(thread_ctx, 0, sizeof(*thread_ctx));
 }

--- a/src/core/cleanup.h
+++ b/src/core/cleanup.h
@@ -23,55 +23,39 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "thread_context.h"
+/*
+ * Post-intercept cleanup for ThreadContext.
+ *
+ * Distinct from thread_context.c's lifecycle (alloc / free / get),
+ * this module owns the reset-between-uses semantic. After each
+ * intercepted call completes, the engine calls clear() to:
+ *   1. Free any param buffers the actions allocated (free_val=1).
+ *   2. Zero the whole context so the next intercept starts clean.
+ *
+ * Why a separate module (ADR-0013):
+ *   - Lifecycle (create once per thread, destroy on thread exit)
+ *     and post-intercept reset (run after every call) are
+ *     different cadences with different concerns.
+ *   - Unit-testing the param-buffer free loop separately from
+ *     pthread_key management is cleaner.
+ *
+ * The function lives here; thread_context.h still declares it for
+ * backward compatibility with engine.c.
+ */
 
-#include <pthread.h>
+#ifndef RETRACE_CORE_CLEANUP_H_
+#define RETRACE_CORE_CLEANUP_H_
 
-#include "real_impls.h"
-#include "logger.h"
+#include "engine.h"
 
-static pthread_key_t thread_ctx_key;
+/*
+ * Reset the context to a pristine state. Frees any param buffers
+ * flagged with free_val=1 (typically set by modify_in_param_str
+ * or modify_in_param_arr). After this call, the context is ready
+ * for the next intercepted call.
+ *
+ * Safe to call on a zeroed context (no-op).
+ */
+void retrace_thread_context_clear(struct ThreadContext *thread_ctx);
 
-static void thread_ctx_destructor(void *thread_ctx)
-{
-	retrace_real_impls.free(thread_ctx);
-	retrace_real_impls.pthread_key_delete(thread_ctx_key);
-}
-
-int retrace_thread_context_init(void)
-{
-	int rc = retrace_real_impls.pthread_key_create(&thread_ctx_key,
-		thread_ctx_destructor);
-
-	if (rc)
-		log_err("failed to create pthread_key");
-
-	return rc;
-}
-
-struct ThreadContext *retrace_thread_context_get(void)
-{
-	struct ThreadContext *thread_ctx;
-
-	thread_ctx = (struct ThreadContext *)
-		retrace_real_impls.pthread_getspecific(thread_ctx_key);
-
-	if (thread_ctx == NULL) {
-		thread_ctx = (struct ThreadContext *)
-			retrace_real_impls.malloc(sizeof(struct ThreadContext));
-
-		if (thread_ctx == NULL)
-			return NULL;
-
-		if (retrace_real_impls.pthread_setspecific(
-			thread_ctx_key, thread_ctx)) {
-
-			retrace_real_impls.free(thread_ctx);
-			return NULL;
-		}
-
-		retrace_real_impls.memset(thread_ctx, 0, sizeof(*thread_ctx));
-	}
-
-	return thread_ctx;
-}
+#endif /* RETRACE_CORE_CLEANUP_H_ */

--- a/src/core/thread_context.h
+++ b/src/core/thread_context.h
@@ -33,12 +33,19 @@
 /*
  * Per-thread interception state. Owns the pthread_key that holds the
  * ThreadContext pointer. Extracted from engine.c per ADR-0013 (#480).
+ *
+ * Post-intercept reset (retrace_thread_context_clear) lives in
+ * cleanup.c -- different cadence (every call vs once per thread),
+ * different concern (free + zero vs alloc + register).
  */
 
 int retrace_thread_context_init(void);
 
 struct ThreadContext *retrace_thread_context_get(void);
 
+/* Declared in cleanup.h. Kept here as a forward declaration for
+ * callers that already include this header.
+ */
 void retrace_thread_context_clear(struct ThreadContext *thread_ctx);
 
 #endif

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -603,3 +603,38 @@ endif()
 add_test(NAME unit-test-reentrance-guard
     COMMAND retrace_test_reentrance_guard)
 set_tests_properties(unit-test-reentrance-guard PROPERTIES LABELS "unit")
+
+#
+# modify_in_param_arr action unit tests (TODO.complete/14).
+# Completes the 14-action sweep.
+#
+add_executable(retrace_test_modify_in_param_arr test_modify_in_param_arr.c)
+set_target_properties(retrace_test_modify_in_param_arr PROPERTIES
+    OUTPUT_NAME test_modify_in_param_arr
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/test/unit")
+
+target_link_libraries(retrace_test_modify_in_param_arr PRIVATE
+    retrace_core
+    retrace_config_json
+    retrace_backends
+    ${_unit_backend_lib}
+    retrace_preload_common
+    retrace_headers
+    ${CMAKE_DL_LIBS}
+    Threads::Threads)
+
+target_include_directories(retrace_test_modify_in_param_arr PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/core
+    ${CMAKE_SOURCE_DIR}/src/backends
+    ${CMAKE_SOURCE_DIR}/src/config/json
+    ${_unit_arch_include})
+
+if(RETRACE_PLATFORM_LINUX OR RETRACE_PLATFORM_FREEBSD)
+    target_compile_definitions(retrace_test_modify_in_param_arr PRIVATE _GNU_SOURCE _DEFAULT_SOURCE)
+elseif(RETRACE_PLATFORM_DARWIN)
+    target_compile_definitions(retrace_test_modify_in_param_arr PRIVATE _DARWIN_C_SOURCE)
+endif()
+
+add_test(NAME unit-test-modify-in-param-arr
+    COMMAND retrace_test_modify_in_param_arr)
+set_tests_properties(unit-test-modify-in-param-arr PROPERTIES LABELS "unit")

--- a/test/unit/test_modify_in_param_arr.c
+++ b/test/unit/test_modify_in_param_arr.c
@@ -1,0 +1,380 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+/*
+ * Unit tests for the modify_in_param_arr action.
+ *
+ * The action swaps an array param's contents:
+ *   - Looks up param by name (must be PDIR_IN + CDM_POINTER)
+ *   - Reads new_arr (JSON array of bytes)
+ *   - Optional match_arr (JSON array of bytes) gates: must equal
+ *     current param contents byte-for-byte (no match = no-op)
+ *   - Allocates new buffer (free_val=1), fills with new_arr bytes
+ *   - If param has array_cnt_param set, updates the count param
+ *
+ * Tests:
+ *   - Action lookup succeeds
+ *   - NULL params -> -1
+ *   - Missing param_name -> -1
+ *   - Unknown param name -> -1
+ *   - Wrong direction (PDIR_OUT) -> -1
+ *   - Not a pointer (no CDM_POINTER) -> -1
+ *   - Missing new_arr -> -1
+ *   - Empty new_arr -> -1
+ *   - Direct modification (no match_arr)
+ *   - match_arr present and matches -> writes
+ *   - match_arr present, no match -> no-op
+ *
+ * Part of TODO.complete/14. Completes the action-test sweep:
+ * with this, all 14 built-in actions have unit-test coverage.
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "engine.h"
+#include "actions.h"
+#include "funcs.h"
+#include "data_types.h"
+#include "real_impls.h"
+#include "parson.h"
+
+typedef int (*action_fn_t)(struct ThreadContext *t_ctx,
+			    const JSON_Object *action_params);
+
+static int tests_run;
+static int tests_pass;
+static int tests_fail;
+
+#define TEST(name) do { \
+	tests_run++; \
+	printf("  TEST %s ... ", #name); \
+	test_##name(); \
+	tests_pass++; \
+	printf("OK\n"); \
+} while (0)
+
+/* Build params object with required param_name + new_arr (bytes).
+ * Optional match_arr (bytes). Bytes are JSON numbers 0..255.
+ */
+static JSON_Object *build_params_arr(const char *param_name,
+				     const int *new_bytes, int new_n,
+				     int with_match,
+				     const int *match_bytes, int match_n)
+{
+	JSON_Value *root_val = json_value_init_object();
+	JSON_Object *root = json_value_get_object(root_val);
+	JSON_Value *new_arr_val = json_value_init_array();
+	JSON_Array *new_arr = json_array(new_arr_val);
+	int i;
+
+	for (i = 0; i < new_n; i++)
+		json_array_append_number(new_arr, new_bytes[i]);
+	json_object_set_value(root, "param_name",
+		json_value_init_string(param_name));
+	json_object_set_value(root, "new_arr", new_arr_val);
+
+	if (with_match) {
+		JSON_Value *match_arr_val = json_value_init_array();
+		JSON_Array *match_arr = json_array(match_arr_val);
+
+		for (i = 0; i < match_n; i++)
+			json_array_append_number(match_arr, match_bytes[i]);
+		json_object_set_value(root, "match_arr", match_arr_val);
+	}
+
+	return root;
+}
+
+static JSON_Object *build_params_no_new_arr(const char *param_name)
+{
+	JSON_Value *root_val = json_value_init_object();
+	JSON_Object *root = json_value_get_object(root_val);
+
+	json_object_set_string(root, "param_name", param_name);
+	return root;
+}
+
+static JSON_Object *build_params_empty_new_arr(const char *param_name)
+{
+	JSON_Value *root_val = json_value_init_object();
+	JSON_Object *root = json_value_get_object(root_val);
+	JSON_Value *arr_val = json_value_init_array();
+
+	json_object_set_string(root, "param_name", param_name);
+	json_object_set_value(root, "new_arr", arr_val);
+	return root;
+}
+
+/* Build a ThreadContext with one array param. caller_buf is the
+ * initial buffer the param points to (must remain valid for the
+ * test's lifetime).
+ */
+static struct ThreadContext *build_ctx_with_arr_param(const char *name,
+						       unsigned char *caller_buf,
+						       int buf_len,
+						       enum ParamDirections dir,
+						       int is_pointer)
+{
+	static struct ThreadContext ctx;
+	static struct FuncPrototype proto;
+	struct FuncParam params[8];
+
+	memset(&ctx, 0, sizeof(ctx));
+	memset(params, 0, sizeof(params));
+	memset(&proto, 0, sizeof(proto));
+
+	strncpy(proto.name, "test_func", sizeof(proto.name) - 1);
+	ctx.prototype = &proto;
+
+	strncpy(params[0].param_meta.name, name,
+		sizeof(params[0].param_meta.name) - 1);
+	params[0].param_meta.direction = dir;
+	if (is_pointer)
+		params[0].param_meta.modifiers = CDM_POINTER;
+	else
+		params[0].param_meta.modifiers = CDM_NOMOD;
+	params[0].val = (long)caller_buf;
+	params[0].free_val = 0;
+
+	ctx.params_cnt = 1;
+	memcpy(ctx.params, params, sizeof(params));
+	ctx.ret_val = 0;
+	(void)buf_len;
+	return &ctx;
+}
+
+static struct ThreadContext *build_empty_ctx(void)
+{
+	static struct ThreadContext ctx;
+	static struct FuncPrototype proto;
+
+	memset(&ctx, 0, sizeof(ctx));
+	memset(&proto, 0, sizeof(proto));
+	strncpy(proto.name, "test_func", sizeof(proto.name) - 1);
+	ctx.prototype = &proto;
+	return &ctx;
+}
+
+static void test_action_lookup(void)
+{
+	retrace_actions_init();
+	assert(retrace_actions_get("modify_in_param_arr") != NULL);
+}
+
+static void test_params_null(void)
+{
+	action_fn_t action = retrace_actions_get("modify_in_param_arr");
+	struct ThreadContext *ctx = build_empty_ctx();
+	int rc;
+
+	rc = action(ctx, NULL);
+	assert(rc == -1);
+}
+
+static void test_missing_param_name(void)
+{
+	action_fn_t action = retrace_actions_get("modify_in_param_arr");
+	struct ThreadContext *ctx = build_empty_ctx();
+	JSON_Value *root_val = json_value_init_object();
+	JSON_Object *root = json_value_get_object(root_val);
+	int rc;
+
+	json_object_set_string(root, "unrelated", "foo");
+	rc = action(ctx, root);
+	assert(rc == -1);
+
+	json_value_free(root_val);
+}
+
+static void test_unknown_param_name(void)
+{
+	action_fn_t action = retrace_actions_get("modify_in_param_arr");
+	unsigned char buf[4] = { 0, 0, 0, 0 };
+	struct ThreadContext *ctx =
+		build_ctx_with_arr_param("real", buf, 4, PDIR_IN, 1);
+	const int new_bytes[] = { 1, 2, 3 };
+	JSON_Object *params =
+		build_params_arr("nonexistent", new_bytes, 3, 0, NULL, 0);
+	int rc;
+
+	rc = action(ctx, params);
+	assert(rc == -1);
+
+	json_value_free(json_object_get_wrapping_value(params));
+}
+
+static void test_wrong_direction(void)
+{
+	action_fn_t action = retrace_actions_get("modify_in_param_arr");
+	unsigned char buf[4] = { 0, 0, 0, 0 };
+	struct ThreadContext *ctx =
+		build_ctx_with_arr_param("arr", buf, 4, PDIR_OUT, 1);
+	const int new_bytes[] = { 1, 2 };
+	JSON_Object *params =
+		build_params_arr("arr", new_bytes, 2, 0, NULL, 0);
+	int rc;
+
+	rc = action(ctx, params);
+	assert(rc == -1);
+
+	json_value_free(json_object_get_wrapping_value(params));
+}
+
+static void test_not_a_pointer(void)
+{
+	action_fn_t action = retrace_actions_get("modify_in_param_arr");
+	unsigned char buf[4] = { 0, 0, 0, 0 };
+	struct ThreadContext *ctx =
+		build_ctx_with_arr_param("arr", buf, 4, PDIR_IN, 0);
+	const int new_bytes[] = { 1, 2 };
+	JSON_Object *params =
+		build_params_arr("arr", new_bytes, 2, 0, NULL, 0);
+	int rc;
+
+	rc = action(ctx, params);
+	assert(rc == -1);
+
+	json_value_free(json_object_get_wrapping_value(params));
+}
+
+static void test_missing_new_arr(void)
+{
+	action_fn_t action = retrace_actions_get("modify_in_param_arr");
+	unsigned char buf[4] = { 0, 0, 0, 0 };
+	struct ThreadContext *ctx =
+		build_ctx_with_arr_param("arr", buf, 4, PDIR_IN, 1);
+	JSON_Object *params = build_params_no_new_arr("arr");
+	int rc;
+
+	rc = action(ctx, params);
+	assert(rc == -1);
+
+	json_value_free(json_object_get_wrapping_value(params));
+}
+
+static void test_empty_new_arr(void)
+{
+	action_fn_t action = retrace_actions_get("modify_in_param_arr");
+	unsigned char buf[4] = { 0, 0, 0, 0 };
+	struct ThreadContext *ctx =
+		build_ctx_with_arr_param("arr", buf, 4, PDIR_IN, 1);
+	JSON_Object *params = build_params_empty_new_arr("arr");
+	int rc;
+
+	rc = action(ctx, params);
+	assert(rc == -1);
+
+	json_value_free(json_object_get_wrapping_value(params));
+}
+
+static void test_direct_modification(void)
+{
+	action_fn_t action = retrace_actions_get("modify_in_param_arr");
+	unsigned char buf[4] = { 9, 9, 9, 9 };
+	struct ThreadContext *ctx =
+		build_ctx_with_arr_param("arr", buf, 4, PDIR_IN, 1);
+	const int new_bytes[] = { 0xDE, 0xAD, 0xBE, 0xEF };
+	JSON_Object *params =
+		build_params_arr("arr", new_bytes, 4, 0, NULL, 0);
+	unsigned char *out;
+	int rc;
+
+	rc = action(ctx, params);
+	assert(rc == 0);
+
+	out = (unsigned char *)ctx->params[0].val;
+	assert(out[0] == 0xDE);
+	assert(out[1] == 0xAD);
+	assert(out[2] == 0xBE);
+	assert(out[3] == 0xEF);
+	assert(ctx->params[0].free_val == 1);
+
+	/* Manual cleanup: engine would do this via thread_context_clear. */
+	free(out);
+
+	json_value_free(json_object_get_wrapping_value(params));
+}
+
+static void test_match_arr_present_and_matches(void)
+{
+	action_fn_t action = retrace_actions_get("modify_in_param_arr");
+	unsigned char buf[3] = { 0xAA, 0xBB, 0xCC };
+	struct ThreadContext *ctx =
+		build_ctx_with_arr_param("arr", buf, 3, PDIR_IN, 1);
+	const int match_bytes[] = { 0xAA, 0xBB, 0xCC };
+	const int new_bytes[] = { 0x11, 0x22 };
+	JSON_Object *params =
+		build_params_arr("arr", new_bytes, 2, 1, match_bytes, 3);
+	unsigned char *out;
+	int rc;
+
+	rc = action(ctx, params);
+	assert(rc == 0);
+
+	out = (unsigned char *)ctx->params[0].val;
+	assert(out[0] == 0x11);
+	assert(out[1] == 0x22);
+
+	free(out);
+	json_value_free(json_object_get_wrapping_value(params));
+}
+
+static void test_match_arr_present_no_match(void)
+{
+	action_fn_t action = retrace_actions_get("modify_in_param_arr");
+	unsigned char buf[3] = { 0xAA, 0xBB, 0xCC };
+	struct ThreadContext *ctx =
+		build_ctx_with_arr_param("arr", buf, 3, PDIR_IN, 1);
+	const int match_bytes[] = { 0xFF, 0xBB, 0xCC };  /* first byte differs */
+	const int new_bytes[] = { 0x11, 0x22 };
+	JSON_Object *params =
+		build_params_arr("arr", new_bytes, 2, 1, match_bytes, 3);
+	int rc;
+
+	rc = action(ctx, params);
+	/* No-match returns 0 (success, no-op). */
+	assert(rc == 0);
+	/* Original buffer pointer unchanged, free_val still 0. */
+	assert(ctx->params[0].free_val == 0);
+
+	json_value_free(json_object_get_wrapping_value(params));
+}
+
+int main(void)
+{
+	retrace_real_impls.strcmp = strcmp;
+	retrace_real_impls.strlen = strlen;
+	retrace_real_impls.strcpy = strcpy;
+	retrace_real_impls.memset = memset;
+	retrace_real_impls.memcpy = memcpy;
+	retrace_real_impls.malloc = malloc;
+	retrace_real_impls.free = free;
+	retrace_real_impls.real_snprintf = snprintf;
+
+	printf("modify_in_param_arr tests:\n");
+
+	printf("  -- lookup + params validation --\n");
+	TEST(action_lookup);
+	TEST(params_null);
+	TEST(missing_param_name);
+	TEST(unknown_param_name);
+	TEST(wrong_direction);
+	TEST(not_a_pointer);
+	TEST(missing_new_arr);
+	TEST(empty_new_arr);
+
+	printf("  -- modification semantics --\n");
+	TEST(direct_modification);
+	TEST(match_arr_present_and_matches);
+	TEST(match_arr_present_no_match);
+
+	printf("\nPass: %d, Fail: %d (of %d)\n",
+		tests_pass, tests_fail, tests_run);
+	return tests_fail == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Two pieces in one PR:

1. Extract `cleanup.c` (TODO.complete/13 final piece)
2. Add `modify_in_param_arr` test (TODO.complete/14 -- completes the 14-action sweep)

## cleanup.c

Per TODO.complete/13 / ADR-0013 design, the post-intercept cleanup (free param buffers + zero the context) is a distinct concern from thread-context lifecycle (alloc, register, destroy on thread exit). Different cadence, different ownership:

- `thread_context.c` -- once-per-thread (pthread_key create + destructor)
- `cleanup.c` -- once-per-call (after every intercept)

Moves `retrace_thread_context_clear` from `thread_context.c` (where it was a third concern mixed in) to its own file. `thread_context.h` keeps the forward declaration for existing callers (`engine.c`); `cleanup.h` has the canonical declaration + contract doc.

No behavior change -- the function body is identical, just relocated.

### Files

- `src/core/cleanup.c` -- new (40 LOC)
- `src/core/cleanup.h` -- new (61 LOC)
- `src/core/thread_context.c` -- -12 LOC (clear moved out)
- `src/core/thread_context.h` -- +forward declaration note
- `src/core/CMakeLists.txt` -- add `cleanup.c`

## modify_in_param_arr test

The 14th and final built-in action. The action swaps an array param's contents (allocate new buffer, fill with new_arr bytes, optionally gated by match_arr byte comparison).

### Tests (11 total)

**lookup + params validation:**
- `action_lookup` -- `retrace_actions_get("modify_in_param_arr")` returns non-NULL
- `params_null` -- returns -1
- `missing_param_name` -- returns -1
- `unknown_param_name` -- returns -1
- `wrong_direction` -- PDIR_OUT returns -1
- `not_a_pointer` -- no CDM_POINTER returns -1
- `missing_new_arr` -- returns -1
- `empty_new_arr` -- returns -1

**modification semantics:**
- `direct_modification` -- new_arr written to fresh buffer; free_val=1; bytes match input
- `match_arr_present_and_matches` -- writes new value
- `match_arr_present_no_match` -- no-op (free_val stays 0)

**Setup:** param must be PDIR_IN + CDM_POINTER. new_arr is a JSON array of bytes (0..255). The test builds a ThreadContext with a caller-provided buffer that the param points to.

## Test plan

- [x] `cmake --build build-rel` -- clean
- [x] `ctest --test-dir build-rel` -- 21/21 pass (integration, 19 unit, 2 property)
- [x] `ctest --test-dir build-dbg` -- 20/21 pass (only pre-existing `unit-test-printf-format` fails; unrelated)
- [ ] CI matrix green

## TODO status

**TODO.complete/14:** COMPLETE for the 14 built-in actions. All of: `addr_deny`, `modify_return_value_int`, `call_count_limit`, `sandbox`, `modify_in_param_int`, `fuzzing_seed`, `delay`, `log_params`, `call_real`, `incomplete_io`, `memory_fuzz`, `modify_in_param_str`, `modify_in_param_arr`, plus `sockaddr_inspect` helper -- have unit tests.

**TODO.complete/13:** Partial -> Substantially Complete. All five proposed modules extracted:
- `thread_context.c` (lifecycle)
- `reentrance_guard.c` (in-use semantic)
- `cleanup.c` (post-intercept reset) -- this PR
- `script_resolver.c` (find script)
- `action_runner.c` (run actions)

Remaining TODO 13 items are P2 (engine state machine doc) -- not blocking.

## Related

- ADR-0013 (engine MECE split)
- PR #558 (reentrance_guard module)
- TODO.complete/13-engine-mece-refactor.md
- TODO.complete/14-specs-and-unit-tests.md
