### PR TITLE
logger: RETRACE_LOGGER_RING env gate for OHOS compatibility

### DIFF
--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -173,6 +173,7 @@ jobs:
             sh -c '
               LD_LIBRARY_PATH=. LD_PRELOAD=./libretrace.so.2 \
               RETRACE_JSON_CONFIG=./retrace-config.json \
+              RETRACE_LOGGER_RING=0 \
               ./ohos-ldpreload-target 2>&1
             ' 2>&1)
           rc=$?

--- a/src/core/logger.c
+++ b/src/core/logger.c
@@ -41,6 +41,13 @@ static int logger_emit_entry(const struct LogEntry *entry, void *ctx);
 extern int retrace_inited;
 
 /*
+ * Ring enabled flag. Defaults to 1 (use the lock-free ring + flusher
+ * post-init). Set to 0 by RETRACE_LOGGER_RING=0 env var, for platforms
+ * where the background thread is unstable (OHOS Docker/QEMU).
+ */
+static int g_logger_ring_enabled;
+
+/*
  * Lazy flusher spawn: on the first log push, atomically try to
  * spawn the flusher thread. Only one thread wins the race; the
  * others skip. This avoids spawning the thread during the dyld
@@ -393,13 +400,30 @@ int retrace_logger_init(void)
 		 * Thread creation during a dyld __attribute__((constructor))
 		 * can crash on some platforms (OHOS/musl under QEMU);
 		 * deferring to first use avoids that.
+		 *
+		 * RETRACE_LOGGER_RING=0 disables the ring entirely;
+		 * log_json falls back to synchronous writes for every
+		 * call. Default: enabled. Use 0 on platforms where the
+		 * background flusher thread is unstable (OHOS Docker/QEMU).
 		 */
-		if (retrace_log_ring_init() != 0) {
-			log_err("logger: log_ring_init failed; "
-				"falling back to no-op log path");
-			return 0;
+		{
+			char *ring_env = retrace_real_impls.getenv(
+				"RETRACE_LOGGER_RING");
+
+			if (ring_env != NULL && ring_env[0] == '0')
+				g_logger_ring_enabled = 0;
+			else
+				g_logger_ring_enabled = 1;
 		}
-		g_logger_ring_ready = 1;
+		if (g_logger_ring_enabled) {
+			if (retrace_log_ring_init() != 0) {
+				log_err("logger: log_ring_init failed; "
+					"falling back to sync log path");
+				g_logger_ring_enabled = 0;
+			} else {
+				g_logger_ring_ready = 1;
+			}
+		}
 	}
 
 	return 0;
@@ -489,7 +513,8 @@ void retrace_logger_log_json(int module, int sev, JSON_Value *msg_value)
 	 * This avoids spawning the flusher thread inside the
 	 * constructor (which crashes on OHOS/musl under QEMU).
 	 */
-	if (g_logger_ring_ready && retrace_inited) {
+	if (g_logger_ring_ready && g_logger_ring_enabled &&
+	    retrace_inited) {
 		ensure_flusher_running();
 		ring = retrace_log_ring_get();
 		if (ring != NULL) {


### PR DESCRIPTION
## Summary

Adds `RETRACE_LOGGER_RING` env var (default: 1/enabled). When set to 0, the logger uses synchronous writes for ALL log calls (no ring, no background flusher, no thread). The OHOS cross-compile-and-verify workflow now sets this to 0.

## Why

The OHOS Docker/QEMU environment crashes (SIGSEGV, rc=139) when the lock-free logger spawns a background thread. The QEMU user-mode emulation's clone/futex handling is incompatible with background threads from a preloaded library. This env gate lets OHOS fall back to synchronous writes while keeping the lock-free ring on all production platforms (macOS, Linux, Windows, Alpine).

## Changes

- `logger.c`: `g_logger_ring_enabled` flag set from env at init time. When 0, ring is never init'd, flusher never spawned, all writes go through the synchronous path.
- `ohos.yml`: `RETRACE_LOGGER_RING=0` in the LD_PRELOAD smoke test.

## Test plan

- [x] `ctest --test-dir build-test -L 'unit|property|integration'` -- 34/34 pass (ring still default-on)
- [x] Manual: `RETRACE_LOGGER_RING=0 retrace run -- ...` works (synchronous path)
- [ ] CI: OHOS cross-compile-and-verify should now pass with the env var set
