### PR TITLE
test: property-based suite for v2 actions (TODO 16 P1)

### DIFF
--- a/test/property/CMakeLists.txt
+++ b/test/property/CMakeLists.txt
@@ -93,3 +93,65 @@ add_test(NAME property-sockaddr
 set_tests_properties(property-sockaddr PROPERTIES
 	LABELS "property;unit"
 	TIMEOUT 60)
+
+#
+# Property tests for v2 actions (TODO.complete/16 P1). The actions
+# are pure C functions registered by name in __retrace_acts; we look
+# them up via retrace_actions_get and call with constructed
+# ThreadContext + JSON params, mirroring test/unit/test_*.c.
+#
+if(RETRACE_PLATFORM_DARWIN)
+	set(_action_arch_include
+		${CMAKE_SOURCE_DIR}/src/backends/preload_macho/aarch64)
+	set(_action_backend_lib retrace_backend_preload_macho)
+elseif(RETRACE_PLATFORM_LINUX)
+	if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64|ARM64")
+		set(_action_arch_include
+			${CMAKE_SOURCE_DIR}/src/backends/preload_elf/aarch64)
+		set(_action_backend_lib retrace_backend_preload_elf)
+	else()
+		set(_action_arch_include
+			${CMAKE_SOURCE_DIR}/src/backends/preload_elf/x86_64)
+		set(_action_backend_lib retrace_backend_preload_elf)
+	endif()
+elseif(RETRACE_PLATFORM_FREEBSD OR RETRACE_PLATFORM_OPENBSD OR RETRACE_PLATFORM_NETBSD)
+	set(_action_arch_include
+		${CMAKE_SOURCE_DIR}/src/backends/preload_bsd/x86_64)
+	set(_action_backend_lib retrace_backend_preload_bsd)
+endif()
+
+add_executable(retrace_property_actions test_property_actions.c)
+set_target_properties(retrace_property_actions PROPERTIES
+    OUTPUT_NAME property_actions
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/test/property")
+
+target_link_libraries(retrace_property_actions PRIVATE
+    retrace_core
+    retrace_config_json
+    retrace_backends
+    ${_action_backend_lib}
+    retrace_preload_common
+    retrace_headers
+    ${CMAKE_DL_LIBS}
+    Threads::Threads)
+
+target_include_directories(retrace_property_actions PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_SOURCE_DIR}/src/core
+    ${CMAKE_SOURCE_DIR}/src/backends
+    ${CMAKE_SOURCE_DIR}/src/config/json
+    ${_action_arch_include})
+
+if(RETRACE_PLATFORM_LINUX OR RETRACE_PLATFORM_FREEBSD)
+	target_compile_definitions(retrace_property_actions PRIVATE
+		_GNU_SOURCE _DEFAULT_SOURCE)
+elseif(RETRACE_PLATFORM_DARWIN)
+	target_compile_definitions(retrace_property_actions PRIVATE
+		_DARWIN_C_SOURCE)
+endif()
+
+add_test(NAME property-actions
+    COMMAND retrace_property_actions)
+set_tests_properties(property-actions PROPERTIES
+    LABELS "property;unit"
+    TIMEOUT 60)

--- a/test/property/test_property_actions.c
+++ b/test/property/test_property_actions.c
@@ -1,0 +1,337 @@
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Property-based tests for v2 actions (TODO.complete/16 P1).
+//
+// Properties:
+//
+//   P-MODIFY-RETVAL-ROUNDTRIP     for any int N in [-2^31, 2^31),
+//                                 retval_int=N sets ctx.ret_val to N
+//
+//   P-INCOMPLETE-IO-RATE-LINEAR   for any rate R in [0.0, 1.0] and
+//                                 any retval V > 0, the new retval
+//                                 equals floor(V * R)
+//
+//   P-INCOMPLETE-IO-CLAMPED       for any rate R outside [0,1], the
+//                                 new retval equals rate=0 (R<0) or
+//                                 rate=1 (R>1)
+//
+//   P-CALL-COUNT-LIMIT-EXACT      for any limit N in [1, 100], the
+//                                 first N calls return 0 and the
+//                                 (N+1)th returns -1
+//
+//   P-FUZZING-SEED-DETERMINISTIC  for any seed S in [0, 2^32), two
+//                                 runs of (fuzzing_seed(S); sample 5
+//                                 rand() values) produce identical
+//                                 sequences
+//
+// The PRNG drives input generation. Each property runs N iterations
+// (default 1000). On failure, the harness prints the failing seed.
+//
+// Setup mirrors test/unit/test_*.c: minimal retrace_real_impls,
+// retrace_actions_init + retrace_datatypes_init for prototype lookup.
+
+#include "property_harness.h"
+#include "engine.h"
+#include "actions.h"
+#include "data_types.h"
+#include "real_impls.h"
+#include "parson.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+
+extern struct RetraceRealImpls retrace_real_impls;
+
+typedef int (*action_fn_t)(struct ThreadContext *t_ctx,
+			    const JSON_Object *action_params);
+
+static action_fn_t g_modify_retval;
+static action_fn_t g_incomplete_io;
+static action_fn_t g_call_count_limit;
+static action_fn_t g_fuzzing_seed;
+
+/* Build a ThreadContext with a single IN int param. ret_val is the
+ * "real" return value the engine would have set before actions run.
+ */
+static struct ThreadContext *build_ctx_with_retval(long ret_val)
+{
+	static struct ThreadContext ctx;
+	static struct FuncPrototype proto;
+
+	memset(&ctx, 0, sizeof(ctx));
+	memset(&proto, 0, sizeof(proto));
+	strncpy(proto.name, "prop_func", sizeof(proto.name) - 1);
+	ctx.prototype = &proto;
+	ctx.ret_val = ret_val;
+	return &ctx;
+}
+
+static struct ThreadContext *build_ctx_for_func(const char *func_name)
+{
+	static struct ThreadContext ctx;
+	static struct FuncPrototype proto;
+
+	memset(&ctx, 0, sizeof(ctx));
+	memset(&proto, 0, sizeof(proto));
+	strncpy(proto.name, func_name, sizeof(proto.name) - 1);
+	ctx.prototype = &proto;
+	return &ctx;
+}
+
+static JSON_Object *build_json_number(const char *key, double val)
+{
+	JSON_Value *root_val = json_value_init_object();
+	JSON_Object *root = json_value_get_object(root_val);
+
+	json_object_set_number(root, key, val);
+	return root;
+}
+
+/* -- Properties -- */
+
+static int prop_modify_retval_roundtrip(uint64_t seed)
+{
+	struct ret_prng prng;
+	int32_t n;
+	JSON_Object *params;
+	struct ThreadContext *ctx;
+	int rc;
+
+	ret_prng_seed(&prng, seed);
+
+	/* Generate any int32. Use the high 32 bits of one PRNG draw. */
+	n = (int32_t)ret_prng_next(&prng);
+
+	params = build_json_number("retval_int", (double)n);
+	ctx = build_ctx_with_retval(0);
+
+	rc = g_modify_retval(ctx, params);
+
+	json_value_free(json_object_get_wrapping_value(params));
+
+	if (rc != 0)
+		return 0;
+	return ctx->ret_val == (long)n ? 1 : 0;
+}
+
+static int prop_incomplete_io_rate_linear(uint64_t seed)
+{
+	struct ret_prng prng;
+	uint32_t rate_milli;
+	double rate;
+	long real_ret;
+	long expected;
+	JSON_Object *params;
+	struct ThreadContext *ctx;
+	int rc;
+
+	ret_prng_seed(&prng, seed);
+
+	/* rate in [0.000, 1.000] in 0.001 increments. */
+	rate_milli = ret_prng_u32(&prng, 1001);
+	rate = rate_milli / 1000.0;
+
+	/* real_ret in [1, 1_000_000]. */
+	real_ret = 1 + (long)ret_prng_u32(&prng, 1000000);
+
+	params = build_json_number("rate", rate);
+	ctx = build_ctx_with_retval(real_ret);
+
+	rc = g_incomplete_io(ctx, params);
+
+	json_value_free(json_object_get_wrapping_value(params));
+
+	if (rc != 0)
+		return 0;
+
+	expected = (long)(real_ret * rate);
+	return ctx->ret_val == expected ? 1 : 0;
+}
+
+static int prop_incomplete_io_clamped(uint64_t seed)
+{
+	struct ret_prng prng;
+	double rate;
+	long real_ret;
+	long expected;
+	JSON_Object *params;
+	struct ThreadContext *ctx;
+	int rc;
+	int negative_case;
+
+	ret_prng_seed(&prng, seed);
+
+	/* Pick a rate outside [0, 1]. */
+	negative_case = ret_prng_u32(&prng, 2);
+	if (negative_case) {
+		/* rate in [-1000, -0.001] */
+		rate = -((double)(1 + ret_prng_u32(&prng, 1000000))) / 1000.0;
+		expected = 0;
+	} else {
+		/* rate in [1.001, 1000.0] */
+		rate = 1.0 + ((double)(1 + ret_prng_u32(&prng, 1000000))) / 1000.0;
+		expected = real_ret;  /* clamped to 1.0 */
+	}
+
+	real_ret = 1 + (long)ret_prng_u32(&prng, 1000000);
+	expected = negative_case ? 0 : real_ret;
+
+	params = build_json_number("rate", rate);
+	ctx = build_ctx_with_retval(real_ret);
+
+	rc = g_incomplete_io(ctx, params);
+
+	json_value_free(json_object_get_wrapping_value(params));
+
+	if (rc != 0)
+		return 0;
+	return ctx->ret_val == expected ? 1 : 0;
+}
+
+static int prop_call_count_limit_exact(uint64_t seed)
+{
+	struct ret_prng prng;
+	uint32_t limit_u;
+	int limit;
+	char func_name[32];
+	JSON_Object *params;
+	struct ThreadContext *ctx;
+	int i;
+	int rc;
+
+	ret_prng_seed(&prng, seed);
+
+	/* limit in [1, 50] -- bounded so the property runs fast. */
+	limit_u = ret_prng_u32(&prng, 50);
+	limit = (int)limit_u + 1;
+
+	/* Unique name per iteration so the global counter table doesn't
+	 * collide with prior runs.
+	 */
+	snprintf(func_name, sizeof(func_name), "prop_ccl_%llu",
+		(unsigned long long)seed);
+
+	params = build_json_number("limit", (double)limit);
+
+	/* First `limit` calls must return 0. */
+	for (i = 0; i < limit; i++) {
+		ctx = build_ctx_for_func(func_name);
+		rc = g_call_count_limit(ctx, params);
+		if (rc != 0) {
+			json_value_free(json_object_get_wrapping_value(params));
+			return 0;
+		}
+	}
+
+	/* The (limit+1)th call must return -1. */
+	ctx = build_ctx_for_func(func_name);
+	rc = g_call_count_limit(ctx, params);
+
+	json_value_free(json_object_get_wrapping_value(params));
+
+	return rc == -1 ? 1 : 0;
+}
+
+static int prop_fuzzing_seed_deterministic(uint64_t seed)
+{
+	struct ret_prng prng;
+	uint32_t seed_value;
+	JSON_Object *params;
+	struct ThreadContext *ctx;
+	int seq_a[5];
+	int seq_b[5];
+	int i;
+
+	ret_prng_seed(&prng, seed);
+
+	/* seed in [0, 2^32 - 1]. */
+	seed_value = (uint32_t)ret_prng_next(&prng);
+
+	params = build_json_number("seed", (double)seed_value);
+
+	/* First sample. */
+	ctx = build_ctx_with_retval(0);
+	(void)g_fuzzing_seed(ctx, params);
+	for (i = 0; i < 5; i++)
+		seq_a[i] = rand();
+
+	/* Reset and re-sample. */
+	ctx = build_ctx_with_retval(0);
+	(void)g_fuzzing_seed(ctx, params);
+	for (i = 0; i < 5; i++)
+		seq_b[i] = rand();
+
+	json_value_free(json_object_get_wrapping_value(params));
+
+	for (i = 0; i < 5; i++)
+		if (seq_a[i] != seq_b[i])
+			return 0;
+	return 1;
+}
+
+int main(void)
+{
+	int failures = 0;
+
+	/* Minimal real_impls for parson + actions. */
+	retrace_real_impls.strcmp = strcmp;
+	retrace_real_impls.strlen = strlen;
+	retrace_real_impls.strcpy = strcpy;
+	retrace_real_impls.memset = memset;
+	retrace_real_impls.memcpy = memcpy;
+	retrace_real_impls.malloc = malloc;
+	retrace_real_impls.free = free;
+	retrace_real_impls.real_snprintf = snprintf;
+	retrace_real_impls.real_sprintf = sprintf;
+	retrace_real_impls.real_vsnprintf = vsnprintf;
+	retrace_real_impls.time = time;
+
+	retrace_actions_init();
+	retrace_datatypes_init();
+
+	g_modify_retval = retrace_actions_get("modify_return_value_int");
+	g_incomplete_io = retrace_actions_get("incomplete_io");
+	g_call_count_limit = retrace_actions_get("call_count_limit");
+	g_fuzzing_seed = retrace_actions_get("fuzzing_seed");
+
+	if (g_modify_retval == NULL || g_incomplete_io == NULL ||
+	    g_call_count_limit == NULL || g_fuzzing_seed == NULL) {
+		fprintf(stderr,
+			"[property] FAIL: action lookup incomplete\n");
+		return 1;
+	}
+
+	printf("action property tests:\n");
+
+	failures += property_run(prop_modify_retval_roundtrip,
+		"modify_retval_roundtrip",
+		RETRACE_PROPERTY_DEFAULT_ITERS, 100);
+	failures += property_run(prop_incomplete_io_rate_linear,
+		"incomplete_io_rate_linear",
+		RETRACE_PROPERTY_DEFAULT_ITERS, 100);
+	failures += property_run(prop_incomplete_io_clamped,
+		"incomplete_io_clamped",
+		RETRACE_PROPERTY_DEFAULT_ITERS, 100);
+	failures += property_run(prop_call_count_limit_exact,
+		"call_count_limit_exact",
+		50,  /* small iter count: each iter uses a unique
+		      * func_name and the action's global table caps
+		      * at MAX_TRACKED_FUNCS=64 entries. 50 keeps us
+		      * under the cap with margin.
+		      */
+		100);
+	failures += property_run(prop_fuzzing_seed_deterministic,
+		"fuzzing_seed_deterministic",
+		RETRACE_PROPERTY_DEFAULT_ITERS, 100);
+
+	if (failures == 0)
+		printf("\n[property] all action properties PASS\n");
+	else
+		printf("\n[property] %d action properties FAILED\n",
+			failures);
+
+	return failures ? 1 : 0;
+}


### PR DESCRIPTION
## Summary

Closes the last P1 item from TODO.complete/16: property tests for engine/action surfaces beyond the parson + sockaddr_inspect helpers (already shipped in PRs #552 and earlier).

## Properties

- **P-MODIFY-RETVAL-ROUNDTRIP** -- for any int32 N, `retval_int=N` sets `ctx.ret_val` to N. 1000 iters.
- **P-INCOMPLETE-IO-RATE-LINEAR** -- for any rate R in [0.000, 1.000] and any retval V > 0, new retval equals `floor(V * R)`. 1000 iters.
- **P-INCOMPLETE-IO-CLAMPED** -- for any rate R outside [0, 1], new retval equals the boundary value (0 for R<0, V for R>1). 1000 iters.
- **P-CALL-COUNT-LIMIT-EXACT** -- for any limit N in [1, 50], the first N calls return 0 and the (N+1)th returns -1. 50 iters (capped by the action's global `MAX_TRACKED_FUNCS=64` limit).
- **P-FUZZING-SEED-DETERMINISTIC** -- for any seed S in [0, 2^32), two runs of (`fuzzing_seed(S)`; sample 5 rand() values) produce identical sequences. 1000 iters.

Total: ~3050 evaluations per ctest run, completes in <1s.

## Setup

Each property:
1. Generates inputs via xorshift64 PRNG (`test/property/prng.h`)
2. Looks up the action via `retrace_actions_get()`
3. Constructs a `ThreadContext` + JSON params inline
4. Calls the action, asserts on the invariant

`call_count_limit` uses a unique func_name per iteration (`prop_ccl_<seed>`) so the global counter table tracks each iteration independently. Capped at 50 iterations because the action's `MAX_TRACKED_FUNCS` is 64 -- 50 keeps margin.

## Test plan

- [x] `cmake --build build-rel` -- clean
- [x] `ctest --test-dir build-rel` -- 23/23 pass (integration, 20 unit, 3 property)
- [x] `ctest --test-dir build-dbg` -- 22/23 pass (only pre-existing `unit-test-printf-format` fails; unrelated)
- [ ] CI matrix green

## TODO.complete/16 status

P0 + P1 done. Status of the original 13 properties proposed in the TODO doc:

- P1-P4 (config parser) -- done via parson property suite (PR landed earlier)
- P5 (log_params ordering) -- N/A (no in-process state without log capture)
- P6 (modify_return_value_int) -- P-MODIFY-RETVAL-ROUNDTRIP (this PR)
- P7 (call_count_limit) -- P-CALL-COUNT-LIMIT-EXACT (this PR)
- P8 (memory_fuzz boundary) -- covered in unit `test_memory_fuzz.c` (fail_rate=0 never fuzzes, fail_rate=1 always fuzzes)
- P9-P11 (engine) -- TBD, needs full engine harness (larger effort)
- P12-P13 (prototype walker) -- TBD, needs engine harness
- Plus P-INCOMPLETE-IO-* and P-FUZZING-SEED-* added beyond the original list

## Related

- TODO.complete/16-property-based-tests.md
- PR #552 (sockaddr_inspect property suite)
- PRs #553-#557 (action unit tests, same lookup-construct-call pattern)
