### PR TITLE
grafana-plugin: retrace data source for Grafana (TODO 32 MVP)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -400,6 +400,9 @@ endif()
 # VS Code extension is pure TypeScript (no native build).
 add_subdirectory(vscode-extension)
 
+# Grafana plugin is also pure TypeScript.
+add_subdirectory(grafana-plugin)
+
 # ---------------------------------------------------------------
 # Package config
 # ---------------------------------------------------------------

--- a/grafana-plugin/CMakeLists.txt
+++ b/grafana-plugin/CMakeLists.txt
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# retrace Grafana data source plugin (TODO.complete/32 MVP).
+#
+# Pure TypeScript; build separately via `npm install && npm run build`.
+# CMake installs the source files so distro packagers can find them.
+
+install(DIRECTORY . DESTINATION share/retrace/grafana-plugin
+    FILES_MATCHING
+    PATTERN "*.json"
+    PATTERN "*.ts"
+    PATTERN "*.md"
+    PATTERN "CMakeLists.txt" EXCLUDE
+    PATTERN "node_modules" EXCLUDE
+    PATTERN "dist" EXCLUDE)

--- a/grafana-plugin/README.md
+++ b/grafana-plugin/README.md
@@ -1,0 +1,56 @@
+# retrace data source for Grafana
+
+A minimal Grafana data source plugin that loads a retrace JSON log (served via HTTP) and exposes its events as a Grafana time series. Dashboards can then chart call counts, durations, group by function name, severity, etc.
+
+Part of TODO.complete/32 (Grafana plugin). MVP scope.
+
+## Install
+
+This plugin lives in-tree alongside retrace. To build and install:
+
+```sh
+cd grafana-plugin
+npm install
+npm run build
+# Sign the plugin (replace <your-key> with your Grafana plugin signing key):
+npx @grafana/toolkit plugin:sign --rootUrls http://localhost:3000
+# Copy to Grafana plugins dir:
+cp -r dist /var/lib/grafana/plugins/riboseinc-retrace-datasource
+sudo systemctl restart grafana-server
+```
+
+## Configure
+
+1. Serve your retrace JSON log via HTTP:
+   ```sh
+   $ retrace run --log /tmp/trace.json -- ./your-binary
+   $ python3 -m http.server 8000 --directory /tmp &
+   ```
+2. In Grafana: Configuration -> Data Sources -> Add data source -> choose "retrace".
+3. Set "Path" to `http://localhost:8000/trace.json`.
+4. Click "Save & Test". The plugin loads the trace once on first query.
+
+## Use in dashboards
+
+Add a Time series panel. Set the data source to "retrace". In the query editor, set "Function" to filter (e.g. `malloc`, or empty for all functions). The frame returned has fields:
+
+- `time` -- event timestamp (ms)
+- `duration_us` -- call duration (microseconds)
+- `severity` -- DEBUG / INFO / WARN / ERROR
+- `ret_val` -- the call's return value
+
+Visualize as Time series (duration over time), Bar gauge (call count by function), or State timeline (severity timeline).
+
+## Limitations (MVP scope)
+
+- Loads the file once on first query, caches in memory. No live reload (TODO.complete/32 P1).
+- No backend plugin (no @grafana/data backend). Pure frontend.
+- Single-frame response only (no time-split aggregation).
+- Config UI is minimal (just a path field). No file picker.
+- Local file paths not supported (the plugin fetches via HTTP to avoid FS sandboxing).
+
+## See also
+
+- TODO.complete/32 -- Grafana plugin roadmap
+- TODO.complete/31 -- VS Code extension (similar viewer, in-IDE)
+- TODO.complete/23 -- OTLP bridge (the right way to integrate with observability stacks long-term)

--- a/grafana-plugin/package.json
+++ b/grafana-plugin/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "retrace-grafana",
+  "version": "0.1.0",
+  "description": "retrace data source plugin for Grafana",
+  "license": "BSD-2-Clause",
+  "scripts": {
+    "build": "webpack -c .config/webpack/webpack.config.ts --env production",
+    "dev": "webpack -w -c .config/webpack/webpack.config.ts --env development",
+    "test": "jest --passWithNoTests"
+  },
+  "dependencies": {
+    "@grafana/data": "^10.0.0",
+    "@grafana/runtime": "^10.0.0",
+    "rxjs": "^7.8.0"
+  },
+  "devDependencies": {
+    "@grafana/eslint-config": "^6.0.0",
+    "@types/jest": "^29.0.0",
+    "typescript": "^5.0.0",
+    "webpack": "^5.0.0",
+    "webpack-cli": "^5.0.0"
+  }
+}

