### PR TITLE
test+docs: conf loader tests + engine state machine doc (TODO 13/14 finish)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -31,6 +31,7 @@ docs/
 ├── configuration.md       ← JSON config schema + action parameter reference
 ├── development.md         ← building, testing, contributing, debugging retrace
 ├── architecture.md        ← how engine, backends, and actions fit together
+├── engine-state-machine.md ← per-call lifecycle (engine_wrapper flow)
 ├── cookbook/              ← 21 recipe-driven walkthroughs
 │   ├── README.md          ← index + compact action reference
 │   ├── 01-trace-all-calls.md

--- a/docs/engine-state-machine.md
+++ b/docs/engine-state-machine.md
@@ -1,0 +1,131 @@
+# Engine state machine
+
+The lifecycle of a single intercepted call, from the asm trampoline
+through the engine back to the caller. This doc explains the order
+of operations in `retrace_engine_wrapper` and the role of each
+MECE module (per ADR-0013).
+
+## Big picture
+
+```
+caller             asm trampoline      engine.c            actions            real libc
+  |                      |                |                   |                   |
+  | -- call open() ----> |                |                   |                   |
+  |                      | -- push frame, |                   |                   |
+  |                      |   bl engine -->|                   |                   |
+  |                      |   _wrapper     |                   |                   |
+  |                      |                |                   |                   |
+  |                      |                +-- get real_impl (dlsym RTLD_NEXT)      |
+  |                      |                |                   |                   |
+  |                      |                +-- if not inited: sched real, return   |
+  |                      |                |                                       |
+  |                      |                +-- acquire ThreadContext (per-thread)  |
+  |                      |                |                                       |
+  |                      |                +-- if real_impl is NULL:               |
+  |                      |                |       set ret_val=-1, return          |
+  |                      |                |                                       |
+  |                      |                +-- sched real (default)                |
+  |                      |                |                                       |
+  |                      |                +-- if guard_active(ctx): return        |
+  |                      |                |   (nested call -- avoid recursion)    |
+  |                      |                |                                       |
+  |                      |                +-- guard_enter(ctx, real_impl, arch)   |
+  |                      |                |                                       |
+  |                      |                +-- look up prototype                  |
+  |                      |                |       if missing: goto cleanup        |
+  |                      |                |                                       |
+  |                      |                +-- log-filter check                   |
+  |                      |                |       if filtered: goto cleanup      |
+  |                      |                |                                       |
+  |                      |                +-- setup_params from frame            |
+  |                      |                |       if fails: goto cleanup         |
+  |                      |                |                                       |
+  |                      |                +-- find intercept_script              |
+  |                      |                |       if none: goto cleanup          |
+  |                      |                |                                       |
+  |                      |                +-- cancel default sched_real          |
+  |                      |                |                                       |
+  |                      |                +-- action_runner_run(actions[]) -----+|
+  |                      |                |                   |                   ||
+  |                      |                |                   +-- log_params --->||
+  |                      |                |                   |                   ||
+  |                      |                |                   +-- call_real ----->|----> real open()
+  |                      |                |                   |                   ||<-- ret
+  |                      |                |                   |                   ||
+  |                      |                |                   +-- modify_ret -->  ||
+  |                      |                |                   |                   ||
+  |                      |                |                   <-- return -----------||
+  |                      |                |                                       |
+  |                      |                +-- set_ret_val(ctx->ret_val)           |
+  |                      |                |                                       |
+  |                      |                +-- cleanup: ctx_clear (free params)    |
+  |                      |                |                                       |
+  |                      | <-- ret -------+                                       |
+  | <--- ret ------------+                                               |
+```
+
+## MECE module responsibilities
+
+| Module | Responsibility | Why separate |
+|--------|----------------|--------------|
+| `engine.c` | Orchestrator. Calls the others in strict order. | Single point of dispatch; no business logic. |
+| `thread_context.c` | Per-thread state lifecycle (alloc, register, destroy on thread exit). | Runs once per thread, not per call. |
+| `reentrance_guard.c` | In-use marker (`active` / `enter`). | Distinguishes "what is the real impl?" from "is this thread already inside an intercept?" -- previously overloaded on `real_impl != NULL`. |
+| `cleanup.c` | Post-intercept reset (free param buffers + zero context). | Runs after every call. Different cadence from lifecycle. |
+| `script_resolver.c` | Find the matching `intercept_script` for a given func_name. | Isolates JSON-walking from engine orchestration. |
+| `action_runner.c` | Iterate the script's actions array, dispatch each via the registry. | Isolates action-loop semantics (abort on -1, logging) from engine. |
+
+## State machine (formal)
+
+The engine transitions through these states per call:
+
+1. **ENTER** -- trampoline called `retrace_engine_wrapper(func_name, arch_spec_ctx)`.
+2. **REAL_IMPL_LOOKUP** -- `retrace_as_get_real_safe(func_name)` returns the real libc pointer (or NULL).
+3. **INIT_CHECK** -- if `!retrace_inited`, schedule real call and return. Skip everything else.
+4. **CTX_ACQUIRE** -- `retrace_thread_context_get()` returns the per-thread `ThreadContext*` (allocating one if first call on this thread).
+5. **REAL_IMPL_NULL_CHECK** -- if real_impl is NULL, set `ret_val=-1` and return. (For CRT funcs; caller probably crashes anyway.)
+6. **DEFAULT_REAL_SCHED** -- `retrace_as_sched_real(arch_spec_ctx, real_impl)`. Marks the trampoline to call real by default.
+7. **GUARD_CHECK** -- `retrace_reentrance_guard_active(ctx)`. If true: nested call from inside an action, return early (real will run via the sched above).
+8. **GUARD_ENTER** -- `retrace_reentrance_guard_enter(ctx, real_impl, arch_spec_ctx)`. Mark active.
+9. **PROTO_LOOKUP** -- `retrace_func_get(func_name)`. If NULL: `goto cleanup`.
+10. **LOG_FILTER** -- `retrace_logger_func_loggable(func_name)`. If false: `goto cleanup` (real still runs).
+11. **SETUP_PARAMS** -- `retrace_as_setup_params(arch_spec_ctx, proto, params, &cnt)`. If fails: `goto cleanup`.
+12. **SCRIPT_LOOKUP** -- `retrace_script_find(intercept_scripts, func_name, ret_addr)`. If NULL: `goto cleanup`.
+13. **CANCEL_DEFAULT_REAL** -- `retrace_as_cancel_sched_real(arch_spec_ctx)`. Real won't run unless `call_real` action re-schedules it.
+14. **ACTION_RUN** -- `retrace_action_runner_run(ctx, func_name, script)`. Walks the actions array.
+15. **RETVAL_WRITEBACK** -- `retrace_as_set_ret_val(arch_spec_ctx, ctx->ret_val)`.
+16. **CLEANUP** -- `retrace_thread_context_clear(ctx)`. Frees any param buffers actions allocated; zeroes ctx for next call.
+
+States 1-7 are pre-flight (always run, no actions yet). States 8-14 are the intercept body. States 15-16 are post-intercept.
+
+## Reentrance handling
+
+The guard is critical because any libc call inside an action (e.g. `log_info -> fprintf -> malloc`) is itself intercepted. Without the guard, the recursion is unbounded.
+
+The guard works because:
+- `real_impl` is set on enter (step 8).
+- A nested call from inside an action reacquires the same `ThreadContext` (per-thread), sees `guard_active`, bails.
+- `cleanup` zeroes `real_impl` after the outer action completes.
+
+Without the per-thread `ThreadContext`, two threads could clobber each other's guard state.
+
+## Failure modes
+
+| Failure | Engine response |
+|---------|-----------------|
+| Init never completed | Schedule real, return. No intercept. |
+| `real_impl == NULL` (no libc symbol) | Set `ret_val=-1`, return. |
+| `ThreadContext` alloc fails | Log error, return. Real does not run (sched was set). |
+| Prototype missing | Skip actions, real runs. |
+| Log filter excludes function | Skip actions, real runs. |
+| `setup_params` fails | Skip actions, real runs. |
+| No matching script | Skip actions, real runs. |
+| Action returns non-zero | `action_runner` aborts script, real does not run (default was cancelled). |
+| Param buffer alloc inside action fails | Action handles it; typically logs + continues. |
+
+## See also
+
+- `src/core/engine.c` -- the orchestrator (state machine implementation)
+- `docs/adr/0013-engine-mece-split.md` -- the architectural decision
+- `docs/architecture.md` -- higher-level architecture overview
+- `TODO.complete/13-engine-mece-refactor.md` -- the tactical plan that drove the split

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -638,3 +638,38 @@ endif()
 add_test(NAME unit-test-modify-in-param-arr
     COMMAND retrace_test_modify_in_param_arr)
 set_tests_properties(unit-test-modify-in-param-arr PROPERTIES LABELS "unit")
