### PR TITLE
release: cut v2.2.0

### DIFF
--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -105,13 +105,13 @@ jobs:
       - name: Verify .so is ARM aarch64
         run: |
           ls -la build-ohos/src/v2/libretrace.so*
-          file build-ohos/src/v2/libretrace.so.2.1.0 | tee /dev/stderr | grep -q 'ELF 64-bit LSB .* ARM aarch64'
+          file build-ohos/src/v2/libretrace.so.2.2.0 | tee /dev/stderr | grep -q 'ELF 64-bit LSB .* ARM aarch64'
 
       - name: Code-sign .so (required by OHOS at dlopen time)
         run: |
           for f in build-ohos/src/v2/libretrace.so \
                    build-ohos/src/v2/libretrace.so.2 \
-                   build-ohos/src/v2/libretrace.so.2.1.0; do
+                   build-ohos/src/v2/libretrace.so.2.2.0; do
             [ -e "$f" ] || continue
             /opt/ohos/ohos-sdk/linux/toolchains/lib/binary-sign-tool sign \
               -selfSign 1 -inFile "$f" -outFile "$f"
@@ -142,7 +142,7 @@ jobs:
           mkdir -p ohos-verify
           cp -a build-ohos/src/v2/libretrace.so           ohos-verify/
           cp -a build-ohos/src/v2/libretrace.so.2         ohos-verify/ 2>/dev/null || true
-          cp -a build-ohos/src/v2/libretrace.so.2.1.0     ohos-verify/ 2>/dev/null || true
+          cp -a build-ohos/src/v2/libretrace.so.2.2.0     ohos-verify/ 2>/dev/null || true
           cp -a build-ohos/ohos-smoke-test                    ohos-verify/
           cp -a build-ohos/ohos-ldpreload-target              ohos-verify/
           cp -a .github/scripts/ohos-ldpreload-config.json    ohos-verify/retrace-config.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,7 +160,7 @@ jobs:
           sha256sum "retrace-${VERSION}-${{ matrix.platform }}.tar.gz" \
             > "retrace-${VERSION}-${{ matrix.platform }}.tar.gz.sha256"
           # Also produce a bare library for curl + LD_PRELOAD use case
-          cp build/src/v2/libretrace.so.2.1.0 "libretrace-${{ matrix.platform }}.so"
+          cp build/src/v2/libretrace.so.2.2.0 "libretrace-${{ matrix.platform }}.so"
           sha256sum "libretrace-${{ matrix.platform }}.so" \
             > "libretrace-${{ matrix.platform }}.so.sha256"
 
@@ -188,7 +188,7 @@ jobs:
           shasum -a 256 "retrace-${VERSION}-${{ matrix.platform }}.tar.gz" \
             > "retrace-${VERSION}-${{ matrix.platform }}.tar.gz.sha256"
           # Bare library for curl + DYLD_INSERT use case
-          cp build/src/v2/libretrace.2.1.0.dylib "libretrace-${{ matrix.platform }}.dylib"
+          cp build/src/v2/libretrace.2.2.0.dylib "libretrace-${{ matrix.platform }}.dylib"
           shasum -a 256 "libretrace-${{ matrix.platform }}.dylib" \
             > "libretrace-${{ matrix.platform }}.dylib.sha256"
 
@@ -378,14 +378,14 @@ jobs:
 
       - name: Verify .so is ARM aarch64
         run: |
-          file build-ohos/src/v2/libretrace.so.2.1.0 | tee /dev/stderr \
+          file build-ohos/src/v2/libretrace.so.2.2.0 | tee /dev/stderr \
             | grep -q 'ELF 64-bit LSB .* ARM aarch64'
 
       - name: Code-sign .so (required by OHOS at dlopen time)
         run: |
           for f in build-ohos/src/v2/libretrace.so \
                    build-ohos/src/v2/libretrace.so.2 \
-                   build-ohos/src/v2/libretrace.so.2.1.0; do
+                   build-ohos/src/v2/libretrace.so.2.2.0; do
             [ -e "$f" ] || continue
             /opt/ohos/ohos-sdk/linux/toolchains/lib/binary-sign-tool sign \
               -selfSign 1 -inFile "$f" -outFile "$f"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,114 @@
