### PR TITLE
core: capture_buffer action — post-call memory observation

### DIFF
--- a/docs/cookbook/README.md
+++ b/docs/cookbook/README.md
@@ -114,6 +114,7 @@ Compact form. For the full schema and parameter reference, see
 | `filter` | Run the next actions only if a param matches an operator/value. |
 | `decode_http` | Parse a buffer as HTTP/1.x and log method/path/status. |
 | `decode_dns` | Parse a buffer as DNS wire format and log id/qname/qtype/answers. |
+| `capture_buffer` | Read memory at a pointer param (post-call) and log as hex or string. |
 
 ## Environment variables
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -40,7 +40,8 @@ set(_core_action_sources
 	actions/incomplete_io.c actions/fuzzing_seed.c
 	actions/delay.c actions/call_count_limit.c
 	actions/sandbox.c actions/addr_deny.c
-	actions/filter.c actions/decode_http.c actions/decode_dns.c)
+	actions/filter.c actions/decode_http.c actions/decode_dns.c
+	actions/capture_buffer.c)
 
 set(_core_datatype_sources
 	datatypes/basic.c datatypes/uio.c datatypes/unistd.c)

--- a/src/core/actions/capture_buffer.c
+++ b/src/core/actions/capture_buffer.c
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "actions.h"
+#include "logger.h"
+#include "real_impls.h"
+#include "action_utils.h"
+
+/*
+ * Note: deliberately does NOT include <string.h>.
+ * On macOS with _USE_FORTIFY_LEVEL > 0 (default), that header
+ * macro-substitutes memcpy/strcmp/etc., which would rewrite
+ * the retrace_real_impls.* calls. Same pattern as log_ring.c,
+ * sockaddr_inspect.c, and the other action files.
+ */
+
+#define CAPTURE_MAX_BYTES 4096
+#define CAPTURE_HEX_BUF (CAPTURE_MAX_BYTES * 2 + 1)
+
+static int ia_capture_buffer(struct ThreadContext *t_ctx,
+			     const JSON_Object *action_params)
+{
+	const char *param_name;
+	const char *size_param_name;
+	const char *format;
+	int buf_idx;
+	int size_idx;
+	const char *buf_ptr;
+	long capture_size;
+	long max_bytes;
+	size_t actual;
+	char hex_buf[CAPTURE_HEX_BUF];
+	char str_buf[CAPTURE_MAX_BYTES + 1];
+	size_t i;
+
+	if (action_params == NULL) {
+		log_err("capture_buffer: action_params required");
+		return -1;
+	}
+
+	param_name = json_object_get_string(action_params, "param_name");
+	if (param_name == NULL) {
+		log_err("capture_buffer: param_name required");
+		return -1;
+	}
+
+	buf_idx = retrace_action_find_param(t_ctx, param_name);
+	if (buf_idx < 0) {
+		log_dbg("capture_buffer: param '%s' not found", param_name);
+		return 0;
+	}
+
+	buf_ptr = (const char *)t_ctx->params[buf_idx].val;
+	if (buf_ptr == NULL) {
+		log_dbg("capture_buffer: '%s' is NULL", param_name);
+		return 0;
+	}
+
+	size_param_name = json_object_get_string(action_params,
+		"size_param");
+	if (size_param_name != NULL) {
+		size_idx = retrace_action_find_param(t_ctx,
+			size_param_name);
+		if (size_idx >= 0)
+			capture_size = (long)t_ctx->params[size_idx].val;
+		else
+			capture_size = CAPTURE_MAX_BYTES;
+	} else {
+		capture_size = CAPTURE_MAX_BYTES;
+	}
+
+	max_bytes = (long)json_object_get_number(action_params,
+		"max_bytes");
+	if (max_bytes <= 0 || max_bytes > CAPTURE_MAX_BYTES)
+		max_bytes = CAPTURE_MAX_BYTES;
+
+	if (capture_size > max_bytes)
+		capture_size = max_bytes;
+	if (capture_size <= 0)
+		capture_size = max_bytes;
+
+	format = json_object_get_string(action_params, "format");
+	if (format == NULL)
+		format = "hex";
+
+	actual = (size_t)capture_size;
+
+	if (retrace_real_impls.strcmp(format, "string") == 0) {
+		size_t copy_len = actual < sizeof(str_buf) - 1
+			? actual : sizeof(str_buf) - 1;
+
+		retrace_real_impls.memcpy(str_buf, buf_ptr, copy_len);
+		str_buf[copy_len] = '\0';
+		for (i = 0; i < copy_len; i++) {
+			if (str_buf[i] < 0x20 || str_buf[i] > 0x7e) {
+				if (str_buf[i] == '\n' || str_buf[i] == '\r'
+				    || str_buf[i] == '\t') {
+					continue;
+				}
+				str_buf[i] = '.';
+			}
+		}
+		log_info("capture_buffer: %s[%ld]=%s", param_name,
+			capture_size, str_buf);
+	} else {
+		static const char hex[] = "0123456789abcdef";
+
+		if (actual > CAPTURE_MAX_BYTES)
+			actual = CAPTURE_MAX_BYTES;
+		for (i = 0; i < actual; i++) {
+			unsigned char b = (unsigned char)buf_ptr[i];
+
+			hex_buf[i * 2] = hex[b >> 4];
+			hex_buf[i * 2 + 1] = hex[b & 0xf];
+		}
+		hex_buf[actual * 2] = '\0';
+		log_info("capture_buffer: %s[%ld]=%s", param_name,
+			capture_size, hex_buf);
+	}
+
+	return 0;
+}
+
+retrace_actions_define_package(capture_buffer) = {
+	{
+		.name = "capture_buffer",
+		.action = ia_capture_buffer
+	}
+};


### PR DESCRIPTION
## Summary

Adds the `capture_buffer` action for post-call memory content capture. Runs AFTER `call_real` to observe what the real libc function wrote into a buffer. Critical for security auditing: without it, you see that `read()` was called but not WHAT was read.

## Usage

```json
{
  "func_name": "read",
  "actions": [
    {"action_name": "call_real"},
    {"action_name": "capture_buffer",
     "action_params": {
       "param_name": "buf",
       "size_param": "count",
       "max_bytes": 256,
       "format": "hex"
     }
    },
    {"action_name": "log_params"}
  ]
}
```

## Output

```
capture_buffer: buf[256]=48656c6c6f20576f726c64...
capture_buffer: buf[256]=Hello World...
```

Hex format (default) prints 2 chars per byte. String format replaces non-printable chars with `.` and NUL-terminates.

## Implementation

- Self-registers via `retrace_actions_define_package` (OCP: new action = new file, no engine change)
- Deliberately avoids `<string.h>` (macOS macro substitution); uses `retrace_real_impls` for all string/mem ops
- Uses `retrace_action_find_param` (the DRY helper from PR #584)
- Cap at 4096 bytes to bound log output

## Test plan

- [x] `cmake --build build-test` -- clean
- [x] `ctest --test-dir build-test -L 'unit|property|integration'` -- 34/34 pass
- [x] Action is discoverable via `retrace list-actions`
- [ ] CI matrix green
