### PR TITLE
tools: retrace-audit -- compliance audit MVP (TODO 26)

### DIFF
--- a/share/policies/baseline.json
+++ b/share/policies/baseline.json
@@ -1,0 +1,65 @@
+{
+  "name": "baseline",
+  "rules": [
+    {
+      "id": "BASE-001",
+      "description": "Subprocess spawned via shell -- audit for injection",
+      "match": { "func_exact": "system" },
+      "severity": "high"
+    },
+    {
+      "id": "BASE-002",
+      "description": "exec-family call -- subprocess spawning",
+      "match": { "func_prefix": "exec" },
+      "severity": "medium"
+    },
+    {
+      "id": "BASE-003",
+      "description": "Reads /etc/shadow -- credential access",
+      "match": { "func_prefix": "open", "path_contains": "/etc/shadow" },
+      "severity": "critical"
+    },
+    {
+      "id": "BASE-004",
+      "description": "Reads /etc/passwd -- user enumeration",
+      "match": { "func_prefix": "open", "path_contains": "/etc/passwd" },
+      "severity": "medium"
+    },
+    {
+      "id": "BASE-005",
+      "description": "Reads SSH directory -- private key access",
+      "match": { "func_prefix": "open", "path_contains": ".ssh/" },
+      "severity": "critical"
+    },
+    {
+      "id": "BASE-006",
+      "description": "Reads a token env var -- credential exposure",
+      "match": { "func_exact": "getenv", "env_pattern": "*_TOKEN" },
+      "severity": "high"
+    },
+    {
+      "id": "BASE-007",
+      "description": "Reads a password env var -- credential exposure",
+      "match": { "func_exact": "getenv", "env_pattern": "*_PASSWORD" },
+      "severity": "high"
+    },
+    {
+      "id": "BASE-008",
+      "description": "Reads a key env var -- credential exposure",
+      "match": { "func_exact": "getenv", "env_pattern": "*_KEY" },
+      "severity": "high"
+    },
+    {
+      "id": "BASE-009",
+      "description": "Reads LD_PRELOAD -- runtime hijack risk",
+      "match": { "func_exact": "getenv", "env_pattern": "LD_*" },
+      "severity": "medium"
+    },
+    {
+      "id": "BASE-010",
+      "description": "Writes to /etc -- system config modification",
+      "match": { "func_prefix": "open", "path_contains": "/etc/" },
+      "severity": "high"
+    }
+  ]
+}

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -5,3 +5,4 @@
 add_subdirectory(spawn)
 add_subdirectory(stringinjector)
 add_subdirectory(otlp-converter)
+add_subdirectory(audit-converter)

