### PR TITLE
core: background log flusher thread (TODO 19 PR B -- standalone module)

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -15,7 +15,8 @@ set(_core_sources
 	sockaddr_inspect.c
 	caller_match.c
 	caller_cache.c
-	log_ring.c)
+	log_ring.c
+	log_flusher.c)
 
 # dlopen_guard.c is Linux-only: it exports dlopen/dlclose/dlsym/dlerror
 # as global symbols for LD_PRELOAD interposition. On macOS these symbols

--- a/src/core/log_flusher.c
+++ b/src/core/log_flusher.c
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "log_flusher.h"
+
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stddef.h>
+#include <time.h>
+
+#include "real_impls.h"
+#include "logger.h"
+#include "log_ring.h"
+
+/*
+ * Flusher cadence. 1 ms keeps latency low while keeping CPU use
+ * bounded: the thread does O(N_rings) work per iteration, where
+ * N_rings is bounded by the thread count of the target.
+ *
+ * A future P2 task can make this configurable via
+ * RETRACE_LOGGER_FLUSH_MS. For now, 1 ms is the right default
+ * for the latency-vs-throughput tradeoff in tracing workloads.
+ */
+#define FLUSHER_INTERVAL_NS 1000000  /* 1 ms */
+
+struct FlusherState {
+	retrace_log_flusher_emit_cb cb;
+	void *ctx;
+	pthread_t tid;
+	_Atomic int running;     /* 1 between init and stop, else 0 */
+	_Atomic int stop_signal; /* set by stop(), checked by thread */
+};
+
+static struct FlusherState g_flusher;
+
+/*
+ * Adapter to bridge retrace_log_ring_drain's per-entry callback
+ * signature to our emit callback. We pass the emit callback pair
+ * via a thread-local context struct.
+ */
+struct DrainAdapterCtx {
+	retrace_log_flusher_emit_cb cb;
+	void *user_ctx;
+	size_t emitted;
+	int stop;
+};
+
+static int drain_adapter(const struct LogEntry *e, void *p)
+{
+	struct DrainAdapterCtx *c = (struct DrainAdapterCtx *)p;
+	int rc;
+
+	if (c->stop)
+		return 1;
+	rc = c->cb(e, c->user_ctx);
+	if (rc != 0)
+		c->stop = 1;
+	else
+		c->emitted++;
+	return rc;
+}
+
+/* Walk callback: drain each ring into the adapter. */
+static void ring_walk_drain(struct LogRing *r, void *p)
+{
+	struct DrainAdapterCtx *c = (struct DrainAdapterCtx *)p;
+
+	if (c->stop)
+		return;
+	retrace_log_ring_drain(r, drain_adapter, p);
+}
+
+size_t retrace_log_flusher_drain_all(retrace_log_flusher_emit_cb cb,
+				     void *ctx)
+{
+	struct DrainAdapterCtx c = {.cb = cb, .user_ctx = ctx,
+				    .emitted = 0, .stop = 0};
+
+	if (cb == NULL)
+		return 0;
+	retrace_log_ring_walk(ring_walk_drain, &c);
+	return c.emitted;
+}
+
+static void *flusher_main(void *arg)
+{
+	struct timespec ts = {
+		.tv_sec = 0,
+		.tv_nsec = FLUSHER_INTERVAL_NS,
+	};
+	struct FlusherState *s = (struct FlusherState *)arg;
+
+	while (atomic_load_explicit(&s->stop_signal,
+		memory_order_relaxed) == 0) {
+		retrace_log_flusher_drain_all(s->cb, s->ctx);
+		nanosleep(&ts, NULL);
+	}
+
+	/* Final drain after the stop signal to capture in-flight. */
+	retrace_log_flusher_drain_all(s->cb, s->ctx);
+	return NULL;
+}
+
+int retrace_log_flusher_init(retrace_log_flusher_emit_cb cb, void *ctx)
+{
+	int rc;
+
+	if (cb == NULL) {
+		log_err("log_flusher: callback required");
+		return -1;
+	}
+
+	if (atomic_load_explicit(&g_flusher.running,
+		memory_order_relaxed) == 1) {
+		log_err("log_flusher: already running");
+		return -1;
+	}
+
+	g_flusher.cb = cb;
+	g_flusher.ctx = ctx;
+	atomic_store_explicit(&g_flusher.stop_signal, 0,
+		memory_order_relaxed);
+
+	rc = retrace_real_impls.pthread_create(&g_flusher.tid, NULL,
+		flusher_main, &g_flusher);
+	if (rc != 0) {
+		log_err("log_flusher: pthread_create failed: %d", rc);
+		return -1;
+	}
+
+	atomic_store_explicit(&g_flusher.running, 1,
+		memory_order_relaxed);
+	return 0;
+}
+
+void retrace_log_flusher_stop(void)
+{
+	if (atomic_load_explicit(&g_flusher.running,
+		memory_order_relaxed) != 1)
+		return;
+
+	atomic_store_explicit(&g_flusher.stop_signal, 1,
+		memory_order_relaxed);
+
+	retrace_real_impls.pthread_join(g_flusher.tid, NULL);
+
+	atomic_store_explicit(&g_flusher.running, 0,
+		memory_order_relaxed);
+}

