### PR TITLE
packaging: Debian + Fedora + Arch + Nix (TODO 38)

### DIFF
--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: BSD-2-Clause
+# Maintainer: Ribose Inc <opensource@ribose.com>
+# Contributor: Ribose Inc <opensource@ribose.com>
+
+pkgname=retrace
+pkgver=2.2.2
+pkgrel=1
+pkgdesc="Userspace libc interceptor for security discovery"
+arch=('x86_64' 'aarch64')
+url="https://github.com/riboseinc/retrace"
+license=('BSD-2-Clause')
+depends=('openssl')
+makedepends=('cmake' 'ninja')
+source=("$url/archive/v$pkgver/retrace-$pkgver.tar.gz")
+sha256sums=('SKIP')
+
+build() {
+    cd "$pkgname-$pkgver"
+    cmake -B build -G Ninja \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DBUILD_SHARED_LIBS=ON \
+        -DRETRACE_BUILD_TESTS=OFF \
+        -DRETRACE_BUILD_EXAMPLES=OFF
+    cmake --build build
+}
+
+package() {
+    cd "$pkgname-$pkgver"
+    DESTDIR="$pkgdir" cmake --install build
+    install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}

--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -1,0 +1,13 @@
+retrace (2.2.2-1) unstable; urgency=medium
+
+  * Initial Debian packaging.
+  * Network function interception (27 BSD-sockets functions).
+  * Per-return-address routing (caller_matches array).
+  * HTTP/1.x and DNS protocol decoders.
+  * Filter action (conditional param-value guards).
+  * Config cache (compile/execute separation).
+  * OTLP/JSON converter tool.
+  * Python config builder binding.
+  * Engine MECE refactor (5 single-concern modules).
+
+ -- Ribose Inc <opensource@ribose.com>  Sat, 09 Aug 2026 00:00:00 +0000

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -1,0 +1,45 @@
+Source: retrace
+Section: devel
+Priority: optional
+Maintainer: Ribose Inc <opensource@ribose.com>
+Build-Depends: debhelper-compat (= 13),
+               cmake (>= 3.20),
+               ninja-build,
+               libssl-dev
+Standards-Version: 4.6.0
+Homepage: https://github.com/riboseinc/retrace
+Vcs-Browser: https://github.com/riboseinc/retrace
+Vcs-Git: https://github.com/riboseinc/retrace.git
+
+Package: retrace
+Architecture: any
+Depends: ${shlibs:Depends}, ${misc:Depends}
+Description: Userspace libc interceptor for security discovery
+ retrace intercepts libc calls in dynamically-linked binaries by
+ preloading a shared library (LD_PRELOAD on ELF, DYLD_INSERT_LIBRARIES
+ on Darwin). It can log, modify, or fault every intercepted call.
+ .
+ This package contains the retrace shared library, the retrace CLI,
+ and the OTLP converter tool.
+ .
+ Features:
+  * 400+ intercepted libc functions (stdio, stdlib, unistd, string,
+    pthread, network sockets)
+  * 16 built-in actions (log_params, call_real, modify_return,
+    memory_fuzz, sandbox, addr_deny, filter, decode_http, decode_dns,
+    and more)
+  * JSON-driven configuration via RETRACE_JSON_CONFIG
+  * Per-return-address routing (caller_matches)
+  * Config cache (compile/execute separation)
+  * OTLP/JSON export via retrace-to-otlp
+  * Python config builder (python3-retrace)
+
+Package: python3-retrace
+Architecture: all
+Depends: ${misc:Depends}, python3
+Description: Python config builder for retrace
+ Pure Python 3 module that generates retrace JSON configs
+ programmatically with a fluent API. No C extension needed.
+ .
+ Provides presets for HTTP tracing, DNS tracing, network tracing,
+ malloc fuzzing, and path sandboxing.

