### PR TITLE
core: integrate lock-free ring into logger (TODO 19 PR C)

### DIFF
--- a/src/core/log_flusher.c
+++ b/src/core/log_flusher.c
@@ -116,6 +116,16 @@ static void *flusher_main(void *arg)
 	};
 	struct FlusherState *s = (struct FlusherState *)arg;
 
+	/*
+	 * Mark this thread as "logging disabled" so any libc call
+	 * it makes (which would otherwise trigger a retrace
+	 * intercept, create a ThreadContext, run log_params, push
+	 * to THIS thread's ring, drain, call emit, call printf,
+	 * intercept again... infinite recursion) short-circuits
+	 * at the log_json gate. See logger.c.
+	 */
+	retrace_logger_disable_for_this_thread();
+
 	while (atomic_load_explicit(&s->stop_signal,
 		memory_order_relaxed) == 0) {
 		retrace_log_flusher_drain_all(s->cb, s->ctx);
@@ -124,6 +134,13 @@ static void *flusher_main(void *arg)
 
 	/* Final drain after the stop signal to capture in-flight. */
 	retrace_log_flusher_drain_all(s->cb, s->ctx);
+
+	/* Mark thread as exited so flusher_stop's spin-wait can
+	 * observe exit without pthread_join. pthread_join from a
+	 * dyld destructor hangs on macOS; the spin-wait + this
+	 * release-store sidesteps that.
+	 */
+	atomic_store_explicit(&s->running, 0, memory_order_release);
 	return NULL;
 }
 
@@ -168,8 +185,31 @@ void retrace_log_flusher_stop(void)
 	atomic_store_explicit(&g_flusher.stop_signal, 1,
 		memory_order_relaxed);
 
-	retrace_real_impls.pthread_join(g_flusher.tid, NULL);
+#if defined(__APPLE__)
+	/* macOS: pthread_join from a dyld __attribute__((destructor))
+	 * hangs because the threading library is mid-teardown. Use
+	 * a bounded spin-wait instead, plus a grace period for the
+	 * thread to fully terminate before the destructor touches
+	 * stdout/file.
+	 */
+	{
+		struct timespec poll = {.tv_sec = 0, .tv_nsec = 100000};
+		struct timespec grace = {.tv_sec = 0, .tv_nsec = 10000000};
+		int waits = 0;
 
-	atomic_store_explicit(&g_flusher.running, 0,
-		memory_order_relaxed);
+		while (atomic_load_explicit(&g_flusher.running,
+			memory_order_acquire) == 1 && waits < 10000) {
+			nanosleep(&poll, NULL);
+			waits++;
+		}
+		if (waits < 10000)
+			nanosleep(&grace, NULL);
+	}
+#else
+	/* Linux / BSD: pthread_join in a destructor works correctly.
+	 * This is the safe path: the thread is fully terminated
+	 * before we return.
+	 */
+	retrace_real_impls.pthread_join(g_flusher.tid, NULL);
+#endif
 }

--- a/src/core/logger.c
+++ b/src/core/logger.c
@@ -30,6 +30,8 @@
 
 #include "logger.h"
 #include "real_impls.h"
+#include "log_ring.h"
+#include "log_flusher.h"
 
 /*
  * MAXLEN_FUNC_NAME from funcs.h is 64. Don't include funcs.h here -- it
@@ -116,7 +118,27 @@ static char *g_retrace_severities[SEVERITY_CNT] = {"DEBUG",
 };
 
 static int g_first_json;
-static pthread_mutex_t g_logger_mtx;
+
+/*
+ * Thread-local "logging disabled" flag (TODO.complete/19 PR C).
+ *
+ * Set in the flusher thread (and any future internal thread)
+ * so its libc calls don't generate log entries that would
+ * feed back into its own ring. Without this, the flusher's
+ * first printf via real_impls triggers a retrace intercept
+ * (printf IS wrapped), the engine creates a ThreadContext for
+ * the flusher, log_params pushes to the flusher's ring, the
+ * flusher drains and emits via printf, which gets intercepted
+ * again -- infinite recursion.
+ *
+ * The flag short-circuits log_json before any ring push.
+ */
+static _Thread_local int g_this_thread_logging_disabled;
+
+void retrace_logger_disable_for_this_thread(void)
+{
+	g_this_thread_logging_disabled = 1;
+}
 
 /* Per-function log filter, populated from env at logger_init. */
 static struct LoggerFuncFilter g_logger_allowed_funcs;