--- a/src/core/log_flusher.c
+++ b/src/core/log_flusher.c
@@ -47,10 +47,14 @@
 
 struct FlusherState {
 	retrace_log_flusher_emit_cb cb;
+
 	void *ctx;
+
 	pthread_t tid;
-	_Atomic int running;     /* 1 between init and stop, else 0 */
-	_Atomic int stop_signal; /* set by stop(), checked by thread */
+
+	_Atomic int running;
+
+	_Atomic int stop_signal;
 };
 
 static struct FlusherState g_flusher;

--- a/src/core/log_flusher.h
+++ b/src/core/log_flusher.h
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef RETRACE_CORE_LOG_FLUSHER_H_
+#define RETRACE_CORE_LOG_FLUSHER_H_
+
+#include <stdint.h>
+#include <stddef.h>
+
+#include "log_ring.h"
+
+/*
+ * Background flusher thread (TODO.complete/19 PR B).
+ *
+ * Walks every registered LogRing at a fixed cadence (default 1 ms),
+ * drains each into the user-supplied emit callback, and sleeps.
+ *
+ * The flusher is the SINGLE CONSUMER in the SPSC contract -- only
+ * it may call retrace_log_ring_drain(). Producer threads never
+ * block on I/O; they only push to their own ring.
+ *
+ * Lifecycle:
+ *   1. retrace_log_ring_init()         (PR A -- module)
+ *   2. retrace_log_flusher_init(cb)    (PR B -- this module)
+ *   3. <target runs, threads push>
+ *   4. retrace_log_flusher_stop()      -- signals stop, joins,
+ *                                         does one final drain
+ *   5. retrace_log_ring_deinit()       (PR A -- module)
+ *
+ * The flusher thread runs at normal priority. A future P2 task
+ * can drop it to priority 0 via nice()/setpriority() on POSIX,
+ * but that's portability overhead for marginal gain right now.
+ */
+
+/*
+ * Emit callback. Called once per drained entry, on the flusher
+ * thread. The entry pointer is valid only for the duration of
+ * the call. Returns 0 on success, non-zero to signal "stop
+ * emitting this batch" (the flusher will skip remaining entries
+ * in the current drain but continue running).
+ */
+typedef int (*retrace_log_flusher_emit_cb)(const struct LogEntry *entry,
+					   void *ctx);
+
+/*
+ * Spawn the flusher thread. Returns 0 on success, -1 on failure
+ * (thread creation failure, or already running).
+ *
+ * The thread runs until retrace_log_flusher_stop() is called.
+ * The callback is invoked on the flusher thread, so it must be
+ * thread-safe with respect to anything it touches. In particular,
+ * stdio writes via the real libc functions are NOT safe unless
+ * routed through retrace_real_impls (which is the integration
+ * path PR C will take).
+ */
+int retrace_log_flusher_init(retrace_log_flusher_emit_cb cb, void *ctx);
+
+/*
+ * Signal the flusher to stop, then join. Performs one final
+ * drain before returning so all in-flight entries are emitted.
+ *
+ * Safe to call from the same thread that called init(). Not
+ * safe to call from the flusher thread itself (would deadlock).
+ *
+ * After stop returns, the flusher is idle and init() can be
+ * called again if desired.
+ */
+void retrace_log_flusher_stop(void);
+
+/*
+ * Drain-on-demand: walk all rings once and emit current contents.
+ * Used by retrace_log_flusher_stop() for the final drain, and
+ * exposed for tests that don't want to spawn the thread.
+ *
+ * Returns the total number of entries emitted across all rings.
+ */
+size_t retrace_log_flusher_drain_all(retrace_log_flusher_emit_cb cb,
+				     void *ctx);
+
+#endif /* RETRACE_CORE_LOG_FLUSHER_H_ */

