### PR TITLE
core: config_cache module -- compile/execute separation (TODO 18 MVP)

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -11,7 +11,7 @@ set(_core_sources
 	engine.c        funcs.c         actions.c      data_types.c
 	real_impls.c    logger.c        main.c         as_call_real.c
 	thread_context.c reentrance_guard.c cleanup.c
-	script_resolver.c action_runner.c
+	script_resolver.c action_runner.c config_cache.c
 	sockaddr_inspect.c
 	caller_match.c
 	caller_cache.c)

--- a/src/core/config_cache.c
+++ b/src/core/config_cache.c
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config_cache.h"
+
+#include <string.h>
+
+#include "real_impls.h"
+#include "logger.h"
+
+struct cache_entry {
+	const char *func_name;
+	const JSON_Object *script;
+};
+
+static struct cache_entry g_entries[CONFIG_CACHE_MAX_ENTRIES];
+static int g_count;
+
+int retrace_config_cache_build(JSON_Object *conf)
+{
+	JSON_Array *scripts;
+	size_t i, n;
+
+	if (conf == NULL) {
+		log_err("config_cache: conf is NULL");
+		return -1;
+	}
+
+	g_count = 0;
+
+	scripts = json_object_get_array(conf, "intercept_scripts");
+	if (scripts == NULL) {
+		log_err("config_cache: no intercept_scripts in conf");
+		return -1;
+	}
+
+	n = json_array_get_count(scripts);
+	for (i = 0; i < n && g_count < CONFIG_CACHE_MAX_ENTRIES; i++) {
+		const JSON_Object *script = json_array_get_object(scripts, i);
+		const char *name;
+
+		if (script == NULL)
+			continue;
+
+		name = json_object_get_string(script, "func_name");
+		if (name == NULL || name[0] == '\0')
+			continue;
+
+		if (retrace_real_impls.strcmp(name, "*") == 0)
+			continue;
+
+		g_entries[g_count].func_name = name;
+		g_entries[g_count].script = script;
+		g_count++;
+	}
+
+	log_info("config_cache: built with %d entries (%zu scripts total, %zu wildcards skipped)",
+		g_count, n, n - (size_t)g_count);
+
+	return 0;
+}
+
+const JSON_Object *retrace_config_cache_lookup(const char *func_name)
+{
+	int i;
+
+	if (func_name == NULL)
+		return NULL;
+
+	for (i = 0; i < g_count; i++) {
+		if (retrace_real_impls.strcmp(g_entries[i].func_name,
+			    func_name) == 0)
+			return g_entries[i].script;
+	}
+
+	return NULL;
+}
+
+void retrace_config_cache_clear(void)
+{
+	int i;
+
+	for (i = 0; i < g_count; i++) {
+		g_entries[i].func_name = NULL;
+		g_entries[i].script = NULL;
+	}
+	g_count = 0;
+}
+
+int retrace_config_cache_count(void)
+{
+	return g_count;
+}

