### PR TITLE
vscode-extension: retrace viewer for VS Code (TODO 31 MVP)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -397,6 +397,9 @@ if(NOT RETRACE_PLATFORM_WINDOWS)
 	endif()
 endif()
 
+# VS Code extension is pure TypeScript (no native build).
+add_subdirectory(vscode-extension)
+
 # ---------------------------------------------------------------
 # Package config
 # ---------------------------------------------------------------

--- a/vscode-extension/CMakeLists.txt
+++ b/vscode-extension/CMakeLists.txt
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# retrace VS Code extension (TODO.complete/31 MVP).
+#
+# Pure TypeScript; build separately via `npm install && npm run compile`.
+# CMake just installs the source files so distro packagers can find them.
+
+install(DIRECTORY . DESTINATION share/retrace/vscode-extension
+    FILES_MATCHING
+    PATTERN "*.json"
+    PATTERN "*.ts"
+    PATTERN "*.md"
+    PATTERN "CMakeLists.txt" EXCLUDE
+    PATTERN "node_modules" EXCLUDE
+    PATTERN "out" EXCLUDE)

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -1,0 +1,44 @@
+# retrace viewer for VS Code
+
+A minimal VS Code extension that loads a retrace JSON log and renders it in a webview with function-name highlighting and severity coloring. Also exposes a stats command that shows per-function call counts.
+
+Part of TODO.complete/31 (VS Code extension). This is the MVP scaffold.
+
+## Features
+
+- **retrace: Open Log Viewer** -- opens a webview showing every event in the log, with color-coded severity and function-name emphasis.
+- **retrace: Show Stats** -- quick-pick menu of all functions, sorted by call count, with total time per function.
+
+Both commands are available in the Command Palette and via right-click on a `.json` file in the Explorer.
+
+## Install
+
+This extension lives in-tree alongside retrace. To package it for local testing:
+
+```sh
+cd vscode-extension
+npm install
+npm run compile
+npx vsce package
+# Install the resulting retrace-viewer-0.1.0.vsix into VS Code:
+code --install-extension retrace-viewer-0.1.0.vsix
+```
+
+## Use
+
+1. Run retrace on a binary to produce a JSON log:
+   ```sh
+   retrace run --log /tmp/trace.json -- ./your-binary
+   ```
+2. Open the Command Palette in VS Code, run `retrace: Open Log Viewer`, select `/tmp/trace.json`.
+
+## Limitations (MVP scope)
+
+- No live streaming (load is one-shot).
+- No filtering in the viewer; loads every event at once. For very large logs (>10 MB), this is slow.
+- No config builder (TODO.complete/31 P1).
+
+## See also
+
+- TODO.complete/31 -- VS Code extension roadmap
+- TODO.complete/32 -- Grafana plugin (server-side dashboard)

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -1,0 +1,72 @@
+{
+  "name": "retrace-viewer",
+  "displayName": "retrace viewer",
+  "description": "View retrace JSON logs in VS Code with function-name highlighting and severity coloring.",
+  "version": "0.1.0",
+  "publisher": "riboseinc",
+  "license": "BSD-2-Clause",
+  "engines": {
+    "vscode": "^1.85.0"
+  },
+  "categories": [
+    "Other",
+    "Debuggers"
+  ],
+  "keywords": [
+    "retrace",
+    "tracing",
+    "debugging",
+    "libc",
+    "interception"
+  ],
+  "activationEvents": [],
+  "main": "./out/extension.js",
+  "contributes": {
+    "commands": [
+      {
+        "command": "retrace.showViewer",
+        "title": "retrace: Open Log Viewer",
+        "category": "retrace"
+      },
+      {
+        "command": "retrace.showStats",
+        "title": "retrace: Show Stats",
+        "category": "retrace"
+      }
+    ],
+    "menus": {
+      "commandPalette": [
+        {
+          "command": "retrace.showViewer"
+        },
+        {
+          "command": "retrace.showStats"
+        }
+      ],
+      "explorer/context": [
+        {
+          "command": "retrace.showViewer",
+          "when": "resourceExtname == '.json'",
+          "group": "navigation"
+        }
+      ]
+    }
+  },
+  "scripts": {
+    "vscode:prepublish": "npm run compile",
+    "compile": "tsc -p ./",
+    "watch": "tsc -watch -p ./",
+    "package": "vsce package"
+  },
+  "devDependencies": {
+    "@types/node": "^18.0.0",
+    "@types/vscode": "^1.85.0",
+    "typescript": "^5.0.0"
+  },
+  "homepage": "https://github.com/riboseinc/retrace",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/riboseinc/retrace.git",
+    "directory": "vscode-extension"
+  }
+}

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1,0 +1,209 @@
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * retrace viewer VS Code extension (TODO.complete/31 MVP).
+ *
+ * Activates on first run of either command. The viewer command
+ * opens a webview that loads a retrace JSON log and renders it
+ * with function-name highlighting + severity coloring. The
+ * stats command opens a quick summary (call counts per function).
+ */
+
+import * as vscode from "vscode";
+import * as fs from "fs";
+import * as path from "path";
+
+interface RetraceEntry {
+    time?: number;
+    module?: string;
+    severity?: "DEBUG" | "INFO" | "WARN" | "ERROR";
+    message: {
+        func?: string;
+        text?: string;
+        call_duration_us?: number;
+        ret_val?: number | string;
+        [k: string]: unknown;
+    };
+}
+
+/**
+ * Load a retrace JSON log from a path. Returns the entries.
+ * Throws on parse error or non-array root.
+ */
+function loadTrace(filePath: string): RetraceEntry[] {
+    const text = fs.readFileSync(filePath, "utf-8");
+    const data = JSON.parse(text);
+    if (!Array.isArray(data)) {
+        throw new Error(`${filePath} is not a JSON array`);
+    }
+    return data as RetraceEntry[];
+}
+
+/**
+ * Compute per-function stats: call count, total duration.
+ */
+function computeStats(entries: RetraceEntry[]): Map<string, { count: number; totalUs: number }> {
+    const stats = new Map<string, { count: number; totalUs: number }>();
+    for (const e of entries) {
+        const func = e.message?.func;
+        if (!func) continue;
+        const cur = stats.get(func) ?? { count: 0, totalUs: 0 };
+        cur.count++;
+        if (typeof e.message.call_duration_us === "number") {
+            cur.totalUs += e.message.call_duration_us;
+        }
+        stats.set(func, cur);
+    }
+    return stats;
+}
+
+/**
+ * Render the viewer HTML for a set of entries.
+ */
+function renderViewer(entries: RetraceEntry[], fileName: string): string {
+    const rows = entries
+        .map((e, i) => {
+            const func = e.message?.func ?? "(no func)";
+            const sev = e.severity ?? "INFO";
+            const args = JSON.stringify(
+                Object.fromEntries(
+                    Object.entries(e.message).filter(
+                        ([k]) =>
+                            k !== "func" &&
+                            k !== "call_duration_us" &&
+                            k !== "ret_val" &&
+                            k !== "text"
+                    )
+                )
+            );
+            const ret = e.message?.ret_val;
+            const us = e.message?.call_duration_us;
+            return `<div class="event sev-${sev}">
+                <span class="idx">#${i}</span>
+                <span class="func">${escapeHtml(func)}</span>
+                <span class="sev">${sev}</span>
+                <span class="args">${escapeHtml(args)}</span>
+                ${ret !== undefined ? `<span class="ret">→ ${escapeHtml(String(ret))}</span>` : ""}
+                ${us !== undefined ? `<span class="dur">${us}µs</span>` : ""}
+            </div>`;
+        })
+        .join("\n");
+
+    return `<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>retrace: ${escapeHtml(fileName)}</title>
+<style>
+body { font-family: var(--vscode-editor-font-family, monospace); margin: 0; padding: 8px; color: var(--vscode-editor-foreground, #eee); background: var(--vscode-editor-background, #1e1e1e); }
+.event { display: flex; gap: 12px; padding: 2px 4px; border-bottom: 1px solid var(--vscode-editorWidget-background, #2a2a2a); white-space: nowrap; overflow-x: auto; }
+.idx { color: var(--vscode-descriptionForeground, #888); min-width: 60px; }
+.func { color: var(--vscode-textLink-foreground, #6ed6ff); font-weight: bold; min-width: 160px; }
+.sev { min-width: 60px; }
+.sev-WARN { color: #ffcc66; }
+.sev-ERROR { color: #ff6666; }
+.args { color: var(--vscode-editor-foreground, #ddd); flex-grow: 1; }
+.ret { color: var(--vscode-textPreformat-foreground, #b5cea8); }
+.dur { color: var(--vscode-descriptionForeground, #888); min-width: 80px; text-align: right; }
+h1 { font-size: 14px; margin: 8px 0; padding: 0; color: var(--vscode-foreground, #eee); }
+</style>
+</head>
+<body>
+<h1>${escapeHtml(fileName)} (${entries.length} events)</h1>
+${rows}
+</body>
+</html>`;
+}
+
+function escapeHtml(s: string): string {
+    return s
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;");
+}
+
+export function activate(context: vscode.ExtensionContext): void {
+    const showViewer = vscode.commands.registerCommand(
+        "retrace.showViewer",
+        async (uri?: vscode.Uri) => {
+            let filePath: string | undefined;
+            if (uri?.fsPath) {
+                filePath = uri.fsPath;
+            } else {
+                const picked = await vscode.window.showOpenDialog({
+                    canSelectMany: false,
+                    filters: { "JSON logs": ["json"] },
+                    title: "Select a retrace log",
+                });
+                filePath = picked?.[0]?.fsPath;
+            }
+            if (!filePath) return;
+
+            let entries: RetraceEntry[];
+            try {
+                entries = loadTrace(filePath);
+            } catch (err) {
+                void vscode.window.showErrorMessage(
+                    `retrace: cannot load ${filePath}: ${(err as Error).message}`
+                );
+                return;
+            }
+
+            const panel = vscode.window.createWebviewPanel(
+                "retraceViewer",
+                `retrace: ${path.basename(filePath)}`,
+                vscode.ViewColumn.Active,
+                { enableScripts: false }
+            );
+            panel.webview.html = renderViewer(entries, path.basename(filePath));
+        }
+    );
+
+    const showStats = vscode.commands.registerCommand(
+        "retrace.showStats",
+        async (uri?: vscode.Uri) => {
+            let filePath: string | undefined;
+            if (uri?.fsPath) {
+                filePath = uri.fsPath;
+            } else {
+                const picked = await vscode.window.showOpenDialog({
+                    canSelectMany: false,
+                    filters: { "JSON logs": ["json"] },
+                    title: "Select a retrace log",
+                });
+                filePath = picked?.[0]?.fsPath;
+            }
+            if (!filePath) return;
+
+            let entries: RetraceEntry[];
+            try {
+                entries = loadTrace(filePath);
+            } catch (err) {
+                void vscode.window.showErrorMessage(
+                    `retrace: cannot load ${filePath}: ${(err as Error).message}`
+                );
+                return;
+            }
+
+            const stats = computeStats(entries);
+            const items = Array.from(stats.entries())
+                .sort((a, b) => b[1].count - a[1].count)
+                .map(([func, s]) => ({
+                    label: func,
+                    description: `${s.count} calls`,
+                    detail: `${(s.totalUs / 1000).toFixed(1)}ms total`,
+                }));
+
+            await vscode.window.showQuickPick(items, {
+                placeHolder: `${stats.size} functions, ${entries.length} events`,
+            });
+        }
+    );
+
+    context.subscriptions.push(showViewer, showStats);
+}
+
+export function deactivate(): void {
+    /* nothing to clean up */
+}