+
+#
+# JSON config loader unit tests (TODO.complete/14). conf.c lives
+# in src/config/json/, so we add that to includes.
+#
+add_executable(retrace_test_conf test_conf.c)
+set_target_properties(retrace_test_conf PROPERTIES
+    OUTPUT_NAME test_conf
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/test/unit")
+
+target_link_libraries(retrace_test_conf PRIVATE
+    retrace_core
+    retrace_config_json
+    retrace_backends
+    ${_unit_backend_lib}
+    retrace_preload_common
+    retrace_headers
+    ${CMAKE_DL_LIBS}
+    Threads::Threads)
+
+target_include_directories(retrace_test_conf PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/core
+    ${CMAKE_SOURCE_DIR}/src/backends
+    ${CMAKE_SOURCE_DIR}/src/config/json
+    ${_unit_arch_include})
+
+if(RETRACE_PLATFORM_LINUX OR RETRACE_PLATFORM_FREEBSD)
+    target_compile_definitions(retrace_test_conf PRIVATE _GNU_SOURCE _DEFAULT_SOURCE)
+elseif(RETRACE_PLATFORM_DARWIN)
+    target_compile_definitions(retrace_test_conf PRIVATE _DARWIN_C_SOURCE)
+endif()
+
+add_test(NAME unit-test-conf
+    COMMAND retrace_test_conf)
+set_tests_properties(unit-test-conf PROPERTIES LABELS "unit")

--- a/test/unit/test_conf.c
+++ b/test/unit/test_conf.c
@@ -1,0 +1,295 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+/*
+ * Unit tests for the JSON config loader (src/config/json/conf.c).
+ *
+ * retrace_conf_init() reads RETRACE_JSON_CONFIG env var, opens
+ * the file, parses it via parson-with-comments, and stores the
+ * root JSON_Object in the global retrace_conf. If the env var
+ * is unset or the file can't be opened, falls back to the
+ * built-in default config (log_params + call_real for "*").
+ *
+ * Tests:
+ *   - default_config_used_when_no_env_var
+ *   - valid_file_with_one_script
+ *   - valid_file_with_multiple_scripts
+ *   - valid_file_with_comments
+ *   - malformed_file_returns_error
+ *   - missing_file_falls_back_to_default
+ *   - empty_intercept_scripts_array
+ *
+ * Setup: each test writes a temp file to /tmp, sets the env var,
+ * calls retrace_conf_init, asserts on retrace_conf, cleans up.
+ *
+ * Part of TODO.complete/14. Closes the last open item (json
+ * config loader) per the TODO doc.
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include "conf.h"
+#include "real_impls.h"
+#include "parson.h"
+
+static int tests_run;
+static int tests_pass;
+static int tests_fail;
+
+#define TEST(name) do { \
+	tests_run++; \
+	printf("  TEST %s ... ", #name); \
+	test_##name(); \
+	tests_pass++; \
+	printf("OK\n"); \
+} while (0)
+
+#define TEST_FILE "/tmp/retrace_conf_test.json"
+
+static void write_file(const char *path, const char *content)
+{
+	FILE *f = fopen(path, "w");
+
+	assert(f != NULL);
+	fputs(content, f);
+	fclose(f);
+}
+
+static void remove_file(const char *path)
+{
+	unlink(path);
+}
+
+static void unset_env(void)
+{
+	unsetenv("RETRACE_JSON_CONFIG");
+}
+
+static void set_env(const char *path)
+{
+	setenv("RETRACE_JSON_CONFIG", path, 1);
+}
+
+static void test_default_config_used_when_no_env_var(void)
+{
+	unset_env();
+	assert(retrace_conf_init() == 0);
+	assert(retrace_conf != NULL);
+
+	/* Default config has intercept_scripts[0].func_name == "*" */
+	{
+		JSON_Array *scripts = json_object_get_array(retrace_conf,
+			"intercept_scripts");
+
+		assert(scripts != NULL);
+		assert(json_array_get_count(scripts) == 1);
+		assert(strcmp(json_object_get_string(
+			json_array_get_object(scripts, 0), "func_name"),
+			"*") == 0);
+	}
+}
+
+static void test_valid_file_with_one_script(void)
+{
+	const char *json =
+		"{\"intercept_scripts\": ["
+		"  {\"func_name\": \"open\","
+		"   \"actions\": ["
+		"     {\"action_name\": \"log_params\"},"
+		"     {\"action_name\": \"call_real\"}"
+		"   ]}"
+		"]}";
+
+	write_file(TEST_FILE, json);
+	set_env(TEST_FILE);
+
+	assert(retrace_conf_init() == 0);
+
+	{
+		JSON_Array *scripts = json_object_get_array(retrace_conf,
+			"intercept_scripts");
+
+		assert(scripts != NULL);
+		assert(json_array_get_count(scripts) == 1);
+		assert(strcmp(json_object_get_string(
+			json_array_get_object(scripts, 0), "func_name"),
+			"open") == 0);
+
+		{
+			JSON_Array *actions = json_object_get_array(
+				json_array_get_object(scripts, 0), "actions");
+
+			assert(actions != NULL);
+			assert(json_array_get_count(actions) == 2);
+		}
+	}
+
+	remove_file(TEST_FILE);
+	unset_env();
+}
+
+static void test_valid_file_with_multiple_scripts(void)
+{
+	const char *json =
+		"{\"intercept_scripts\": ["
+		"  {\"func_name\": \"open\","
+		"   \"actions\": [{\"action_name\": \"log_params\"}]},"
+		"  {\"func_name\": \"malloc\","
+		"   \"actions\": [{\"action_name\": \"log_params\"},"
+		"                 {\"action_name\": \"call_real\"}]}"
+		"]}";
+
+	write_file(TEST_FILE, json);
+	set_env(TEST_FILE);
+
+	assert(retrace_conf_init() == 0);
+
+	{
+		JSON_Array *scripts = json_object_get_array(retrace_conf,
+			"intercept_scripts");
+
+		assert(json_array_get_count(scripts) == 2);
+		assert(strcmp(json_object_get_string(
+			json_array_get_object(scripts, 0), "func_name"),
+			"open") == 0);
+		assert(strcmp(json_object_get_string(
+			json_array_get_object(scripts, 1), "func_name"),
+			"malloc") == 0);
+	}
+
+	remove_file(TEST_FILE);
+	unset_env();
+}
+
+static void test_valid_file_with_comments(void)
+{
+	/* parson's comment-tolerant parser must accept // and /* */
+	const char *json =
+		"// top-level comment\n"
+		"{\n"
+		"  \"intercept_scripts\": [\n"
+		"    /* script for open */\n"
+		"    {\"func_name\": \"open\",\n"
+		"     \"actions\": [{\"action_name\": \"log_params\"}]}\n"
+		"  ]\n"
+		"}\n";
+
+	write_file(TEST_FILE, json);
+	set_env(TEST_FILE);
+
+	assert(retrace_conf_init() == 0);
+
+	{
+		JSON_Array *scripts = json_object_get_array(retrace_conf,
+			"intercept_scripts");
+
+		assert(json_array_get_count(scripts) == 1);
+	}
+
+	remove_file(TEST_FILE);
+	unset_env();
+}
+
+static void test_malformed_file_returns_error(void)
+{
+	const char *json = "{ this is not valid json";
+
+	write_file(TEST_FILE, json);
+	set_env(TEST_FILE);
+
+	/* retrace_conf_init returns -1 on parse failure. */
+	assert(retrace_conf_init() == -1);
+
+	remove_file(TEST_FILE);
+	unset_env();
+}
+
+static void test_missing_file_falls_back_to_default(void)
+{
+	/* Point to a path that doesn't exist; init should fall back
+	 * to the default config (returns 0, retrace_conf populated).
+	 */
+	set_env("/tmp/retrace_nonexistent_file_12345.json");
+
+	assert(retrace_conf_init() == 0);
+
+	{
+		JSON_Array *scripts = json_object_get_array(retrace_conf,
+			"intercept_scripts");
+
+		assert(scripts != NULL);
+		/* Default config: 1 wildcard script. */
+		assert(json_array_get_count(scripts) == 1);
+		assert(strcmp(json_object_get_string(
+			json_array_get_object(scripts, 0), "func_name"),
+			"*") == 0);
+	}
+
+	unset_env();
+}
+
+static void test_empty_intercept_scripts_array(void)
+{
+	const char *json = "{\"intercept_scripts\": []}";
+
+	write_file(TEST_FILE, json);
+	set_env(TEST_FILE);
+
+	assert(retrace_conf_init() == 0);
+
+	{
+		JSON_Array *scripts = json_object_get_array(retrace_conf,
+			"intercept_scripts");
+
+		assert(scripts != NULL);
+		assert(json_array_get_count(scripts) == 0);
+	}
+
+	remove_file(TEST_FILE);
+	unset_env();
+}
+
+int main(void)
+{
+	/* conf.c uses retrace_real_impls for fopen/fread/etc. */
+	retrace_real_impls.fopen = fopen;
+	retrace_real_impls.fclose = fclose;
+	retrace_real_impls.fread = fread;
+	retrace_real_impls.fseek = fseek;
+	retrace_real_impls.ftell = ftell;
+	retrace_real_impls.malloc = malloc;
+	retrace_real_impls.free = free;
+	retrace_real_impls.getenv = getenv;
+	retrace_real_impls.strcmp = strcmp;
+	retrace_real_impls.strlen = strlen;
+	retrace_real_impls.strcpy = strcpy;
+	retrace_real_impls.memset = memset;
+	retrace_real_impls.memcpy = memcpy;
+	retrace_real_impls.real_snprintf = snprintf;
+
+	printf("json config loader tests:\n");
+
+	printf("  -- default config --\n");
+	TEST(default_config_used_when_no_env_var);
+	TEST(missing_file_falls_back_to_default);
+
+	printf("  -- file parsing --\n");
+	TEST(valid_file_with_one_script);
+	TEST(valid_file_with_multiple_scripts);
+	TEST(valid_file_with_comments);
+	TEST(empty_intercept_scripts_array);
+
+	printf("  -- error paths --\n");
+	TEST(malformed_file_returns_error);
+
+	printf("\nPass: %d, Fail: %d (of %d)\n",
+		tests_pass, tests_fail, tests_run);
+	return tests_fail == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Closes the last open items on TODO.complete/13 and TODO.complete/14.

## JSON config loader tests (`test/unit/test_conf.c`)

7 tests covering `retrace_conf_init()` behavior:

**default config:**
- `default_config_used_when_no_env_var` -- no env var -> default `"*"` wildcard script
- `missing_file_falls_back_to_default` -- env var set but file missing -> default

**file parsing:**
- `valid_file_with_one_script` -- parses one func + 2 actions
- `valid_file_with_multiple_scripts` -- two scripts, both func_names readable
- `valid_file_with_comments` -- `//` and `/* */` accepted by parson
- `empty_intercept_scripts_array` -- valid empty array

**error paths:**
- `malformed_file_returns_error` -- invalid JSON -> -1

**Setup:** each test writes `/tmp/retrace_conf_test.json`, sets `RETRACE_JSON_CONFIG`, calls `retrace_conf_init`, asserts on the global `retrace_conf`, cleans up.

## Engine state machine doc (`docs/engine-state-machine.md`)

The TODO.complete/13 P2 item: a doc showing the lifecycle of a single intercepted call from the asm trampoline through the engine back to the caller.

**Sections:**
- Big picture (ASCII flow diagram with caller, trampoline, engine, actions, real libc)
- MECE module responsibilities (table: what each module owns and why it's separate)
- State machine (formal, 16 states from `ENTER` to `CLEANUP`, with the 3 phases: pre-flight / intercept body / post-intercept)
- Reentrance handling (why the guard works, why per-thread context matters)
- Failure modes (table: failure -> engine response)
- See also (cross-refs to `engine.c`, ADR-0013, `architecture.md`)

`docs/README.md` updated to list the new doc in the documentation map.

## Files

| File | Change |
|------|--------|
| `test/unit/test_conf.c` | new -- 7 tests |
| `test/unit/CMakeLists.txt` | register `unit-test-conf` |
| `docs/engine-state-machine.md` | new -- 131 LOC |
| `docs/README.md` | add new doc to documentation map |

## Test plan

- [x] `cmake --build build-rel` -- clean
- [x] `ctest --test-dir build-rel` -- 22/22 pass (integration, 20 unit, 2 property)
- [x] `ctest --test-dir build-dbg` -- 21/22 pass (only pre-existing `unit-test-printf-format` fails; unrelated)
- [ ] CI matrix green

## TODO status

**TODO.complete/13:** Substantially Complete -> Done. All 5 MECE modules extracted (engine.c, thread_context.c, reentrance_guard.c, cleanup.c, script_resolver.c, action_runner.c) plus engine state machine doc landed.

**TODO.complete/14:** Action sweep was complete (14 of 14); now also includes json config loader tests. Done.

## Related

- ADR-0013 (engine MECE split)
- PR #558 (reentrance_guard module)
- PR #559 (cleanup.c + modify_in_param_arr test)
- TODO.complete/13-engine-mece-refactor.md
- TODO.complete/14-specs-and-unit-tests.md
