### PR TITLE
release: v2.3.0 — lock-free logger + tools ecosystem

### DIFF
--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -105,13 +105,14 @@ jobs:
       - name: Verify .so is ARM aarch64
         run: |
           ls -la build-ohos/src/v2/libretrace.so*
-          file build-ohos/src/v2/libretrace.so.2.2.2 | tee /dev/stderr | grep -q 'ELF 64-bit LSB .* ARM aarch64'
+          SO_FILE="$(ls build-ohos/src/v2/libretrace.so.*.*.* | head -1)"
+          file "$SO_FILE" | tee /dev/stderr | grep -q 'ELF 64-bit LSB .* ARM aarch64'
 
       - name: Code-sign .so (required by OHOS at dlopen time)
         run: |
-          for f in build-ohos/src/v2/libretrace.so \
-                   build-ohos/src/v2/libretrace.so.2 \
-                   build-ohos/src/v2/libretrace.so.2.2.2; do
+          for f in $(ls build-ohos/src/v2/libretrace.so \
+                     build-ohos/src/v2/libretrace.so.* \
+                     build-ohos/src/v2/libretrace.so.*.*.* 2>/dev/null); do
             [ -e "$f" ] || continue
             /opt/ohos/ohos-sdk/linux/toolchains/lib/binary-sign-tool sign \
               -selfSign 1 -inFile "$f" -outFile "$f"
@@ -141,8 +142,8 @@ jobs:
         run: |
           mkdir -p ohos-verify
           cp -a build-ohos/src/v2/libretrace.so           ohos-verify/
-          cp -a build-ohos/src/v2/libretrace.so.2         ohos-verify/ 2>/dev/null || true
-          cp -a build-ohos/src/v2/libretrace.so.2.2.2     ohos-verify/ 2>/dev/null || true
+          cp -a build-ohos/src/v2/libretrace.so.*         ohos-verify/ 2>/dev/null || true
+          cp -a build-ohos/src/v2/libretrace.so.*.*.*     ohos-verify/ 2>/dev/null || true
           cp -a build-ohos/ohos-smoke-test                    ohos-verify/
           cp -a build-ohos/ohos-ldpreload-target              ohos-verify/
           cp -a .github/scripts/ohos-ldpreload-config.json    ohos-verify/retrace-config.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,7 +160,7 @@ jobs:
           sha256sum "retrace-${VERSION}-${{ matrix.platform }}.tar.gz" \
             > "retrace-${VERSION}-${{ matrix.platform }}.tar.gz.sha256"
           # Also produce a bare library for curl + LD_PRELOAD use case
-          cp build/src/v2/libretrace.so.2.2.2 "libretrace-${{ matrix.platform }}.so"
+          cp "$(ls build/src/v2/libretrace.so.*.*.* | head -1)" "libretrace-${{ matrix.platform }}.so"
           sha256sum "libretrace-${{ matrix.platform }}.so" \
             > "libretrace-${{ matrix.platform }}.so.sha256"
 
@@ -188,7 +188,7 @@ jobs:
           shasum -a 256 "retrace-${VERSION}-${{ matrix.platform }}.tar.gz" \
             > "retrace-${VERSION}-${{ matrix.platform }}.tar.gz.sha256"
           # Bare library for curl + DYLD_INSERT use case
-          cp build/src/v2/libretrace.2.2.2.dylib "libretrace-${{ matrix.platform }}.dylib"
+          cp "$(ls build/src/v2/libretrace.*.*.*.dylib | head -1)" "libretrace-${{ matrix.platform }}.dylib"
           shasum -a 256 "libretrace-${{ matrix.platform }}.dylib" \
             > "libretrace-${{ matrix.platform }}.dylib.sha256"
 
@@ -378,14 +378,15 @@ jobs:
 
       - name: Verify .so is ARM aarch64
         run: |
-          file build-ohos/src/v2/libretrace.so.2.2.2 | tee /dev/stderr \
+          SO_FILE="$(ls build-ohos/src/v2/libretrace.so.*.*.* | head -1)"
+          file "$SO_FILE" | tee /dev/stderr \
             | grep -q 'ELF 64-bit LSB .* ARM aarch64'
 
       - name: Code-sign .so (required by OHOS at dlopen time)
         run: |