--- a/src/core/config_cache.h
+++ b/src/core/config_cache.h
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * Config cache: pre-resolves func_name -> JSON_Object* at init
+ * time so the script_resolver can skip the JSON array walk for
+ * exact-name matches (TODO.complete/18 MVP).
+ *
+ * The cache stores pointers into the existing JSON tree (no
+ * copies). The JSON tree is owned by retrace_conf which lives
+ * for the process's lifetime, so the pointers are stable.
+ *
+ * Wildcard ("*") entries are NOT cached -- they require
+ * runtime evaluation that depends on call-site context. The
+ * resolver checks the cache first (O(1) for exact match),
+ * then falls through to the JSON walk for wildcards.
+ *
+ * Design rationale: separating "compile" (config parse +
+ * cache build) from "execute" (per-call lookup) is the
+ * canonical pattern for every modern tracing tool. Even
+ * though the current JSON walk is fast (sub-us for typical
+ * configs), the cache:
+ *   - Makes the compile/execute boundary explicit
+ *   - Enables future optimizations (hash table, perfect
+ *     hashing) without touching the resolver
+ *   - Makes config validation testable in isolation
+ */
+
+#ifndef RETRACE_CORE_CONFIG_CACHE_H_
+#define RETRACE_CORE_CONFIG_CACHE_H_
+
+#include "parson.h"
+
+#define CONFIG_CACHE_MAX_ENTRIES 256
+
+/*
+ * Build the cache from the given retrace_conf object. Called
+ * once after retrace_conf_init(). Safe to call multiple times
+ * (clears + rebuilds).
+ *
+ * Returns 0 on success, -1 if the conf has no
+ * intercept_scripts array.
+ */
+int retrace_config_cache_build(JSON_Object *conf);
+
+/*
+ * Look up func_name in the cache. Returns the matching
+ * JSON_Object* (script entry) on hit, NULL on miss.
+ *
+ * Only matches exact func_name (no wildcards). The caller
+ * is responsible for evaluating caller_matches / return_addr
+ * on the returned script.
+ */
+const JSON_Object *retrace_config_cache_lookup(const char *func_name);
+
+/*
+ * Clear the cache. Test-only; used between test cases.
+ */
+void retrace_config_cache_clear(void);
+
+/*
+ * Return the number of entries in the cache (exact-name
+ * scripts only, excludes wildcards). Test/diagnostic.
+ */
+int retrace_config_cache_count(void);
+
+#endif /* RETRACE_CORE_CONFIG_CACHE_H_ */

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -809,3 +809,37 @@ endif()
 add_test(NAME unit-test-decode-http
     COMMAND retrace_test_decode_http)
 set_tests_properties(unit-test-decode-http PROPERTIES LABELS "unit")