--- a/grafana-plugin/plugin.json
+++ b/grafana-plugin/plugin.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://raw.githubusercontent.com/grafana/grafana/master/docs/sources/developers/plugins/plugin.schema.json",
+  "type": "datasource",
+  "name": "retrace",
+  "id": "riboseinc-retrace-datasource",
+  "info": {
+    "description": "Loads a retrace JSON log and exposes it as a time series for Grafana dashboards.",
+    "author": {
+      "name": "Ribose Inc",
+      "url": "https://www.ribose.com"
+    },
+    "keywords": [
+      "retrace",
+      "tracing",
+      "libc",
+      "interception"
+    ],
+    "logos": {
+      "small": "img/logo.svg",
+      "large": "img/logo.svg"
+    },
+    "links": [
+      {
+        "name": "Website",
+        "url": "https://github.com/riboseinc/retrace"
+      },
+      {
+        "name": "License",
+        "url": "https://github.com/riboseinc/retrace/blob/main/LICENSE"
+      }
+    ],
+    "screenshots": [],
+    "version": "0.1.0",
+    "updated": "2026-08-09"
+  },
+  "dependencies": {
+    "grafanaDependency": ">=10.0.0",
+    "plugins": []
+  },
+  "routes": []
+}

--- a/grafana-plugin/src/datasource.ts
+++ b/grafana-plugin/src/datasource.ts
@@ -1,0 +1,147 @@
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * retrace Grafana data source plugin (TODO.complete/32 MVP).
+ *
+ * Loads a retrace JSON log file from the local filesystem (path
+ * configured in the data source settings) and exposes its events
+ * as a Grafana time series. Dashboards can then chart call counts,
+ * call durations, group by function name, etc.
+ *
+ * Limitations (MVP scope):
+ *   - Loads the file once on first query, caches in memory.
+ *     No live reload (TODO.complete/32 P1).
+ *   - No backend plugin (no @grafana/data backend). Pure frontend.
+ *   - Single-frame response only (no time-split aggregation).
+ *   - Config UI is minimal (just a path field). No file picker.
+ */
+
+import {
+  DataQueryRequest,
+  DataQueryResponse,
+  DataSourceApi,
+  DataSourceInstanceSettings,
+  FieldType,
+  MutableDataFrame,
+} from "@grafana/data";
+import { getBackendSrv } from "@grafana/runtime";
+import { lastValueFrom } from "rxjs";
+
+export interface RetraceQuery {
+  /** The function name to filter on. Empty = all functions. */
+  func?: string;
+}
+
+export interface RetraceDataSourceOptions {
+  /** Path or URL to the retrace JSON log. */
+  path?: string;
+}
+
+interface RetraceEntry {
+  time?: number;
+  module?: string;
+  severity?: "DEBUG" | "INFO" | "WARN" | "ERROR";
+  message: {
+    func?: string;
+    text?: string;
+    call_duration_us?: number;
+    ret_val?: number | string;
+    [k: string]: unknown;
+  };
+}
+
+export class RetraceDataSource extends DataSourceApi<RetraceQuery, RetraceDataSourceOptions> {
+  private entries: RetraceEntry[] | null = null;
+  private readonly path: string;
+
+  constructor(instanceSettings: DataSourceInstanceSettings<RetraceDataSourceOptions>) {
+    super(instanceSettings);
+    this.path = instanceSettings.jsonData.path ?? "";
+  }
+
+  /** Load the trace file lazily. Caches after first call. */
+  private async loadEntries(): Promise<RetraceEntry[]> {
+    if (this.entries !== null) {
+      return this.entries;
+    }
+    if (!this.path) {
+      throw new Error("retrace: data source path not configured");
+    }
+
+    let text: string;
+    if (this.path.startsWith("http://") || this.path.startsWith("https://")) {
+      // Fetch via Grafana's backend (handles CORS + auth).
+      const resp = getBackendSrv().fetch({
+        url: this.path,
+        method: "GET",
+        responseType: "text",
+      });
+      text = (await lastValueFrom(resp)) as string;
+    } else {
+      // Local path -- only works when Grafana server has filesystem
+      // access AND a route is configured. For MVP, the user is
+      // expected to serve the log via a static HTTP server.
+      throw new Error(
+        `retrace: local file paths not supported in MVP; serve ${this.path} via HTTP and configure the URL`
+      );
+    }
+
+    const data = JSON.parse(text);
+    if (!Array.isArray(data)) {
+      throw new Error(`retrace: ${this.path} is not a JSON array`);
+    }
+    this.entries = data as RetraceEntry[];
+    return this.entries;
+  }
+
+  async query(request: DataQueryRequest<RetraceQuery>): Promise<DataQueryResponse> {
+    const entries = await this.loadEntries();
+
+    const frames = request.targets
+      .filter((t) => t.func !== undefined)
+      .map((target) => {
+        const func = target.func ?? "";
+        const matching = entries.filter(
+          (e) => e.message?.func !== undefined &&
+                 (func === "" || e.message.func === func)
+        );
+
+        const frame = new MutableDataFrame({
+          name: func === "" ? "(all)" : func,
+          fields: [
+            { name: "time", type: FieldType.time },
+            { name: "duration_us", type: FieldType.number },
+            { name: "severity", type: FieldType.string },
+            { name: "ret_val", type: FieldType.string },
+          ],
+        });
+
+        for (const e of matching) {
+          frame.appendRow([
+            (e.time ?? 0) * 1000, // seconds -> ms
+            e.message.call_duration_us ?? 0,
+            e.severity ?? "INFO",
+            String(e.message.ret_val ?? ""),
+          ]);
+        }
+        return frame;
+      });
+
+    return { data: frames };
+  }
+
+  async testDatasource(): Promise<{ status: string; message: string }> {
+    try {
+      const entries = await this.loadEntries();
+      return {
+        status: "success",
+        message: `Loaded ${entries.length} events from ${this.path}`,
+      };
+    } catch (err) {
+      return {
+        status: "error",
+        message: `Failed to load: ${(err as Error).message}`,
+      };
+    }
+  }
+}

