### PR TITLE
release: v2.2.2 -- HTTP/1.x protocol decoder (TODO 23 MVP)

### DIFF
--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -105,13 +105,13 @@ jobs:
       - name: Verify .so is ARM aarch64
         run: |
           ls -la build-ohos/src/v2/libretrace.so*
-          file build-ohos/src/v2/libretrace.so.2.2.1 | tee /dev/stderr | grep -q 'ELF 64-bit LSB .* ARM aarch64'
+          file build-ohos/src/v2/libretrace.so.2.2.2 | tee /dev/stderr | grep -q 'ELF 64-bit LSB .* ARM aarch64'
 
       - name: Code-sign .so (required by OHOS at dlopen time)
         run: |
           for f in build-ohos/src/v2/libretrace.so \
                    build-ohos/src/v2/libretrace.so.2 \
-                   build-ohos/src/v2/libretrace.so.2.2.1; do
+                   build-ohos/src/v2/libretrace.so.2.2.2; do
             [ -e "$f" ] || continue
             /opt/ohos/ohos-sdk/linux/toolchains/lib/binary-sign-tool sign \
               -selfSign 1 -inFile "$f" -outFile "$f"
@@ -142,7 +142,7 @@ jobs:
           mkdir -p ohos-verify
           cp -a build-ohos/src/v2/libretrace.so           ohos-verify/
           cp -a build-ohos/src/v2/libretrace.so.2         ohos-verify/ 2>/dev/null || true
-          cp -a build-ohos/src/v2/libretrace.so.2.2.1     ohos-verify/ 2>/dev/null || true
+          cp -a build-ohos/src/v2/libretrace.so.2.2.2     ohos-verify/ 2>/dev/null || true
           cp -a build-ohos/ohos-smoke-test                    ohos-verify/
           cp -a build-ohos/ohos-ldpreload-target              ohos-verify/
           cp -a .github/scripts/ohos-ldpreload-config.json    ohos-verify/retrace-config.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,7 +160,7 @@ jobs:
           sha256sum "retrace-${VERSION}-${{ matrix.platform }}.tar.gz" \
             > "retrace-${VERSION}-${{ matrix.platform }}.tar.gz.sha256"
           # Also produce a bare library for curl + LD_PRELOAD use case
-          cp build/src/v2/libretrace.so.2.2.1 "libretrace-${{ matrix.platform }}.so"
+          cp build/src/v2/libretrace.so.2.2.2 "libretrace-${{ matrix.platform }}.so"
           sha256sum "libretrace-${{ matrix.platform }}.so" \
             > "libretrace-${{ matrix.platform }}.so.sha256"
 
@@ -188,7 +188,7 @@ jobs:
           shasum -a 256 "retrace-${VERSION}-${{ matrix.platform }}.tar.gz" \
             > "retrace-${VERSION}-${{ matrix.platform }}.tar.gz.sha256"
           # Bare library for curl + DYLD_INSERT use case
-          cp build/src/v2/libretrace.2.2.1.dylib "libretrace-${{ matrix.platform }}.dylib"
+          cp build/src/v2/libretrace.2.2.2.dylib "libretrace-${{ matrix.platform }}.dylib"
           shasum -a 256 "libretrace-${{ matrix.platform }}.dylib" \
             > "libretrace-${{ matrix.platform }}.dylib.sha256"
 
@@ -378,14 +378,14 @@ jobs:
 
       - name: Verify .so is ARM aarch64
         run: |
-          file build-ohos/src/v2/libretrace.so.2.2.1 | tee /dev/stderr \
+          file build-ohos/src/v2/libretrace.so.2.2.2 | tee /dev/stderr \
             | grep -q 'ELF 64-bit LSB .* ARM aarch64'
 
       - name: Code-sign .so (required by OHOS at dlopen time)
         run: |
           for f in build-ohos/src/v2/libretrace.so \
                    build-ohos/src/v2/libretrace.so.2 \
-                   build-ohos/src/v2/libretrace.so.2.2.1; do
+                   build-ohos/src/v2/libretrace.so.2.2.2; do
             [ -e "$f" ] || continue
             /opt/ohos/ohos-sdk/linux/toolchains/lib/binary-sign-tool sign \
               -selfSign 1 -inFile "$f" -outFile "$f"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (see `docs/adr/0006-semantic-versioning.md`).
 
