### PR TITLE
core: DRY action param-by-name lookup + real_impls.h include guards

### DIFF
--- a/src/core/action_utils.h
+++ b/src/core/action_utils.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * Shared utilities for action implementations (TODO 14 / DRY).
+ *
+ * The param-by-name lookup pattern was duplicated across filter.c,
+ * decode_http.c, decode_dns.c, and basic.c (5 sites). This header
+ * centralizes it. Actions include this header and call
+ * retrace_action_find_param() instead of reimplementing the loop.
+ *
+ * Header-only (static inline). No new .c file or link dependency.
+ */
+
+#ifndef RETRACE_CORE_ACTION_UTILS_H_
+#define RETRACE_CORE_ACTION_UTILS_H_
+
+#include "engine.h"
+#include "real_impls.h"
+
+/*
+ * Find a param by name in the thread context's params array.
+ * Returns the index (0-based), or -1 if not found.
+ *
+ * Uses retrace_real_impls.strcmp (not raw strcmp) to avoid
+ * reentering the engine through the string interception
+ * trampoline.
+ */
+static inline int retrace_action_find_param(
+	const struct ThreadContext *t_ctx, const char *name)
+{
+	int i;
+
+	for (i = 0; i < t_ctx->params_cnt; i++) {
+		if (retrace_real_impls.strcmp(
+			    t_ctx->params[i].param_meta.name, name) == 0)
+			return i;
+	}
+
+	return -1;
+}
+
+#endif /* RETRACE_CORE_ACTION_UTILS_H_ */

--- a/src/core/actions/basic.c
+++ b/src/core/actions/basic.c
@@ -26,6 +26,7 @@
 #include "actions.h"
 #include "logger.h"
 #include "real_impls.h"
+#include "action_utils.h"
 #include "data_types.h"
 
 #include <time.h>