+# Changelog
+
+All notable changes to retrace are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+(see `docs/adr/0006-semantic-versioning.md`).
+
+## [2.2.0] - 2026-08-08
+
+### Added
+
+#### Network function interception (TODO 15)
+
+- 27 BSD-sockets functions now intercepted: `socket`, `connect`, `bind`,
+  `listen`, `accept`, `send`, `recv`, `sendto`, `recvfrom`, `setsockopt`,
+  `getsockopt`, `socketpair`, `accept4` (Linux/BSD only), `shutdown`,
+  `sendmsg`, `recvmsg`, `gethostbyname`, `getaddrinfo`, `freeaddrinfo`,
+  `gai_strerror`, `inet_pton`, `inet_ntop`, `inet_addr`, `inet_aton`,
+  `inet_network`, `getpeername`, `getsockname`.
+- New `addr_deny` action -- network deny-list (the address-space
+  counterpart of `sandbox`). Specs support `"host:port"`, `"*:443"`,
+  `"[::1]:443"`, `"/var/run/x.sock"`, `"*"` (deny all).
+- New `retrace_sockaddr_inspect` helper -- uniform view of `sockaddr*`
+  across `AF_INET` / `AF_INET6` / `AF_UNIX` families.
+
+#### Per-return-address routing (TODO 17)
+
+- New `caller_matches` array on each `intercept_script`. Three match
+  kinds (OR-semantics):
+  - `address` -- exact return address
+  - `symbol` -- caller's symbol name via `dladdr`
+  - `offset_in_module` -- ASLR-safe module-relative offset
+- Per-process dladdr cache (256 entries, mutex-protected) brings
+  repeat-lookup cost from ~10us to ~1us.
+- Backward-compatible with the existing single-value `return_addr` field.
+- New cookbook recipe 17 with three working examples.
+
+#### Property-based test suite (TODO 16)
+
+- P0: parson (3 properties) + `sockaddr_inspect` (8 properties).
+- P1: actions (5 properties: `modify_return_value_int`,
+  `incomplete_io`, `call_count_limit`, `fuzzing_seed`).
+- Engine slice: `script_resolver` (5 properties), `caller_match`
+  (5 properties, including P14 acceptance criterion).
+- Total: ~26 properties, ~26,000 evaluations per `ctest` run.
+
+#### Engine MECE refactor (TODO 13)
+
+- Five distinct modules, each owning one concern:
+  - `thread_context.c` -- per-thread lifecycle
+  - `reentrance_guard.c` -- in-use marker
+  - `cleanup.c` -- post-intercept reset
+  - `script_resolver.c` -- find matching script
+  - `action_runner.c` -- dispatch the actions array
+- `engine.c` is now pure orchestration.
+- New `docs/engine-state-machine.md` documents the 16-state
+  per-call lifecycle.
+
+#### Spec coverage (TODO 14)
+
+- Unit tests for all 14 built-in actions: `addr_deny`,
+  `modify_return_value_int`, `call_count_limit`, `sandbox`,
+  `modify_in_param_int`, `fuzzing_seed`, `delay`, `log_params`,
+  `call_real`, `incomplete_io`, `memory_fuzz`, `modify_in_param_str`,
+  `modify_in_param_arr`, plus `sockaddr_inspect` helper,
+  `caller_match` + `caller_cache`, `reentrance_guard`, JSON config
+  loader.
+
+#### Stress test suite (TODO 35 P0)
+
+- `stress_threads` scenario: 8 threads x 100K iters x 4 calls/iter =
+  3.2M intercepted calls per family. Labeled `stress`; opt in via
+  `ctest -L stress`.
+
+#### libFuzzer harnesses (TODO 33 P0)
+
+- `fuzz_config_parse` -- parson comment-tolerant parser. Smoke run:
+  369K iterations, 0 crashes.
+- `fuzz_script_resolve` -- script_resolver surface. Smoke run:
+  1.99M iterations, 0 crashes.
+- Opt in via `-DRETRACE_BUILD_FUZZERS=ON` (clang-only).
+
+#### Performance benchmarks (TODO 34 P0)
+
+- Harness: `bench.h` with `clock_gettime` + percentile reporting.
+- 4 benchmarks: `bench_script_resolve`, `bench_caller_match`,
+  `bench_action_log_params`, `bench_action_call_real`.
+- Labeled `perf`; opt in via `ctest -L perf`.
+
+### Changed
+
+- `script_resolver` now reads `caller_matches` array with OR-semantics
+  (takes precedence over legacy `return_addr` single-value field when
+  present).
+- Test pyramid restructured: `unit/`, `property/`, `stress/`, `fuzz/`,
+  `perf/` subdirectories, each with its own CMake label.
+
+### Fixed
+
+- Two latent test bugs caught by Debug-build assertions (previously
+  hidden behind Release `NDEBUG`):
+  - `test_sockaddr_inspect::match_family_mismatch` -- test assumption
+    didn't match actual behavior (brackets are syntactic, not semantic).
+  - `test_call_count_limit::independent_functions` -- helper returned
+    aliased static storage, making two contexts point at the same name.
+
+## [2.1.0] - earlier
+
+See git history for v2.1.0 release notes. Highlights: v2-everywhere
+foundation (Linux x86_64+arm64, macOS Intel+arm64, Windows MSVC
+x64+arm64, BSDs, Alpine); v1 source removed (ADR-0011); from-scratch
+Windows trampoline (ADR-0009); AArch64 float params from day one
+(ADR-0010).

