### PR TITLE
audit: ship PCI-DSS, HIPAA, ISO 27001 policies (TODO 26 P1)

### DIFF
--- a/share/policies/hipaa.json
+++ b/share/policies/hipaa.json
@@ -1,0 +1,77 @@
+{
+  "name": "hipaa",
+  "rules": [
+    {
+      "id": "HIPAA-1",
+      "description": "Access to Protected Health Information (PHI) paths",
+      "match": { "func_prefix": "open", "path_contains": "/phi/" },
+      "severity": "critical"
+    },
+    {
+      "id": "HIPAA-2",
+      "description": "Access to patient-records directory",
+      "match": { "func_prefix": "open", "path_contains": "patient" },
+      "severity": "critical"
+    },
+    {
+      "id": "HIPAA-3",
+      "description": "Access to medical-records directory",
+      "match": { "func_prefix": "open", "path_contains": "medical" },
+      "severity": "critical"
+    },
+    {
+      "id": "HIPAA-4",
+      "description": "Access to EHR/EMR systems",
+      "match": { "func_prefix": "open", "path_contains": "ehr" },
+      "severity": "critical"
+    },
+    {
+      "id": "HIPAA-5",
+      "description": "Reads health-related env vars (cover IDs, patient keys)",
+      "match": { "func_exact": "getenv", "env_pattern": "*_PATIENT_*" },
+      "severity": "high"
+    },
+    {
+      "id": "HIPAA-6",
+      "description": "Reads EHR API credentials",
+      "match": { "func_exact": "getenv", "env_pattern": "*_EHR_*" },
+      "severity": "high"
+    },
+    {
+      "id": "HIPAA-7",
+      "description": "Outbound network connection (audit for unencrypted PHI transmission)",
+      "match": { "func_exact": "connect" },
+      "severity": "medium"
+    },
+    {
+      "id": "HIPAA-8",
+      "description": "Subprocess spawned (audit for PHI leaking through pipes)",
+      "match": { "func_exact": "system" },
+      "severity": "high"
+    },
+    {
+      "id": "HIPAA-9",
+      "description": "exec-family call (potential PHI boundary crossing)",
+      "match": { "func_prefix": "exec" },
+      "severity": "medium"
+    },
+    {
+      "id": "HIPAA-10",
+      "description": "Reads standard credential file (/etc/shadow)",
+      "match": { "func_prefix": "open", "path_contains": "/etc/shadow" },
+      "severity": "critical"
+    },
+    {
+      "id": "HIPAA-11",
+      "description": "Reads audit-log paths (tampering risk)",
+      "match": { "func_prefix": "open", "path_contains": "/var/log/audit" },
+      "severity": "high"
+    },
+    {
+      "id": "HIPAA-12",
+      "description": "Reads SSH credentials",
+      "match": { "func_prefix": "open", "path_contains": ".ssh/" },
+      "severity": "critical"
+    }
+  ]
+}