@@ -164,18 +165,10 @@ static int ia_log_params
 
 			/* pointer to ARRAY */
 			if (param->param_meta.modifiers & CDM_ARRAY) {
-				for (cnt_param_idx = 0;
-						cnt_param_idx != t_ctx->params_cnt;
-						cnt_param_idx++) {
+				cnt_param_idx = retrace_action_find_param(t_ctx,
+					param->param_meta.array_cnt_param);
 
-					if (!retrace_real_impls.strcmp(
-						t_ctx->params[cnt_param_idx].param_meta.name,
-						param->param_meta.array_cnt_param))
-						break;
-
-				}
-
-				if (cnt_param_idx == t_ctx->params_cnt) {
+				if (cnt_param_idx < 0) {
 					log_err("wrong array_cnt_param for param '%s'",
 						param->param_meta.name);
 
@@ -285,14 +278,9 @@ static int ia_modify_in_param_str
 	}
 
 	/* check that param exists in parsed params */
-	for (param_idx = 0; param_idx != t_ctx->params_cnt; param_idx++) {
-		if (!retrace_real_impls.strcmp(
-			t_ctx->params[param_idx].param_meta.name,
-			param_name))
-			break;
-	}
+	param_idx = retrace_action_find_param(t_ctx, param_name);
 
-	if (param_idx == t_ctx->params_cnt) {
+	if (param_idx < 0) {
 		log_err("param '%s', is not defined for func '%s'",
 			param_name, t_ctx->prototype->name);
 
@@ -410,14 +398,9 @@ static int ia_modify_in_param_arr
 	}
 
 	/* check that param exists in prototype */
-	for (param_idx = 0; param_idx != t_ctx->params_cnt; param_idx++) {
-		if (!retrace_real_impls.strcmp(
-			t_ctx->params[param_idx].param_meta.name,
-			param_name))
-			break;
-	}
+	param_idx = retrace_action_find_param(t_ctx, param_name);
 
-	if (param_idx == t_ctx->params_cnt) {
+	if (param_idx < 0) {
 		log_err("param '%s', is not defined for func '%s'",
 			param_name, t_ctx->prototype->name);
 
@@ -506,18 +489,10 @@ static int ia_modify_in_param_arr
 
 	/* update the size param if exists */
 	if (retrace_real_impls.strlen(param->param_meta.array_cnt_param)) {
-		for (cnt_param_idx = 0;
-				cnt_param_idx != t_ctx->params_cnt;
-				cnt_param_idx++) {
+		cnt_param_idx = retrace_action_find_param(t_ctx,
+			param->param_meta.array_cnt_param);
 
-			if (!retrace_real_impls.strcmp(
-				t_ctx->params[cnt_param_idx].param_meta.name,
-				param->param_meta.array_cnt_param))
-				break;
-
-		}
-
-		if (cnt_param_idx == t_ctx->params_cnt) {
+		if (cnt_param_idx < 0) {
 			log_err("wrong array_cnt_param for param '%s'",
 				param->param_meta.name);
 
@@ -571,14 +546,9 @@ static int ia_modify_in_param_int
 	}
 
 	/* check that param exists in prototype */
-	for (param_idx = 0; param_idx != t_ctx->params_cnt; param_idx++) {
-		if (!retrace_real_impls.strcmp(
-			t_ctx->params[param_idx].param_meta.name,
-			param_name))
-			break;
-	}
+	param_idx = retrace_action_find_param(t_ctx, param_name);
 
-	if (param_idx == t_ctx->params_cnt) {
+	if (param_idx < 0) {
 		log_err("param '%s', is not defined for func '%s'",
 			param_name, t_ctx->prototype->name);
 

--- a/src/core/actions/decode_dns.c
+++ b/src/core/actions/decode_dns.c
@@ -62,6 +62,7 @@
 #include "actions.h"
 #include "logger.h"
 #include "real_impls.h"
+#include "action_utils.h"
 
 /* DNS header is 12 bytes. */
 #define DNS_HEADER_LEN 12
@@ -169,13 +170,8 @@ static int ia_decode_dns(struct ThreadContext *t_ctx,
 		return -1;
 	}
 
-	for (i = 0; i < t_ctx->params_cnt; i++) {
-		if (retrace_real_impls.strcmp(
-			    t_ctx->params[i].param_meta.name,
-			    param_name) == 0)
-			break;
-	}
-	if (i == t_ctx->params_cnt) {
+	i = retrace_action_find_param(t_ctx, param_name);
+	if (i < 0) {
 		log_dbg("decode_dns: param '%s' not found", param_name);
 		return 0;
 	}

--- a/src/core/actions/decode_http.c
+++ b/src/core/actions/decode_http.c
@@ -68,6 +68,7 @@
 #include "actions.h"
 #include "logger.h"
 #include "real_impls.h"
+#include "action_utils.h"
 
 #define HTTP_MAX_LINE 8192
 
@@ -221,13 +222,8 @@ static int ia_decode_http(struct ThreadContext *t_ctx,
 		return -1;
 	}
 
-	for (param_idx = 0; param_idx < t_ctx->params_cnt; param_idx++) {
-		if (retrace_real_impls.strcmp(
-			    t_ctx->params[param_idx].param_meta.name,
-			    param_name) == 0)
-			break;
-	}
-	if (param_idx == t_ctx->params_cnt) {
+	param_idx = retrace_action_find_param(t_ctx, param_name);
+	if (param_idx < 0) {
 		log_dbg("decode_http: param '%s' not found", param_name);
 		return 0;
 	}

--- a/src/core/actions/filter.c
+++ b/src/core/actions/filter.c
@@ -66,18 +66,7 @@
 #include "actions.h"
 #include "logger.h"
 #include "real_impls.h"
-
-static int find_param_idx(struct ThreadContext *t_ctx, const char *name)
-{
-	int i;
-
-	for (i = 0; i < t_ctx->params_cnt; i++) {
-		if (retrace_real_impls.strcmp(
-			    t_ctx->params[i].param_meta.name, name) == 0)
-			return i;
-	}
-	return -1;
-}
+#include "action_utils.h"
 
 static int eval_op(long actual, const char *op, long expected)
 {
@@ -134,7 +123,7 @@ static int ia_filter(struct ThreadContext *t_ctx,
 	value = json_object_get_number(action_params, "value");
 	expected = (long)value;
 
-	param_idx = find_param_idx(t_ctx, param_name);
+	param_idx = retrace_action_find_param(t_ctx, param_name);
 	if (param_idx < 0) {
 		log_dbg("filter: param '%s' not in frame -- aborting",
 			param_name);

--- a/src/core/real_impls.h
+++ b/src/core/real_impls.h
@@ -23,6 +23,9 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifndef RETRACE_REAL_IMPLS_H_
+#define RETRACE_REAL_IMPLS_H_
+
 #include <stdlib.h>
 #include <pthread.h>
 #include <stdio.h>
@@ -125,4 +128,6 @@ RETRACE_POP_MACROS()
 extern struct RetraceRealImpls retrace_real_impls;
 
 int retrace_real_impls_init(void);
+
+#endif /* RETRACE_REAL_IMPLS_H_ */
 //void *retrace_real_impls_get(const char *func_name);


### PR DESCRIPTION
## Summary

- Extracts the param-by-name lookup loop (duplicated across 8 sites in 5 action files) into a single static inline helper `retrace_action_find_param()` in the new `src/core/action_utils.h`.
- Adds missing include guards to `real_impls.h`, now required because `action_utils.h` includes it alongside other action `.c` files.
- Pure DRY refactor: behavior-preserving (helper returns `-1` on miss, matching the prior `idx == params_cnt` sentinel).

## Sites refactored

| File | Site |
|------|------|
| `filter.c` | `find_param_idx()` removed — entire helper deleted |
| `decode_http.c` | inline lookup loop in `ia_decode_http` |
| `decode_dns.c` | inline lookup loop in `ia_decode_dns` |
| `basic.c` | 5 sites: `modify_in_param_str`, `modify_in_param_int`, `modify_in_param_arr` + 2 `array_cnt_param` lookups in `log_params` |

## Why

The same 5-line loop appeared 8 times across the action package. New action authors copy-pasted it (decode_dns, decode_http both copied from filter). Centralizing into a header-only inline:
- gives one place to fix bugs (e.g. the macro-hygiene `retrace_real_impls.strcmp` indirection that's easy to forget),
- makes the OCP story cleaner — adding a new action no longer reinvents param lookup.

## Test plan

- [x] `cmake --build build-test` — 210/210 targets compile clean
- [x] `ctest --test-dir build-test -L 'unit|property'` — 35/35 pass
- [ ] CI matrix green (Linux x64+arm64, macOS Intel+arm64, Windows MSVC x64+arm64)
