### PR TITLE
core: decode_dns action -- DNS protocol decoder (TODO 23 expansion)

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -37,7 +37,7 @@ set(_core_action_sources
 	actions/incomplete_io.c actions/fuzzing_seed.c
 	actions/delay.c actions/call_count_limit.c
 	actions/sandbox.c actions/addr_deny.c
-	actions/filter.c actions/decode_http.c)
+	actions/filter.c actions/decode_http.c actions/decode_dns.c)
 
 set(_core_datatype_sources
 	datatypes/basic.c datatypes/uio.c datatypes/unistd.c)

--- a/src/core/actions/decode_dns.c
+++ b/src/core/actions/decode_dns.c
@@ -1,0 +1,260 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * decode_dns -- DNS protocol decoder (TODO.complete/23 expansion).
+ *
+ * Reads a named buffer param (typically from sendto/recvfrom on
+ * port 53), parses the DNS wire format header + first question,
+ * and logs the decoded fields.
+ *
+ * DNS wire format (RFC 1035):
+ *   Header (12 bytes):
+ *     ID (2), flags (2), QDCOUNT (2), ANCOUNT (2),
+ *     NSCOUNT (2), ARCOUNT (2)
+ *   Question:
+ *     QNAME (length-prefixed labels, NUL-terminated),
+ *     QTYPE (2), QCLASS (2)
+ *
+ * action_params:
+ *   param_name  - string, required. Name of the buffer param.
+ *
+ * Example:
+ *   {
+ *     "func_name": "sendto",
+ *     "actions": [
+ *       { "action_name": "decode_dns",
+ *         "action_params": { "param_name": "buf" } },
+ *       { "action_name": "log_params" },
+ *       { "action_name": "call_real" }
+ *     ]
+ *   }
+ *
+ * Non-DNS data is silently skipped (returns 0, no abort).
+ *
+ * Part of TODO.complete/23.
+ */
+
+#include <string.h>
+
+#include "actions.h"
+#include "logger.h"
+#include "real_impls.h"
+
+/* DNS header is 12 bytes. */
+#define DNS_HEADER_LEN 12
+#define DNS_MAX_NAME 256
+
+/* Read a 16-bit big-endian value from a byte buffer. */
+static unsigned int read_u16be(const unsigned char *p)
+{
+	return ((unsigned int)p[0] << 8) | (unsigned int)p[1];
+}
+
+/* Parse a DNS QNAME (sequence of length-prefixed labels) into
+ * a dot-separated string. Returns the number of bytes consumed,
+ * or 0 on error (malformed name).
+ */
+static size_t parse_qname(const unsigned char *buf, size_t buf_len,
+			  size_t offset, char *out, size_t out_cap)
+{
+	size_t pos = offset;
+	size_t out_pos = 0;
+	int label_count = 0;
+
+	while (pos < buf_len) {
+		unsigned char label_len = buf[pos];
+
+		if (label_len == 0) {
+			pos++;
+			break;
+		}
+
+		if ((label_len & 0xC0) == 0xC0) {
+			pos += 2;
+			break;
+		}
+
+		if (label_len > 63)
+			return 0;
+
+		pos++;
+		if (pos + label_len > buf_len)
+			return 0;
+
+		if (label_count > 0 && out_pos < out_cap - 1)
+			out[out_pos++] = '.';
+		label_count++;
+
+		{
+			size_t i;
+
+			for (i = 0; i < label_len && out_pos < out_cap - 1;
+			     i++)
+				out[out_pos++] = (char)buf[pos + i];
+		}
+
+		pos += label_len;
+	}
+
+	out[out_pos] = '\0';
+	return pos - offset;
+}
+
+/* Map a DNS QTYPE to a human-readable string. */
+static const char *qtype_str(unsigned int qtype)
+{
+	switch (qtype) {
+	case 1:  return "A";
+	case 2:  return "NS";
+	case 5:  return "CNAME";
+	case 6:  return "SOA";
+	case 12: return "PTR";
+	case 15: return "MX";
+	case 16: return "TXT";
+	case 28: return "AAAA";
+	case 33: return "SRV";
+	case 65: return "HTTPS";
+	default: return "UNKNOWN";
+	}
+}
+
+static int ia_decode_dns(struct ThreadContext *t_ctx,
+			 const JSON_Object *action_params)
+{
+	const char *param_name;
+	const unsigned char *buf;
+	int param_idx;
+	int i;
+	unsigned int tx_id;
+	unsigned int flags;
+	unsigned int qdcount;
+	unsigned int ancount;
+	int is_response;
+	char qname[DNS_MAX_NAME];
+	size_t qname_consumed;
+	unsigned int qtype;
+	const char *qtype_name;
+
+	if (action_params == NULL) {
+		log_err("decode_dns: action_params required");
+		return -1;
+	}
+
+	param_name = json_object_get_string(action_params, "param_name");
+	if (param_name == NULL) {
+		log_err("decode_dns: param_name required");
+		return -1;
+	}
+
+	for (i = 0; i < t_ctx->params_cnt; i++) {
+		if (retrace_real_impls.strcmp(
+			    t_ctx->params[i].param_meta.name,
+			    param_name) == 0)
+			break;
+	}
+	if (i == t_ctx->params_cnt) {
+		log_dbg("decode_dns: param '%s' not found", param_name);
+		return 0;
+	}
+
+	buf = (const unsigned char *)t_ctx->params[i].val;
+	if (buf == NULL)
+		return 0;
+
+	/* DNS header is 12 bytes minimum. The len param might
+	 * tell us the buffer size, but for safety we just check
+	 * the header fits.
+	 */
+	{
+		long buf_len = 0;
+		int j;
+
+		for (j = 0; j < t_ctx->params_cnt; j++) {
+			const char *nm =
+				t_ctx->params[j].param_meta.name;
+
+			if (retrace_real_impls.strcmp(nm, "len") == 0 ||
+			    retrace_real_impls.strcmp(nm, "size") == 0) {
+				buf_len = t_ctx->params[j].val;
+				break;
+			}
+		}
+
+		if (buf_len > 0 && buf_len < DNS_HEADER_LEN) {
+			log_dbg("decode_dns: buffer too short (%ld bytes)",
+				buf_len);
+			return 0;
+		}
+	}
+
+	tx_id = read_u16be(buf);
+	flags = read_u16be(buf + 2);
+	qdcount = read_u16be(buf + 4);
+	ancount = read_u16be(buf + 6);
+	is_response = (flags & 0x8000) ? 1 : 0;
+
+	if (qdcount == 0 && ancount == 0) {
+		log_dbg("decode_dns: no questions or answers");
+		return 0;
+	}
+
+	qname[0] = '\0';
+	qtype = 0;
+	qtype_name = "";
+
+	if (qdcount > 0) {
+		qname_consumed = parse_qname(buf, 65536, DNS_HEADER_LEN,
+			qname, sizeof(qname));
+		if (qname_consumed > 0 &&
+		    DNS_HEADER_LEN + qname_consumed + 4 <= 65536) {
+			qtype = read_u16be(buf + DNS_HEADER_LEN +
+				qname_consumed);
+			qtype_name = qtype_str(qtype);
+		}
+	}
+
+	if (is_response) {
+		log_info("decode_dns: response id=0x%04x qname=%s qtype=%s answers=%u",
+			tx_id,
+			qname[0] ? qname : "(none)",
+			qtype_name,
+			ancount);
+	} else {
+		log_info("decode_dns: query id=0x%04x qname=%s qtype=%s",
+			tx_id,
+			qname[0] ? qname : "(none)",
+			qtype_name);
+	}
+
+	return 0;
+}
+
+retrace_actions_define_package(decode_dns) = {
+	{
+		.name = "decode_dns",
+		.action = ia_decode_dns
+	}
+};