-          for f in build-ohos/src/v2/libretrace.so \
-                   build-ohos/src/v2/libretrace.so.2 \
-                   build-ohos/src/v2/libretrace.so.2.2.2; do
+          for f in $(ls build-ohos/src/v2/libretrace.so \
+                     build-ohos/src/v2/libretrace.so.* \
+                     build-ohos/src/v2/libretrace.so.*.*.* 2>/dev/null); do
             [ -e "$f" ] || continue
             /opt/ohos/ohos-sdk/linux/toolchains/lib/binary-sign-tool sign \
               -selfSign 1 -inFile "$f" -outFile "$f"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,130 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (see `docs/adr/0006-semantic-versioning.md`).
 
+## [2.3.0] - 2026-08-12
+
+### Added
+
+#### Lock-free logger (TODO 19)
+
+- Per-thread SPSC ring buffer replaces the global-mutex logger
+  hot path. Background flusher thread drains rings at 1ms cadence.
+  Eliminates contention; sustains 100K+ events/sec on multi-core.
+  `RETRACE_LOGGER_RING=0` env gate for platforms where background
+  threads are unstable (OHOS Docker/QEMU).
+
+#### capture_buffer action (new — 17th built-in)
+
+- Post-call memory observation. Reads N bytes from a pointer param
+  (after `call_real`) and logs as hex or string. Critical for
+  security auditing: see WHAT was read/received, not just that
+  read()/recv() was called.
+
+#### Call-hash coverage feedback for libFuzzer (TODO 24)
+
+- Per-thread FNV-1a rolling hash of intercepted libc calls.
+  Exported as `retrace_call_hash_last` global for a libFuzzer
+  custom mutator (`fuzz_call_hash`) that biases mutations toward
+  inputs exercising new call sequences.
+
+#### Compliance audit tool (TODO 26)
+
+- `retrace-audit` reads a retrace JSON log, applies policy rules,
+  and emits findings as JSON, SARIF 2.1.0, or printable PDF.
+  Ships with 4 policies: baseline, PCI-DSS, HIPAA, ISO 27001.
+
+#### Differential trace analysis (TODO 27)
+
+- `retrace-diff` compares two traces per function call-count and
+  total-time. Supports `--threshold` (CI gating), `--order` (LCS
+  sequence alignment), and `--stats` (statistical significance
+  via z-score against N baseline traces).
+
+#### Time-travel replay (TODO 25)
+
+- `retrace-replay` interactive tool: step forward/backward
+  through trace events, jump to indices, search by regex.
+  Surfaces `capture_buffer` entries alongside parent calls.
+
+#### WebSocket live streaming (TODO 22)
+
+- `retrace-ws` tails the JSON log and broadcasts to WebSocket
+  clients. Built-in browser viewer with function-name highlighting
+  and severity coloring.
+
+#### Frida bridge (TODO 28)
+
+- `retrace-frida.js`: hooks 30 libc functions via Frida's
+  Interceptor, dereferences string args (path, name, command),
+  emits retrace-compatible JSON to stdout.
+
+#### eBPF backend (TODO 29)
+
+- BPF program + Python loader skeleton for kernel-level syscall
+  observation on Linux. Observation-only (eBPF cannot mutate).
+
+#### VS Code extension (TODO 31)
+
+- `retrace: Open Log Viewer` — webview with function-name
+  highlighting and severity coloring. `retrace: Show Stats` —
+  per-function call count quick-pick. `retrace: Connect to Live
+  Stream` — WebSocket client consuming retrace-ws output.
+
+#### Grafana data source (TODO 32)
+
+- Loads retrace JSON log (via HTTP) as a Grafana time series.
+  5-second cache TTL for live-reload dashboards.
+
+#### CLI fuzz-replay (TODO 33)
+
+- `retrace fuzz-replay <fuzzer-name> <crash-input>` replays a
+  crash reproducer through the named libFuzzer harness.
+
+#### Nightly fuzz workflow (TODO 33)
+
+- `.github/workflows/fuzz.yml` runs all 5 fuzzers for 5 minutes
+  each, uploads crash artifacts (exit 77/71/70) on failure.
+
+#### Website interactive features (TODO 36)
+
+- Decision Wizard: 4-step wizard (goal → sub-goal → target →
+  config + command + recipe link).
+- Recipe Builder: drag-and-drop action chain composer with live
+  JSON output.
+- Wasm playground: browser-based trace demo running entirely in
+  WebAssembly.
+
+#### Cookbook recipes 22-23
+
+- Recipe 22: Decode HTTP and DNS wire formats.
+- Recipe 23: Bridge to OpenTelemetry (OTLP) via retrace-to-otlp.
+
+### Fixed
+
+- macOS dyld destructor crash: `thread_context.c` destructor was
+  deleting the global pthread_key from a per-thread context.
+- OHOS Docker/QEMU crash: background flusher thread spawned during
+  constructor. Fixed via lazy spawn + `RETRACE_LOGGER_RING=0`.
+- Alpine arm64 perf-bench timeout: reduced iterations from 100K
+  to 10K for QEMU-compatible runtime.
+- Parson OOM: 129-byte adversarial input caused ~2GB allocation.
+  Added allocation budget (`input_size * 1000`) to
+  `json_parse_string_with_comments`.
+- CLI `cmd_trace` stack overflow: snprintf return accumulation
+  without bounds checking. Fixed via extracted config builders.
+
+### Changed
+
+- Logger hot path: global mutex → per-thread SPSC ring + background
+  flusher (3 PRs: ring, flusher, integration).
+- Audit tool: MECE refactor — scan/present/format layers are
+  separate (OCP: adding a format = new function, no engine change).
+- Action param lookup: DRY extraction into `retrace_action_find_param`
+  shared across 8 sites in 5 files.
+- Flusher stop: `pthread_join` (hangs on macOS dyld destructor) →
+  spin-wait + grace period.
+- Removed `retrace_logger_log_old` (dead code, pre-JSON legacy).
+
 ## [2.2.2] - 2026-08-08
 
 ### Added

