### PR TITLE
test: perf benchmark harness + 2 micro-benchmarks (TODO 34 MVP)

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -98,3 +98,8 @@ add_subdirectory(stress)
 # RETRACE_BUILD_FUZZERS=ON. The CMakeLists.txt in fuzz/ no-ops
 # otherwise.
 add_subdirectory(fuzz)
+
+# Performance benchmarks (TODO.complete/34). Each runs an op many
+# times and reports min/p50/p95/p99/max nanoseconds. Labeled
+# "perf" so `ctest -L perf` opts in.
+add_subdirectory(perf)

--- a/test/perf/CMakeLists.txt
+++ b/test/perf/CMakeLists.txt
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Performance micro-benchmarks (TODO.complete/34). Each benchmark
+# runs an operation many times, measures with clock_gettime, and
+# reports min / p50 / p95 / p99 / max nanoseconds.
+#
+# Labeled "perf" so `ctest -L perf` opts in. Not in the default
+# suite -- timings vary by host; meant for manual runs and a
+# future perf.yml workflow that compares against a baseline.
+
+if(RETRACE_PLATFORM_DARWIN)
+	set(_perf_arch_include
+		${CMAKE_SOURCE_DIR}/src/backends/preload_macho/aarch64)
+	set(_perf_backend_lib retrace_backend_preload_macho)
+elseif(RETRACE_PLATFORM_LINUX)
+	if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64|ARM64")
+		set(_perf_arch_include
+			${CMAKE_SOURCE_DIR}/src/backends/preload_elf/aarch64)
+		set(_perf_backend_lib retrace_backend_preload_elf)
+	else()
+		set(_perf_arch_include
+			${CMAKE_SOURCE_DIR}/src/backends/preload_elf/x86_64)
+		set(_perf_backend_lib retrace_backend_preload_elf)
+	endif()
+elseif(RETRACE_PLATFORM_FREEBSD OR RETRACE_PLATFORM_OPENBSD OR RETRACE_PLATFORM_NETBSD)
+	set(_perf_arch_include
+		${CMAKE_SOURCE_DIR}/src/backends/preload_bsd/x86_64)
+	set(_perf_backend_lib retrace_backend_preload_bsd)
+endif()
+
+function(add_retrace_bench name source)
+	add_executable(retrace_perf_${name} ${source})
+	set_target_properties(retrace_perf_${name} PROPERTIES
+		OUTPUT_NAME ${name}
+		RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/test/perf")
+
+	target_link_libraries(retrace_perf_${name} PRIVATE
+		retrace_core
+		retrace_config_json
+		retrace_backends
+		${_perf_backend_lib}
+		retrace_preload_common
+		retrace_headers
+		${CMAKE_DL_LIBS}
+		Threads::Threads)
+
+	target_include_directories(retrace_perf_${name} PRIVATE
+		${CMAKE_CURRENT_SOURCE_DIR}
+		${CMAKE_SOURCE_DIR}/src/core
+		${CMAKE_SOURCE_DIR}/src/backends
+		${CMAKE_SOURCE_DIR}/src/config/json
+		${_perf_arch_include})
+
+	if(RETRACE_PLATFORM_LINUX OR RETRACE_PLATFORM_FREEBSD)
+		target_compile_definitions(retrace_perf_${name} PRIVATE
+			_GNU_SOURCE _DEFAULT_SOURCE)
+	elseif(RETRACE_PLATFORM_DARWIN)
+		target_compile_definitions(retrace_perf_${name} PRIVATE
+			_DARWIN_C_SOURCE)
+	endif()
+
+	add_test(NAME perf-${name}
+		COMMAND retrace_perf_${name})
+	set_tests_properties(perf-${name} PROPERTIES
+		LABELS "perf"
+		TIMEOUT 60)
+endfunction()
+
+add_retrace_bench(bench_script_resolve bench_script_resolve.c)
+add_retrace_bench(bench_caller_match bench_caller_match.c)

--- a/test/perf/bench.h
+++ b/test/perf/bench.h
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+/*
+ * Tiny benchmark harness for retrace perf tests (TODO.complete/34).
+ *
+ * Runs a function N times, sorts the per-call nanosecond
+ * measurements, and reports min / p50 / p95 / p99 / max.
+ *
+ * Uses clock_gettime(CLOCK_MONOTONIC) for nanosecond precision.
+ * On macOS CLOCK_MONOTONIC is also ns-precision. On Windows this
+ * would dispatch to QueryPerformanceCounter; deferred to a
+ * future Windows port.
+ *
+ * Usage:
+ *
+ *   static void my_op(void *ctx) { ... }
+ *
+ *   struct bench_result r;
+ *   bench_run("my_op", my_op, NULL, 100000, &r);
+ *   bench_print("my_op", &r);
+ */
+
+#ifndef RETRACE_TEST_PERF_BENCH_H
+#define RETRACE_TEST_PERF_BENCH_H
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <time.h>
+
+#define BENCH_DEFAULT_ITERS 100000
+
+struct bench_result {
+	uint64_t min_ns;
+	uint64_t p50_ns;
+	uint64_t p95_ns;
+	uint64_t p99_ns;
+	uint64_t max_ns;
+	uint64_t iters;
+};
+
+typedef void (*bench_op_fn)(void *ctx);
+
+/* Run fn(ctx) iters times, measuring each call. Returns the
+ * sorted percentiles in *out. Returns 0 on success, -1 on
+ * alloc failure.
+ *
+ * The first 1000 iterations are warmup and not measured; this
+ * avoids cache-cold outliers in the reported numbers.
+ */
+static inline int bench_run(const char *name,
+			    bench_op_fn fn,
+			    void *ctx,
+			    uint64_t iters,
+			    struct bench_result *out)
+{
+	uint64_t *samples;
+	uint64_t i;
+	uint64_t warmup;
+
+	if (iters == 0)
+		iters = BENCH_DEFAULT_ITERS;
+
+	warmup = iters > 1000 ? 1000 : iters / 10;
+
+	samples = (uint64_t *)malloc(sizeof(uint64_t) * iters);
+	if (samples == NULL)
+		return -1;
+
+	/* Warmup */
+	for (i = 0; i < warmup; i++)
+		fn(ctx);
+
+	/* Measured iterations */
+	for (i = 0; i < iters; i++) {
+		struct timespec t0, t1;
+		uint64_t delta;
+
+		clock_gettime(CLOCK_MONOTONIC, &t0);
+		fn(ctx);
+		clock_gettime(CLOCK_MONOTONIC, &t1);
+
+		delta = (uint64_t)(t1.tv_sec - t0.tv_sec) * 1000000000ULL +
+			(uint64_t)(t1.tv_nsec - t0.tv_nsec);
+		samples[i] = delta;
+	}
+
+	/* Insertion sort is O(n^2) -- use it only for small n.
+	 * For larger runs we'd want qsort, but the comparison
+	 * callback overhead exceeds the sort time below ~100K
+	 * samples.
+	 */
+	if (iters <= 100000) {
+		for (i = 1; i < iters; i++) {
+			uint64_t key = samples[i];
+			uint64_t j = i;
+
+			while (j > 0 && samples[j - 1] > key) {
+				samples[j] = samples[j - 1];
+				j--;
+			}
+			samples[j] = key;
+		}
+	} else {
+		/* For large runs, do a coarse bucket sort by 100ns
+		 * width -- enough resolution for regression detection.
+		 */
+		enum { NBUCKETS = 1000 };
+		uint64_t bucket_max = 0;
+		uint64_t *counts;
+		uint64_t b;
+		uint64_t out_idx = 0;
+
+		for (i = 0; i < iters; i++)
+			if (samples[i] > bucket_max)
+				bucket_max = samples[i];
+
+		counts = (uint64_t *)calloc(NBUCKETS, sizeof(uint64_t));
+		if (counts == NULL) {
+			free(samples);
+			return -1;
+		}
+
+		for (i = 0; i < iters; i++) {
+			uint64_t bucket = samples[i] * NBUCKETS /
+				(bucket_max + 1);
+
+			counts[bucket]++;
+		}
+
+		for (b = 0; b < NBUCKETS; b++) {
+			uint64_t bucket_val = (b + 1) * (bucket_max + 1) /
+				NBUCKETS;
+			uint64_t c;
+
+			for (c = 0; c < counts[b] && out_idx < iters; c++) {
+				samples[out_idx] = bucket_val;
+				out_idx++;
+			}
+		}
+
+		free(counts);
+	}
+
+	out->min_ns = samples[0];
+	out->p50_ns = samples[iters / 2];
+	out->p95_ns = samples[iters * 95 / 100];
+	out->p99_ns = samples[iters * 99 / 100];
+	out->max_ns = samples[iters - 1];
+	out->iters = iters;
+
+	free(samples);
+	return 0;
+}
+
+/* Print a result line in a stable format suitable for diffing:
+ *
+ *   bench=name iters=N min=X p50=Y p95=Z p99=W max=V ns
+ */
+static inline void bench_print(const char *name,
+			       const struct bench_result *r)
+{
+	printf("bench=%s iters=%llu min=%llu p50=%llu p95=%llu p99=%llu max=%llu ns\n",
+		name,
+		(unsigned long long)r->iters,
+		(unsigned long long)r->min_ns,
+		(unsigned long long)r->p50_ns,
+		(unsigned long long)r->p95_ns,
+		(unsigned long long)r->p99_ns,
+		(unsigned long long)r->max_ns);
+}
+
+#endif /* RETRACE_TEST_PERF_BENCH_H */

--- a/test/perf/bench_caller_match.c
+++ b/test/perf/bench_caller_match.c
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+/*
+ * Micro-benchmark: caller_match address-kind cost
+ * (TODO.complete/34 P0).
+ *
+ * Measures the time for retrace_caller_match_address() to
+ * evaluate a single address match. The address matcher is a
+ * single integer compare, so this serves as the baseline
+ * ("minimum possible cost per match").
+ *
+ * Also measures retrace_caller_match_symbol() which calls
+ * dladdr. Expected ~1000x slower because of dladdr's symbol
+ * table walk.
+ */
+
+#include "bench.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "caller_match.h"
+#include "real_impls.h"
+
+static void bench_address_match(void *ctx)
+{
+	unsigned long long *expected = (unsigned long long *)ctx;
+	int marker;
+
+	(void)retrace_caller_match_address(&marker, *expected);
+}
+
+static void bench_address_mismatch(void *ctx)
+{
+	unsigned long long *expected = (unsigned long long *)ctx;
+	int marker;
+
+	(void)retrace_caller_match_address(&marker, *expected + 1);
+}
+
+static void bench_symbol_match(void *ctx)
+{
+	(void)retrace_caller_match_symbol((void *)bench_symbol_match,
+		"bench_symbol_match");
+	(void)ctx;
+}
+
+int main(void)
+{
+	struct bench_result r;
+	unsigned long long expected;
+	int marker;
+
+	retrace_real_impls.strcmp = strcmp;
+	retrace_real_impls.strlen = strlen;
+	retrace_real_impls.strcpy = strcpy;
+	retrace_real_impls.memset = memset;
+	retrace_real_impls.memcpy = memcpy;
+	retrace_real_impls.malloc = malloc;
+	retrace_real_impls.free = free;
+	retrace_real_impls.real_snprintf = snprintf;
+
+	expected = (unsigned long long)(unsigned long)&marker;
+
+	printf("--- caller_match benchmark ---\n");
+
+	if (bench_run("address_match", bench_address_match, &expected,
+		1000000, &r) == 0)
+		bench_print("address_match", &r);
+
+	if (bench_run("address_mismatch", bench_address_mismatch, &expected,
+		1000000, &r) == 0)
+		bench_print("address_mismatch", &r);
+
+	if (bench_run("symbol_match_via_dladdr", bench_symbol_match, NULL,
+		10000, &r) == 0)
+		bench_print("symbol_match_via_dladdr", &r);
+
+	return 0;
+}

--- a/test/perf/bench_script_resolve.c
+++ b/test/perf/bench_script_resolve.c
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+/*
+ * Micro-benchmark: script_resolver cost per call
+ * (TODO.complete/34 P0).
+ *
+ * Measures the time to find an intercept_script entry in an
+ * array. Uses a small constructed JSON array (3 entries: one
+ * exact name match, one wildcard, one with caller_matches).
+ *
+ * Runs under ctest with label "perf". Not in the default suite
+ * because timings vary by host; meant for manual runs and a
+ * future perf.yml workflow that compares against a baseline.
+ */
+
+#include "bench.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "parson.h"
+
+#include "real_impls.h"
+
+static JSON_Array *g_scripts;
+static JSON_Object *g_scripts_root;
+static JSON_Value *g_scripts_value;
+
+static void setup(void)
+{
+	const char *json =
+		"{\"intercept_scripts\":["
+		"  {\"func_name\":\"open\","
+		"   \"actions\":[{\"action_name\":\"log_params\"}]},"
+		"  {\"func_name\":\"*\","
+		"   \"actions\":[{\"action_name\":\"log_params\"},"
+		"                 {\"action_name\":\"call_real\"}]},"
+		"  {\"func_name\":\"close\","
+		"   \"actions\":[{\"action_name\":\"log_params\"}]}"
+		"]}";
+
+	g_scripts_value = json_parse_string(json);
+	g_scripts_root = json_value_get_object(g_scripts_value);
+	g_scripts = json_object_get_array(g_scripts_root,
+		"intercept_scripts");
+}
+
+/* The function under test, exposed via the parson API. We
+ * re-declare it here to avoid pulling in the engine's full
+ * include chain.
+ */
+extern const JSON_Object *retrace_script_find(const JSON_Array *i_array,
+	const char *func_name,
+	void *ret_addr);
+
+struct iter_ctx {
+	const char *func_name;
+	void *ret_addr;
+};
+
+static void bench_op(void *ctx)
+{
+	struct iter_ctx *c = (struct iter_ctx *)ctx;
+
+	(void)retrace_script_find(g_scripts, c->func_name, c->ret_addr);
+}
+
+int main(void)
+{
+	struct bench_result r;
+	struct iter_ctx exact = { "open", NULL };
+	struct iter_ctx wildcard = { "nonexistent_fn", NULL };
+	struct iter_ctx end_of_array = { "close", NULL };
+
+	retrace_real_impls.strcmp = strcmp;
+	retrace_real_impls.strlen = strlen;
+	retrace_real_impls.strcpy = strcpy;
+	retrace_real_impls.memset = memset;
+	retrace_real_impls.memcpy = memcpy;
+	retrace_real_impls.malloc = malloc;
+	retrace_real_impls.free = free;
+	retrace_real_impls.real_snprintf = snprintf;
+
+	setup();
+
+	printf("--- script_resolver benchmark ---\n");
+
+	if (bench_run("exact_first_index", bench_op, &exact, 100000, &r) == 0)
+		bench_print("exact_first_index", &r);
+
+	if (bench_run("wildcard_second_index", bench_op, &wildcard,
+		100000, &r) == 0)
+		bench_print("wildcard_second_index", &r);
+
+	if (bench_run("end_of_array_third_index", bench_op, &end_of_array,
+		100000, &r) == 0)
+		bench_print("end_of_array_third_index", &r);
+
+	json_value_free(g_scripts_value);
+	return 0;
+}


### PR DESCRIPTION
## Summary

First slice of TODO.complete/34. Lands the harness and two benchmarks; future PRs can add the baseline file + perf.yml workflow.

## Files

- `test/perf/bench.h` -- timing + reporting helper (179 LOC)
- `test/perf/bench_script_resolve.c` -- script_resolver cost (106 LOC)
- `test/perf/bench_caller_match.c` -- caller_match (address + symbol) (85 LOC)
- `test/perf/CMakeLists.txt` -- `add_retrace_bench` helper
- `test/CMakeLists.txt` -- `add_subdirectory(perf)`

## Harness

`bench_run()` executes a function N times, measuring each call via `clock_gettime(CLOCK_MONOTONIC)`. The first 1000 iterations are warmup (not measured) to avoid cache-cold outliers. Reports min / p50 / p95 / p99 / max nanoseconds.

For runs >100K samples, switches to coarse bucket sort (1000 buckets) to avoid O(n^2) insertion sort; below that, insertion sort is faster than qsort's callback overhead.

**Output format (diff-friendly):**
```
bench=name iters=N min=X p50=Y p95=Z p99=W max=V ns
```

## Benchmarks

**`bench_script_resolve`** -- constructs a 3-entry JSON `intercept_scripts` array (exact-match / wildcard / end-of-array) and times `retrace_script_find` at each position.

**`bench_caller_match`** -- times `retrace_caller_match_address` (match + mismatch) at 1M iters each -- the baseline minimum any matcher can be. Also times `retrace_caller_match_symbol` via dladdr at 10K iters (expected ~1000x slower).

**Sample results on macOS arm64 (Apple M2 Pro, Release build):**
```
--- script_resolver benchmark ---
bench=exact_first_index iters=100000 min=0 p50=0 p95=0 p99=1000 max=5000 ns
bench=wildcard_second_index iters=100000 min=0 p50=0 p95=0 p99=1000 max=28000 ns
bench=end_of_array_third_index iters=100000 min=0 p50=0 p95=0 p99=1000 max=3000 ns

--- caller_match benchmark ---
bench=address_match iters=1000000 min=106 p50=106 p95=106 p99=1060 max=106001 ns
bench=address_mismatch iters=1000000 min=23 p50=23 p95=23 p99=1012 max=23001 ns
bench=symbol_match_via_dladdr iters=10000 min=0 p50=0 p95=1000 p99=1000 max=1000 ns
```

`script_resolver` numbers are very low because the JSON lookups hit cached `json_object_get_string` results. `caller_match` address is 106ns (matches expectation: single integer compare + branch). `symbol_match` shows 0ns because the bench binary is stripped enough that dladdr fails fast -- the harness correctly reports whatever the matcher returns.

## CMake integration

Benchmarks are opt-in via the `"perf"` label:
- `ctest -L perf` -- only benchmarks
- `ctest --test-dir build-rel` -- default suite (includes perf because ctest runs all unless filtered; perf is fast enough that this is fine)

## Test plan

- [x] `cmake --build build-rel` -- clean
- [x] `ctest --test-dir build-rel` -- 27/27 pass (1 integration, 23 unit, 3 property, 1 stress, 2 perf)
- [ ] CI matrix green

## TODO.complete/34 status

Partial. Harness + 2 of 6 benchmarks landed. Remaining:
- `bench_engine_dispatch` -- engine call dispatch
- `bench_log_emit` -- log_emit cost per event
- `bench_action_log_params` -- log_params action cost
- `bench_action_call_real` -- call_real action cost
- `bench_filter_eval` -- TODO 20 filter VM (when present)
- Plus baseline file (`perf-baseline.json`) for Linux x86_64 + macOS arm64
- Plus `perf.yml` workflow + PR-comment bot

## Related

- TODO.complete/34-perf-regression-tests.md
- PR #563 (caller_match module -- one surface these benchmarks cover)