--- a/test/helpers/test_utils.h
+++ b/test/helpers/test_utils.h
@@ -76,15 +76,14 @@ typedef int (*action_fn_t)(struct ThreadContext *t_ctx,
 	printf("OK\n"); \
 } while (0)
 
-/* Print summary and return exit code. Not a macro (checkpatch
- * flags do-while with return). Must be called as the last
- * statement in main().
+/* Print summary and return exit code. Pass the counters from
+ * DECLARE_TEST_STATE(). Usage: return finish_tests(tests_run,
+ * tests_pass, tests_fail);
  */
-static inline int finish_tests(void)
+static inline int finish_tests(int run, int pass, int fail)
 {
-	printf("\nPass: %d, Fail: %d (of %d)\n",
-		tests_pass, tests_fail, tests_run);
-	return tests_fail == 0 ? 0 : 1;
+	printf("\nPass: %d, Fail: %d (of %d)\n", pass, fail, run);
+	return fail == 0 ? 0 : 1;
 }
 
 /* --- JSON builder helpers --- */

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -844,3 +844,39 @@ endif()
 add_test(NAME unit-test-config-cache
     COMMAND retrace_test_config_cache)
 set_tests_properties(unit-test-config-cache PROPERTIES LABELS "unit")
+
+#
+# decode_dns action unit tests (TODO.complete/23). Uses shared
+# test_utils.h for the first time in the test suite.
+#
+add_executable(retrace_test_decode_dns test_decode_dns.c)
+set_target_properties(retrace_test_decode_dns PROPERTIES
+    OUTPUT_NAME test_decode_dns
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/test/unit")
+
+target_link_libraries(retrace_test_decode_dns PRIVATE
+    retrace_core
+    retrace_config_json
+    retrace_backends
+    ${_unit_backend_lib}
+    retrace_preload_common
+    retrace_headers
+    ${CMAKE_DL_LIBS}
+    Threads::Threads)
+
+target_include_directories(retrace_test_decode_dns PRIVATE
+    ${CMAKE_SOURCE_DIR}/test/helpers
+    ${CMAKE_SOURCE_DIR}/src/core
+    ${CMAKE_SOURCE_DIR}/src/backends
+    ${CMAKE_SOURCE_DIR}/src/config/json
+    ${_unit_arch_include})
+
+if(RETRACE_PLATFORM_LINUX OR RETRACE_PLATFORM_FREEBSD)
+    target_compile_definitions(retrace_test_decode_dns PRIVATE _GNU_SOURCE _DEFAULT_SOURCE)
+elseif(RETRACE_PLATFORM_DARWIN)
+    target_compile_definitions(retrace_test_decode_dns PRIVATE _DARWIN_C_SOURCE)
+endif()
+
+add_test(NAME unit-test-decode-dns
+    COMMAND retrace_test_decode_dns)
+set_tests_properties(unit-test-decode-dns PROPERTIES LABELS "unit")

--- a/test/unit/test_decode_dns.c
+++ b/test/unit/test_decode_dns.c
@@ -1,0 +1,296 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+/*
+ * Unit tests for the decode_dns action (TODO.complete/23).
+ *
+ * Tests verify DNS query parsing (A, AAAA records), response
+ * parsing, non-DNS passthrough, and edge cases.
+ */
+
+#include "test_utils.h"
+
+DECLARE_TEST_STATE();
+
+static struct ThreadContext *build_ctx_with_buf(const char *name,
+						const unsigned char *data,
+						int data_len)
+{
+	static struct ThreadContext ctx;
+	static struct FuncPrototype proto;
+	static unsigned char buf[4096];
+	struct FuncParam params[8];
+
+	memset(&ctx, 0, sizeof(ctx));
+	memset(params, 0, sizeof(params));
+	memset(&proto, 0, sizeof(proto));
+
+	strncpy(proto.name, "sendto", sizeof(proto.name) - 1);
+	ctx.prototype = &proto;
+
+	if (data && data_len > 0) {
+		memcpy(buf, data, data_len);
+	} else {
+		memset(buf, 0, sizeof(buf));
+	}
+
+	strncpy(params[0].param_meta.name, name,
+		sizeof(params[0].param_meta.name) - 1);
+	params[0].param_meta.modifiers = CDM_POINTER;
+	params[0].param_meta.direction = PDIR_IN;
+	params[0].val = (long)buf;
+
+	strncpy(params[1].param_meta.name, "len",
+		sizeof(params[1].param_meta.name) - 1);
+	params[1].param_meta.direction = PDIR_IN;
+	params[1].val = data_len;
+
+	ctx.params_cnt = 2;
+	memcpy(ctx.params, params, sizeof(params));
+	return &ctx;
+}
+
+static JSON_Object *build_params(const char *param_name)
+{
+	return build_json_string_kv("param_name", param_name);
+}
+
+/* Build a DNS query for example.com type A (1). */
+static void build_dns_query(unsigned char *buf, int *out_len)
+{
+	/* Header: ID=0x1234, flags=0x0100 (RD), QDCOUNT=1 */
+	unsigned char header[] = {
+		0x12, 0x34, /* ID */
+		0x01, 0x00, /* flags: RD */
+		0x00, 0x01, /* QDCOUNT */
+		0x00, 0x00, /* ANCOUNT */
+		0x00, 0x00, /* NSCOUNT */
+		0x00, 0x00  /* ARCOUNT */
+	};
+	/* Question: example.com type A class IN */
+	unsigned char question[] = {
+		7, 'e', 'x', 'a', 'm', 'p', 'l', 'e',
+		3, 'c', 'o', 'm',
+		0, /* null label */
+		0x00, 0x01, /* QTYPE = A */
+		0x00, 0x01  /* QCLASS = IN */
+	};
+
+	memcpy(buf, header, sizeof(header));
+	memcpy(buf + sizeof(header), question, sizeof(question));
+	*out_len = sizeof(header) + sizeof(question);
+}
+
+static void build_dns_aaaa_query(unsigned char *buf, int *out_len)
+{
+	unsigned char header[] = {
+		0xAB, 0xCD, 0x01, 0x00,
+		0x00, 0x01, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00
+	};
+	unsigned char question[] = {
+		3, 'f', 'o', 'o',
+		3, 'b', 'a', 'r',
+		0,
+		0x00, 0x1C, /* QTYPE = AAAA */
+		0x00, 0x01
+	};
+
+	memcpy(buf, header, sizeof(header));
+	memcpy(buf + sizeof(header), question, sizeof(question));
+	*out_len = sizeof(header) + sizeof(question);
+}
+
+static void build_dns_response(unsigned char *buf, int *out_len)
+{
+	unsigned char header[] = {
+		0x12, 0x34,
+		0x81, 0x80, /* flags: QR + RD + RA */
+		0x00, 0x01, /* QDCOUNT */
+		0x00, 0x01, /* ANCOUNT */
+		0x00, 0x00, 0x00, 0x00
+	};
+	unsigned char question[] = {
+		7, 'e', 'x', 'a', 'm', 'p', 'l', 'e',
+		3, 'c', 'o', 'm',
+		0,
+		0x00, 0x01, 0x00, 0x01
+	};
+
+	memcpy(buf, header, sizeof(header));
+	memcpy(buf + sizeof(header), question, sizeof(question));
+	*out_len = sizeof(header) + sizeof(question);
+}
+
+static void test_action_lookup(void)
+{
+	retrace_actions_init();
+	assert(retrace_actions_get("decode_dns") != NULL);
+}
+
+static void test_params_null(void)
+{
+	action_fn_t action = retrace_actions_get("decode_dns");
+	struct ThreadContext ctx;
+
+	memset(&ctx, 0, sizeof(ctx));
+	assert(action(&ctx, NULL) == -1);
+}
+
+static void test_missing_param_name(void)
+{
+	action_fn_t action = retrace_actions_get("decode_dns");
+	struct ThreadContext ctx;
+	JSON_Value *v = json_value_init_object();
+
+	memset(&ctx, 0, sizeof(ctx));
+	assert(action(&ctx, json_value_get_object(v)) == -1);
+	json_value_free(v);
+}
+
+static void test_dns_a_query(void)
+{
+	action_fn_t action = retrace_actions_get("decode_dns");
+	unsigned char dns_buf[256];
+	int dns_len;
+	struct ThreadContext *ctx;
+	JSON_Object *p;
+
+	build_dns_query(dns_buf, &dns_len);
+	ctx = build_ctx_with_buf("buf", dns_buf, dns_len);
+	p = build_params("buf");
+
+	assert(action(ctx, p) == 0);
+
+	json_value_free(json_object_get_wrapping_value(p));
+}
+
+static void test_dns_aaaa_query(void)
+{
+	action_fn_t action = retrace_actions_get("decode_dns");
+	unsigned char dns_buf[256];
+	int dns_len;
+	struct ThreadContext *ctx;
+	JSON_Object *p;
+
+	build_dns_aaaa_query(dns_buf, &dns_len);
+	ctx = build_ctx_with_buf("buf", dns_buf, dns_len);
+	p = build_params("buf");
+
+	assert(action(ctx, p) == 0);
+
+	json_value_free(json_object_get_wrapping_value(p));
+}
+
+static void test_dns_response(void)
+{
+	action_fn_t action = retrace_actions_get("decode_dns");
+	unsigned char dns_buf[256];
+	int dns_len;
+	struct ThreadContext *ctx;
+	JSON_Object *p;
+
+	build_dns_response(dns_buf, &dns_len);
+	ctx = build_ctx_with_buf("buf", dns_buf, dns_len);
+	p = build_params("buf");
+
+	assert(action(ctx, p) == 0);
+
+	json_value_free(json_object_get_wrapping_value(p));
+}
+
+static void test_non_dns_data(void)
+{
+	action_fn_t action = retrace_actions_get("decode_dns");
+	unsigned char raw[] = {0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x00,
+			       0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+	struct ThreadContext *ctx = build_ctx_with_buf("buf", raw, sizeof(raw));
+	JSON_Object *p = build_params("buf");
+
+	/* Non-DNS: no questions, no answers -> no-op. */
+	assert(action(ctx, p) == 0);
+
+	json_value_free(json_object_get_wrapping_value(p));
+}
+
+static void test_short_buffer(void)
+{
+	action_fn_t action = retrace_actions_get("decode_dns");
+	unsigned char short_buf[] = {0x01, 0x02, 0x03};
+	struct ThreadContext *ctx = build_ctx_with_buf("buf", short_buf, 3);
+	JSON_Object *p = build_params("buf");
+
+	/* Buffer too short (< 12 bytes) -> no-op. */
+	assert(action(ctx, p) == 0);
+
+	json_value_free(json_object_get_wrapping_value(p));
+}
+
+static void test_null_buffer(void)
+{
+	action_fn_t action = retrace_actions_get("decode_dns");
+	static struct ThreadContext ctx;
+	static struct FuncPrototype proto;
+	struct FuncParam params[8];
+	JSON_Object *p = build_params("buf");
+
+	memset(&ctx, 0, sizeof(ctx));
+	memset(params, 0, sizeof(params));
+	memset(&proto, 0, sizeof(proto));
+	strncpy(proto.name, "sendto", sizeof(proto.name) - 1);
+	ctx.prototype = &proto;
+	strncpy(params[0].param_meta.name, "buf",
+		sizeof(params[0].param_meta.name) - 1);
+	params[0].val = 0;
+	ctx.params_cnt = 1;
+	memcpy(ctx.params, params, sizeof(params));
+
+	assert(action(&ctx, p) == 0);
+	json_value_free(json_object_get_wrapping_value(p));
+}
+
+static void test_unknown_param(void)
+{
+	action_fn_t action = retrace_actions_get("decode_dns");
+	unsigned char dns_buf[256];
+	int dns_len;
+	struct ThreadContext *ctx;
+	JSON_Object *p;
+
+	build_dns_query(dns_buf, &dns_len);
+	ctx = build_ctx_with_buf("buf", dns_buf, dns_len);
+	p = build_params("nonexistent");
+
+	assert(action(ctx, p) == 0);
+	json_value_free(json_object_get_wrapping_value(p));
+}
+
+int main(void)
+{
+	init_minimal_real_impls();
+
+	printf("decode_dns action tests:\n");
+
+	printf("  -- lookup + params validation --\n");
+	TEST(action_lookup);
+	TEST(params_null);
+	TEST(missing_param_name);
+	TEST(unknown_param);
+
+	printf("  -- DNS queries --\n");
+	TEST(dns_a_query);
+	TEST(dns_aaaa_query);
+
+	printf("  -- DNS response --\n");
+	TEST(dns_response);
+
+	printf("  -- non-DNS + edge cases --\n");
+	TEST(non_dns_data);
+	TEST(short_buffer);
+	TEST(null_buffer);
+
+	return finish_tests(tests_run, tests_pass, tests_fail);
+}


### PR DESCRIPTION
Second protocol decoder after HTTP/1.x. Parses DNS wire format (RFC 1035): transaction ID, query/response flag, question domain name, query type (A/AAAA/NS/CNAME/SOA/PTR/MX/TXT/SRV/HTTPS). 10 unit tests. First test to use shared test_utils.h. Total actions: 16.