### PR TITLE
audit: SARIF output + MECE refactor (TODO 26 P1)

### DIFF
--- a/tools/audit-converter/audit.c
+++ b/tools/audit-converter/audit.c
@@ -6,7 +6,7 @@
 
 /*
  * retrace-audit: compliance audit report generator
- * (TODO.complete/26 MVP).
+ * (TODO.complete/26).
  *
  * Reads a retrace JSON log, applies each policy rule's predicate
  * against each entry, and emits findings as JSON.
@@ -14,24 +14,20 @@
  * Usage:
  *   retrace run --log /tmp/trace.json -- ./your-binary
  *   retrace-audit --policy share/policies/baseline.json \
- *                 --trace /tmp/trace.json > findings.json
+ *                 --trace /tmp/trace.json [--format default|sarif]
  *
- * Output schema (one JSON object on stdout):
- *   {
- *     "policy": "baseline",
- *     "trace": "/tmp/trace.json",
- *     "summary": { "critical": N, "high": N, "medium": N, "info": N },
- *     "findings": [
- *       { "rule_id": "...", "severity": "high",
- *         "description": "...", "entry_index": N,
- *         "entry": { ... original log entry ... } }
- *     ]
- *   }
+ * Output formats:
+ *   default  -- human-readable JSON with policy, summary, findings
+ *               array. Each finding includes the rule_id, severity,
+ *               description, entry_index, and the original log
+ *               entry for evidence.
+ *   sarif    -- SARIF 2.1.0 (industry-standard static-analysis
+ *               format). Consumed natively by GitHub Code Scanning,
+ *               Azure DevOps, and other CI tools.
  *
- * PDF rendering, SARIF output, and the full filter-DSL predicates
- * land in follow-up PRs. This MVP covers the most common
- * compliance questions: PII path access, network connects,
- * subprocess spawning, sensitive env var reads.
+ * PDF rendering is out of scope here (TODO.complete/26 P2 -- the
+ * "tiny PDF writer" sub-task). This module owns the data model
+ * + JSON/SARIF serialization.
  */
 
 #include "parson.h"
@@ -42,12 +38,10 @@
 #include <string.h>
 
 /*
- * Predicate evaluation.
- *
- * The entry is the log entry's "message" object (the part that
- * varies by action). For log_params entries, "func" is the
- * intercepted function name and other fields are the parsed
- * arguments (path, buf, etc.).
+ * Predicate evaluation. The entry is the log entry's "message"
+ * object (the part that varies by action). For log_params
+ * entries, "func" is the intercepted function name and other
+ * fields are the parsed arguments (path, buf, etc.).
  *
  * Predicate semantics: a rule matches if ALL of its non-NULL
  * constraints match (AND). NULL constraints are wildcards.
@@ -136,55 +130,298 @@ static int rule_matches(const struct Rule *rule, JSON_Object *msg)
 }
 
 /*
- * Emit a finding as a JSON object. The finding includes:
- *   - rule_id, severity, description from the rule
- *   - entry_index (0-based position in the log array)
- *   - entry (the original log entry, for evidence)
+ * Internal finding representation. Decoupled from the on-disk
+ * format so we can add formatters (default, SARIF, future PDF
+ * text) without touching the matcher.
  */
-static void emit_finding(const struct Rule *rule, size_t entry_idx,
-			 JSON_Object *original_entry, JSON_Array *findings)
+struct Finding {
+	const struct Rule *rule;
+
+	size_t entry_index;
+
+	JSON_Object *entry;  /* borrowed from trace_root; do not free */
+};
+
+struct Findings {
+	struct Finding *items;
+
+	size_t count;
+
+	size_t cap;
+};
+
+static void findings_init(struct Findings *f)
 {
-	JSON_Value *finding;
-	JSON_Object *obj;
+	f->items = NULL;
+	f->count = 0;
+	f->cap = 0;
+}
 
-	finding = json_value_init_object();
-	obj = json_value_get_object(finding);
+static void findings_free(struct Findings *f)
+{
+	free(f->items);
+	f->items = NULL;
+	f->count = 0;
+	f->cap = 0;
+}
 