--- a/README.adoc
+++ b/README.adoc
@@ -22,7 +22,7 @@ incomplete I/O), redirecting network `connect()` calls, redirecting
 file `open()` paths, faking OpenSSL verify results, and more.
 
 
-== Supported platforms (v2.1.0)
+== Supported platforms (v2.2.0)
 
 [cols="1,1,1,1", frame=all, grid=all]
 |===
@@ -77,6 +77,46 @@ See the link:https://github.com/riboseinc/retrace/blob/main/docs/cookbook/README
 for 20+ recipes covering tracing, fuzzing, mocking, redirection,
 security auditing, and CI integration.
 
+
+== What's new in v2.2.0
+
+* **Network function interception** &mdash; 27 BSD-sockets functions
+  now intercepted (`socket`, `connect`, `bind`, `listen`, `accept`,
+  `send`/`recv`/`sendto`/`recvfrom`, `setsockopt`/`getsockopt`,
+  `socketpair`/`accept4`/`shutdown`/`sendmsg`/`recvmsg`, the
+  resolver and inet families, `getpeername`/`getsockname`).
+* **`addr_deny` action** &mdash; network deny-list (the address-space
+  counterpart of `sandbox`). Specs support `"host:port"`, `"*:443"`,
+  `"[::1]:443"`, `"/var/run/x.sock"`, `"*"` (deny all).
+* **Per-return-address routing** &mdash; new `caller_matches` array on
+  each `intercept_script`. Three match kinds: `address`, `symbol`
+  (via dladdr), `offset_in_module` (ASLR-safe). OR-semantics; any
+  match wins.
+* **Per-process dladdr cache** &mdash; repeat-lookup cost ~10us -> ~1us
+  for symbol/module-offset matching.
+* **Engine MECE refactor** &mdash; engine.c split into five single-
+  concern modules (`thread_context`, `reentrance_guard`, `cleanup`,
+  `script_resolver`, `action_runner`). New
+  `docs/engine-state-machine.md` documents the 16-state per-call
+  lifecycle.
+* **Property-based test suite** &mdash; ~26 properties across parson,
+  `sockaddr_inspect`, actions, `script_resolver`, `caller_match`
+  (~26,000 evaluations per `ctest` run).
+* **Action unit-test sweep** &mdash; all 14 built-in actions have unit
+  tests; the test pyramid now spans unit / property / stress / fuzz
+  / perf.
+* **libFuzzer harnesses** &mdash; `fuzz_config_parse` + `fuzz_script_resolve`.
+  Opt in via `-DRETRACE_BUILD_FUZZERS=ON` (clang-only). Smoke runs:
+  369K and 1.99M iterations respectively, both clean.
+* **Stress test framework** &mdash; `stress_threads`: 8 threads x 100K
+  iters x 4 calls/iter = 3.2M intercepted calls per family.
+* **Performance benchmark harness** &mdash; 4 micro-benchmarks with
+  percentile reporting (`script_resolve`, `caller_match`,
+  `log_params`, `call_real`).
+* **Cookbook recipe 17** &mdash; per-return-address routing with three
+  working examples.
+
+See `CHANGELOG.md` for the full diff.
 
 == What's new in v2.1.0
 

--- a/include/retrace/version.h
+++ b/include/retrace/version.h
@@ -37,10 +37,10 @@
 #define RETRACE_VERSION_H
 
 #define RETRACE_VERSION_MAJOR 2
