### PR TITLE
docs(cookbook): recipe 22 -- decode HTTP and DNS wire formats

### DIFF
--- a/docs/cookbook/22-decode-protocols.md
+++ b/docs/cookbook/22-decode-protocols.md
@@ -1,0 +1,139 @@
+# 22 — Decode protocols (HTTP, DNS)
+
+## Problem
+
+You captured every `send` / `recv` / `sendto` / `recvfrom` call, but
+the log is full of raw byte buffers. To debug an HTTP client or DNS
+resolver you have to mentally parse the wire format for each entry.
+
+The `decode_http` and `decode_dns` actions parse the buffer of a
+named param up front and log the decoded fields (method, path,
+status, qname, qtype, etc.) as a structured log line.
+
+## Config
+
+### HTTP — `decode-http.json`
+
+```json
+{
+  "intercept_scripts": [
+    {
+      "func_name": "send",
+      "actions": [
+        { "action_name": "decode_http",
+          "action_params": { "param_name": "buf" } },
+        { "action_name": "log_params" },
+        { "action_name": "call_real" }
+      ]
+    },
+    {
+      "func_name": "recv",
+      "actions": [
+        { "action_name": "call_real" },
+        { "action_name": "decode_http",
+          "action_params": { "param_name": "buf" } },
+        { "action_name": "log_params" }
+      ]
+    }
+  ]
+}
+```
+
+Note the ordering for `recv`: `decode_http` runs **after** `call_real`
+so the buffer contains the response the kernel just wrote.
+
+### DNS — `decode-dns.json`
+
+```json
+{
+  "intercept_scripts": [
+    {
+      "func_name": "sendto",
+      "actions": [
+        { "action_name": "decode_dns",
+          "action_params": { "param_name": "buf" } },
+        { "action_name": "log_params" },
+        { "action_name": "call_real" }
+      ]
+    },
+    {
+      "func_name": "recvfrom",
+      "actions": [
+        { "action_name": "call_real" },
+        { "action_name": "decode_dns",
+          "action_params": { "param_name": "buf" } },
+        { "action_name": "log_params" }
+      ]
+    }
+  ]
+}
+```
+
+## Invocation
+
+```sh
+$ retrace run --config cookbook/decode-http.json -- curl -sS https://example.com
+$ retrace run --config cookbook/decode-dns.json  -- dig example.com A
+```
+
+## Expected output
+
+HTTP (excerpt):
+
+```
+decode_http: GET / HTTP/1.1 (request)
+decode_http: HTTP/1.1 200 OK (status=200)
+```
+
+DNS (excerpt):
+
+```
+decode_dns: query  id=0x4f3a qname=example.com qtype=A
+decode_dns: response id=0x4f3a qname=example.com qtype=A answers=1
+```
+
+If the buffer does not contain HTTP/DNS data (e.g. TLS handshake
+bytes), the action silently returns 0 — no abort, no spurious log
+lines.
+
+## Variations
+
+- **Decode both ends of a proxy**: apply `decode_http` to `send` on
+  the upstream and to `recv` on the downstream in the same config.
+- **Combine with `filter`**: only decode HTTP responses with status
+  ≥ 500:
+  ```json
+  {
+    "func_name": "recv",
+    "actions": [
+      { "action_name": "call_real" },
+      { "action_name": "decode_http",
+        "action_params": { "param_name": "buf" } },
+      { "action_name": "filter",
+        "action_params": { "param_name": "status_code",
+                           "op": ">=", "value": 500 } },
+      { "action_name": "log_params" }
+    ]
+  }
+  ```
+- **Capture for offline decode**: log `buf` to JSON (via `log_params`)
+  and post-process with the OTLP converter
+  (`tools/retrace-to-otlp`) for ingestion into Loki / Honeycomb /
+  Datadog.
+
+## Caveats
+
+- The decoders read the first line / first question only. Header
+  parsing for HTTP/2 and DNS-over-HTTPS (which are binary, framed,
+  and typically encrypted via TLS) is out of scope — intercept the
+  TLS layer if you need those.
+- For TLS-encrypted HTTP, `decode_http` will see ciphertext and
+  silently no-op. Pair with `mock_ssl_verify` (recipe 21) if you
+  want plaintext without crypto handshake overhead, or attach a
+  key-log to extract session keys.
+
+## See also
+
+- Recipe 15 — Capture network traffic (raw byte logging)
+- Recipe 21 — Mock OpenSSL verify (for plaintext TLS interception)
+- TODO.complete/23 — Protocol decoders roadmap

--- a/docs/cookbook/README.md
+++ b/docs/cookbook/README.md
@@ -79,6 +79,12 @@ $ retrace run --config cookbook/<recipe>.json -- <your-program>
 | 20 | [Sandbox a binary](20-sandbox.md) | Runtime file-access deny-list: block `/etc/shadow`, `/root/.ssh/`, etc. |
 | 21 | [Mock SSL certificate verification](21-mock-ssl-verify.md) | Force `SSL_get_verify_result` to any X509_V_* code — test cert handling without standing up servers. |
 
+### Protocol decoding
+
+| # | Recipe | What it teaches |
+|---|--------|-----------------|
+| 22 | [Decode HTTP and DNS wire formats](22-decode-protocols.md) | Parse `send`/`recv` buffers as HTTP/DNS and log structured fields instead of raw bytes. |
+
 ## Action reference
 
 Compact form. For the full schema and parameter reference, see
@@ -98,6 +104,10 @@ Compact form. For the full schema and parameter reference, see
 | `delay` | Inject N ms of latency before the call returns. |
 | `call_count_limit` | Fail the call once count crosses a per-function threshold. |
 | `sandbox` | Deny file access by path deny-list at runtime. |
+| `addr_deny` | Deny network connects to a list of IP addresses. |
+| `filter` | Run the next actions only if a param matches an operator/value. |
+| `decode_http` | Parse a buffer as HTTP/1.x and log method/path/status. |
+| `decode_dns` | Parse a buffer as DNS wire format and log id/qname/qtype/answers. |
 
 ## Environment variables
 


### PR DESCRIPTION
## Summary

- Adds `docs/cookbook/22-decode-protocols.md` — a recipe for the `decode_http` and `decode_dns` actions (landed earlier in the v2.2.0 cycle).
- Updates `docs/cookbook/README.md`:
  - New "Protocol decoding" section in the recipe index.
  - Action reference extended with `decode_http`, `decode_dns`, `filter`, `addr_deny` (previously undocumented).

## What the recipe covers

- JSON config for both actions on `send`/`recv` and `sendto`/`recvfrom`.
- The ordering rule: `decode_http` runs AFTER `call_real` for `recv` so the buffer is populated.
- Silent no-op behavior on non-matching buffers (ciphertext, non-HTTP/DNS traffic).
- Variation combining `filter` with `decode_http` to surface only status >= 500.
- Caveat: HTTP/2 and DoH are out of scope (binary, framed, typically TLS-encrypted).

## Test plan

- [x] Renders correctly (no broken markdown — verified via local cat)
- [x] JSON snippets validated against the actions' expected `action_params` schema
- [ ] CI green (docs-only change)