--- a/share/policies/iso27001.json
+++ b/share/policies/iso27001.json
@@ -1,0 +1,89 @@
+{
+  "name": "iso27001",
+  "rules": [
+    {
+      "id": "ISO-1",
+      "description": "Subprocess spawned via shell -- audit for injection (A.8.7)",
+      "match": { "func_exact": "system" },
+      "severity": "high"
+    },
+    {
+      "id": "ISO-2",
+      "description": "exec-family call -- subprocess spawning (A.8.7)",
+      "match": { "func_prefix": "exec" },
+      "severity": "medium"
+    },
+    {
+      "id": "ISO-3",
+      "description": "Reads /etc/shadow -- credential access (A.5.17)",
+      "match": { "func_prefix": "open", "path_contains": "/etc/shadow" },
+      "severity": "critical"
+    },
+    {
+      "id": "ISO-4",
+      "description": "Reads /etc/passwd -- user enumeration (A.5.16)",
+      "match": { "func_prefix": "open", "path_contains": "/etc/passwd" },
+      "severity": "medium"
+    },
+    {
+      "id": "ISO-5",
+      "description": "Reads SSH directory -- private key access (A.5.17)",
+      "match": { "func_prefix": "open", "path_contains": ".ssh/" },
+      "severity": "critical"
+    },
+    {
+      "id": "ISO-6",
+      "description": "Writes to system paths (A.8.13)",
+      "match": { "func_prefix": "open", "path_contains": "/etc/" },
+      "severity": "high"
+    },
+    {
+      "id": "ISO-7",
+      "description": "Reads authentication token env vars (A.5.17)",
+      "match": { "func_exact": "getenv", "env_pattern": "*_TOKEN" },
+      "severity": "high"
+    },
+    {
+      "id": "ISO-8",
+      "description": "Reads password env vars (A.5.17)",
+      "match": { "func_exact": "getenv", "env_pattern": "*_PASSWORD" },
+      "severity": "high"
+    },
+    {
+      "id": "ISO-9",
+      "description": "Reads cryptographic key env vars (A.8.24)",
+      "match": { "func_exact": "getenv", "env_pattern": "*_KEY" },
+      "severity": "high"
+    },
+    {
+      "id": "ISO-10",
+      "description": "Reads LD_PRELOAD and related (runtime hijack risk, A.8.7)",
+      "match": { "func_exact": "getenv", "env_pattern": "LD_*" },
+      "severity": "medium"
+    },
+    {
+      "id": "ISO-11",
+      "description": "Outbound network connection (A.8.20 network services)",
+      "match": { "func_exact": "connect" },
+      "severity": "medium"
+    },
+    {
+      "id": "ISO-12",
+      "description": "Reads system log paths (A.8.15 logging)",
+      "match": { "func_prefix": "open", "path_contains": "/var/log/" },
+      "severity": "medium"
+    },
+    {
+      "id": "ISO-13",
+      "description": "Reads root's home directory (A.5.15 access control)",
+      "match": { "func_prefix": "open", "path_contains": "/root/" },
+      "severity": "high"
+    },
+    {
+      "id": "ISO-14",
+      "description": "Reads system crontabs (A.5.15)",
+      "match": { "func_prefix": "open", "path_contains": "/etc/cron" },
+      "severity": "high"
+    }
+  ]
+}

--- a/share/policies/pci-dss.json
+++ b/share/policies/pci-dss.json
@@ -1,0 +1,77 @@
+{
+  "name": "pci-dss",
+  "rules": [
+    {
+      "id": "PCI-1",
+      "description": "Access to potential cardholder data (PAN-shaped filenames)",
+      "match": { "func_prefix": "open", "path_contains": "card" },
+      "severity": "critical"
+    },
+    {
+      "id": "PCI-2",
+      "description": "Access to payment-related directories",
+      "match": { "func_prefix": "open", "path_contains": "payment" },
+      "severity": "critical"
+    },
+    {
+      "id": "PCI-3",
+      "description": "Reads PCI-DSS scope env vars (merchant IDs, keys)",
+      "match": { "func_exact": "getenv", "env_pattern": "*_MERCHANT_ID" },
+      "severity": "high"
+    },
+    {
+      "id": "PCI-4",
+      "description": "Reads payment-gateway API key env vars",
+      "match": { "func_exact": "getenv", "env_pattern": "*_API_KEY" },
+      "severity": "high"
+    },
+    {
+      "id": "PCI-5",
+      "description": "Reads payment-gateway secret env vars",
+      "match": { "func_exact": "getenv", "env_pattern": "*_SECRET" },
+      "severity": "high"
+    },
+    {
+      "id": "PCI-6",
+      "description": "Outbound connects to non-standard payment ports (audit manually)",
+      "match": { "func_exact": "connect" },
+      "severity": "medium"
+    },
+    {
+      "id": "PCI-7",
+      "description": "Subprocess spawned (potential CDE boundary crossing)",
+      "match": { "func_exact": "system" },
+      "severity": "high"
+    },
+    {
+      "id": "PCI-8",
+      "description": "exec-family call (subprocess spawning)",
+      "match": { "func_prefix": "exec" },
+      "severity": "medium"
+    },
+    {
+      "id": "PCI-9",
+      "description": "Reads PCI-DSS config directory",
+      "match": { "func_prefix": "open", "path_contains": "/etc/pci/" },
+      "severity": "medium"
+    },
+    {
+      "id": "PCI-10",
+      "description": "Reads standard credential file (/etc/shadow)",
+      "match": { "func_prefix": "open", "path_contains": "/etc/shadow" },
+      "severity": "critical"
+    },
+    {
+      "id": "PCI-11",
+      "description": "Reads SSH credentials",
+      "match": { "func_prefix": "open", "path_contains": ".ssh/" },
+      "severity": "critical"
+    },
+    {
+      "id": "PCI-12",
+      "description": "Reads token env vars (any framework -- catch-all)",
+      "match": { "func_exact": "getenv", "env_pattern": "*_TOKEN" },
+      "severity": "medium"
+    }
+  ]
+}