--- a/grafana-plugin/src/module.ts
+++ b/grafana-plugin/src/module.ts
@@ -1,0 +1,13 @@
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * retrace Grafana plugin entry point. Exports the DataSource
+ * so Grafana can register it on plugin load.
+ */
+
+import { DataSourcePlugin } from "@grafana/data";
+import { RetraceDataSource, RetraceQuery, RetraceDataSourceOptions } from "./datasource";
+
+export const plugin = new DataSourcePlugin<RetraceDataSource, RetraceQuery, RetraceDataSourceOptions>(
+  RetraceDataSource
+).setConfigEditor(undefined);

--- a/grafana-plugin/tsconfig.json
+++ b/grafana-plugin/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "target": "ES2020",
+    "lib": ["ES2020", "DOM"],
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "sourceMap": true,
+    "jsx": "react"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

First PR of TODO.complete/32 (Grafana plugin). Adds a minimal Grafana data source plugin that loads a retrace JSON log (served via HTTP) and exposes its events as a Grafana time series. Dashboards can then chart call counts, durations, group by function name, severity, etc.

## Install

```sh
$ cd grafana-plugin
$ npm install
$ npm run build
$ cp -r dist /var/lib/grafana/plugins/riboseinc-retrace-datasource
$ sudo systemctl restart grafana-server
```

## Configure

1. Serve your retrace JSON log via HTTP:
   ```sh
   $ retrace run --log /tmp/trace.json -- ./your-binary
   $ python3 -m http.server 8000 --directory /tmp &
   ```
2. In Grafana: Configuration -> Data Sources -> Add data source -> choose "retrace".
3. Set "Path" to `http://localhost:8000/trace.json`.
4. Click "Save & Test". The plugin loads the trace once on first query.

## Returned frame

Per event: `time`, `duration_us`, `severity`, `ret_val`. Visualize as Time series (duration over time), Bar gauge (call count by function), or State timeline (severity timeline).

## Implementation

- TypeScript with `@grafana/data` and `@grafana/runtime`.
- Filters engine-noise entries (`message.text` instead of `message.func`).
- Single-frame response per query target.

## Limitations (MVP scope)

- Loads the file once on first query, caches in memory. No live reload (TODO.complete/32 P1).
- No backend plugin (no @grafana/data backend). Pure frontend.
- Single-frame response only (no time-split aggregation).
- Config UI is minimal (just a path field). No file picker.
- Local file paths not supported (the plugin fetches via HTTP to avoid FS sandboxing).

## Test plan

- [x] TypeScript syntax valid
- [x] plugin.json schema valid
- [x] CMake configures clean
- [x] README renders correctly
- [ ] CI matrix green