-	json_object_set_string(obj, "rule_id", rule->id);
-	json_object_set_string(obj, "severity", severity_str(rule->severity));
-	json_object_set_string(obj, "description", rule->description);
-	json_object_set_number(obj, "entry_index", (double)entry_idx);
+static int findings_append(struct Findings *f, const struct Rule *rule,
+			   size_t entry_index, JSON_Object *entry)
+{
+	struct Finding *newbuf;
 
-	/* Deep-copy the original entry so the caller can free its
-	 * root value without invalidating the finding's reference.
-	 */
-	{
-		JSON_Value *entry_copy = json_value_deep_copy(
-			json_object_get_wrapping_value(original_entry));
+	if (f->count == f->cap) {
+		size_t newcap = (f->cap == 0) ? 16 : f->cap * 2;
 
-		json_object_set_value(obj, "entry", entry_copy);
+		newbuf = (struct Finding *)realloc(f->items,
+			newcap * sizeof(*newbuf));
+		if (newbuf == NULL)
+			return -1;
+		f->items = newbuf;
+		f->cap = newcap;
+	}
+	f->items[f->count].rule = rule;
+	f->items[f->count].entry_index = entry_index;
+	f->items[f->count].entry = entry;
+	f->count++;
+	return 0;
+}
+
+/*
+ * Walks every (entry, rule) pair, appends matches to findings.
+ */
+static void scan_trace(JSON_Array *trace, const struct Policy *policy,
+		       struct Findings *out)
+{
+	size_t i, n = json_array_get_count(trace);
+
+	for (i = 0; i < n; i++) {
+		JSON_Object *entry = json_array_get_object(trace, i);
+		JSON_Object *msg;
+		size_t r;
+
+		if (entry == NULL)
+			continue;
+		msg = json_object_get_object(entry, "message");
+		if (msg == NULL)
+			continue;
+
+		for (r = 0; r < policy->rules_count; r++) {
+			const struct Rule *rule = &policy->rules[r];
+
+			if (rule_matches(rule, msg))
+				findings_append(out, rule, i, msg);
+		}
+	}
+}
+
+/* ----- Severity mappings for SARIF ----- */
+
+static const char *sarif_level(enum Severity s)
+{
+	switch (s) {
+	case SEV_CRITICAL:
+		return "error";
+	case SEV_HIGH:
+		return "error";
+	case SEV_MEDIUM:
+		return "warning";
+	case SEV_INFO:
+	default:
+		return "note";
+	}
+}
+
+/* ----- Formatters ----- */
+
+static JSON_Value *format_default(const struct Policy *policy,
+				  const char *trace_path,
+				  const struct Findings *findings)
+{
+	JSON_Value *root = json_value_init_object();
+	JSON_Object *obj = json_value_get_object(root);
+	JSON_Array *arr;
+	JSON_Object *summary;
+	size_t i;
+
+	json_object_set_string(obj, "policy", policy->name);
+	json_object_set_string(obj, "trace", trace_path);
+
+	arr = json_value_get_array(json_value_init_array());
+	json_object_set_value(obj, "findings",
+		json_array_get_wrapping_value(arr));
+
+	for (i = 0; i < findings->count; i++) {
+		const struct Finding *f = &findings->items[i];
+		JSON_Value *fv = json_value_init_object();
+		JSON_Object *fo = json_value_get_object(fv);
+		JSON_Value *entry_copy;
+
+		json_object_set_string(fo, "rule_id", f->rule->id);
+		json_object_set_string(fo, "severity",
+			severity_str(f->rule->severity));
+		json_object_set_string(fo, "description", f->rule->description);
+		json_object_set_number(fo, "entry_index",
+			(double)f->entry_index);
+		entry_copy = json_value_deep_copy(
+			json_object_get_wrapping_value(f->entry));
+		json_object_set_value(fo, "entry", entry_copy);
+		json_array_append_value(arr, fv);
 	}
 
-	json_array_append_value(findings, finding);
+	summary = json_value_get_object(json_value_init_object());
+	json_object_set_value(obj, "summary",
+		json_object_get_wrapping_value(summary));
+	json_object_set_number(summary, "critical", 0);
+	json_object_set_number(summary, "high", 0);
+	json_object_set_number(summary, "medium", 0);
+	json_object_set_number(summary, "info", 0);
+	for (i = 0; i < findings->count; i++) {
+		const char *sev = severity_str(findings->items[i].rule->severity);
+		double cur = json_object_get_number(summary, sev);
+
+		json_object_set_number(summary, sev, cur + 1);
+	}
+
+	return root;
 }
+
+/*
+ * SARIF 2.1.0 format. Schema:
+ * https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html
+ *
+ * One run, one tool (retrace-audit). Each finding becomes a
+ * result. ruleId is the policy rule's id; level is mapped from
+ * severity (critical/high -> error, medium -> warning, info ->
+ * note). The trace file is the artifactLocation; entry_index is
+ * encoded as a region.startLine (1-based; SARIF doesn't have a
+ * native "array index" concept, so we use line numbers as a
+ * proxy).
+ */
+static JSON_Value *format_sarif(const struct Policy *policy,
+				const char *trace_path,
+				const struct Findings *findings)
+{
+	JSON_Value *root = json_value_init_object();
+	JSON_Object *obj = json_value_get_object(root);
+	JSON_Array *runs;
+	JSON_Value *run_v;
+	JSON_Object *run;
+	JSON_Object *tool;
+	JSON_Object *driver;
+	JSON_Array *results;
+	size_t i;
+
+	json_object_set_string(obj, "$schema",
+		"https://json.schemastore.org/sarif-2.1.0.json");
+	json_object_set_string(obj, "version", "2.1.0");
+
+	runs = json_value_get_array(json_value_init_array());
+	json_object_set_value(obj, "runs",
+		json_array_get_wrapping_value(runs));
+
+	run_v = json_value_init_object();
+	run = json_value_get_object(run_v);
+	json_array_append_value(runs, run_v);
+
+	tool = json_value_get_object(json_value_init_object());
+	json_object_set_value(run, "tool",
+		json_object_get_wrapping_value(tool));
+
+	driver = json_value_get_object(json_value_init_object());
+	json_object_set_value(tool, "driver",
+		json_object_get_wrapping_value(driver));
+	json_object_set_string(driver, "name", "retrace-audit");
+	json_object_set_string(driver, "version", "0.1.0");
+	json_object_set_string(driver, "informationUri",
+		"https://github.com/riboseinc/retrace");
+
+	results = json_value_get_array(json_value_init_array());
+	json_object_set_value(run, "results",
+		json_array_get_wrapping_value(results));
+
+	for (i = 0; i < findings->count; i++) {
+		const struct Finding *f = &findings->items[i];
+		JSON_Value *rv = json_value_init_object();
+		JSON_Object *r = json_value_get_object(rv);
+		JSON_Object *msg;
+		JSON_Object *loc;
+		JSON_Object *phys;
+		JSON_Object *art;
+		JSON_Object *region;
+
+		json_object_set_string(r, "ruleId", f->rule->id);
+		json_object_set_string(r, "level", sarif_level(f->rule->severity));
+
+		msg = json_value_get_object(json_value_init_object());
+		json_object_set_value(r, "message",
+			json_object_get_wrapping_value(msg));
+		json_object_set_string(msg, "text", f->rule->description);
+
+		loc = json_value_get_object(json_value_init_object());
+		{
+			JSON_Array *locs = json_value_get_array(
+				json_value_init_array());
+
+			json_object_set_value(r, "locations",
+				json_array_get_wrapping_value(locs));
+			json_array_append_value(locs,
+				json_object_get_wrapping_value(loc));
+		}
+
+		phys = json_value_get_object(json_value_init_object());
+		json_object_set_value(loc, "physicalLocation",
+			json_object_get_wrapping_value(phys));
+
+		art = json_value_get_object(json_value_init_object());
+		json_object_set_value(phys, "artifactLocation",
+			json_object_get_wrapping_value(art));
+		json_object_set_string(art, "uri", trace_path);
+
+		region = json_value_get_object(json_value_init_object());
+		json_object_set_value(phys, "region",
+			json_object_get_wrapping_value(region));
+		/* SARIF region.startLine is 1-based; our entry_index
+		 * is 0-based. Bump by 1 so the first entry maps to
+		 * line 1.
+		 */
+		json_object_set_number(region, "startLine",
+			(double)f->entry_index + 1);
+
+		json_array_append_value(results, rv);
+	}
+
+	(void)policy;
+	return root;
+}
+
+/* ----- CLI ----- */
+
+enum OutputFormat {
+	OUT_DEFAULT,
+	OUT_SARIF
+};
 
 static void usage(FILE *out)
 {
 	fprintf(out,
-"retrace-audit -- compliance audit report generator (TODO.complete/26 MVP)\n"
+"retrace-audit -- compliance audit report generator (TODO.complete/26)\n"
 "\n"
 "Usage:\n"
-"  retrace-audit --policy POLICY.json --trace TRACE.json [-o FINDINGS.json]\n"
+"  retrace-audit --policy POLICY.json --trace TRACE.json\n"
+"                [--format default|sarif] [-o FINDINGS.json]\n"
 "\n"
 "Reads a retrace trace log, applies each policy rule's predicate\n"
-"against each entry, and writes findings as JSON. Default output\n"
-"is stdout; use -o to write to a file.\n"
+"against each entry, and writes findings.\n"
 "\n"
 "Options:\n"
-"  --policy PATH   Path to a policy JSON file (required)\n"
-"  --trace  PATH   Path to a retrace JSON log (required)\n"
-"  -o       PATH   Output path (default: stdout)\n"
-"  --help         Show this message\n");
+"  --policy PATH     Path to a policy JSON file (required)\n"
+"  --trace  PATH     Path to a retrace JSON log (required)\n"
+"  --format NAME     Output format: 'default' (custom JSON) or\n"
+"                    'sarif' (SARIF 2.1.0 for GitHub Code Scanning,\n"
+"                    Azure DevOps, etc.). Default: default.\n"
+"  -o       PATH     Output path (default: stdout)\n"
+"  --help           Show this message\n");
 }
 
 int main(int argc, char **argv)