--- a/packaging/debian/copyright
+++ b/packaging/debian/copyright
@@ -1,0 +1,31 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: retrace
+Upstream-Contact: Ribose Inc <opensource@ribose.com>
+Source: https://github.com/riboseinc/retrace
+
+Files: *
+Copyright: 2017-2026 Ribose Inc
+License: BSD-2-Clause
+
+License: BSD-2-Clause
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ .
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ .
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -1,0 +1,23 @@
+#!/usr/bin/make -f
+# SPDX-License-Identifier: BSD-2-Clause
+
+export DEB_BUILD_MAINT_OPTIONS = hardening=+all
+
+%:
+	dh $@
+
+override_dh_auto_configure:
+	dh_auto_configure -- \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DBUILD_SHARED_LIBS=ON \
+		-DRETRACE_BUILD_TESTS=OFF \
+		-DRETRACE_BUILD_EXAMPLES=OFF \
+		-G Ninja
+
+override_dh_auto_install:
+	dh_auto_install
+
+override_dh_auto_test:
+	# Tests require LD_PRELOAD which doesn't work in pbuilder/sbuild.
+	# Users can run tests manually after install:
+	#   cmake -B build -DRETRACE_BUILD_TESTS=ON && ctest --test-dir build

--- a/packaging/fedora/retrace.spec
+++ b/packaging/fedora/retrace.spec
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Fedora RPM spec for retrace (TODO.complete/38).
+# Build: rpmbuild -ba retrace.spec
+# Install: dnf install retrace-2.2.2-1.*.rpm
+
+Name:           retrace
+Version:        2.2.2
+Release:        1%{?dist}
+Summary:        Userspace libc interceptor for security discovery
+
+License:        BSD-2-Clause
+URL:            https://github.com/riboseinc/retrace
+Source0:        %{url}/archive/v%{version}/retrace-%{version}.tar.gz
+
+BuildRequires:  cmake >= 3.20
+BuildRequires:  ninja-build
+BuildRequires:  gcc
+BuildRequires:  openssl-devel
+
+Requires:       openssl-libs
+
+%description
+retrace intercepts libc calls in dynamically-linked binaries by
+preloading a shared library. It can log, modify, or fault every
+intercepted call. Features include network function interception,
+HTTP/DNS protocol decoders, per-return-address routing, filter
+action, OTLP/JSON export, and a Python config builder.
+
+%prep
+%autosetup
+
+%build
+%cmake -G Ninja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DBUILD_SHARED_LIBS=ON \
+    -DRETRACE_BUILD_TESTS=OFF \
+    -DRETRACE_BUILD_EXAMPLES=OFF
+%cmake_build
+
+%install
+%cmake_install
+
+%files
+%license LICENSE
+%doc README.adoc CHANGELOG.md
+%{_libdir}/libretrace.so.*
+%{_bindir}/retrace
+%{_bindir}/retrace-to-otlp
+%{_includedir}/retrace/
+
+%changelog
+* Sat Aug 09 2026 Ribose Inc <opensource@ribose.com> - 2.2.2-1
+- Initial Fedora packaging

--- a/packaging/nix/default.nix
+++ b/packaging/nix/default.nix
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Nix derivation for retrace (TODO.complete/38).
+# Build: nix-build -E 'with import <nixpkgs> {}; callPackage ./default.nix {}'
+# Install: nix-env -iA retrace -f default.nix
+
+{ lib, stdenv, cmake, ninja, openssl, python3 }:
+
+stdenv.mkDerivation rec {
+  pname = "retrace";
+  version = "2.2.2";
+
+  src = ./.;
+
+  nativeBuildInputs = [ cmake ninja ];
+
+  buildInputs = [ openssl ];
+
+  cmakeFlags = [
+    "-DCMAKE_BUILD_TYPE=Release"
+    "-DBUILD_SHARED_LIBS=ON"
+    "-DRETRACE_BUILD_TESTS=OFF"
+    "-DRETRACE_BUILD_EXAMPLES=OFF"
+  ];
+
+  meta = with lib; {
+    description = "Userspace libc interceptor for security discovery";
+    homepage = "https://github.com/riboseinc/retrace";
+    license = licenses.bsd2;
+    platforms = platforms.linux ++ platforms.darwin;
+    maintainers = [{
+      name = "Ribose Inc";
+      email = "opensource@ribose.com";
+    }];
+  };
+}


### PR DESCRIPTION
Adds packaging files for 4 Linux distributions + Nix. Combined with the existing Homebrew formula, retrace is now installable on 5 distribution systems. 234 LOC of metadata files, no C changes.