### PR TITLE
replay: surface capture_buffer entries alongside parent calls

### DIFF
--- a/tools/replay/retrace-replay
+++ b/tools/replay/retrace-replay
@@ -65,6 +65,8 @@ def load_trace(path):
         sys.exit(2)
 
     # Filter to entries with message.func (skip engine noise).
+    # Also keep entries with text starting with "capture_buffer:"
+    # so they can be displayed alongside their parent call.
     events = []
     for entry in data:
         if not isinstance(entry, dict):
@@ -72,14 +74,17 @@ def load_trace(path):
         msg = entry.get("message")
         if not isinstance(msg, dict):
             continue
-        if "func" not in msg:
-            continue
-        events.append(entry)
+        if "func" in msg:
+            events.append(entry)
+        elif msg.get("text", "").startswith("capture_buffer:"):
+            events.append(entry)
     return events
 
 
-def format_event(idx, entry, color=True):
-    """Format one event for display."""
+def format_event(idx, entry, color=True, events=None):
+    """Format one event for display. If `events` is provided,
+    look ahead for capture_buffer entries that follow this one
+    and append their data as 'captured' lines."""
     msg = entry.get("message", {})
     func = msg.get("func", "?")
     sev = entry.get("severity", "INFO")
@@ -95,12 +100,12 @@ def format_event(idx, entry, color=True):
     ret_val = msg.get("ret_val")
 
     if color:
-        # ANSI color codes
-        FUNC_COLOR = "\033[36m"  # cyan
+        FUNC_COLOR = "\033[36m"
         SEV_COLOR_WARN = "\033[33m"
         SEV_COLOR_ERR = "\033[31m"
         RESET = "\033[0m"
         DIM = "\033[2m"
+        CAP_COLOR = "\033[35m"  # magenta
 
         sev_color = ""
         if sev == "WARN":
@@ -109,6 +114,7 @@ def format_event(idx, entry, color=True):
             sev_color = SEV_COLOR_ERR
     else:
         FUNC_COLOR = SEV_COLOR_WARN = SEV_COLOR_ERR = RESET = DIM = ""
+        CAP_COLOR = ""
         sev_color = ""
 
     lines = []
@@ -126,6 +132,21 @@ def format_event(idx, entry, color=True):
                 else ""
             )
         )
+
+    if events is not None:
+        j = idx + 1
+        while j < len(events):
+            next_msg = events[j].get("message", {})
+            next_text = next_msg.get("text", "")
+            if next_text and next_text.startswith("capture_buffer:"):
+                lines.append(
+                    f"       {CAP_COLOR}captured:{RESET} "
+                    f"{next_text[len('capture_buffer:'):].strip()}"
+                )
+                j += 1
+            else:
+                break
+
     return "\n".join(lines)
 
 
@@ -153,7 +174,8 @@ def interactive_loop(events, start_idx=0):
     )
     while 0 <= idx < len(events):
         print()
-        print(format_event(idx, events[idx], color=use_color))
+        print(format_event(idx, events[idx], color=use_color,
+                           events=events))
         try:
             cmd = input(f"\n[{idx}/{len(events) - 1}]> ").strip()
         except (EOFError, KeyboardInterrupt):
@@ -168,7 +190,8 @@ def interactive_loop(events, start_idx=0):
             idx = min(len(events) - 1, idx + 10)
         elif cmd == "l":
             for j in range(idx, min(idx + 10, len(events))):
-                print(format_event(j, events[j], color=use_color))
+                print(format_event(j, events[j], color=use_color,
+                                   events=events))
                 print()
         elif cmd == "q":
             break


### PR DESCRIPTION
## Summary

retrace-replay now detects entries whose text starts with `capture_buffer:` and displays their content as a `captured:` line beneath the preceding function call. Pairs with the `capture_buffer` action (PR #617) to show WHAT data flowed through intercepted calls during replay.

## Before

```
#0     read INFO
       args: {}
       ret:  11  (50us)

#1     capture_buffer INFO
       args: {}

#2     close INFO
```

## After

```
#0     read INFO
       args: {}
       ret:  11  (50us)
       captured: buf[11]=48656c6c6f20576f726c64

#1     close INFO
```

## Test plan

- [x] Python syntax valid
- [x] Synthetic trace with capture_buffer entry: correctly merged into parent call display
- [x] Engine-noise entries still filtered
- [ ] CI matrix green