@@ -192,14 +429,12 @@ int main(int argc, char **argv)
 	const char *policy_path = NULL;
 	const char *trace_path = NULL;
 	const char *out_path = NULL;
+	enum OutputFormat fmt = OUT_DEFAULT;
 	JSON_Value *trace_root;
 	JSON_Array *trace;
 	JSON_Value *out_root;
-	JSON_Object *out_obj;
-	JSON_Array *findings;
-	JSON_Object *summary;
 	struct Policy policy;
-	size_t i, n;
+	struct Findings findings;
 	FILE *out = stdout;
 	int argi;
 
@@ -212,6 +447,21 @@ int main(int argc, char **argv)
 		} else if (strcmp(argv[argi], "-o") == 0 &&
 			   argi + 1 < argc) {
 			out_path = argv[++argi];
+		} else if (strcmp(argv[argi], "--format") == 0 &&
+			   argi + 1 < argc) {
+			const char *f = argv[++argi];
+
+			if (strcmp(f, "default") == 0)
+				fmt = OUT_DEFAULT;
+			else if (strcmp(f, "sarif") == 0)
+				fmt = OUT_SARIF;
+			else {
+				fprintf(stderr,
+					"retrace-audit: unknown format '%s'\n",
+					f);
+				usage(stderr);
+				return 1;
+			}
 		} else if (strcmp(argv[argi], "--help") == 0 ||
 			   strcmp(argv[argi], "-h") == 0) {
 			usage(stdout);
@@ -250,71 +500,17 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
-	out_root = json_value_init_object();
-	out_obj = json_value_get_object(out_root);
-	json_object_set_string(out_obj, "policy", policy.name);
-	json_object_set_string(out_obj, "trace", trace_path);
+	findings_init(&findings);
+	scan_trace(trace, &policy, &findings);
 
-	findings = json_value_get_array(json_value_init_array());
-	json_object_set_value(out_obj, "findings",
-		json_array_get_wrapping_value(findings));
-
-	summary = json_value_get_object(json_value_init_object());
-	json_object_set_value(out_obj, "summary",
-		json_object_get_wrapping_value(summary));
-	json_object_set_number(summary, "critical", 0);
-	json_object_set_number(summary, "high", 0);
-	json_object_set_number(summary, "medium", 0);
-	json_object_set_number(summary, "info", 0);
-
-	/* Apply each rule against each trace entry. */
-	n = json_array_get_count(trace);
-	for (i = 0; i < n; i++) {
-		JSON_Object *entry = json_array_get_object(trace, i);
-		JSON_Object *msg;
-		size_t r;
-
-		if (entry == NULL)
-			continue;
-		msg = json_object_get_object(entry, "message");
-		if (msg == NULL)
-			continue;
-
-		for (r = 0; r < policy.rules_count; r++) {
-			struct Rule *rule = &policy.rules[r];
-
-			if (rule_matches(rule, msg)) {
-				emit_finding(rule, i, msg, findings);
-
-				switch (rule->severity) {
-				case SEV_CRITICAL:
-					json_object_set_number(summary,
-						"critical",
-						json_object_get_number(summary,
-							"critical") + 1);
-					break;
-				case SEV_HIGH:
-					json_object_set_number(summary,
-						"high",
-						json_object_get_number(summary,
-							"high") + 1);
-					break;
-				case SEV_MEDIUM:
-					json_object_set_number(summary,
-						"medium",
-						json_object_get_number(summary,
-							"medium") + 1);
-					break;
-				case SEV_INFO:
-				default:
-					json_object_set_number(summary,
-						"info",
-						json_object_get_number(summary,
-							"info") + 1);
-					break;
-				}
-			}
-		}
+	switch (fmt) {
+	case OUT_SARIF:
+		out_root = format_sarif(&policy, trace_path, &findings);
+		break;
+	case OUT_DEFAULT:
+	default:
+		out_root = format_default(&policy, trace_path, &findings);
+		break;
 	}
 
 	if (out_path != NULL) {
@@ -324,6 +520,7 @@ int main(int argc, char **argv)
 				out_path);
 			json_value_free(out_root);
 			json_value_free(trace_root);
+			findings_free(&findings);
 			policy_free(&policy);
 			return 1;
 		}
@@ -342,6 +539,7 @@ int main(int argc, char **argv)
 
 	json_value_free(out_root);
 	json_value_free(trace_root);
+	findings_free(&findings);
 	policy_free(&policy);
 	return 0;
 }