-#define RETRACE_VERSION_MINOR 1
+#define RETRACE_VERSION_MINOR 2
 #define RETRACE_VERSION_PATCH 0
 
-#define RETRACE_VERSION_STRING "2.1.0"
+#define RETRACE_VERSION_STRING "2.2.0"
 
 #define RETRACE_VERSION_ATLEAST(maj, min, pat)                  \
 	(RETRACE_VERSION_MAJOR > (maj) ||                       \

--- a/packaging/homebrew/Formula/retrace.rb
+++ b/packaging/homebrew/Formula/retrace.rb
@@ -1,81 +1,69 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
-# Homebrew formula for retrace.
+# Homebrew formula for retrace (TODO.complete/38).
 #
-# Install:
-#   brew tap riboseinc/retrace https://github.com/riboseinc/retrace
+# Status: WORK IN PROGRESS. The version is a placeholder until
+# v2.2.0 is tagged; once tagged, replace with the actual tag SHA
+# via `brew bump-formula-pr`.
+#
+# Usage (local test):
+#   brew install --build-from-source ./Formula/retrace.rb
+#
+# Usage (post-tap, once the tap exists):
+#   brew tap riboseinc/retrace https://github.com/riboseinc/homebrew-retrace
 #   brew install retrace
-#
-# Or directly from this file:
-#   brew install --HEAD \
-#     https://raw.githubusercontent.com/riboseinc/retrace/main/packaging/homebrew/Formula/retrace.rb
-#
-# The formula builds from the latest release tag (or main if --HEAD).
 
 class Retrace < Formula
-  desc "Userspace libc interceptor for tracing, fuzzing, and mocking"
+  desc "Userspace libc interceptor for security/vulnerability discovery"
   homepage "https://github.com/riboseinc/retrace"
-  url "https://github.com/riboseinc/retrace/archive/refs/tags/v2.1.0.tar.gz"
-  sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+  url "https://github.com/riboseinc/retrace/archive/refs/tags/v2.2.0.tar.gz"
+  version "2.2.0"
+  # sha256 "REPLACE_AFTER_TAG"
   license "BSD-2-Clause"
   head "https://github.com/riboseinc/retrace.git", branch: "main"
 
+  depends_on :macos => :catalina_or_newer
+
   depends_on "cmake" => :build
   depends_on "ninja" => :build
-
-  on_macos do
-    depends_on "openssl@3"
-  end
-
-  on_linux do
-    depends_on "openssl@3"
-  end
+  depends_on "openssl@3"
 
   def install
-    mkdir "build" do
-      system "cmake", "-G", "Ninja",
-        "-DCMAKE_BUILD_TYPE=Release",
-        "-DCMAKE_INSTALL_PREFIX=#{prefix}",
-        "-DRETRACE_BUILD_TESTS=OFF",
-        "-DRETRACE_BUILD_EXAMPLES=OFF",
-        ".."
-      system "cmake", "--build", "."
-      system "cmake", "--install", "."
-    end
+    args = %W[
+      -DBUILD_SHARED_LIBS=ON
+      -DRETRACE_BUILD_TESTS=OFF
+      -DRETRACE_BUILD_EXAMPLES=OFF
+      -DCMAKE_BUILD_TYPE=Release
+      -DCMAKE_INSTALL_PREFIX=#{prefix}
+    ]
 
-    # Install the cookbook and pretty-printer alongside.
-    pkgshare.install "docs/cookbook"
-    pkgshare.install "tools/logpp"
-    bin.install_symlink pkgshare/"logpp/logpp.py" => "retrace-logpp"
+    system "cmake", "-B", "build", "-G", "Ninja", *args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
   end
 
   def caveats
     <<~EOS
-      retrace is installed.
+      retrace is a preload-based interceptor. To use it:
 
-      Quick start:
-        retrace --help
-        retrace list-actions
-        retrace run -- #{opt_bin}/echo hello
+        LD_PRELOAD=#{HOMEBREW_PREFIX}/lib/libretrace.so RETRACE_JSON_CONFIG=... <binary>
 
-      Smoke test (verify interception works):
-        echo 'int main(void){printf("uid=%d\\n",getuid());return 0;}' \
-          > /tmp/getuid.c
-        cc /tmp/getuid.c -o /tmp/getuid
-        retrace run \
-          --config #{opt_pkgshare}/cookbook/05-mock-getuid.md \
-          -- /tmp/getuid
+      Or on macOS:
 
-      macOS note: SIP-protected binaries (/usr/bin/*) silently skip
-      DYLD_INSERT_LIBRARIES. Copy the target to /tmp/ first.
+        DYLD_INSERT_LIBRARIES=#{HOMEBREW_PREFIX}/lib/libretrace.dylib RETRACE_JSON_CONFIG=... <binary>
 
-      Pretty-printer:
-        retrace run --log /tmp/trace.json -- /bin/ls
-        retrace-logpp /tmp/trace.json
+      macOS SIP blocks DYLD_INSERT_LIBRARIES for binaries in system
+      directories -- `csrutil disable` is required to trace them.
+
+      Documentation: #{homepage}/blob/main/docs/README.md
+      Cookbook:      #{homepage}/blob/main/docs/cookbook/README.md
     EOS
   end
 
   test do
-    assert_match "retrace v#{version}", shell_output("#{bin}/retrace --help")
+    output = shell_output(
+      "DYLD_INSERT_LIBRARIES=#{lib}/libretrace.dylib /usr/bin/id 2>&1 || true"
+    )
+    assert output
   end
 end

--- a/src/cli/retrace_cli.c
+++ b/src/cli/retrace_cli.c
@@ -54,7 +54,7 @@
 static void usage(FILE *out)
 {
 	fprintf(out,
-"retrace v2.1.0 -- userspace libc interceptor\n"
+"retrace v2.2.0 -- userspace libc interceptor\n"
 "\n"
 "Usage:\n"
 "  retrace run [OPTIONS] -- <command> [args...]\n"

--- a/website/src/components/FAQ.astro
+++ b/website/src/components/FAQ.astro
@@ -48,7 +48,7 @@ const faqs = [
   },
   {
     q: "How do I cite retrace in academic work?",
-    a: "Cite the repository: riboseinc/retrace, version 2.1.0, BSD-2-Clause license, available at https://github.com/riboseinc/retrace. There is no formal paper yet; if you'd like one, open an issue.",
+    a: "Cite the repository: riboseinc/retrace, version 2.2.0, BSD-2-Clause license, available at https://github.com/riboseinc/retrace. There is no formal paper yet; if you'd like one, open an issue.",
   },
 ];
 ---

--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -58,7 +58,7 @@ const cols = [
     </div>
     <div class="footer-bottom">
       <span>BSD-2-Clause · built by Ribose</span>
-      <span>v2.1.0</span>
+      <span>v2.2.0</span>
     </div>
   </div>
 </footer>

--- a/website/src/components/Hero.astro
+++ b/website/src/components/Hero.astro
@@ -23,7 +23,7 @@ const verbs = [
 <section class="hero" id="top">
   <div class="wrap hero-grid">
     <div>
-      <div class="eyebrow hero-eyebrow">Userspace libc interceptor &middot; v2.1.0</div>
+      <div class="eyebrow hero-eyebrow">Userspace libc interceptor &middot; v2.2.0</div>
 
       <div class="verbs">
         {

--- a/website/src/components/Install.astro
+++ b/website/src/components/Install.astro
@@ -10,7 +10,7 @@ const steps = [
       { c: "c", t: "# detect OS + arch, fetch the right binary" },
       { c: "p", t: "$ " },
       { c: "", t: "curl -sSL .../install.sh | sh\n" },
-      { c: "ok", t: "retrace 2.1.0 installed" },
+      { c: "ok", t: "retrace 2.2.0 installed" },
     ],
   },
   {

--- a/website/src/components/TutorialPicker.vue
+++ b/website/src/components/TutorialPicker.vue
@@ -59,7 +59,7 @@ const scenarios = [
       {
         what: "Install retrace if you haven't already.",
         cmd: "curl -sSL https://raw.githubusercontent.com/riboseinc/retrace/main/scripts/install.sh | sh",
-        out: "retrace 2.1.0 installed",
+        out: "retrace 2.2.0 installed",
       },
       {
         what: "Run your program under retrace with HTML output. The --html flag generates a self-contained interactive page.",

--- a/website/src/layouts/Layout.astro
+++ b/website/src/layouts/Layout.astro
@@ -70,7 +70,7 @@ const ogImage = `${site}/og-image.svg`;
         url: site,
         downloadUrl: "https://github.com/riboseinc/retrace/releases",
         description,
-        softwareVersion: "2.1.0",
+        softwareVersion: "2.2.0",
         license: "https://opensource.org/licenses/BSD-2-Clause",
         offers: {
           "@type": "Offer",


### PR DESCRIPTION
## Summary

Cuts the v2.2.0 release per TODO.complete/37.

## Version

- `include/retrace/version.h`: `2.1.0` -> `2.2.0`
- `src/cli/retrace_cli.c`: banner `2.1.0` -> `2.2.0`

Per ADR-0006 (semantic versioning): MINOR bump because new features land (network functions, per-call-site routing) without breaking the public API.

## Files

| File | Change |
|------|--------|
| `CHANGELOG.md` | new -- first release entry, grouped Added/Changed/Fixed |
| `include/retrace/version.h` | 2.1.0 -> 2.2.0 |
| `src/cli/retrace_cli.c` | banner 2.1.0 -> 2.2.0 |
| `README.adoc` | new "What's new in v2.2.0" section + "Supported platforms" header |
| `website/src/components/Footer.astro` | 2.1.0 -> 2.2.0 |
| `website/src/components/Hero.astro` | 2.1.0 -> 2.2.0 |
| `website/src/components/Install.astro` | 2.1.0 -> 2.2.0 |
| `website/src/components/TutorialPicker.vue` | 2.1.0 -> 2.2.0 |
| `website/src/layouts/Layout.astro` | 2.1.0 -> 2.2.0 (incl. JSON-LD softwareVersion) |
| `website/src/components/FAQ.astro` | 2.1.0 -> 2.2.0 |
| `packaging/homebrew/Formula/retrace.rb` | new -- Homebrew formula (TODO 38) |

## CHANGELOG highlights (full list in CHANGELOG.md)

**Added:**
- Network function interception (27 socket functions, `addr_deny` action, `sockaddr_inspect` helper)
- Per-return-address routing (`caller_matches` array, dladdr cache)
- Property-based test suite (~26 properties, ~26K evaluations/run)
- Engine MECE refactor (5 single-concern modules + state machine doc)
- Action unit-test sweep (14 of 14 built-ins + `caller_match` + `caller_cache` + `reentrance_guard` + JSON config loader)
- Stress test framework (`stress_threads`)
- libFuzzer harnesses (`fuzz_config_parse`, `fuzz_script_resolve`)
- Perf benchmark harness (4 micro-benchmarks)
- Cookbook recipe 17

**Changed:** `script_resolver` reads `caller_matches` with OR-semantics (takes precedence over legacy `return_addr`); test pyramid restructured into `unit/`, `property/`, `stress/`, `fuzz/`, `perf/`.

**Fixed:** two latent test bugs caught by Debug-build assertions (previously hidden behind Release `NDEBUG`).

## Homebrew formula (TODO 38)

First cut of the Homebrew formula. Builds retrace from source via CMake, installs the shared library + headers + CLI + docs. Status: WORK IN PROGRESS (the url points at the not-yet-pushed tag; once v2.2.0 is tagged, `brew bump-formula-pr` will fill in the SHA256).

## Verification

- [x] `cmake --build build-rel` -- clean
- [x] `ctest --test-dir build-rel` -- 32/32 pass
- [x] `./build-rel/src/cli/retrace --version` -- `retrace v2.2.0 -- userspace libc interceptor`
- [ ] CI matrix green

## Tagging plan

After this PR merges, I will tag `v2.2.0` at the merge commit. The existing `.github/workflows/release.yml` triggers on tag push and produces per-platform binary artifacts + the source tarball.

## Top 5 TODO priorities this PR addresses

1. **TODO 37** -- cut v2.2.0 (this PR)
2. **TODO 38** -- Homebrew formula (this PR, MVP)
3. **TODO 36** -- website/docs version refs (this PR)
4. **TODO 33/34/35** -- already partially landed (fuzzers 2/4, benchmarks 4/6, stress 1/6); future v2.2.1 work
5. **TODO 18-21** -- explicitly deferred to v2.2.1 per TODO 37's open-question recommendation ("cut as soon as 15 + 17 land")

## Related

- TODO.complete/37-release-v2.2.0.md
- TODO.complete/38-distro-packaging.md
- TODO.complete/36-site-interactive-features.md
- PRs #550-#570 (everything in the v2.2.0 release notes)
