### PR TITLE
test: 3 more stress scenarios (TODO 35)

### DIFF
--- a/test/stress/CMakeLists.txt
+++ b/test/stress/CMakeLists.txt
@@ -19,6 +19,21 @@ set_target_properties(retrace_stress_threads PROPERTIES
 
 target_link_libraries(retrace_stress_threads PRIVATE Threads::Threads)
 
+add_executable(retrace_stress_many_funcs stress_many_funcs.c)
+set_target_properties(retrace_stress_many_funcs PROPERTIES
+    OUTPUT_NAME stress_many_funcs
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/test/stress")
+
+add_executable(retrace_stress_deep_stack stress_deep_stack.c)
+set_target_properties(retrace_stress_deep_stack PROPERTIES
+    OUTPUT_NAME stress_deep_stack
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/test/stress")
+
+add_executable(retrace_stress_large_args stress_large_args.c)
+set_target_properties(retrace_stress_large_args PROPERTIES
+    OUTPUT_NAME stress_large_args
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/test/stress")
+
 # Stress scenarios are opt-in via label so `ctest -L stress` runs
 # only them. Default ctest invocation skips them.
 add_test(NAME stress-threads
@@ -26,3 +41,21 @@ add_test(NAME stress-threads
 set_tests_properties(stress-threads PROPERTIES
     LABELS "stress"
     TIMEOUT 120)
+
+add_test(NAME stress-many-funcs
+    COMMAND retrace_stress_many_funcs)
+set_tests_properties(stress-many-funcs PROPERTIES
+    LABELS "stress"
+    TIMEOUT 60)
+
+add_test(NAME stress-deep-stack
+    COMMAND retrace_stress_deep_stack)
+set_tests_properties(stress-deep-stack PROPERTIES
+    LABELS "stress"
+    TIMEOUT 60)
+
+add_test(NAME stress-large-args
+    COMMAND retrace_stress_large_args)
+set_tests_properties(stress-large-args PROPERTIES
+    LABELS "stress"
+    TIMEOUT 60)

--- a/test/stress/stress_deep_stack.c
+++ b/test/stress/stress_deep_stack.c
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+/*
+ * Stress scenario: deep call stack (TODO.complete/35 P0).
+ *
+ * A recursive function that calls libc at each level, going
+ * DEPTH levels deep. Under LD_PRELOAD, each libc call fires
+ * the trampoline + engine, stressing:
+ *   - Per-thread context allocation/reuse
+ *   - Stack depth of the trampoline chain
+ *   - Reentrance guard correctness at every level
+ *
+ * Default: 100 levels. Override via:
+ *   STRESS_DEPTH=N    default 100
+ *
+ * Part of TODO.complete/35.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#define DEFAULT_DEPTH 100
+
+static void recurse(int depth, int max)
+{
+	char buf[32];
+
+	if (depth >= max)
+		return;
+
+	snprintf(buf, sizeof(buf), "depth-%d", depth);
+	(void)strlen(buf);
+	(void)getuid();
+
+	recurse(depth + 1, max);
+}
+
+int main(void)
+{
+	const char *depth_env;
+	int max_depth;
+
+	depth_env = getenv("STRESS_DEPTH");
+	max_depth = depth_env ? atoi(depth_env) : DEFAULT_DEPTH;
+	if (max_depth <= 0 || max_depth > 10000)
+		max_depth = DEFAULT_DEPTH;
+
+	printf("[stress] recursing to depth %d...\n", max_depth);
+
+	recurse(0, max_depth);
+
+	printf("[stress] PASS: depth %d\n", max_depth);
+	return 0;
+}

--- a/test/stress/stress_large_args.c
+++ b/test/stress/stress_large_args.c
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+/*
+ * Stress scenario: large argument buffers (TODO.complete/35 P0).
+ *
+ * Allocates progressively larger buffers and passes them to
+ * memset/memcpy. Under LD_PRELOAD, retrace intercepts each
+ * call and walks the buffer for logging (if log_params is
+ * configured).
+ *
+ * Stress points:
+ *   - log_params serialization cost scales with buffer size
+ *   - Memory pressure from large allocations
+ *   - Potential integer overflow in size calculations
+ *
+ * Default: 10 sizes from 1KB to 1MB. Override:
+ *   STRESS_MAX_BYTES=N    default 1048576 (1 MB)
+ *
+ * Part of TODO.complete/35.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define DEFAULT_MAX_BYTES (1024 * 1024)
+
+int main(void)
+{
+	const char *max_env;
+	size_t max_bytes;
+	size_t sz;
+	unsigned char *buf;
+
+	max_env = getenv("STRESS_MAX_BYTES");
+	max_bytes = max_env ? (size_t)atol(max_env) : DEFAULT_MAX_BYTES;
+	if (max_bytes < 1024 || max_bytes > 100 * 1024 * 1024)
+		max_bytes = DEFAULT_MAX_BYTES;
+
+	printf("[stress] testing buffer sizes up to %zu bytes\n",
+		max_bytes);
+
+	for (sz = 1024; sz <= max_bytes; sz *= 4) {
+		buf = (unsigned char *)malloc(sz);
+		if (buf == NULL) {
+			fprintf(stderr,
+				"[stress] FAIL: malloc %zu\n", sz);
+			return 1;
+		}
+
+		memset(buf, 0xAB, sz);
+		memcpy(buf + sz / 2, buf, sz / 2);
+		(void)strlen((char *)buf);
+
+		free(buf);
+	}
+
+	printf("[stress] PASS: up to %zu bytes\n", max_bytes);
+	return 0;
+}

--- a/test/stress/stress_many_funcs.c
+++ b/test/stress/stress_many_funcs.c
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+/*
+ * Stress scenario: many intercept_scripts in one config
+ * (TODO.complete/35 P0).
+ *
+ * Generates a JSON config with N intercept_scripts (default
+ * 1000), writes it to a temp file, sets RETRACE_JSON_CONFIG,
+ * and runs a workload that calls libc functions.
+ *
+ * Designed to stress:
+ *   - script_resolver linear scan (O(N) per call)
+ *   - JSON config memory footprint
+ *   - parson's object lookup
+ *
+ * Default: 1000 scripts x 100 calls. Override via env:
+ *   STRESS_FUNCS=N    default 1000
+ *   STRESS_ITERS=N    default 100
+ *
+ * Part of TODO.complete/35.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#define DEFAULT_FUNCS 1000
+#define DEFAULT_ITERS 100
+#define TEST_FILE "/tmp/retrace_stress_funcs.json"
+
+int main(void)
+{
+	const char *funcs_env;
+	const char *iters_env;
+	int n_funcs;
+	int n_iters;
+	FILE *f;
+	int i, j;
+
+	funcs_env = getenv("STRESS_FUNCS");
+	n_funcs = funcs_env ? atoi(funcs_env) : DEFAULT_FUNCS;
+	if (n_funcs <= 0 || n_funcs > 10000)
+		n_funcs = DEFAULT_FUNCS;
+
+	iters_env = getenv("STRESS_ITERS");
+	n_iters = iters_env ? atoi(iters_env) : DEFAULT_ITERS;
+	if (n_iters <= 0)
+		n_iters = DEFAULT_ITERS;
+
+	printf("[stress] generating config with %d scripts...\n",
+		n_funcs);
+
+	f = fopen(TEST_FILE, "w");
+	if (f == NULL) {
+		fprintf(stderr, "[stress] FAIL: cannot write %s\n",
+			TEST_FILE);
+		return 1;
+	}
+
+	fprintf(f, "{\"intercept_scripts\":[");
+	for (i = 0; i < n_funcs; i++) {
+		if (i > 0)
+			fprintf(f, ",");
+		fprintf(f,
+			"{\"func_name\":\"func_%d\","
+			"\"actions\":["
+			"{\"action_name\":\"log_params\"},"
+			"{\"action_name\":\"call_real\"}"
+			"]}",
+			i);
+	}
+	fprintf(f, "]}");
+	fclose(f);
+
+	printf("[stress] config written, %d bytes\n",
+		(int)strlen(TEST_FILE));
+
+	/* Workload: call libc functions n_iters times. Under
+	 * LD_PRELOAD, retrace resolves each call through the
+	 * N-script config. None of the scripts match our calls
+	 * (we call getuid, not func_N), so the resolver walks
+	 * the entire array each time.
+	 */
+	for (j = 0; j < n_iters; j++)
+		(void)getuid();
+
+	unlink(TEST_FILE);
+
+	printf("[stress] PASS: %d funcs, %d iters\n",
+		n_funcs, n_iters);
+	return 0;
+}


### PR DESCRIPTION
Closes 3 more of 6 stress scenarios: stress_many_funcs (1000-script config), stress_deep_stack (100-level recursion), stress_large_args (1KB-1MB buffers). TODO 35 now 4 of 6.