--- a/include/retrace/version.h
+++ b/include/retrace/version.h
@@ -37,10 +37,10 @@
 #define RETRACE_VERSION_H
 
 #define RETRACE_VERSION_MAJOR 2
-#define RETRACE_VERSION_MINOR 2
-#define RETRACE_VERSION_PATCH 2
+#define RETRACE_VERSION_MINOR 3
+#define RETRACE_VERSION_PATCH 0
 
-#define RETRACE_VERSION_STRING "2.2.2"
+#define RETRACE_VERSION_STRING "2.3.0"
 
 #define RETRACE_VERSION_ATLEAST(maj, min, pat)                  \
 	(RETRACE_VERSION_MAJOR > (maj) ||                       \

--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -1,4 +1,4 @@
-retrace (2.2.2-1) unstable; urgency=medium
+retrace (2.3.0-1) unstable; urgency=medium
 
   * Initial Debian packaging.
   * Network function interception (27 BSD-sockets functions).

--- a/packaging/fedora/retrace.spec
+++ b/packaging/fedora/retrace.spec
@@ -2,10 +2,10 @@
 #
 # Fedora RPM spec for retrace (TODO.complete/38).
 # Build: rpmbuild -ba retrace.spec
-# Install: dnf install retrace-2.2.2-1.*.rpm
+# Install: dnf install retrace-2.3.0-1.*.rpm
 
 Name:           retrace
-Version:        2.2.2
+Version:        2.3.0
 Release:        1%{?dist}
 Summary:        Userspace libc interceptor for security discovery
 
@@ -50,5 +50,5 @@ action, OTLP/JSON export, and a Python config builder.
 %{_includedir}/retrace/
 
 %changelog
-* Sat Aug 09 2026 Ribose Inc <opensource@ribose.com> - 2.2.2-1
+* Sat Aug 09 2026 Ribose Inc <opensource@ribose.com> - 2.3.0-1
 - Initial Fedora packaging

--- a/packaging/nix/default.nix
+++ b/packaging/nix/default.nix
@@ -8,7 +8,7 @@
 
 stdenv.mkDerivation rec {
   pname = "retrace";
-  version = "2.2.2";
+  version = "2.3.0";
 
   src = ./.;
 

--- a/src/cli/retrace_cli.c
+++ b/src/cli/retrace_cli.c
@@ -55,7 +55,7 @@
 static void usage(FILE *out)
 {
 	fprintf(out,
-"retrace v2.2.2 -- userspace libc interceptor\n"
+"retrace v2.3.0 -- userspace libc interceptor\n"
 "\n"
 "Usage:\n"
 "  retrace run [OPTIONS] -- <command> [args...]\n"


### PR DESCRIPTION
## Summary

Bumps retrace from v2.2.2 to **v2.3.0** (MINOR per ADR-0006; opaque-types promise preserved per ADR-0008). This release ships the lock-free logger rewrite, the tools ecosystem (audit/diff/replay/ws/Frida/eBPF/VS Code/Grafana), the capture_buffer and call_hash engine features, and the parson OOM hardening.

## What's in the bump

### Core engine
- **Lock-free SPSC ring logger** with background flusher thread: per-thread ring (atomic head/tail, acquire/release ordering), lazy flusher spawn gated on `retrace_inited`, `RETRACE_LOGGER_RING` env gate for OHOS/QEMU compat. Hot path is now a non-blocking push instead of a mutexed fwrite.
- **capture_buffer** action: post-call memory observation (hex or string mode) with 4 KB cap.
- **call_hash**: per-thread FNV-1a rolling hash for fuzzer coverage feedback; libFuzzer custom mutator integration via weak symbol.
- **parson**: allocation budget (`input_len * 1000`) prevents OOM from small adversarial inputs in comment-stripping path.

### Tooling ecosystem
- **retrace-audit**: policy scanner with 4 baseline profiles (baseline, pci-dss, hipaa, iso27001), SARIF 2.1.0 + PDF 1.4 report output.
- **retrace-diff**: threshold filtering (`--threshold pct=N`), LCS-based call-ordering diff (`--order`), statistical significance (`--stats`, z-score against N baselines).
- **retrace-replay**: interactive trace player (step/jump/find); surfaces capture_buffer entries alongside parent calls.
- **retrace-ws**: WebSocket streamer with JSON brace-counting parser and built-in browser viewer.
- **Frida bridge**: 30-function instrumentation script (`frida-bridge/retrace-frida.js`).
- **eBPF bridge**: sys_enter_openat/close tracepoint program.
- **VS Code extension**: viewer + live WebSocket streaming.
- **Grafana plugin**: live reload via cache TTL.

### CLI
- `fuzz-replay` subcommand for crash reproduction through libFuzzer harnesses.
- Config builders extracted to `config_builder.{c,h}` (MECE separation, bounds-checked `append()` helper).
- Fixed stack overflow in `cmd_trace` (snprintf return accumulation underflow).

### Fuzzing & tests
- Nightly fuzz workflow (5 fuzzers, 5 minutes each, crash artifact upload).
- Property-based test suite for parson parser.
- All 39 tests pass (33 unit + 5 property + 1 integration).

### Website
- Decision Wizard, Recipe Builder, site-wide search (Cmd-K palette), Glossary, Community, Back-to-top.

## Files changed

- `include/retrace/version.h`: 2.2.2 -> 2.3.0
- `src/cli/retrace_cli.c`: banner 2.2.2 -> 2.3.0
- `CHANGELOG.md`: comprehensive [2.3.0] entry
- `packaging/nix/default.nix`, `packaging/debian/changelog`, `packaging/fedora/retrace.spec`: version bump

## Test plan

- [x] `cmake -B build -G Ninja -DRETRACE_BUILD_TESTS=ON`
- [x] `cmake --build build`
- [x] `ctest --test-dir build --output-on-failure` — 39/39 pass
- [x] `./build/src/cli/retrace --version` reports `retrace v2.3.0`
- [x] No AI attribution in commit message
- [ ] CI green on all matrix legs
- [ ] After merge: tag v2.3.0 at the merge commit; release.yml produces binary artifacts

## Tagging plan

After this PR rebase-merges, tag `v2.3.0` at the merge commit. The existing `release.yml` workflow triggers on tag push and produces per-platform binary artifacts + source tarball. (Tag will be pushed by the user, not by the agent — per project policy.)