--- a/vscode-extension/tsconfig.json
+++ b/vscode-extension/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "ES2020",
+        "lib": ["ES2020"],
+        "outDir": "out",
+        "rootDir": "src",
+        "sourceMap": true,
+        "strict": true,
+        "esModuleInterop": true,
+        "skipLibCheck": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "include": ["src/**/*"],
+    "exclude": ["node_modules", "out"]
+}


### PR DESCRIPTION
## Summary

First PR of TODO.complete/31 (VS Code extension). Adds a minimal VS Code extension that loads a retrace JSON log and renders it in a webview with function-name highlighting and severity coloring. Also exposes a stats command.

## Features

- **retrace: Open Log Viewer** -- webview showing every event in the log, with color-coded severity and function-name emphasis.
- **retrace: Show Stats** -- quick-pick menu of all functions, sorted by call count, with total time per function.

Both available in the Command Palette and via right-click on a `.json` file in the Explorer.

## Build

```sh
$ cd vscode-extension
$ npm install
$ npm run compile
$ npx vsce package
$ code --install-extension retrace-viewer-0.1.0.vsix
```

## Use

1. Run retrace on a binary to produce a JSON log.
2. In VS Code, run `retrace: Open Log Viewer` from the Command Palette.
3. Select the JSON log.

## Implementation

- TypeScript with VS Code's theme variables (adapts to user's color theme).
- Filters engine-noise entries (`message.text` instead of `message.func`) -- same convention as the OTLP converter and trace-diff tool.
- Per-function stats: call count + total `call_duration_us`.

## Limitations (MVP scope)

- No live streaming (load is one-shot).
- No filtering in the viewer; loads every event at once. For very large logs (>10 MB), this is slow.
- No config builder (TODO.complete/31 P1).

## Test plan

- [x] TypeScript syntax valid
- [x] CMake configures clean
- [x] README renders correctly
- [ ] CI matrix green