--- a/src/core/real_impls.c
+++ b/src/core/real_impls.c
@@ -179,40 +179,50 @@ int retrace_real_impls_init(void)
 	if (retrace_real_impls.pthread_mutex_destroy == NULL)
 		return -29;
 
+	retrace_real_impls.pthread_create =
+		retrace_as_get_real_safe("pthread_create");
+	if (retrace_real_impls.pthread_create == NULL)
+		return -30;
+
+	retrace_real_impls.pthread_join =
+		retrace_as_get_real_safe("pthread_join");
+	if (retrace_real_impls.pthread_join == NULL)
+		return -31;
+
 	retrace_real_impls.real_vsnprintf =
 		retrace_as_get_real_safe("vsnprintf");
 	if (retrace_real_impls.real_vsnprintf == NULL)
-		return -30;
+		return -32;
 
 	retrace_real_impls.time =
 		retrace_as_get_real_safe("time");
 	if (retrace_real_impls.time == NULL)
-		return -31;
+		return -33;
 
 	retrace_real_impls.localtime_r =
 		retrace_as_get_real_safe("localtime_r");
 	if (retrace_real_impls.localtime_r == NULL)
-		return -32;
+		return -34;
 
 	retrace_real_impls.fprintf =
 		retrace_as_get_real_safe("fprintf");
 	if (retrace_real_impls.fprintf == NULL)
-		return -33;
+		return -35;
 
 	retrace_real_impls.fflush =
 		retrace_as_get_real_safe("fflush");
 	if (retrace_real_impls.fflush == NULL)
-		return -34;
+		return -36;
 
 	retrace_real_impls.vprintf =
 		retrace_as_get_real_safe("vprintf");
 	if (retrace_real_impls.vprintf == NULL)
-		return -35;
+		return -37;
 
 	retrace_real_impls.ctime_r =
 		retrace_as_get_real_safe("ctime_r");
 	if (retrace_real_impls.ctime_r == NULL)
-		return -36;
+		return -38;
 
 	return 0;
 }