### PR DESCRIPTION
## Summary

Refactors `retrace-audit` to support multiple output formats via `--format` flag, with SARIF 2.1.0 as the new option. The default format (custom JSON) is unchanged.

SARIF (Static Analysis Results Interchange Format) is the OASIS-standard format for static analysis. GitHub Code Scanning, Azure DevOps, SonarQube, and other CI tools consume SARIF natively -- uploading `retrace-audit`'s output to GitHub Code Scanning surfaces findings as PR annotations.

## Usage

```sh
$ retrace-audit --policy share/policies/baseline.json \
                --trace /tmp/trace.json \
                --format sarif -o findings.sarif
```

Then in CI:

```sh
$ gh api -X POST repos/:owner/:repo/code-scanning/sarifs \
    -H "Accept: application/vnd.github+json" \
    -F file=@findings.sarif
```

## Severity mapping

| retrace severity | SARIF level |
|---|---|
| critical | error |
| high | error |
| medium | warning |
| info | note |

## MECE refactor

- `scan_trace()` walks `(entry, rule)` pairs and produces a `struct Findings` array. **Pure data** -- no formatting.
- `format_default()` / `format_sarif()` consume `struct Findings` and produce a `JSON_Value` tree. **Pure presentation**.
- `main()` wires CLI -> scan -> format -> serialize.

This is OCP-friendly: adding a new format (e.g. PDF text in TODO.complete/26 P2) means adding a new `format_*` function and a new enum constant. No changes to `scan_trace` or the matcher.

## Sample SARIF output

```json
{
  "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
  "version": "2.1.0",
  "runs": [{
    "tool": { "driver": {
      "name": "retrace-audit",
      "version": "0.1.0",
      "informationUri": "https://github.com/riboseinc/retrace"
    }},
    "results": [{
      "ruleId": "BASE-003",
      "level": "error",
      "message": { "text": "Reads /etc/shadow -- credential access" },
      "locations": [{
        "physicalLocation": {
          "artifactLocation": { "uri": "/tmp/trace.json" },
          "region": { "startLine": 2 }
        }
      }]
    }]
  }]
}
```

## Test plan

- [x] `cmake --build build-test --target retrace_audit` -- clean
- [x] Default format: byte-identical output to the prior implementation (manual diff on 3-entry synthetic trace)
- [x] SARIF format: 6 findings -> 6 results, severity mapping correct, locations point at trace file with incrementing startLine
- [x] `ctest --test-dir build-test -L 'unit|property'` -- 38/38 pass (no regressions)
- [ ] CI matrix green