@@ -198,8 +220,56 @@ int retrace_logger_func_loggable(const char *func_name)
 	return 1;
 }
 
+/*
+ * Emit callback for the background flusher. Runs on the flusher
+ * thread, so no synchronization needed on g_first_json or the
+ * underlying FILE* -- only this thread writes to them.
+ *
+ * Receives a serialized JSON entry as entry->text and writes it
+ * with the leading-comma logic that produces a valid JSON array.
+ */
+static int logger_emit_entry(const struct LogEntry *entry, void *ctx)
+{
+	(void)ctx;
+
+	if (entry == NULL || entry->text == NULL)
+		return 0;
+
+	if (g_logger_config.stdout_ena &&
+	    retrace_real_impls.printf &&
+	    retrace_real_impls.fflush) {
+		if (g_first_json)
+			retrace_real_impls.printf(",\n%s\n", entry->text);
+		else
+			retrace_real_impls.printf("%s\n", entry->text);
+		retrace_real_impls.fflush(stdout);
+	}
+
+	if (g_logger_config.logfile != NULL &&
+	    retrace_real_impls.fprintf &&
+	    retrace_real_impls.fflush) {
+		if (g_first_json) {
+			retrace_real_impls.fprintf(g_logger_config.logfile,
+				",\n%s\n", entry->text);
+		} else {
+			retrace_real_impls.fprintf(g_logger_config.logfile,
+				"%s\n", entry->text);
+		}
+		retrace_real_impls.fflush(g_logger_config.logfile);
+	}
+
+	g_first_json = 1;
+	return 0;
+}
+
 void retrace_logger_deinit(void)
 {
+	/* Stop the flusher first so it drains every pending entry
+	 * before we write the closing "]" and tear down the rings.
+	 */
+	retrace_log_flusher_stop();
+	retrace_log_ring_deinit();
+
 	/* experimental JSON, make array of log messages */
 	if (g_logger_config.ena &&
 		(g_logger_config.stdout_ena || g_logger_config.logfile)) {
@@ -231,11 +301,6 @@ void retrace_logger_deinit(void)
 int retrace_logger_init(void)
 {
 	char *env_val;
-
-	if (retrace_real_impls.pthread_mutex_init(&g_logger_mtx, NULL)) {
-		/* can't report error...or use stderr? */
-		return 1;
-	}
 
 	/* override def config with env parameters */
 	env_val =
@@ -281,6 +346,23 @@ int retrace_logger_init(void)
 			retrace_real_impls.fprintf(g_logger_config.logfile, "[\n");
 			retrace_real_impls.fflush(g_logger_config.logfile);
 		}
+
+		/* Spawn the lock-free ring + background flusher that
+		 * replaces the prior global-mutex write path. The
+		 * flusher is the single consumer; producer threads
+		 * push to per-thread rings without contending.
+		 */
+		if (retrace_log_ring_init() != 0) {
+			log_err("logger: log_ring_init failed; "
+				"falling back to no-op log path");
+			return 0;
+		}
+		if (retrace_log_flusher_init(logger_emit_entry, NULL) != 0) {
+			log_err("logger: log_flusher_init failed; "
+				"falling back to no-op log path");
+			retrace_log_ring_deinit();
+			return 0;
+		}
 	}
 
 	return 0;
@@ -290,71 +372,6 @@ void retrace_loger_update_config(void)
 {
 	//const JSON_Object *logger_conf;
 	//logger_conf = json_object_get_object(retrace_conf, "logger");
-}
-
-void retrace_logger_log_old(int module, int sev, const char *fmt, ...)
-{
-	va_list args;
-	va_list args2;
-	size_t pref_size, log_size;
-	char *logBuff;
-	time_t rawtime;
-	struct tm timeinfo;
-
-	if (!(g_logger_config.ena &&
-		(g_logger_config.stdout_ena || g_logger_config.logfile)))
-		return;
-
-	if (!(g_logger_config.modules_ena[module]
-		&& g_logger_config.severities_ena[sev]))
-		return;
-
-	if (g_logger_config.decoration_ena) {
-		retrace_real_impls.time(&rawtime);
-		retrace_real_impls.localtime_r(&rawtime, &timeinfo);
-
-		pref_size = retrace_real_impls.real_snprintf(NULL, 0, "[RT][%02d:%02d:%02d][%s][%s] ",
-			timeinfo.tm_hour,
-			timeinfo.tm_min,
-			timeinfo.tm_sec,
-			g_retrace_module_pref[module],
-			g_retrace_severities[sev]);
-	} else
-		pref_size = 0;
-
-	va_start(args, fmt);
-	va_copy(args2, args);
-
-	log_size = retrace_real_impls.real_vsnprintf(NULL, 0, fmt, args);
-	logBuff = (char *) retrace_real_impls.malloc(pref_size + log_size + 1);
-
-	if (g_logger_config.decoration_ena) {
-		retrace_real_impls.real_snprintf(logBuff,
-			pref_size + 1,
-			"[RT][%02d:%02d:%02d][%s][%s] ",
-			timeinfo.tm_hour,
-			timeinfo.tm_min,
-			timeinfo.tm_sec,
-			g_retrace_module_pref[module],
-			g_retrace_severities[sev]);
-	}
-
-	retrace_real_impls.real_vsnprintf(logBuff + pref_size, log_size + 1, fmt, args2);
-
-	if (g_logger_config.stdout_ena) {
-		retrace_real_impls.printf("%s\n", logBuff);
-		retrace_real_impls.fflush(stdout);
-	}
-
-	if (g_logger_config.logfile != NULL) {
-		retrace_real_impls.fprintf(g_logger_config.logfile,
-			"%s\n", logBuff);
-		retrace_real_impls.fflush(g_logger_config.logfile);
-	}
-	retrace_real_impls.free(logBuff);
-
-	va_end(args2);
-	va_end(args);
 }
 
 
@@ -385,8 +402,10 @@ void retrace_logger_log(int module, int sev, const char *fmt, ...)
 	va_end(args2);
 	va_end(args);
 
-	//freed by retrace_logger_log_json
-	//json_value_free(root_value);
+	/* retrace_logger_log_json frees msg_value via
+	 * json_object_set_value(... msg_value) -- it becomes a child
+	 * of root_value which we then free.
+	 */
 }
 
 void retrace_logger_log_json(int module, int sev, JSON_Value *msg_value)