--- a/tools/audit-converter/CMakeLists.txt
+++ b/tools/audit-converter/CMakeLists.txt
@@ -19,5 +19,9 @@ target_include_directories(retrace_audit PRIVATE
 install(TARGETS retrace_audit
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
-install(FILES ${CMAKE_SOURCE_DIR}/share/policies/baseline.json
+install(FILES
+    ${CMAKE_SOURCE_DIR}/share/policies/baseline.json
+    ${CMAKE_SOURCE_DIR}/share/policies/pci-dss.json
+    ${CMAKE_SOURCE_DIR}/share/policies/hipaa.json
+    ${CMAKE_SOURCE_DIR}/share/policies/iso27001.json
     DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/retrace/policies)


### PR DESCRIPTION
## Summary

Adds three new policies alongside the existing baseline, each focused on a different compliance framework. Same trace, run under each policy, surfaces different concerns -- that's the value of multi-framework auditing.

## Files

- `share/policies/pci-dss.json` -- PCI DSS (cardholder data)
- `share/policies/hipaa.json` -- HIPAA (protected health info)
- `share/policies/iso27001.json` -- ISO/IEC 27001 (information security)

Each policy maps framework-specific concerns to the predicates `retrace-audit` supports (`func_prefix`, `func_exact`, `path_contains`, `env_pattern`). Rules reference framework control numbers in their descriptions where applicable (e.g. "ISO-1 ... A.8.7", "PCI-3 ... merchant IDs").

## Coverage

| Policy | Rules | Highlights |
|---|---|---|
| pci-dss | 12 | cardholder/payment paths, merchant/API/secret env vars, outbound connects, subprocess spawning, /etc/shadow, .ssh/ |
| hipaa | 12 | PHI paths, patient/medical/ehr dirs, patient/EHR env vars, subprocess spawning, audit-log tampering |
| iso27001 | 14 | system() injection, exec-family, /etc/shadow + /etc/passwd + .ssh/, system path writes, token/password/key env vars, LD_*, system logs, /root/, crontabs |

## Sample run

A single trace (open `/var/ehr/patient_123.json` + getenv `AWS_TOKEN` + connect + system):

| Policy | critical | high | medium |
|---|---|---|---|
| baseline | 0 | 2 | 0 |
| pci-dss | 0 | 1 | 2 |
| hipaa | 2 | 1 | 1 |
| iso27001 | 0 | 2 | 1 |

Same trace, four different audit lenses. Pick the policy that matches your framework; the SARIF output (PR #603) ships findings to your CI as PR annotations.

## Test plan

- [x] All four JSON files parse cleanly
- [x] Each policy loads via `policy_load_from_file` and runs against a synthetic trace
- [x] CMake install rule updated to ship all four
- [ ] CI matrix green