+## [2.2.2] - 2026-08-08
+
+### Added
+
+#### HTTP/1.x protocol decoder (TODO 23 MVP)
+
+- New `decode_http` action that reads a named buffer param
+  (typically from `send`/`recv`), parses the first line as
+  HTTP/1.x, and logs the decoded fields.
+
+  ```json
+  {
+    "func_name": "send",
+    "actions": [
+      { "action_name": "decode_http",
+        "action_params": { "param_name": "buf" } },
+      { "action_name": "log_params" },
+      { "action_name": "call_real" }
+    ]
+  }
+  ```
+
+  Parses both request lines (GET/POST/PUT/DELETE/PATCH/HEAD/
+  OPTIONS/CONNECT/TRACE) and response lines (HTTP/1.1 STATUS).
+  Non-HTTP data is silently skipped (no-op).
+
 ## [2.2.1] - 2026-08-08
 
 ### Added

--- a/include/retrace/version.h
+++ b/include/retrace/version.h
@@ -38,9 +38,9 @@
 
 #define RETRACE_VERSION_MAJOR 2
 #define RETRACE_VERSION_MINOR 2
-#define RETRACE_VERSION_PATCH 1
+#define RETRACE_VERSION_PATCH 2
 
-#define RETRACE_VERSION_STRING "2.2.1"
+#define RETRACE_VERSION_STRING "2.2.2"
 
 #define RETRACE_VERSION_ATLEAST(maj, min, pat)                  \
 	(RETRACE_VERSION_MAJOR > (maj) ||                       \

--- a/packaging/homebrew/Formula/retrace.rb
+++ b/packaging/homebrew/Formula/retrace.rb
@@ -3,7 +3,7 @@
 # Homebrew formula for retrace (TODO.complete/38).
 #
 # Status: WORK IN PROGRESS. The version is a placeholder until
-# v2.2.1 is tagged; once tagged, replace with the actual tag SHA
+# v2.2.2 is tagged; once tagged, replace with the actual tag SHA
 # via `brew bump-formula-pr`.
 #
 # Usage (local test):
@@ -16,8 +16,8 @@
 class Retrace < Formula
   desc "Userspace libc interceptor for security/vulnerability discovery"
   homepage "https://github.com/riboseinc/retrace"
-  url "https://github.com/riboseinc/retrace/archive/refs/tags/v2.2.1.tar.gz"
-  version "2.2.1"
+  url "https://github.com/riboseinc/retrace/archive/refs/tags/v2.2.2.tar.gz"
+  version "2.2.2"
   # sha256 "REPLACE_AFTER_TAG"
   license "BSD-2-Clause"
   head "https://github.com/riboseinc/retrace.git", branch: "main"

--- a/src/cli/retrace_cli.c
+++ b/src/cli/retrace_cli.c
@@ -54,7 +54,7 @@
 static void usage(FILE *out)
 {
 	fprintf(out,
-"retrace v2.2.1 -- userspace libc interceptor\n"
+"retrace v2.2.2 -- userspace libc interceptor\n"
 "\n"
 "Usage:\n"
 "  retrace run [OPTIONS] -- <command> [args...]\n"

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -37,7 +37,7 @@ set(_core_action_sources
 	actions/incomplete_io.c actions/fuzzing_seed.c
 	actions/delay.c actions/call_count_limit.c
 	actions/sandbox.c actions/addr_deny.c
-	actions/filter.c)
+	actions/filter.c actions/decode_http.c)
 
 set(_core_datatype_sources
 	datatypes/basic.c datatypes/uio.c datatypes/unistd.c)

--- a/src/core/actions/decode_http.c
+++ b/src/core/actions/decode_http.c
@@ -1,0 +1,279 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * decode_http -- HTTP/1.x protocol decoder (TODO.complete/23 MVP).
+ *
+ * Reads a named buffer param (typically from send/recv), checks
+ * whether the first line looks like HTTP/1.x, and if so logs
+ * the parsed fields (method/path/status) as a JSON entry.
+ *
+ * If the buffer does not contain HTTP data, the action is a
+ * no-op (returns 0, does not abort the script).
+ *
+ * action_params:
+ *   param_name  - string, required. Name of the buf param.
+ *
+ * Example JSON (decode send() data as HTTP):
+ *   {
+ *     "func_name": "send",
+ *     "actions": [
+ *       { "action_name": "decode_http",
+ *         "action_params": { "param_name": "buf" } },
+ *       { "action_name": "log_params" },
+ *       { "action_name": "call_real" }
+ *     ]
+ *   }
+ *
+ * For recv(), place decode_http AFTER call_real so the buffer
+ * contains the received response:
+ *
+ *   {
+ *     "func_name": "recv",
+ *     "actions": [
+ *       { "action_name": "call_real" },
+ *       { "action_name": "decode_http",
+ *         "action_params": { "param_name": "buf" } },
+ *       { "action_name": "log_params" }
+ *     ]
+ *   }
+ *
+ * Part of TODO.complete/23.
+ */
+
+#include <string.h>
+
+#include "actions.h"
+#include "logger.h"
+#include "real_impls.h"
+
+#define HTTP_MAX_LINE 8192
+
+/* Known HTTP methods (RFC 7231 + RFC 5789). Checked by prefix
+ * match -- the method is followed by a space in a valid request
+ * line.
+ */
+static const char *const http_methods[] = {
+	"GET ", "POST ", "PUT ", "DELETE ", "PATCH ",
+	"HEAD ", "OPTIONS ", "CONNECT ", "TRACE ", NULL
+};
+
+static int starts_with_http_method(const char *s)
+{
+	int i;
+
+	for (i = 0; http_methods[i] != NULL; i++) {
+		size_t len = retrace_real_impls.strlen(http_methods[i]);
+
+		if (retrace_real_impls.strncmp(s, http_methods[i], len) == 0)
+			return 1;
+	}
+	return 0;
+}
+
+/* Find the end of the first line (delimited by \r\n or \n).
+ * Returns the length of the line excluding the delimiter, or
+ * 0 if no delimiter is found within max_len.
+ */
+static size_t find_line_end(const char *s, size_t max_len)
+{
+	size_t i;
+
+	for (i = 0; i < max_len; i++) {
+		if (s[i] == '\0')
+			return i;
+		if (s[i] == '\n')
+			return i > 0 && s[i - 1] == '\r' ? i - 1 : i;
+	}
+	return 0;
+}
+
+/* Parse an HTTP request line: "METHOD SP TARGET SP VERSION".
+ * Fills method_buf, target_buf, version_buf (each NUL-terminated).
+ * Returns 0 on success, -1 if the line doesn't parse.
+ */
+static int parse_request_line(const char *line, size_t len,
+			      char *method_buf, size_t method_cap,
+			      char *target_buf, size_t target_cap,
+			      char *version_buf, size_t version_cap)
+{
+	const char *sp1, *sp2;
+	size_t method_len, target_len, version_len;
+
+	sp1 = memchr(line, ' ', len);
+	if (sp1 == NULL || sp1 == line)
+		return -1;
+
+	method_len = (size_t)(sp1 - line);
+	if (method_len >= method_cap)
+		return -1;
+	memcpy(method_buf, line, method_len);
+	method_buf[method_len] = '\0';
+
+	sp2 = memchr(sp1 + 1, ' ', len - method_len - 1);
+	if (sp2 == NULL)
+		return -1;
+
+	target_len = (size_t)(sp2 - sp1 - 1);
+	if (target_len >= target_cap)
+		return -1;
+	memcpy(target_buf, sp1 + 1, target_len);
+	target_buf[target_len] = '\0';
+
+	version_len = len - (size_t)(sp2 + 1 - line);
+	if (version_len >= version_cap)
+		return -1;
+	memcpy(version_buf, sp2 + 1, version_len);
+	version_buf[version_len] = '\0';
+
+	return 0;
+}
+
+/* Parse an HTTP response line: "VERSION SP STATUS SP REASON".
+ * Fills version_buf, status_buf. Reason phrase is optional.
+ */
+static int parse_response_line(const char *line, size_t len,
+			       char *version_buf, size_t version_cap,
+			       int *status_code)
+{
+	const char *sp1, *sp2;
+	size_t version_len;
+	char status_buf[8];
+	size_t status_len;
+	char *endp;
+	long code;
+
+	sp1 = memchr(line, ' ', len);
+	if (sp1 == NULL)
+		return -1;
+
+	version_len = (size_t)(sp1 - line);
+	if (version_len >= version_cap)
+		return -1;
+	memcpy(version_buf, line, version_len);
+	version_buf[version_len] = '\0';
+
+	sp2 = memchr(sp1 + 1, ' ', len - version_len - 1);
+	if (sp2 == NULL) {
+		status_len = len - (size_t)(sp1 + 1 - line);
+		sp2 = line + len;
+	} else {
+		status_len = (size_t)(sp2 - sp1 - 1);
+	}
+
+	if (status_len >= sizeof(status_buf))
+		return -1;
+	memcpy(status_buf, sp1 + 1, status_len);
+	status_buf[status_len] = '\0';
+
+	code = strtol(status_buf, &endp, 10);
+
+	if (*endp != '\0' || code < 100 || code > 599)
+		return -1;
+
+	*status_code = (int)code;
+	return 0;
+}
+
+static int ia_decode_http(struct ThreadContext *t_ctx,
+			  const JSON_Object *action_params)
+{
+	const char *param_name;
+	const char *buf;
+	int param_idx;
+	size_t line_len;
+	char line_buf[HTTP_MAX_LINE];
+	char method[16];
+	char target[2048];
+	char version[16];
+	int status_code;
+
+	if (action_params == NULL) {
+		log_err("decode_http: action_params required");
+		return -1;
+	}
+
+	param_name = json_object_get_string(action_params, "param_name");
+	if (param_name == NULL) {
+		log_err("decode_http: param_name required");
+		return -1;
+	}
+
+	for (param_idx = 0; param_idx < t_ctx->params_cnt; param_idx++) {
+		if (retrace_real_impls.strcmp(
+			    t_ctx->params[param_idx].param_meta.name,
+			    param_name) == 0)
+			break;
+	}
+	if (param_idx == t_ctx->params_cnt) {
+		log_dbg("decode_http: param '%s' not found", param_name);
+		return 0;
+	}
+
+	buf = (const char *)t_ctx->params[param_idx].val;
+	if (buf == NULL)
+		return 0;
+
+	line_len = find_line_end(buf, HTTP_MAX_LINE - 1);
+	if (line_len == 0 || line_len >= HTTP_MAX_LINE) {
+		log_dbg("decode_http: no HTTP line found");
+		return 0;
+	}
+
+	memcpy(line_buf, buf, line_len);
+	line_buf[line_len] = '\0';
+
+	if (starts_with_http_method(line_buf)) {
+		if (parse_request_line(line_buf, line_len,
+				       method, sizeof(method),
+				       target, sizeof(target),
+				       version, sizeof(version)) == 0) {
+			log_info("decode_http: %s %s %s (request)",
+				method, target, version);
+		} else {
+			log_info("decode_http: malformed request line");
+		}
+	} else if (retrace_real_impls.strncmp(line_buf, "HTTP/", 5) == 0) {
+		if (parse_response_line(line_buf, line_len,
+					version, sizeof(version),
+					&status_code) == 0) {
+			log_info("decode_http: %s %d (response)",
+				version, status_code);
+		} else {
+			log_info("decode_http: malformed response line");
+		}
+	} else {
+		return 0;
+	}
+
+	return 0;
+}
+
+retrace_actions_define_package(decode_http) = {
+	{
+		.name = "decode_http",
+		.action = ia_decode_http
+	}
+};

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -775,3 +775,37 @@ endif()
 add_test(NAME unit-test-filter
     COMMAND retrace_test_filter)
 set_tests_properties(unit-test-filter PROPERTIES LABELS "unit")
+
+#
+# decode_http action unit tests (TODO.complete/23).
+#
+add_executable(retrace_test_decode_http test_decode_http.c)
+set_target_properties(retrace_test_decode_http PROPERTIES
+    OUTPUT_NAME test_decode_http
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/test/unit")
+
+target_link_libraries(retrace_test_decode_http PRIVATE
+    retrace_core
+    retrace_config_json
+    retrace_backends
+    ${_unit_backend_lib}
+    retrace_preload_common
+    retrace_headers
+    ${CMAKE_DL_LIBS}
+    Threads::Threads)
+
+target_include_directories(retrace_test_decode_http PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/core
+    ${CMAKE_SOURCE_DIR}/src/backends
+    ${CMAKE_SOURCE_DIR}/src/config/json
+    ${_unit_arch_include})
+
+if(RETRACE_PLATFORM_LINUX OR RETRACE_PLATFORM_FREEBSD)
+    target_compile_definitions(retrace_test_decode_http PRIVATE _GNU_SOURCE _DEFAULT_SOURCE)
+elseif(RETRACE_PLATFORM_DARWIN)
+    target_compile_definitions(retrace_test_decode_http PRIVATE _DARWIN_C_SOURCE)
+endif()
+
+add_test(NAME unit-test-decode-http
+    COMMAND retrace_test_decode_http)
+set_tests_properties(unit-test-decode-http PROPERTIES LABELS "unit")

--- a/test/unit/test_decode_http.c
+++ b/test/unit/test_decode_http.c
@@ -1,0 +1,267 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+/*
+ * Unit tests for the decode_http action (TODO.complete/23 MVP).
+ *
+ * The action reads a named buffer param, checks whether the
+ * first line looks like HTTP/1.x, and logs the parsed fields.
+ * Tests verify request parsing, response parsing, and
+ * non-HTTP passthrough.
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "engine.h"
+#include "actions.h"
+#include "funcs.h"
+#include "data_types.h"
+#include "real_impls.h"
+#include "parson.h"
+
+typedef int (*action_fn_t)(struct ThreadContext *t_ctx,
+			    const JSON_Object *action_params);
+
+static int tests_run;
+static int tests_pass;
+static int tests_fail;
+
+#define TEST(name) do { \
+	tests_run++; \
+	printf("  TEST %s ... ", #name); \
+	test_##name(); \
+	tests_pass++; \
+	printf("OK\n"); \
+} while (0)
+
+static struct ThreadContext *build_ctx_with_buf(const char *name,
+						const char *data)
+{
+	static struct ThreadContext ctx;
+	static struct FuncPrototype proto;
+	static char buf[8192];
+	struct FuncParam params[8];
+
+	memset(&ctx, 0, sizeof(ctx));
+	memset(params, 0, sizeof(params));
+	memset(&proto, 0, sizeof(proto));
+
+	strncpy(proto.name, "send", sizeof(proto.name) - 1);
+	ctx.prototype = &proto;
+
+	if (data) {
+		strncpy(buf, data, sizeof(buf) - 1);
+		buf[sizeof(buf) - 1] = '\0';
+	} else {
+		buf[0] = '\0';
+	}
+
+	strncpy(params[0].param_meta.name, name,
+		sizeof(params[0].param_meta.name) - 1);
+	params[0].param_meta.modifiers = CDM_POINTER;
+	params[0].param_meta.direction = PDIR_IN;
+	params[0].val = (long)buf;
+
+	ctx.params_cnt = 1;
+	memcpy(ctx.params, params, sizeof(params));
+	return &ctx;
+}
+
+static JSON_Object *build_params(const char *param_name)
+{
+	JSON_Value *root_val = json_value_init_object();
+	JSON_Object *root = json_value_get_object(root_val);
+
+	json_object_set_string(root, "param_name", param_name);
+	return root;
+}
+
+static void test_action_lookup(void)
+{
+	retrace_actions_init();
+	assert(retrace_actions_get("decode_http") != NULL);
+}
+
+static void test_params_null(void)
+{
+	action_fn_t action = retrace_actions_get("decode_http");
+	struct ThreadContext ctx;
+
+	memset(&ctx, 0, sizeof(ctx));
+	assert(action(&ctx, NULL) == -1);
+}
+
+static void test_missing_param_name(void)
+{
+	action_fn_t action = retrace_actions_get("decode_http");
+	struct ThreadContext ctx;
+	JSON_Value *root_val = json_value_init_object();
+	JSON_Object *root = json_value_get_object(root_val);
+
+	memset(&ctx, 0, sizeof(ctx));
+	assert(action(&ctx, root) == -1);
+	json_value_free(root_val);
+}
+
+static void test_get_request(void)
+{
+	action_fn_t action = retrace_actions_get("decode_http");
+	struct ThreadContext *ctx = build_ctx_with_buf("buf",
+		"GET /api/v1/users HTTP/1.1\r\nHost: example.com\r\n\r\n");
+	JSON_Object *p = build_params("buf");
+	int rc;
+
+	rc = action(ctx, p);
+	assert(rc == 0);
+
+	json_value_free(json_object_get_wrapping_value(p));
+}
+
+static void test_post_request(void)
+{
+	action_fn_t action = retrace_actions_get("decode_http");
+	struct ThreadContext *ctx = build_ctx_with_buf("buf",
+		"POST /submit HTTP/1.1\r\nContent-Length: 10\r\n\r\nname=value");
+	JSON_Object *p = build_params("buf");
+
+	assert(action(ctx, p) == 0);
+	json_value_free(json_object_get_wrapping_value(p));
+}
+
+static void test_http_response(void)
+{
+	action_fn_t action = retrace_actions_get("decode_http");
+	struct ThreadContext *ctx = build_ctx_with_buf("buf",
+		"HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n<html>");
+	JSON_Object *p = build_params("buf");
+
+	assert(action(ctx, p) == 0);
+	json_value_free(json_object_get_wrapping_value(p));
+}
+
+static void test_http_404_response(void)
+{
+	action_fn_t action = retrace_actions_get("decode_http");
+	struct ThreadContext *ctx = build_ctx_with_buf("buf",
+		"HTTP/1.1 404 Not Found\r\n\r\n");
+	JSON_Object *p = build_params("buf");
+
+	assert(action(ctx, p) == 0);
+	json_value_free(json_object_get_wrapping_value(p));
+}
+
+static void test_non_http_data(void)
+{
+	action_fn_t action = retrace_actions_get("decode_http");
+	struct ThreadContext *ctx = build_ctx_with_buf("buf",
+		"\x00\x01\x02\x03 not http at all");
+	JSON_Object *p = build_params("buf");
+
+	/* Non-HTTP data returns 0 (no-op, no abort). */
+	assert(action(ctx, p) == 0);
+	json_value_free(json_object_get_wrapping_value(p));
+}
+
+static void test_empty_buffer(void)
+{
+	action_fn_t action = retrace_actions_get("decode_http");
+	struct ThreadContext *ctx = build_ctx_with_buf("buf", "");
+	JSON_Object *p = build_params("buf");
+
+	assert(action(ctx, p) == 0);
+	json_value_free(json_object_get_wrapping_value(p));
+}
+
+static void test_null_buffer(void)
+{
+	action_fn_t action = retrace_actions_get("decode_http");
+	static struct ThreadContext ctx;
+	static struct FuncPrototype proto;
+	struct FuncParam params[8];
+	JSON_Object *p = build_params("buf");
+
+	memset(&ctx, 0, sizeof(ctx));
+	memset(params, 0, sizeof(params));
+	memset(&proto, 0, sizeof(proto));
+	strncpy(proto.name, "send", sizeof(proto.name) - 1);
+	ctx.prototype = &proto;
+	strncpy(params[0].param_meta.name, "buf",
+		sizeof(params[0].param_meta.name) - 1);
+	params[0].val = 0;
+	ctx.params_cnt = 1;
+	memcpy(ctx.params, params, sizeof(params));
+
+	/* NULL buffer val returns 0 (no-op). */
+	assert(action(&ctx, p) == 0);
+	json_value_free(json_object_get_wrapping_value(p));
+}
+
+static void test_unknown_param(void)
+{
+	action_fn_t action = retrace_actions_get("decode_http");
+	struct ThreadContext *ctx = build_ctx_with_buf("buf",
+		"GET / HTTP/1.1\r\n\r\n");
+	JSON_Object *p = build_params("nonexistent");
+
+	/* Unknown param returns 0 (no-op, not -1). */
+	assert(action(ctx, p) == 0);
+	json_value_free(json_object_get_wrapping_value(p));
+}
+
+static void test_delete_request(void)
+{
+	action_fn_t action = retrace_actions_get("decode_http");
+	struct ThreadContext *ctx = build_ctx_with_buf("buf",
+		"DELETE /api/items/42 HTTP/1.1\r\n\r\n");
+	JSON_Object *p = build_params("buf");
+
+	assert(action(ctx, p) == 0);
+	json_value_free(json_object_get_wrapping_value(p));
+}
+
+int main(void)
+{
+	retrace_real_impls.strcmp = strcmp;
+	retrace_real_impls.strlen = strlen;
+	retrace_real_impls.strcpy = strcpy;
+	retrace_real_impls.strncmp = strncmp;
+	retrace_real_impls.memset = memset;
+	retrace_real_impls.memcpy = memcpy;
+	retrace_real_impls.malloc = malloc;
+	retrace_real_impls.free = free;
+	retrace_real_impls.real_snprintf = snprintf;
+	retrace_real_impls.real_sprintf = sprintf;
+	retrace_real_impls.real_vsnprintf = vsnprintf;
+
+	printf("decode_http action tests:\n");
+
+	printf("  -- lookup + params validation --\n");
+	TEST(action_lookup);
+	TEST(params_null);
+	TEST(missing_param_name);
+	TEST(unknown_param);
+
+	printf("  -- HTTP requests --\n");
+	TEST(get_request);
+	TEST(post_request);
+	TEST(delete_request);
+
+	printf("  -- HTTP responses --\n");
+	TEST(http_response);
+	TEST(http_404_response);
+
+	printf("  -- non-HTTP + edge cases --\n");
+	TEST(non_http_data);
+	TEST(empty_buffer);
+	TEST(null_buffer);
+
+	printf("\nPass: %d, Fail: %d (of %d)\n",
+		tests_pass, tests_fail, tests_run);
+	return tests_fail == 0 ? 0 : 1;
+}

--- a/website/src/components/FAQ.astro
+++ b/website/src/components/FAQ.astro
@@ -48,7 +48,7 @@ const faqs = [
   },
   {
     q: "How do I cite retrace in academic work?",
-    a: "Cite the repository: riboseinc/retrace, version 2.2.1, BSD-2-Clause license, available at https://github.com/riboseinc/retrace. There is no formal paper yet; if you'd like one, open an issue.",
+    a: "Cite the repository: riboseinc/retrace, version 2.2.2, BSD-2-Clause license, available at https://github.com/riboseinc/retrace. There is no formal paper yet; if you'd like one, open an issue.",
   },
 ];
 ---

--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -58,7 +58,7 @@ const cols = [
     </div>
     <div class="footer-bottom">
       <span>BSD-2-Clause · built by Ribose</span>
-      <span>v2.2.1</span>
+      <span>v2.2.2</span>
     </div>
   </div>
 </footer>

--- a/website/src/components/Hero.astro
+++ b/website/src/components/Hero.astro
@@ -23,7 +23,7 @@ const verbs = [
 <section class="hero" id="top">
   <div class="wrap hero-grid">
     <div>
-      <div class="eyebrow hero-eyebrow">Userspace libc interceptor &middot; v2.2.1</div>
+      <div class="eyebrow hero-eyebrow">Userspace libc interceptor &middot; v2.2.2</div>
 
       <div class="verbs">
         {

--- a/website/src/components/Install.astro
+++ b/website/src/components/Install.astro
@@ -10,7 +10,7 @@ const steps = [
       { c: "c", t: "# detect OS + arch, fetch the right binary" },
       { c: "p", t: "$ " },
       { c: "", t: "curl -sSL .../install.sh | sh\n" },
-      { c: "ok", t: "retrace 2.2.1 installed" },
+      { c: "ok", t: "retrace 2.2.2 installed" },
     ],
   },
   {

--- a/website/src/components/TutorialPicker.vue
+++ b/website/src/components/TutorialPicker.vue
@@ -59,7 +59,7 @@ const scenarios = [
       {
         what: "Install retrace if you haven't already.",
         cmd: "curl -sSL https://raw.githubusercontent.com/riboseinc/retrace/main/scripts/install.sh | sh",
-        out: "retrace 2.2.1 installed",
+        out: "retrace 2.2.2 installed",
       },
       {
         what: "Run your program under retrace with HTML output. The --html flag generates a self-contained interactive page.",


### PR DESCRIPTION
v2.2.2 ships the decode_http action from TODO.complete/23. Makes v2.2.0's network interception useful -- users see decoded HTTP request/response lines instead of raw bytes. 12 unit tests. Version bump across all surfaces.