--- a/tools/audit-converter/CMakeLists.txt
+++ b/tools/audit-converter/CMakeLists.txt
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# retrace-audit: compliance audit report generator
+# (TODO.complete/26 MVP). Reads a retrace JSON log, applies policy
+# rules, emits findings as JSON. PDF rendering and the full policy
+# schema land in follow-up PRs; this MVP proves the engine.
+
+set(_parson_source ${CMAKE_SOURCE_DIR}/src/config/json/parson.c)
+
+add_executable(retrace_audit audit.c policy.c ${_parson_source})
+set_target_properties(retrace_audit PROPERTIES
+    OUTPUT_NAME retrace-audit
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tools")
+
+target_include_directories(retrace_audit PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/config/json
+    ${CMAKE_SOURCE_DIR}/test/property/parson_stub)
+
+install(TARGETS retrace_audit
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+install(FILES ${CMAKE_SOURCE_DIR}/share/policies/baseline.json
+    DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/retrace/policies)

--- a/tools/audit-converter/audit.c
+++ b/tools/audit-converter/audit.c
@@ -1,0 +1,347 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+/*
+ * retrace-audit: compliance audit report generator
+ * (TODO.complete/26 MVP).
+ *
+ * Reads a retrace JSON log, applies each policy rule's predicate
+ * against each entry, and emits findings as JSON.
+ *
+ * Usage:
+ *   retrace run --log /tmp/trace.json -- ./your-binary
+ *   retrace-audit --policy share/policies/baseline.json \
+ *                 --trace /tmp/trace.json > findings.json
+ *
+ * Output schema (one JSON object on stdout):
+ *   {
+ *     "policy": "baseline",
+ *     "trace": "/tmp/trace.json",
+ *     "summary": { "critical": N, "high": N, "medium": N, "info": N },
+ *     "findings": [
+ *       { "rule_id": "...", "severity": "high",
+ *         "description": "...", "entry_index": N,
+ *         "entry": { ... original log entry ... } }
+ *     ]
+ *   }
+ *
+ * PDF rendering, SARIF output, and the full filter-DSL predicates
+ * land in follow-up PRs. This MVP covers the most common
+ * compliance questions: PII path access, network connects,
+ * subprocess spawning, sensitive env var reads.
+ */
+
+#include "parson.h"
+#include "policy.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/*
+ * Predicate evaluation.
+ *
+ * The entry is the log entry's "message" object (the part that
+ * varies by action). For log_params entries, "func" is the
+ * intercepted function name and other fields are the parsed
+ * arguments (path, buf, etc.).
+ *
+ * Predicate semantics: a rule matches if ALL of its non-NULL
+ * constraints match (AND). NULL constraints are wildcards.
+ *
+ * Returns 1 if the rule matches, 0 otherwise.
+ */
+static int rule_matches(const struct Rule *rule, JSON_Object *msg)
+{
+	const char *func;
+	size_t nkeys, k;
+
+	if (rule == NULL || msg == NULL)
+		return 0;
+
+	func = json_object_get_string(msg, "func");
+
+	if (rule->func_exact != NULL) {
+		if (func == NULL || strcmp(func, rule->func_exact) != 0)
+			return 0;
+	}
+
+	if (rule->func_prefix != NULL) {
+		size_t plen = strlen(rule->func_prefix);
+
+		if (func == NULL || strncmp(func, rule->func_prefix, plen) != 0)
+			return 0;
+	}
+
+	/* path_contains: scan every string value in the message */
+	if (rule->path_contains != NULL) {
+		int found = 0;
+
+		nkeys = json_object_get_count(msg);
+		for (k = 0; k < nkeys; k++) {
+			JSON_Value *v = json_object_get_value_at(msg, k);
+			const char *s;
+
+			if (json_value_get_type(v) != JSONString)
+				continue;
+			s = json_value_get_string(v);
+			if (s != NULL && strstr(s, rule->path_contains) != NULL) {
+				found = 1;
+				break;
+			}
+		}
+		if (!found)
+			return 0;
+	}
+
+	/* env_pattern: glob match against getenv entries.
+	 * Patterns supported:
+	 *   *_TOKEN, *_KEY, *_PASSWORD  (suffix)
+	 *   LD_*, IFS                   (prefix)
+	 *   (anything else is exact)
+	 */
+	if (rule->env_pattern != NULL) {
+		const char *var = json_object_get_string(msg, "name");
+		size_t plen;
+		int match = 0;
+
+		if (var == NULL)
+			return 0;
+		plen = strlen(rule->env_pattern);
+		if (rule->env_pattern[0] == '*' && plen > 1) {
+			/* Suffix match: *_TOKEN */
+			size_t vlen = strlen(var);
+			size_t suffix_len = plen - 1;
+
+			if (vlen >= suffix_len &&
+			    strcmp(var + vlen - suffix_len,
+				   rule->env_pattern + 1) == 0)
+				match = 1;
+		} else if (plen > 0 && rule->env_pattern[plen - 1] == '*') {
+			/* Prefix match: LD_* */
+			if (strncmp(var, rule->env_pattern, plen - 1) == 0)
+				match = 1;
+		} else {
+			if (strcmp(var, rule->env_pattern) == 0)
+				match = 1;
+		}
+		if (!match)
+			return 0;
+	}
+
+	return 1;
+}
+
+/*
+ * Emit a finding as a JSON object. The finding includes:
+ *   - rule_id, severity, description from the rule
+ *   - entry_index (0-based position in the log array)
+ *   - entry (the original log entry, for evidence)
+ */
+static void emit_finding(const struct Rule *rule, size_t entry_idx,
+			 JSON_Object *original_entry, JSON_Array *findings)
+{
+	JSON_Value *finding;
+	JSON_Object *obj;
+
+	finding = json_value_init_object();
+	obj = json_value_get_object(finding);
+
+	json_object_set_string(obj, "rule_id", rule->id);
+	json_object_set_string(obj, "severity", severity_str(rule->severity));
+	json_object_set_string(obj, "description", rule->description);
+	json_object_set_number(obj, "entry_index", (double)entry_idx);
+
+	/* Deep-copy the original entry so the caller can free its
+	 * root value without invalidating the finding's reference.
+	 */
+	{
+		JSON_Value *entry_copy = json_value_deep_copy(
+			json_object_get_wrapping_value(original_entry));
+
+		json_object_set_value(obj, "entry", entry_copy);
+	}
+
+	json_array_append_value(findings, finding);
+}
+
+static void usage(FILE *out)
+{
+	fprintf(out,
+"retrace-audit -- compliance audit report generator (TODO.complete/26 MVP)\n"
+"\n"
+"Usage:\n"
+"  retrace-audit --policy POLICY.json --trace TRACE.json [-o FINDINGS.json]\n"
+"\n"
+"Reads a retrace trace log, applies each policy rule's predicate\n"
+"against each entry, and writes findings as JSON. Default output\n"
+"is stdout; use -o to write to a file.\n"
+"\n"
+"Options:\n"
+"  --policy PATH   Path to a policy JSON file (required)\n"
+"  --trace  PATH   Path to a retrace JSON log (required)\n"
+"  -o       PATH   Output path (default: stdout)\n"
+"  --help         Show this message\n");
+}
+
+int main(int argc, char **argv)
+{
+	const char *policy_path = NULL;
+	const char *trace_path = NULL;
+	const char *out_path = NULL;
+	JSON_Value *trace_root;
+	JSON_Array *trace;
+	JSON_Value *out_root;
+	JSON_Object *out_obj;
+	JSON_Array *findings;
+	JSON_Object *summary;
+	struct Policy policy;
+	size_t i, n;
+	FILE *out = stdout;
+	int argi;
+
+	for (argi = 1; argi < argc; argi++) {
+		if (strcmp(argv[argi], "--policy") == 0 && argi + 1 < argc) {
+			policy_path = argv[++argi];
+		} else if (strcmp(argv[argi], "--trace") == 0 &&
+			   argi + 1 < argc) {
+			trace_path = argv[++argi];
+		} else if (strcmp(argv[argi], "-o") == 0 &&
+			   argi + 1 < argc) {
+			out_path = argv[++argi];
+		} else if (strcmp(argv[argi], "--help") == 0 ||
+			   strcmp(argv[argi], "-h") == 0) {
+			usage(stdout);
+			return 0;
+		} else {
+			fprintf(stderr,
+				"retrace-audit: unknown arg '%s'\n", argv[argi]);
+			usage(stderr);
+			return 1;
+		}
+	}
+
+	if (policy_path == NULL || trace_path == NULL) {
+		fprintf(stderr,
+			"retrace-audit: --policy and --trace required\n");
+		usage(stderr);
+		return 1;
+	}
+
+	if (policy_load_from_file(policy_path, &policy) != 0)
+		return 1;
+
+	trace_root = json_parse_file(trace_path);
+	if (trace_root == NULL) {
+		fprintf(stderr, "retrace-audit: cannot parse %s\n",
+			trace_path);
+		policy_free(&policy);
+		return 1;
+	}
+	trace = json_value_get_array(trace_root);
+	if (trace == NULL) {
+		fprintf(stderr, "retrace-audit: %s is not a JSON array\n",
+			trace_path);
+		json_value_free(trace_root);
+		policy_free(&policy);
+		return 1;
+	}
+
+	out_root = json_value_init_object();
+	out_obj = json_value_get_object(out_root);
+	json_object_set_string(out_obj, "policy", policy.name);
+	json_object_set_string(out_obj, "trace", trace_path);
+
+	findings = json_value_get_array(json_value_init_array());
+	json_object_set_value(out_obj, "findings",
+		json_array_get_wrapping_value(findings));
+
+	summary = json_value_get_object(json_value_init_object());
+	json_object_set_value(out_obj, "summary",
+		json_object_get_wrapping_value(summary));
+	json_object_set_number(summary, "critical", 0);
+	json_object_set_number(summary, "high", 0);
+	json_object_set_number(summary, "medium", 0);
+	json_object_set_number(summary, "info", 0);
+
+	/* Apply each rule against each trace entry. */
+	n = json_array_get_count(trace);
+	for (i = 0; i < n; i++) {
+		JSON_Object *entry = json_array_get_object(trace, i);
+		JSON_Object *msg;
+		size_t r;
+
+		if (entry == NULL)
+			continue;
+		msg = json_object_get_object(entry, "message");
+		if (msg == NULL)
+			continue;
+
+		for (r = 0; r < policy.rules_count; r++) {
+			struct Rule *rule = &policy.rules[r];
+
+			if (rule_matches(rule, msg)) {
+				emit_finding(rule, i, msg, findings);
+
+				switch (rule->severity) {
+				case SEV_CRITICAL:
+					json_object_set_number(summary,
+						"critical",
+						json_object_get_number(summary,
+							"critical") + 1);
+					break;
+				case SEV_HIGH:
+					json_object_set_number(summary,
+						"high",
+						json_object_get_number(summary,
+							"high") + 1);
+					break;
+				case SEV_MEDIUM:
+					json_object_set_number(summary,
+						"medium",
+						json_object_get_number(summary,
+							"medium") + 1);
+					break;
+				case SEV_INFO:
+				default:
+					json_object_set_number(summary,
+						"info",
+						json_object_get_number(summary,
+							"info") + 1);
+					break;
+				}
+			}
+		}
+	}
+
+	if (out_path != NULL) {
+		out = fopen(out_path, "w");
+		if (out == NULL) {
+			fprintf(stderr, "retrace-audit: cannot open %s\n",
+				out_path);
+			json_value_free(out_root);
+			json_value_free(trace_root);
+			policy_free(&policy);
+			return 1;
+		}
+	}
+
+	{
+		char *serialized = json_serialize_to_string_pretty(out_root);
+
+		fputs(serialized, out);
+		fputc('\n', out);
+		json_free_serialized_string(serialized);
+	}
+
+	if (out != stdout)
+		fclose(out);
+
+	json_value_free(out_root);
+	json_value_free(trace_root);
+	policy_free(&policy);
+	return 0;
+}

--- a/tools/audit-converter/policy.c
+++ b/tools/audit-converter/policy.c
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+#include "policy.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static enum Severity parse_severity(const char *s)
+{
+	if (s == NULL)
+		return SEV_INFO;
+	if (strcmp(s, "medium") == 0)
+		return SEV_MEDIUM;
+	if (strcmp(s, "high") == 0)
+		return SEV_HIGH;
+	if (strcmp(s, "critical") == 0)
+		return SEV_CRITICAL;
+	return SEV_INFO;
+}
+
+const char *severity_str(enum Severity s)
+{
+	switch (s) {
+	case SEV_MEDIUM:
+		return "medium";
+	case SEV_HIGH:
+		return "high";
+	case SEV_CRITICAL:
+		return "critical";
+	case SEV_INFO:
+	default:
+		return "info";
+	}
+}
+
+static char *str_dup(const char *s)
+{
+	size_t n;
+	char *out;
+
+	if (s == NULL)
+		return NULL;
+	n = strlen(s);
+	out = (char *)malloc(n + 1);
+	if (out == NULL)
+		return NULL;
+	memcpy(out, s, n + 1);
+	return out;
+}
+
+/*
+ * Copy a string field into a fixed-size buffer. Truncates if too long;
+ * always NUL-terminates.
+ */
+static void set_fixed(char *dst, size_t dstsz, const char *src)
+{
+	size_t n;
+
+	if (dst == NULL || dstsz == 0)
+		return;
+	dst[0] = '\0';
+	if (src == NULL)
+		return;
+	n = strlen(src);
+	if (n >= dstsz)
+		n = dstsz - 1;
+	memcpy(dst, src, n);
+	dst[n] = '\0';
+}
+
+int policy_load_from_json(JSON_Object *root, struct Policy *out)
+{
+	JSON_Array *rules;
+	const char *name;
+	size_t i, n;
+
+	if (root == NULL || out == NULL)
+		return -1;
+
+	name = json_object_get_string(root, "name");
+	set_fixed(out->name, sizeof(out->name), name ? name : "(unnamed)");
+
+	rules = json_object_get_array(root, "rules");
+	if (rules == NULL) {
+		out->rules = NULL;
+		out->rules_count = 0;
+		return 0;
+	}
+
+	n = json_array_get_count(rules);
+	out->rules = (struct Rule *)calloc(n, sizeof(struct Rule));
+	if (out->rules == NULL)
+		return -1;
+	out->rules_count = n;
+
+	for (i = 0; i < n; i++) {
+		JSON_Object *r = json_array_get_object(rules, i);
+		JSON_Object *m;
+		struct Rule *rule = &out->rules[i];
+
+		set_fixed(rule->id, sizeof(rule->id),
+			json_object_get_string(r, "id"));
+		set_fixed(rule->description, sizeof(rule->description),
+			json_object_get_string(r, "description"));
+		rule->severity = parse_severity(
+			json_object_get_string(r, "severity"));
+
+		m = json_object_get_object(r, "match");
+		if (m != NULL) {
+			rule->func_prefix = str_dup(
+				json_object_get_string(m, "func_prefix"));
+			rule->func_exact = str_dup(
+				json_object_get_string(m, "func_exact"));
+			rule->path_contains = str_dup(
+				json_object_get_string(m, "path_contains"));
+			rule->env_pattern = str_dup(
+				json_object_get_string(m, "env_pattern"));
+		}
+	}
+
+	return 0;
+}
+
+void policy_free(struct Policy *p)
+{
+	size_t i;
+
+	if (p == NULL)
+		return;
+	for (i = 0; i < p->rules_count; i++) {
+		free((void *)p->rules[i].func_prefix);
+		free((void *)p->rules[i].func_exact);
+		free((void *)p->rules[i].path_contains);
+		free((void *)p->rules[i].env_pattern);
+	}
+	free(p->rules);
+	p->rules = NULL;
+	p->rules_count = 0;
+}
+
+int policy_load_from_file(const char *path, struct Policy *out)
+{
+	JSON_Value *v;
+
+	v = json_parse_file(path);
+	if (v == NULL) {
+		fprintf(stderr, "retrace-audit: cannot parse %s\n", path);
+		return -1;
+	}
+	if (json_value_get_type(v) != JSONObject) {
+		fprintf(stderr, "retrace-audit: %s is not a JSON object\n",
+			path);
+		json_value_free(v);
+		return -1;
+	}
+	int rc = policy_load_from_json(json_value_get_object(v), out);
+
+	json_value_free(v);
+	return rc;
+}

--- a/tools/audit-converter/policy.h
+++ b/tools/audit-converter/policy.h
@@ -47,20 +47,26 @@ enum Severity {
 
 struct Rule {
 	char id[64];
+
 	char description[256];
 
 	/* Predicate fields (NULL/0 = wildcard) */
 	const char *func_prefix;
+
 	const char *func_exact;
+
 	const char *path_contains;
-	const char *env_pattern;  /* glob: supports trailing *, e.g. "*_TOKEN" */
+
+	const char *env_pattern;
 
 	enum Severity severity;
 };
 
 struct Policy {
 	char name[64];
+
 	struct Rule *rules;
+
 	size_t rules_count;
 };
 

--- a/tools/audit-converter/policy.h
+++ b/tools/audit-converter/policy.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+#ifndef RETRACE_AUDIT_POLICY_H_
+#define RETRACE_AUDIT_POLICY_H_
+
+#include "parson.h"
+
+#include <stddef.h>
+
+/*
+ * Compliance audit policy (TODO.complete/26 MVP).
+ *
+ * A policy is a list of rules. Each rule has:
+ *   - id          : stable identifier (e.g. "SOC2-CC6.1")
+ *   - description : human-readable summary
+ *   - match       : predicate evaluated against each log entry
+ *   - severity    : "info" / "medium" / "high" / "critical"
+ *
+ * Predicate shapes (all optional; missing = match-all):
+ *   func_prefix  : entry's message.func starts with this string
+ *   func_exact   : entry's message.func equals this string
+ *   path_contains: any string param value contains this substring
+ *                   (case-sensitive)
+ *   env_pattern  : getenv calls where the var name matches a
+ *                   glob-style pattern (*_TOKEN, *_KEY, etc.)
+ *
+ * MVP predicates cover the most common compliance questions:
+ *   - Did this binary access PII files?
+ *   - Did it make outbound network connections?
+ *   - Did it spawn subprocesses?
+ *   - Did it read sensitive env vars?
+ *
+ * Richer DSL (regex, address ranges, custom functions) lands in a
+ * follow-up PR (TODO.complete/20 filter DSL).
+ */
+
+enum Severity {
+	SEV_INFO = 0,
+	SEV_MEDIUM = 1,
+	SEV_HIGH = 2,
+	SEV_CRITICAL = 3
+};
+
+struct Rule {
+	char id[64];
+	char description[256];
+
+	/* Predicate fields (NULL/0 = wildcard) */
+	const char *func_prefix;
+	const char *func_exact;
+	const char *path_contains;
+	const char *env_pattern;  /* glob: supports trailing *, e.g. "*_TOKEN" */
+
+	enum Severity severity;
+};
+
+struct Policy {
+	char name[64];
+	struct Rule *rules;
+	size_t rules_count;
+};
+
+/*
+ * Load a policy from a JSON document of shape:
+ *   {
+ *     "name": "baseline",
+ *     "rules": [
+ *       { "id": "...", "description": "...",
+ *         "match": { "func_exact": "system", ... },
+ *         "severity": "high" }
+ *     ]
+ *   }
+ *
+ * Returns 0 on success, -1 on parse error (logs to stderr).
+ * The caller owns the returned Policy and must call policy_free().
+ */
+int policy_load_from_json(JSON_Object *root, struct Policy *out);
+
+void policy_free(struct Policy *p);
+
+/*
+ * Convenience: load a policy from a file path.
+ */
+int policy_load_from_file(const char *path, struct Policy *out);
+
+/*
+ * Returns the severity as a string for JSON output.
+ */
+const char *severity_str(enum Severity s);
+
+#endif /* RETRACE_AUDIT_POLICY_H_ */


### PR DESCRIPTION
## Summary

First PR of the TODO.complete/26 sequence (compliance audit reports). Adds `retrace-audit` -- a JSON-only audit tool that reads a retrace trace log, applies a policy of rules, and emits findings as JSON. **PDF rendering and SARIF output are deliberately out of scope**; they land in follow-up PRs.

## Why

Enterprise security teams spend weeks auditing each new third-party binary. A retrace-driven audit:
- is reproducible (same binary → same report),
- is observable (the trace is the evidence),
- can be diffed between versions.

This MVP proves the engine: load a policy, scan the trace, emit findings.

## Layout

```
tools/audit-converter/
    audit.c        -- engine + CLI
    policy.{c,h}   -- policy loader (JSON -> struct Policy)
    CMakeLists.txt

share/policies/baseline.json   -- shipped default policy (10 rules)
```

## Policy schema

```json
{
  "name": "baseline",
  "rules": [
    { "id": "BASE-003",
      "description": "Reads /etc/shadow -- credential access",
      "match": { "func_prefix": "open",
                 "path_contains": "/etc/shadow" },
      "severity": "critical" }
  ]
}
```

Predicate shapes (all optional; AND semantics):
- `func_exact` -- entry's `message.func` equals this string
- `func_prefix` -- entry's `message.func` starts with this string
- `path_contains` -- any string param value contains this substring
- `env_pattern` -- getenv calls matching a glob (`*_TOKEN`, `LD_*`, etc.)

The richer filter DSL (regex, address ranges, custom functions) lands via TODO.complete/20.

## Baseline policy rules

| ID | What it flags | Severity |
|----|----|---|
| BASE-001 | `system()` -- subprocess spawned via shell | high |
| BASE-002 | `exec*` family -- subprocess spawning | medium |
| BASE-003 | `/etc/shadow` access | critical |
| BASE-004 | `/etc/passwd` reads | medium |
| BASE-005 | `.ssh/` directory access | critical |
| BASE-006 | `*_TOKEN` env vars | high |
| BASE-007 | `*_PASSWORD` env vars | high |
| BASE-008 | `*_KEY` env vars | high |
| BASE-009 | `LD_*` env vars (LD_PRELOAD etc.) | medium |
| BASE-010 | `/etc/` writes | high |

## Usage

```sh
$ retrace run --log /tmp/trace.json -- ./your-binary
$ retrace-audit --policy share/policies/baseline.json \
                 --trace /tmp/trace.json > findings.json
```

Output is a single JSON document with a summary (severity counts) and a findings array referencing the original log entries for evidence.

## Verification

Synthetic trace with 5 entries (open /etc/passwd, open /etc/shadow, getenv AWS_TOKEN, system "ls /", open /tmp/safe.txt) yields:
- 1 critical (BASE-003 /etc/shadow)
- 4 high (BASE-006 AWS_TOKEN, BASE-001 system, BASE-010 x2 /etc access)
- 1 medium (BASE-004 /etc/passwd)
- 0 info

Matches expectations. (BASE-010 fires on reads of /etc because the policy can't distinguish read/write from the log alone -- refining this needs the open() flags field captured, which is future work.)

## Test plan

- [x] `cmake --build build-test --target retrace_audit` -- clean
- [x] Manual run against synthetic trace -- expected findings
- [x] `ctest --test-dir build-test -L 'unit|property'` -- 30/30 pass (no regressions; the audit tool has no unit tests in this PR, those land in a follow-up)
- [ ] CI matrix green