--- a/src/core/real_impls.h
+++ b/src/core/real_impls.h
@@ -80,6 +80,9 @@ struct RetraceRealImpls {
 	int (*pthread_mutex_lock)(pthread_mutex_t *mutex);
 	int (*pthread_mutex_unlock)(pthread_mutex_t *mutex);
 	int (*pthread_mutex_destroy)(pthread_mutex_t *mutex);
+	int (*pthread_create)(pthread_t *thread, const pthread_attr_t *attr,
+			    void *(*start_routine)(void *), void *arg);
+	int (*pthread_join)(pthread_t thread, void **retval);
 
 	void *(*malloc)(size_t size);
 	void (*free)(void *ptr);

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -641,6 +641,41 @@ add_test(NAME unit-test-log-ring
 set_tests_properties(unit-test-log-ring PROPERTIES LABELS "unit")
 
 #
+# Background log flusher unit tests (TODO.complete/19 PR B).
+# Verifies the flusher thread lifecycle + entry delivery contract.
+#
+add_executable(retrace_test_log_flusher test_log_flusher.c)
+set_target_properties(retrace_test_log_flusher PROPERTIES
+    OUTPUT_NAME test_log_flusher
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/test/unit")
+
+target_link_libraries(retrace_test_log_flusher PRIVATE
+    retrace_core
+    retrace_config_json
+    retrace_backends
+    ${_unit_backend_lib}
+    retrace_preload_common
+    retrace_headers
+    ${CMAKE_DL_LIBS}
+    Threads::Threads)
+
+target_include_directories(retrace_test_log_flusher PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/core
+    ${CMAKE_SOURCE_DIR}/src/backends
+    ${CMAKE_SOURCE_DIR}/src/config/json
+    ${_unit_arch_include})
+
+if(RETRACE_PLATFORM_LINUX OR RETRACE_PLATFORM_FREEBSD)
+    target_compile_definitions(retrace_test_log_flusher PRIVATE _GNU_SOURCE _DEFAULT_SOURCE)
+elseif(RETRACE_PLATFORM_DARWIN)
+    target_compile_definitions(retrace_test_log_flusher PRIVATE _DARWIN_C_SOURCE)
+endif()
+
+add_test(NAME unit-test-log-flusher
+    COMMAND retrace_test_log_flusher)
+set_tests_properties(unit-test-log-flusher PROPERTIES LABELS "unit")
+
+#
 # modify_in_param_arr action unit tests (TODO.complete/14).
 # Completes the 14-action sweep.
 #

--- a/test/unit/test_log_flusher.c
+++ b/test/unit/test_log_flusher.c
@@ -1,0 +1,284 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+/*
+ * Unit tests for the background log flusher (TODO.complete/19 PR B).
+ *
+ * Verifies:
+ *
+ *   - init spawns a thread, stop joins it
+ *   - entries pushed after init get drained by the flusher
+ *   - the final drain on stop captures in-flight entries
+ *   - drain_all without a thread works as a one-shot flush
+ *   - per-thread rings from multiple threads all get drained
+ *   - NULL callback to init is rejected
+ *   - calling stop without init is a no-op
+ *
+ * Part of TODO.complete/19.
+ */
+
+#include <assert.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdatomic.h>
+
+#include "log_ring.h"
+#include "log_flusher.h"
+#include "real_impls.h"
+
+static int tests_run;
+static int tests_pass;
+static int tests_fail;
+
+#define TEST(name) do { \
+	tests_run++; \
+	printf("  TEST %s ... ", #name); \
+	test_##name(); \
+	tests_pass++; \
+	printf("OK\n"); \
+} while (0)
+
+/* Emit callback that records each entry into a fixed array. */
+struct EmitCapture {
+	struct LogEntry entries[512];
+	size_t count;
+};
+
+static void emit_capture_reset(struct EmitCapture *c)
+{
+	c->count = 0;
+}
+
+static int emit_capture(const struct LogEntry *e, void *p)
+{
+	struct EmitCapture *c = (struct EmitCapture *)p;
+
+	if (c->count < sizeof(c->entries) / sizeof(c->entries[0]))
+		c->entries[c->count++] = *e;
+	return 0;
+}
+
+static void test_drain_all_oneshot(void)
+{
+	struct LogRing *r;
+	struct EmitCapture cap;
+
+	retrace_log_ring_init();
+	r = retrace_log_ring_get();
+	assert(r != NULL);
+
+	retrace_log_ring_push(r, FUNCS, SEVERITY_INFO, 1, "a");
+	retrace_log_ring_push(r, FUNCS, SEVERITY_INFO, 2, "b");
+	retrace_log_ring_push(r, FUNCS, SEVERITY_INFO, 3, "c");
+
+	emit_capture_reset(&cap);
+	assert(retrace_log_flusher_drain_all(emit_capture, &cap) == 3);
+	assert(cap.count == 3);
+	assert(strcmp(cap.entries[0].text, "a") == 0);
+	assert(strcmp(cap.entries[2].text, "c") == 0);
+
+	retrace_log_ring_deinit();
+}
+
+static void test_init_stop_lifecycle(void)
+{
+	struct EmitCapture cap;
+
+	retrace_log_ring_init();
+	emit_capture_reset(&cap);
+
+	/* Flusher starts with no entries -- should idle harmlessly. */
+	assert(retrace_log_flusher_init(emit_capture, &cap) == 0);
+
+	/* Double-init is rejected. */
+	assert(retrace_log_flusher_init(emit_capture, &cap) == -1);
+
+	/* Stop without entry pushes is just a clean shutdown. */
+	retrace_log_flusher_stop();
+
+	/* Stop again is a no-op (no crash). */
+	retrace_log_flusher_stop();
+
+	retrace_log_ring_deinit();
+}
+
+static void test_flusher_drains_pushed_entries(void)
+{
+	struct LogRing *r;
+	struct EmitCapture cap;
+
+	retrace_log_ring_init();
+	emit_capture_reset(&cap);
+
+	assert(retrace_log_flusher_init(emit_capture, &cap) == 0);
+
+	/* Push from this thread; flusher should pick it up within
+	 * a few intervals (1ms each).
+	 */
+	r = retrace_log_ring_get();
+	assert(r != NULL);
+	retrace_log_ring_push(r, FUNCS, SEVERITY_INFO, 100, "alpha");
+
+	/* Wait up to 50ms for the flusher to drain. */
+	{
+		struct timespec ts = {.tv_sec = 0, .tv_nsec = 1000000};
+		int tries = 50;
+
+		while (cap.count == 0 && tries-- > 0)
+			nanosleep(&ts, NULL);
+	}
+
+	retrace_log_flusher_stop();
+
+	assert(cap.count >= 1);
+	assert(strcmp(cap.entries[0].text, "alpha") == 0);
+
+	retrace_log_ring_deinit();
+}
+
+static void test_stop_does_final_drain(void)
+{
+	/* The contract: stop() does one final drain after the loop
+	 * exits. So an entry pushed just before stop() must be
+	 * captured even if the loop never woke.
+	 */
+	struct LogRing *r;
+	struct EmitCapture cap;
+
+	retrace_log_ring_init();
+	emit_capture_reset(&cap);
+
+	assert(retrace_log_flusher_init(emit_capture, &cap) == 0);
+
+	r = retrace_log_ring_get();
+	retrace_log_ring_push(r, FUNCS, SEVERITY_INFO, 1, "final-drain");
+
+	retrace_log_flusher_stop();
+
+	assert(cap.count >= 1);
+	assert(strcmp(cap.entries[cap.count - 1].text, "final-drain") == 0);
+
+	retrace_log_ring_deinit();
+}
+
+static void test_null_cb_rejected(void)
+{
+	retrace_log_ring_init();
+	assert(retrace_log_flusher_init(NULL, NULL) == -1);
+	retrace_log_ring_deinit();
+}
+
+static void test_stop_without_init_noop(void)
+{
+	retrace_log_ring_init();
+	/* No init -- stop should not crash. */
+	retrace_log_flusher_stop();
+	retrace_log_ring_deinit();
+}
+
+/*
+ * Multi-thread stress: 4 threads each push N entries, then we
+ * stop the flusher and verify all 4N entries were emitted
+ * (modulo drops if the rings filled -- we keep N under capacity
+ * to avoid drops here).
+ */
+struct StressArg {
+	int n;
+};
+
+static void *stress_pusher(void *p)
+{
+	struct StressArg *a = (struct StressArg *)p;
+	struct LogRing *r = retrace_log_ring_get();
+	char buf[32];
+	int i;
+
+	if (r == NULL)
+		return NULL;
+	for (i = 0; i < a->n; i++) {
+		snprintf(buf, sizeof(buf), "s%d", i);
+		retrace_log_ring_push(r, FUNCS, SEVERITY_INFO,
+			(uint32_t)i, buf);
+	}
+	return NULL;
+}
+
+static void test_multi_thread_all_drained(void)
+{
+	enum { NTHREADS = 4, PER_THREAD = 32 };
+	pthread_t tids[NTHREADS];
+	struct StressArg args[NTHREADS];
+	struct EmitCapture cap;
+	int i;
+
+	retrace_log_ring_init();
+	emit_capture_reset(&cap);
+
+	assert(retrace_log_flusher_init(emit_capture, &cap) == 0);
+
+	for (i = 0; i < NTHREADS; i++) {
+		args[i].n = PER_THREAD;
+		pthread_create(&tids[i], NULL, stress_pusher, &args[i]);
+	}
+	for (i = 0; i < NTHREADS; i++)
+		pthread_join(tids[i], NULL);
+
+	retrace_log_flusher_stop();
+
+	/* All entries should be drained (no drops expected since
+	 * PER_THREAD < LOG_RING_DEFAULT_CAP - 1 = 63).
+	 */
+	assert(cap.count == (size_t)(NTHREADS * PER_THREAD));
+	assert(retrace_log_ring_total_dropped() == 0);
+
+	retrace_log_ring_deinit();
+}
+
+int main(void)
+{
+	/* Init real_impls. */
+	retrace_real_impls.strcmp = strcmp;
+	retrace_real_impls.strlen = strlen;
+	retrace_real_impls.strcpy = strcpy;
+	retrace_real_impls.memset = memset;
+	retrace_real_impls.memcpy = memcpy;
+	retrace_real_impls.malloc = malloc;
+	retrace_real_impls.free = free;
+	retrace_real_impls.real_snprintf = snprintf;
+	retrace_real_impls.pthread_mutex_lock = pthread_mutex_lock;
+	retrace_real_impls.pthread_mutex_unlock = pthread_mutex_unlock;
+	retrace_real_impls.pthread_mutex_init = pthread_mutex_init;
+	retrace_real_impls.pthread_mutex_destroy = pthread_mutex_destroy;
+	retrace_real_impls.pthread_key_create = pthread_key_create;
+	retrace_real_impls.pthread_key_delete = pthread_key_delete;
+	retrace_real_impls.pthread_getspecific = pthread_getspecific;
+	retrace_real_impls.pthread_setspecific = pthread_setspecific;
+	retrace_real_impls.pthread_create = pthread_create;
+	retrace_real_impls.pthread_join = pthread_join;
+
+	printf("log_flusher tests:\n");
+
+	printf("  -- one-shot drain --\n");
+	TEST(drain_all_oneshot);
+
+	printf("  -- lifecycle --\n");
+	TEST(init_stop_lifecycle);
+	TEST(null_cb_rejected);
+	TEST(stop_without_init_noop);
+
+	printf("  -- thread-driven drain --\n");
+	TEST(flusher_drains_pushed_entries);
+	TEST(stop_does_final_drain);
+
+	printf("  -- multi-thread stress --\n");
+	TEST(multi_thread_all_drained);
+
+	printf("\nPass: %d, Fail: %d (of %d)\n",
+		tests_pass, tests_fail, tests_run);
+	return tests_fail == 0 ? 0 : 1;
+}

--- a/test/unit/test_log_flusher.c
+++ b/test/unit/test_log_flusher.c
@@ -43,7 +43,10 @@ static int tests_fail;
 	printf("OK\n"); \
 } while (0)
 
-/* Emit callback that records each entry into a fixed array. */
+/* Emit callback that records each entry into a fixed array.
+ * Each entry's text is strdup'd because the flusher's drain frees
+ * the original after the callback returns.
+ */
 struct EmitCapture {
 	struct LogEntry entries[512];
 	size_t count;
@@ -58,8 +61,18 @@ static int emit_capture(const struct LogEntry *e, void *p)
 {
 	struct EmitCapture *c = (struct EmitCapture *)p;
 
-	if (c->count < sizeof(c->entries) / sizeof(c->entries[0]))
-		c->entries[c->count++] = *e;
+	if (c->count < sizeof(c->entries) / sizeof(c->entries[0])) {
+		struct LogEntry *dst = &c->entries[c->count++];
+		size_t len = strlen(e->text);
+
+		dst->ts_ms = e->ts_ms;
+		dst->module = e->module;
+		dst->sev = e->sev;
+		dst->text = (char *)malloc(len + 1);
+		if (dst->text == NULL)
+			return 1;
+		memcpy(dst->text, e->text, len + 1);
+	}
 	return 0;
 }
 


### PR DESCRIPTION
## Summary

Replaces #588 (auto-closed when its base #587 was rebase-merged). Adds `src/core/log_flusher.{c,h}` -- a background thread that walks every registered `LogRing` at a 1ms cadence and emits each entry to a user-supplied callback. **Standalone only** -- does NOT touch `logger.c` yet (that's PR C of this sequence).

## What the flusher does

The flusher is the SINGLE CONSUMER in the SPSC contract -- only it calls `retrace_log_ring_drain()`. Producer threads never block on I/O.

```
init(cb, ctx)  -> spawn thread
loop:
  drain_all(cb, ctx)   -- walk all rings, emit each entry
  nanosleep(1ms)
stop()         -> set stop signal, join, do one final drain
```

The final drain on stop captures in-flight entries -- a push immediately followed by stop still emits.

## API

- `retrace_log_flusher_init(cb, ctx)` -- spawn thread; double-init rejected
- `retrace_log_flusher_stop()` -- signal + join + final drain; idempotent
- `retrace_log_flusher_drain_all(cb, ctx)` -- one-shot flush (no thread); exposed for tests

## real_impls additions

- `pthread_create`, `pthread_join`
- Error codes -30..-38 shifted to accommodate

## Test plan

7 unit tests covering lifecycle, thread-driven drain, final-drain-on-stop, NULL safety, and 4-thread stress.

- [x] `cmake --build build-test --target retrace_test_log_flusher` -- clean
- [x] `ctest --test-dir build-test -L unit` -- 31/31 pass
- [ ] CI green