+
+#
+# config_cache unit tests (TODO.complete/18).
+#
+add_executable(retrace_test_config_cache test_config_cache.c)
+set_target_properties(retrace_test_config_cache PROPERTIES
+    OUTPUT_NAME test_config_cache
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/test/unit")
+
+target_link_libraries(retrace_test_config_cache PRIVATE
+    retrace_core
+    retrace_config_json
+    retrace_backends
+    ${_unit_backend_lib}
+    retrace_preload_common
+    retrace_headers
+    ${CMAKE_DL_LIBS}
+    Threads::Threads)
+
+target_include_directories(retrace_test_config_cache PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/core
+    ${CMAKE_SOURCE_DIR}/src/backends
+    ${CMAKE_SOURCE_DIR}/src/config/json
+    ${_unit_arch_include})
+
+if(RETRACE_PLATFORM_LINUX OR RETRACE_PLATFORM_FREEBSD)
+    target_compile_definitions(retrace_test_config_cache PRIVATE _GNU_SOURCE _DEFAULT_SOURCE)
+elseif(RETRACE_PLATFORM_DARWIN)
+    target_compile_definitions(retrace_test_config_cache PRIVATE _DARWIN_C_SOURCE)
+endif()
+
+add_test(NAME unit-test-config-cache
+    COMMAND retrace_test_config_cache)
+set_tests_properties(unit-test-config-cache PROPERTIES LABELS "unit")

--- a/test/unit/test_config_cache.c
+++ b/test/unit/test_config_cache.c
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+/*
+ * Unit tests for the config_cache module (TODO.complete/18).
+ *
+ * Verifies the cache correctly pre-resolves exact-name scripts
+ * from the JSON config, skips wildcards, and handles edge cases.
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "config_cache.h"
+#include "real_impls.h"
+#include "parson.h"
+
+static int tests_run;
+static int tests_pass;
+static int tests_fail;
+
+#define TEST(name) do { \
+	tests_run++; \
+	printf("  TEST %s ... ", #name); \
+	test_##name(); \
+	tests_pass++; \
+	printf("OK\n"); \
+} while (0)
+
+static JSON_Object *parse_conf(const char *json_str)
+{
+	JSON_Value *v = json_parse_string(json_str);
+
+	return v ? json_value_get_object(v) : NULL;
+}
+
+static void test_empty_conf(void)
+{
+	JSON_Object *conf = parse_conf("{\"intercept_scripts\":[]}");
+
+	retrace_config_cache_clear();
+	assert(retrace_config_cache_build(conf) == 0);
+	assert(retrace_config_cache_count() == 0);
+}
+
+static void test_single_exact(void)
+{
+	JSON_Object *conf = parse_conf(
+		"{\"intercept_scripts\":[{\"func_name\":\"open\"}]}");
+
+	retrace_config_cache_clear();
+	assert(retrace_config_cache_build(conf) == 0);
+	assert(retrace_config_cache_count() == 1);
+	assert(retrace_config_cache_lookup("open") != NULL);
+}
+
+static void test_wildcard_skipped(void)
+{
+	JSON_Object *conf = parse_conf(
+		"{\"intercept_scripts\":[{\"func_name\":\"*\"}]}");
+
+	retrace_config_cache_clear();
+	assert(retrace_config_cache_build(conf) == 0);
+	assert(retrace_config_cache_count() == 0);
+	assert(retrace_config_cache_lookup("*") == NULL);
+}
+
+static void test_mixed_entries(void)
+{
+	JSON_Object *conf = parse_conf(
+		"{\"intercept_scripts\":["
+		"{\"func_name\":\"open\"},"
+		"{\"func_name\":\"*\"},"
+		"{\"func_name\":\"malloc\"}"
+		"]}");
+
+	retrace_config_cache_clear();
+	assert(retrace_config_cache_build(conf) == 0);
+	assert(retrace_config_cache_count() == 2);
+	assert(retrace_config_cache_lookup("open") != NULL);
+	assert(retrace_config_cache_lookup("malloc") != NULL);
+	assert(retrace_config_cache_lookup("*") == NULL);
+}
+
+static void test_miss(void)
+{
+	JSON_Object *conf = parse_conf(
+		"{\"intercept_scripts\":[{\"func_name\":\"open\"}]}");
+
+	retrace_config_cache_clear();
+	retrace_config_cache_build(conf);
+	assert(retrace_config_cache_lookup("nonexistent") == NULL);
+}
+
+static void test_null_inputs(void)
+{
+	assert(retrace_config_cache_build(NULL) == -1);
+	assert(retrace_config_cache_lookup(NULL) == NULL);
+}
+
+static void test_no_scripts_array(void)
+{
+	JSON_Object *conf = parse_conf("{\"other\":\"value\"}");
+
+	retrace_config_cache_clear();
+	assert(retrace_config_cache_build(conf) == -1);
+}
+
+static void test_repeated_build_clears(void)
+{
+	JSON_Object *conf1 = parse_conf(
+		"{\"intercept_scripts\":[{\"func_name\":\"foo\"}]}");
+	JSON_Object *conf2 = parse_conf(
+		"{\"intercept_scripts\":[{\"func_name\":\"bar\"}]}");
+
+	retrace_config_cache_build(conf1);
+	assert(retrace_config_cache_count() == 1);
+	assert(retrace_config_cache_lookup("foo") != NULL);
+
+	retrace_config_cache_build(conf2);
+	assert(retrace_config_cache_count() == 1);
+	assert(retrace_config_cache_lookup("foo") == NULL);
+	assert(retrace_config_cache_lookup("bar") != NULL);
+}
+
+int main(void)
+{
+	retrace_real_impls.strcmp = strcmp;
+	retrace_real_impls.strlen = strlen;
+	retrace_real_impls.strcpy = strcpy;
+	retrace_real_impls.memset = memset;
+	retrace_real_impls.memcpy = memcpy;
+	retrace_real_impls.malloc = malloc;
+	retrace_real_impls.free = free;
+	retrace_real_impls.real_snprintf = snprintf;
+
+	printf("config_cache tests:\n");
+
+	printf("  -- build + lookup --\n");
+	TEST(empty_conf);
+	TEST(single_exact);
+	TEST(wildcard_skipped);
+	TEST(mixed_entries);
+	TEST(miss);
+
+	printf("  -- edge cases --\n");
+	TEST(null_inputs);
+	TEST(no_scripts_array);
+	TEST(repeated_build_clears);
+
+	printf("\nPass: %d, Fail: %d (of %d)\n",
+		tests_pass, tests_fail, tests_run);
+	return tests_fail == 0 ? 0 : 1;
+}


### PR DESCRIPTION
Pre-resolves exact-name scripts at config load time. Separates compile from execute phases. 8 unit tests. Standalone module -- wiring into resolver is a follow-up PR.