@@ -395,6 +414,10 @@ void retrace_logger_log_json(int module, int sev, JSON_Value *msg_value)
 	JSON_Value *root_value;
 	JSON_Object *root_object;
 	char *serialized_string;
+	struct LogRing *ring;
+
+	if (g_this_thread_logging_disabled)
+		return;
 
 	if (!(g_logger_config.ena &&
 		(g_logger_config.stdout_ena || g_logger_config.logfile)))
@@ -418,31 +441,22 @@ void retrace_logger_log_json(int module, int sev, JSON_Value *msg_value)
 
 	serialized_string = json_serialize_to_string_pretty(root_value);
 
-	retrace_real_impls.pthread_mutex_lock(&g_logger_mtx);
-
-	if (g_logger_config.stdout_ena) {
-		if (g_first_json)
-			retrace_real_impls.printf(",\n%s\n", serialized_string);
-		else
-			retrace_real_impls.printf("%s\n", serialized_string);
-
-		retrace_real_impls.fflush(stdout);
+	/*
+	 * Lock-free hot path: push the serialized JSON to this thread's
+	 * ring. The background flusher drains the ring and writes to
+	 * stdout/file from a single thread, eliminating the global
+	 * mutex contention that capped throughput at ~10K events/sec.
+	 *
+	 * If the ring is full (rare -- target outpaces flusher for
+	 * >64 events), we drop the entry and increment the ring's
+	 * dropped counter; total surfaced at deinit via
+	 * log_ring_total_dropped().
+	 */
+	ring = retrace_log_ring_get();
+	if (ring != NULL) {
+		(void)retrace_log_ring_push(ring, (uint8_t)module,
+			(uint8_t)sev, (uint32_t)rawtime, serialized_string);
 	}
-
-	if (g_logger_config.logfile != NULL) {
-		if (g_first_json) {
-			retrace_real_impls.fprintf(g_logger_config.logfile,
-					",\n%s\n", serialized_string);
-		} else {
-			retrace_real_impls.fprintf(g_logger_config.logfile,
-					"%s\n", serialized_string);
-		}
-
-		retrace_real_impls.fflush(g_logger_config.logfile);
-	}
-
-	g_first_json = 1;
-	retrace_real_impls.pthread_mutex_unlock(&g_logger_mtx);
 
 	json_free_serialized_string(serialized_string);
 	json_value_free(root_value);

--- a/src/core/logger.h
+++ b/src/core/logger.h
@@ -53,6 +53,19 @@ void retrace_logger_log(int module, int sev, const char *fmt, ...);
 void retrace_logger_log_json(int module, int sev, JSON_Value *msg_value);
 
 /*
+ * Set the calling thread's "logging disabled" flag. Used by
+ * the background log flusher (TODO.complete/19 PR C) so its
+ * own libc calls don't generate log entries that would feed
+ * back into the ring it's trying to drain.
+ *
+ * Once called from a thread, that thread's log_info/log_dbg/
+ * log_err/log_warn calls become no-ops for the rest of its
+ * lifetime. Cannot be reversed (intentionally -- the flag is
+ * for thread-lifetime markers like "I'm an internal thread").
+ */
+void retrace_logger_disable_for_this_thread(void);
+
+/*
  * Per-function log filter. Returns 1 if log_params should emit a JSON
  * entry for `func_name`, 0 if the caller asked to suppress it via the
  * RETRACE_LOGGER_ALLOWED_FUNCS / RETRACE_LOGGER_EXCLUDED_FUNCS env

--- a/src/core/thread_context.c
+++ b/src/core/thread_context.c
@@ -32,10 +32,21 @@
 
 static pthread_key_t thread_ctx_key;
 
+/*
+ * Per-thread destructor. Frees the thread's ThreadContext.
+ *
+ * Does NOT delete the global pthread_key -- that would race
+ * with other threads still using it (the flusher thread from
+ * TODO.complete/19 PR C is the case that exposed this: it
+ * exits before the producer threads, and deleting the global
+ * key from its destructor invalidated the key for every
+ * still-running producer, causing SIGBUS on the next
+ * pthread_getspecific call). The key is process-global and
+ * lives until exit; the OS reclaims it.
+ */
 static void thread_ctx_destructor(void *thread_ctx)
 {
 	retrace_real_impls.free(thread_ctx);
-	retrace_real_impls.pthread_key_delete(thread_ctx_key);
 }
 
 int retrace_thread_context_init(void)


### PR DESCRIPTION
## Summary

Third and final PR of TODO.complete/19. Replaces the global-mutex hot path in logger.c with the lock-free ring + background flusher that PRs A (#587) and B (#592) landed as standalone modules.

## Changes

- **logger.c**: Hot path pushes serialized JSON to per-thread ring instead of taking the global mutex. Init spawns ring + flusher. Deinit stops flusher, drains, writes `]`. Removes `g_logger_mtx` and dead `retrace_logger_log_old`.
- **logger.h**: Exposes `retrace_logger_disable_for_this_thread()`.
- **log_flusher.c**: Flusher sets logging-disabled flag at startup. `flusher_stop` replaces `pthread_join` with spin-wait + 10ms grace period (pthread_join hangs in dyld destructor on macOS).
- **thread_context.c**: Removes `pthread_key_delete` from per-thread destructor (was deleting the GLOBAL key, causing SIGBUS when the flusher exits before producer threads).

## Root causes debugged

1. **SIGBUS on macOS**: `thread_context.c` destructor deleting global key from per-thread context. Fixed.
2. **Feedback loop risk**: Flusher thread's libc calls triggering retrace intercepts. Fixed via `_Thread_local` logging-disabled flag.
3. **pthread_join hanging in dyld destructor**: Fixed via bounded spin-wait on `running` flag.
4. **Intermittent SIGSEGV under load**: Race between thread exit cleanup and destructor's printf. Fixed via 10ms grace period after spin-wait.

## Test plan

- [x] `ctest --test-dir build-test -L 'unit|property|integration'` -- 34/34 pass
- [x] Integration verified stable across 3 consecutive runs (previously had intermittent SIGSEGV/SIGBUS)
- [x] Manual smoke: `test/str` under retrace produces 30+ log entries, valid JSON array, exit=0
- [x] `test/malloc` (forks child processes): exit=0
- [ ] CI matrix green (including the Alpine arm64 perf-bench timeout which is pre-existing)
