### PR TITLE
perf: reduce bench_action_call_real to 10K iters (fixes Alpine arm64 timeout)

### DIFF
--- a/test/perf/bench_action_call_real.c
+++ b/test/perf/bench_action_call_real.c
@@ -138,10 +138,10 @@ int main(void)
 
 	printf("--- call_real benchmark ---\n");
 
-	if (bench_run("call_real_zero_arg", bench_op, &cz, 100000, &r) == 0)
+	if (bench_run("call_real_zero_arg", bench_op, &cz, 10000, &r) == 0)
 		bench_print("call_real_zero_arg", &r);
 
-	if (bench_run("call_real_one_arg", bench_op, &co, 100000, &r) == 0)
+	if (bench_run("call_real_one_arg", bench_op, &co, 10000, &r) == 0)
 		bench_print("call_real_one_arg", &r);
 
 	return 0;


### PR DESCRIPTION
## Summary

Reduces `bench_action_call_real` from 100K to 10K iterations per bench_run call (2 calls = 20K total, down from 200K). The 100K count consistently exceeded the 60-second ctest timeout on Alpine arm64 under QEMU, causing the only non-experimental CI failure on every PR.

## Why

Alpine arm64 runs under QEMU emulation, which is 5-10x slower than native. 200K iterations of call_real (which invokes a real libc function pointer per iteration) takes >60s on QEMU. 20K iterations gives the same statistical signal (p50/p95/p99 percentiles are stable at 10K+) while finishing in ~10s.

## Test plan

- [x] `cmake --build build-test --target perf_bench_action_call_real` -- clean
- [x] `ctest --test-dir build-test -R bench_action_call_real` -- passes in <5s locally
- [ ] CI: Alpine arm64 build-aarch64 should now pass
