### PR TITLE
release: v2.3.1 — audit policy MECE refactor + tool unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (see `docs/adr/0006-semantic-versioning.md`).
 
+## [2.3.1] - 2026-08-12
+
+### Changed
+- `audit-converter`: moved `rule_matches` from `audit.c` to `policy.c`
+  as the public `policy_rule_matches`. Rule-matching semantics now
+  live with the rule data model (MECE split); `audit.c` is purely
+  trace-scanning + output formatting.
+
+### Added
+- `test/unit/test_policy.c` — 25 unit tests for the audit policy
+  module (severity_str round-trip, policy_load_from_json variants,
+  policy_rule_matches across all 4 predicate types including
+  suffix/prefix/exact env_pattern, AND semantics, NULL safety).
+- `test/unit/test_normalize.c` — 12 unit tests for the trace-diff
+  normalizer (call-count aggregation, duration sum, engine-noise
+  skip, ordering preservation, NULL safety, free idempotency).
+
 ## [2.3.0] - 2026-08-12
 
 ### Added

--- a/include/retrace/version.h
+++ b/include/retrace/version.h
@@ -38,9 +38,9 @@
 
 #define RETRACE_VERSION_MAJOR 2
 #define RETRACE_VERSION_MINOR 3
-#define RETRACE_VERSION_PATCH 0
+#define RETRACE_VERSION_PATCH 1
 
-#define RETRACE_VERSION_STRING "2.3.0"
+#define RETRACE_VERSION_STRING "2.3.1"
 
 #define RETRACE_VERSION_ATLEAST(maj, min, pat)                  \
 	(RETRACE_VERSION_MAJOR > (maj) ||                       \

--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -1,3 +1,11 @@
+retrace (2.3.1-1) unstable; urgency=medium
+
+  * Audit policy MECE refactor: rule matcher moved to policy module.
+  * Unit tests for audit-converter policy (25 cases) and trace-diff
+    normalize (12 cases).
+
+ -- Ribose Inc <opensource@ribose.com>  Tue, 12 Aug 2026 00:00:00 +0000
+
 retrace (2.3.0-1) unstable; urgency=medium
 
   * Initial Debian packaging.

--- a/packaging/fedora/retrace.spec
+++ b/packaging/fedora/retrace.spec
@@ -2,10 +2,10 @@
 #
 # Fedora RPM spec for retrace (TODO.complete/38).
 # Build: rpmbuild -ba retrace.spec
-# Install: dnf install retrace-2.3.0-1.*.rpm
+# Install: dnf install retrace-2.3.1-1.*.rpm
 
 Name:           retrace
-Version:        2.3.0
+Version:        2.3.1
 Release:        1%{?dist}
 Summary:        Userspace libc interceptor for security discovery
 
@@ -50,5 +50,8 @@ action, OTLP/JSON export, and a Python config builder.
 %{_includedir}/retrace/
 
 %changelog
+* Tue Aug 12 2026 Ribose Inc <opensource@ribose.com> - 2.3.1-1
+- Audit policy MECE refactor + unit tests for policy/normalize
+
 * Sat Aug 09 2026 Ribose Inc <opensource@ribose.com> - 2.3.0-1
 - Initial Fedora packaging

--- a/packaging/nix/default.nix
+++ b/packaging/nix/default.nix
@@ -8,7 +8,7 @@
 
 stdenv.mkDerivation rec {
   pname = "retrace";
-  version = "2.3.0";
+  version = "2.3.1";
 
   src = ./.;
 

--- a/src/cli/retrace_cli.c
+++ b/src/cli/retrace_cli.c
@@ -55,7 +55,7 @@
 static void usage(FILE *out)
 {
 	fprintf(out,
-"retrace v2.3.0 -- userspace libc interceptor\n"
+"retrace v2.3.1 -- userspace libc interceptor\n"
 "\n"
 "Usage:\n"
 "  retrace run [OPTIONS] -- <command> [args...]\n"

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -987,3 +987,51 @@ endif()
 add_test(NAME unit-test-decode-dns
     COMMAND retrace_test_decode_dns)
 set_tests_properties(unit-test-decode-dns PROPERTIES LABELS "unit")
+
+#
+# Audit policy unit tests (TODO.complete/26). policy_rule_matches
+# is the audit-converter's predicate engine -- exercises every
+# predicate type (func_exact, func_prefix, path_contains,
+# env_pattern suffix/prefix/exact), AND semantics, and NULL safety.
+# Compiles policy.c directly from tools/audit-converter/.
+#
+set(_audit_policy_source
+    ${CMAKE_SOURCE_DIR}/tools/audit-converter/policy.c)
+set(_parson_for_tools ${CMAKE_SOURCE_DIR}/src/config/json/parson.c)
+
+add_executable(retrace_test_policy test_policy.c
+    ${_audit_policy_source} ${_parson_for_tools})
+set_target_properties(retrace_test_policy PROPERTIES
+    OUTPUT_NAME test_policy
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/test/unit")
+
+target_include_directories(retrace_test_policy PRIVATE
+    ${CMAKE_SOURCE_DIR}/tools/audit-converter
+    ${CMAKE_SOURCE_DIR}/src/config/json
+    ${CMAKE_SOURCE_DIR}/test/property/parson_stub)
+
+add_test(NAME unit-test-policy
+    COMMAND retrace_test_policy)
+set_tests_properties(unit-test-policy PROPERTIES LABELS "unit")
+
+#
+# Trace-diff normalize unit tests (TODO.complete/27). Verifies
+# call-count aggregation, duration sum, engine-noise filtering,
+# ordering preservation, and NULL safety. Compiles normalize.c
+# directly from tools/trace-diff/.
+#
+add_executable(retrace_test_normalize test_normalize.c
+    ${CMAKE_SOURCE_DIR}/tools/trace-diff/normalize.c
+    ${_parson_for_tools})
+set_target_properties(retrace_test_normalize PROPERTIES
+    OUTPUT_NAME test_normalize
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/test/unit")
+
+target_include_directories(retrace_test_normalize PRIVATE
+    ${CMAKE_SOURCE_DIR}/tools/trace-diff
+    ${CMAKE_SOURCE_DIR}/src/config/json
+    ${CMAKE_SOURCE_DIR}/test/property/parson_stub)
+
+add_test(NAME unit-test-normalize
+    COMMAND retrace_test_normalize)
+set_tests_properties(unit-test-normalize PROPERTIES LABELS "unit")

--- a/test/unit/test_normalize.c
+++ b/test/unit/test_normalize.c
@@ -1,0 +1,311 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+/*
+ * Unit tests for the trace-diff normalizer (TODO.complete/27).
+ *
+ * Covers:
+ *   - normalize_from_trace aggregates call_count per function
+ *   - normalize_from_trace sums call_duration_us per function
+ *   - normalize_from_trace skips entries without message.func
+ *     (engine noise)
+ *   - normalize_from_trace skips entries without call_duration_us
+ *   - normalize_from_trace NULL safety
+ *   - normalize_find returns the right FuncStat, NULL for missing
+ *   - normalize_call_sequence preserves call order
+ *   - normalize_call_sequence filters engine noise
+ *   - normalize_free is safe on initialized and zeroed logs
+ */
+
+#include "parson.h"
+#include "normalize.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int tests_run;
+static int tests_pass;
+static int tests_fail;
+
+#define TEST(name) do { \
+	tests_run++; \
+	printf("  TEST %s ... ", #name); \
+	test_##name(); \
+	tests_pass++; \
+	printf("OK\n"); \
+} while (0)
+
+/* ----- Helpers ----- */
+
+/* Build a trace JSON_Array from a source string. Caller frees. */
+static JSON_Array *trace_from_string(const char *src)
+{
+	JSON_Value *v = json_parse_string(src);
+
+	return json_value_get_array(v);
+}
+
+static void trace_free(JSON_Array *a)
+{
+	json_value_free(json_array_get_wrapping_value(a));
+}
+
+/* Append one {message:{func,call_duration_us}} entry to a JSON_Array. */
+static void trace_append_call(JSON_Array *a, const char *func,
+			      double duration_us)
+{
+	JSON_Value *entry = json_value_init_object();
+	JSON_Object *entry_o = json_value_get_object(entry);
+	JSON_Value *msg_v = json_value_init_object();
+	JSON_Object *msg = json_value_get_object(msg_v);
+
+	json_object_set_string(msg, "func", func);
+	json_object_set_number(msg, "call_duration_us", duration_us);
+	json_object_set_value(entry_o, "message", msg_v);
+	json_array_append_value(a, entry);
+}
+
+/* Append an engine-noise entry (has "text" instead of "func"). */
+static void trace_append_noise(JSON_Array *a, const char *text)
+{
+	JSON_Value *entry = json_value_init_object();
+	JSON_Object *entry_o = json_value_get_object(entry);
+	JSON_Value *msg_v = json_value_init_object();
+	JSON_Object *msg = json_value_get_object(msg_v);
+
+	json_object_set_string(msg, "text", text);
+	json_object_set_value(entry_o, "message", msg_v);
+	json_array_append_value(a, entry);
+}
+
+/* ----- normalize_from_trace ----- */
+
+static void test_aggregates_call_count(void)
+{
+	JSON_Array *t = trace_from_string("[]");
+	struct NormalizedLog log;
+	const struct FuncStat *st;
+
+	trace_append_call(t, "malloc", 10.0);
+	trace_append_call(t, "malloc", 20.0);
+	trace_append_call(t, "malloc", 30.0);
+	trace_append_call(t, "free", 5.0);
+
+	assert(normalize_from_trace(t, &log) == 0);
+	assert(log.count == 2);
+
+	st = normalize_find(&log, "malloc");
+	assert(st != NULL);
+	assert(st->call_count == 3);
+
+	st = normalize_find(&log, "free");
+	assert(st != NULL);
+	assert(st->call_count == 1);
+
+	normalize_free(&log);
+	trace_free(t);
+}
+
+static void test_sums_duration(void)
+{
+	JSON_Array *t = trace_from_string("[]");
+	struct NormalizedLog log;
+	const struct FuncStat *st;
+
+	trace_append_call(t, "malloc", 10.0);
+	trace_append_call(t, "malloc", 20.0);
+	trace_append_call(t, "malloc", 30.0);
+
+	assert(normalize_from_trace(t, &log) == 0);
+	st = normalize_find(&log, "malloc");
+	assert(st != NULL);
+	assert(st->total_duration_us == 60);
+	normalize_free(&log);
+	trace_free(t);
+}
+
+static void test_skips_engine_noise(void)
+{
+	JSON_Array *t = trace_from_string("[]");
+	struct NormalizedLog log;
+	const struct FuncStat *st;
+
+	trace_append_noise(t, "engine starting");
+	trace_append_call(t, "open", 1.0);
+	trace_append_noise(t, "engine stopping");
+
+	assert(normalize_from_trace(t, &log) == 0);
+	assert(log.count == 1);
+	st = normalize_find(&log, "open");
+	assert(st != NULL);
+	assert(st->call_count == 1);
+	normalize_free(&log);
+	trace_free(t);
+}
+
+static void test_skips_entries_without_duration(void)
+{
+	/* An entry with func but no call_duration_us is treated as
+	 * noise and skipped (matches OTLP converter convention).
+	 */
+	JSON_Array *t = trace_from_string("[]");
+	JSON_Value *entry = json_value_init_object();
+	JSON_Object *entry_o = json_value_get_object(entry);
+	JSON_Value *msg_v = json_value_init_object();
+	JSON_Object *msg = json_value_get_object(msg_v);
+	struct NormalizedLog log;
+
+	json_object_set_string(msg, "func", "open");
+	json_object_set_value(entry_o, "message", msg_v);
+	json_array_append_value(t, entry);
+
+	trace_append_call(t, "malloc", 5.0);
+
+	assert(normalize_from_trace(t, &log) == 0);
+	assert(log.count == 1);
+	assert(normalize_find(&log, "open") == NULL);
+	assert(normalize_find(&log, "malloc") != NULL);
+	normalize_free(&log);
+	trace_free(t);
+}
+
+static void test_null_safety(void)
+{
+	struct NormalizedLog log;
+
+	assert(normalize_from_trace(NULL, &log) == -1);
+	assert(normalize_from_trace(NULL, NULL) == -1);
+}
+
+static void test_empty_trace_yields_empty_log(void)
+{
+	JSON_Array *t = trace_from_string("[]");
+	struct NormalizedLog log;
+
+	assert(normalize_from_trace(t, &log) == 0);
+	assert(log.count == 0);
+	assert(log.funcs == NULL || log.cap == 0 || log.count == 0);
+	normalize_free(&log);
+	trace_free(t);
+}
+
+/* ----- normalize_find ----- */
+
+static void test_find_missing_returns_null(void)
+{
+	JSON_Array *t = trace_from_string("[]");
+	struct NormalizedLog log;
+
+	trace_append_call(t, "malloc", 1.0);
+	assert(normalize_from_trace(t, &log) == 0);
+	assert(normalize_find(&log, "free") == NULL);
+	assert(normalize_find(NULL, "malloc") == NULL);
+	assert(normalize_find(&log, NULL) == NULL);
+	normalize_free(&log);
+	trace_free(t);
+}
+
+/* ----- normalize_call_sequence ----- */
+
+static void test_sequence_preserves_order(void)
+{
+	JSON_Array *t = trace_from_string("[]");
+	char **seq;
+	size_t len;
+
+	trace_append_call(t, "open", 1.0);
+	trace_append_call(t, "read", 2.0);
+	trace_append_call(t, "close", 3.0);
+	trace_append_call(t, "open", 4.0);
+
+	assert(normalize_call_sequence(t, &seq, &len) == 0);
+	assert(len == 4);
+	assert(strcmp(seq[0], "open") == 0);
+	assert(strcmp(seq[1], "read") == 0);
+	assert(strcmp(seq[2], "close") == 0);
+	assert(strcmp(seq[3], "open") == 0);
+
+	for (len = 0; len < 4; len++)
+		free(seq[len]);
+	free(seq);
+	trace_free(t);
+}
+
+static void test_sequence_filters_noise(void)
+{
+	JSON_Array *t = trace_from_string("[]");
+	char **seq;
+	size_t len;
+
+	trace_append_noise(t, "noise A");
+	trace_append_call(t, "open", 1.0);
+	trace_append_noise(t, "noise B");
+	trace_append_call(t, "close", 2.0);
+
+	assert(normalize_call_sequence(t, &seq, &len) == 0);
+	assert(len == 2);
+	assert(strcmp(seq[0], "open") == 0);
+	assert(strcmp(seq[1], "close") == 0);
+
+	free(seq[0]);
+	free(seq[1]);
+	free(seq);
+	trace_free(t);
+}
+
+static void test_sequence_null_safety(void)
+{
+	char **seq;
+	size_t len;
+
+	assert(normalize_call_sequence(NULL, &seq, &len) == -1);
+}
+
+/* ----- normalize_free ----- */
+
+static void test_free_on_zeroed_log_is_safe(void)
+{
+	struct NormalizedLog log;
+
+	memset(&log, 0, sizeof(log));
+	normalize_free(&log);
+	assert(log.funcs == NULL);
+	assert(log.count == 0);
+}
+
+static void test_free_null_is_safe(void)
+{
+	normalize_free(NULL);
+}
+
+int main(void)
+{
+	printf("-- normalize_from_trace --\n");
+	TEST(aggregates_call_count);
+	TEST(sums_duration);
+	TEST(skips_engine_noise);
+	TEST(skips_entries_without_duration);
+	TEST(null_safety);
+	TEST(empty_trace_yields_empty_log);
+
+	printf("-- normalize_find --\n");
+	TEST(find_missing_returns_null);
+
+	printf("-- normalize_call_sequence --\n");
+	TEST(sequence_preserves_order);
+	TEST(sequence_filters_noise);
+	TEST(sequence_null_safety);
+
+	printf("-- normalize_free --\n");
+	TEST(free_on_zeroed_log_is_safe);
+	TEST(free_null_is_safe);
+
+	printf("\nPass: %d, Fail: %d (of %d)\n",
+		tests_pass, tests_fail, tests_run);
+	return tests_fail == 0 ? 0 : 1;
+}

--- a/test/unit/test_normalize.c
+++ b/test/unit/test_normalize.c
@@ -18,6 +18,9 @@
  *   - normalize_call_sequence preserves call order
  *   - normalize_call_sequence filters engine noise
  *   - normalize_free is safe on initialized and zeroed logs
+ *
+ * Note: function calls live OUTSIDE assert() so the side-effecting
+ * call still happens under -DNDEBUG.
  */
 
 #include "parson.h"
@@ -40,9 +43,16 @@ static int tests_fail;
 	printf("OK\n"); \
 } while (0)
 
+#define CHECK(cond) do { \
+	if (!(cond)) { \
+		printf("FAIL [%s:%d] %s\n", __FILE__, __LINE__, #cond); \
+		tests_fail++; \
+		return; \
+	} \
+} while (0)
+
 /* ----- Helpers ----- */
 
-/* Build a trace JSON_Array from a source string. Caller frees. */
 static JSON_Array *trace_from_string(const char *src)
 {
 	JSON_Value *v = json_parse_string(src);
@@ -55,7 +65,6 @@ static void trace_free(JSON_Array *a)
 	json_value_free(json_array_get_wrapping_value(a));
 }
 
-/* Append one {message:{func,call_duration_us}} entry to a JSON_Array. */
 static void trace_append_call(JSON_Array *a, const char *func,
 			      double duration_us)
 {
@@ -70,7 +79,6 @@ static void trace_append_call(JSON_Array *a, const char *func,
 	json_array_append_value(a, entry);
 }
 
-/* Append an engine-noise entry (has "text" instead of "func"). */
 static void trace_append_noise(JSON_Array *a, const char *text)
 {
 	JSON_Value *entry = json_value_init_object();
@@ -90,22 +98,24 @@ static void test_aggregates_call_count(void)
 	JSON_Array *t = trace_from_string("[]");
 	struct NormalizedLog log;
 	const struct FuncStat *st;
+	int rc;
 
 	trace_append_call(t, "malloc", 10.0);
 	trace_append_call(t, "malloc", 20.0);
 	trace_append_call(t, "malloc", 30.0);
 	trace_append_call(t, "free", 5.0);
 
-	assert(normalize_from_trace(t, &log) == 0);
-	assert(log.count == 2);
+	rc = normalize_from_trace(t, &log);
+	CHECK(rc == 0);
+	CHECK(log.count == 2);
 
 	st = normalize_find(&log, "malloc");
-	assert(st != NULL);
-	assert(st->call_count == 3);
+	CHECK(st != NULL);
+	CHECK(st->call_count == 3);
 
 	st = normalize_find(&log, "free");
-	assert(st != NULL);
-	assert(st->call_count == 1);
+	CHECK(st != NULL);
+	CHECK(st->call_count == 1);
 
 	normalize_free(&log);
 	trace_free(t);
@@ -116,15 +126,17 @@ static void test_sums_duration(void)
 	JSON_Array *t = trace_from_string("[]");
 	struct NormalizedLog log;
 	const struct FuncStat *st;
+	int rc;
 
 	trace_append_call(t, "malloc", 10.0);
 	trace_append_call(t, "malloc", 20.0);
 	trace_append_call(t, "malloc", 30.0);
 
-	assert(normalize_from_trace(t, &log) == 0);
+	rc = normalize_from_trace(t, &log);
+	CHECK(rc == 0);
 	st = normalize_find(&log, "malloc");
-	assert(st != NULL);
-	assert(st->total_duration_us == 60);
+	CHECK(st != NULL);
+	CHECK(st->total_duration_us == 60);
 	normalize_free(&log);
 	trace_free(t);
 }
@@ -134,31 +146,31 @@ static void test_skips_engine_noise(void)
 	JSON_Array *t = trace_from_string("[]");
 	struct NormalizedLog log;
 	const struct FuncStat *st;
+	int rc;
 
 	trace_append_noise(t, "engine starting");
 	trace_append_call(t, "open", 1.0);
 	trace_append_noise(t, "engine stopping");
 
-	assert(normalize_from_trace(t, &log) == 0);
-	assert(log.count == 1);
+	rc = normalize_from_trace(t, &log);
+	CHECK(rc == 0);
+	CHECK(log.count == 1);
 	st = normalize_find(&log, "open");
-	assert(st != NULL);
-	assert(st->call_count == 1);
+	CHECK(st != NULL);
+	CHECK(st->call_count == 1);
 	normalize_free(&log);
 	trace_free(t);
 }
 
 static void test_skips_entries_without_duration(void)
 {
-	/* An entry with func but no call_duration_us is treated as
-	 * noise and skipped (matches OTLP converter convention).
-	 */
 	JSON_Array *t = trace_from_string("[]");
 	JSON_Value *entry = json_value_init_object();
 	JSON_Object *entry_o = json_value_get_object(entry);
 	JSON_Value *msg_v = json_value_init_object();
 	JSON_Object *msg = json_value_get_object(msg_v);
 	struct NormalizedLog log;
+	int rc;
 
 	json_object_set_string(msg, "func", "open");
 	json_object_set_value(entry_o, "message", msg_v);
@@ -166,10 +178,11 @@ static void test_skips_entries_without_duration(void)
 
 	trace_append_call(t, "malloc", 5.0);
 
-	assert(normalize_from_trace(t, &log) == 0);
-	assert(log.count == 1);
-	assert(normalize_find(&log, "open") == NULL);
-	assert(normalize_find(&log, "malloc") != NULL);
+	rc = normalize_from_trace(t, &log);
+	CHECK(rc == 0);
+	CHECK(log.count == 1);
+	CHECK(normalize_find(&log, "open") == NULL);
+	CHECK(normalize_find(&log, "malloc") != NULL);
 	normalize_free(&log);
 	trace_free(t);
 }
@@ -178,18 +191,19 @@ static void test_null_safety(void)
 {
 	struct NormalizedLog log;
 
-	assert(normalize_from_trace(NULL, &log) == -1);
-	assert(normalize_from_trace(NULL, NULL) == -1);
+	CHECK(normalize_from_trace(NULL, &log) == -1);
+	CHECK(normalize_from_trace(NULL, NULL) == -1);
 }
 
 static void test_empty_trace_yields_empty_log(void)
 {
 	JSON_Array *t = trace_from_string("[]");
 	struct NormalizedLog log;
+	int rc;
 
-	assert(normalize_from_trace(t, &log) == 0);
-	assert(log.count == 0);
-	assert(log.funcs == NULL || log.cap == 0 || log.count == 0);
+	rc = normalize_from_trace(t, &log);
+	CHECK(rc == 0);
+	CHECK(log.count == 0);
 	normalize_free(&log);
 	trace_free(t);
 }
@@ -200,12 +214,14 @@ static void test_find_missing_returns_null(void)
 {
 	JSON_Array *t = trace_from_string("[]");
 	struct NormalizedLog log;
+	int rc;
 
 	trace_append_call(t, "malloc", 1.0);
-	assert(normalize_from_trace(t, &log) == 0);
-	assert(normalize_find(&log, "free") == NULL);
-	assert(normalize_find(NULL, "malloc") == NULL);
-	assert(normalize_find(&log, NULL) == NULL);
+	rc = normalize_from_trace(t, &log);
+	CHECK(rc == 0);
+	CHECK(normalize_find(&log, "free") == NULL);
+	CHECK(normalize_find(NULL, "malloc") == NULL);
+	CHECK(normalize_find(&log, NULL) == NULL);
 	normalize_free(&log);
 	trace_free(t);
 }
@@ -215,23 +231,26 @@ static void test_find_missing_returns_null(void)
 static void test_sequence_preserves_order(void)
 {
 	JSON_Array *t = trace_from_string("[]");
-	char **seq;
-	size_t len;
+	char **seq = NULL;
+	size_t len = 0;
+	int rc;
+	size_t i;
 
 	trace_append_call(t, "open", 1.0);
 	trace_append_call(t, "read", 2.0);
 	trace_append_call(t, "close", 3.0);
 	trace_append_call(t, "open", 4.0);
 
-	assert(normalize_call_sequence(t, &seq, &len) == 0);
-	assert(len == 4);
-	assert(strcmp(seq[0], "open") == 0);
-	assert(strcmp(seq[1], "read") == 0);
-	assert(strcmp(seq[2], "close") == 0);
-	assert(strcmp(seq[3], "open") == 0);
+	rc = normalize_call_sequence(t, &seq, &len);
+	CHECK(rc == 0);
+	CHECK(len == 4);
+	CHECK(strcmp(seq[0], "open") == 0);
+	CHECK(strcmp(seq[1], "read") == 0);
+	CHECK(strcmp(seq[2], "close") == 0);
+	CHECK(strcmp(seq[3], "open") == 0);
 
-	for (len = 0; len < 4; len++)
-		free(seq[len]);
+	for (i = 0; i < len; i++)
+		free(seq[i]);
 	free(seq);
 	trace_free(t);
 }
@@ -239,18 +258,20 @@ static void test_sequence_preserves_order(void)
 static void test_sequence_filters_noise(void)
 {
 	JSON_Array *t = trace_from_string("[]");
-	char **seq;
-	size_t len;
+	char **seq = NULL;
+	size_t len = 0;
+	int rc;
 
 	trace_append_noise(t, "noise A");
 	trace_append_call(t, "open", 1.0);
 	trace_append_noise(t, "noise B");
 	trace_append_call(t, "close", 2.0);
 
-	assert(normalize_call_sequence(t, &seq, &len) == 0);
-	assert(len == 2);
-	assert(strcmp(seq[0], "open") == 0);
-	assert(strcmp(seq[1], "close") == 0);
+	rc = normalize_call_sequence(t, &seq, &len);
+	CHECK(rc == 0);
+	CHECK(len == 2);
+	CHECK(strcmp(seq[0], "open") == 0);
+	CHECK(strcmp(seq[1], "close") == 0);
 
 	free(seq[0]);
 	free(seq[1]);
@@ -260,10 +281,10 @@ static void test_sequence_filters_noise(void)
 
 static void test_sequence_null_safety(void)
 {
-	char **seq;
-	size_t len;
+	char **seq = NULL;
+	size_t len = 0;
 
-	assert(normalize_call_sequence(NULL, &seq, &len) == -1);
+	CHECK(normalize_call_sequence(NULL, &seq, &len) == -1);
 }
 
 /* ----- normalize_free ----- */
@@ -274,8 +295,8 @@ static void test_free_on_zeroed_log_is_safe(void)
 
 	memset(&log, 0, sizeof(log));
 	normalize_free(&log);
-	assert(log.funcs == NULL);
-	assert(log.count == 0);
+	CHECK(log.funcs == NULL);
+	CHECK(log.count == 0);
 }
 
 static void test_free_null_is_safe(void)

--- a/test/unit/test_policy.c
+++ b/test/unit/test_policy.c
@@ -1,0 +1,399 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+/*
+ * Unit tests for the audit policy module (TODO.complete/26).
+ *
+ * Covers:
+ *   - severity_str round-trip across all enum values
+ *   - policy_load_from_json parses every predicate type + severity
+ *   - policy_load_from_json tolerates missing rules array
+ *   - policy_load_from_json NULL safety
+ *   - policy_free idempotency
+ *   - policy_rule_matches across every predicate type:
+ *       func_exact, func_prefix, path_contains, env_pattern
+ *       (suffix, prefix, exact)
+ *   - policy_rule_matches AND semantics (all non-NULL constraints
+ *     must match)
+ *   - policy_rule_matches NULL safety
+ */
+
+#include "parson.h"
+#include "policy.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+static int tests_run;
+static int tests_pass;
+static int tests_fail;
+
+#define TEST(name) do { \
+	tests_run++; \
+	printf("  TEST %s ... ", #name); \
+	test_##name(); \
+	tests_pass++; \
+	printf("OK\n"); \
+} while (0)
+
+/* ----- Helpers ----- */
+
+static JSON_Object *msg_from_func(const char *func)
+{
+	JSON_Value *v = json_value_init_object();
+	JSON_Object *o = json_value_get_object(v);
+
+	if (func != NULL)
+		json_object_set_string(o, "func", func);
+	return o;
+}
+
+static JSON_Object *msg_with_string(const char *key, const char *val)
+{
+	JSON_Value *v = json_value_init_object();
+	JSON_Object *o = json_value_get_object(v);
+
+	json_object_set_string(o, key, val);
+	return o;
+}
+
+static void msg_free(JSON_Object *o)
+{
+	json_value_free(json_object_get_wrapping_value(o));
+}
+
+/* ----- severity_str round-trip ----- */
+
+static void test_severity_str_round_trip(void)
+{
+	assert(strcmp(severity_str(SEV_INFO), "info") == 0);
+	assert(strcmp(severity_str(SEV_MEDIUM), "medium") == 0);
+	assert(strcmp(severity_str(SEV_HIGH), "high") == 0);
+	assert(strcmp(severity_str(SEV_CRITICAL), "critical") == 0);
+}
+
+static void test_severity_str_default_is_info(void)
+{
+	assert(strcmp(severity_str((enum Severity)99), "info") == 0);
+}
+
+/* ----- policy_load_from_json ----- */
+
+static void test_load_all_predicate_types(void)
+{
+	const char *src =
+		"{\"name\":\"test\", \"rules\":["
+		"  {\"id\":\"R1\",\"description\":\"d1\","
+		"   \"match\":{\"func_exact\":\"system\"},\"severity\":\"high\"},"
+		"  {\"id\":\"R2\",\"description\":\"d2\","
+		"   \"match\":{\"func_prefix\":\"get\"},\"severity\":\"medium\"},"
+		"  {\"id\":\"R3\",\"description\":\"d3\","
+		"   \"match\":{\"path_contains\":\"/etc/passwd\"},"
+		"   \"severity\":\"critical\"},"
+		"  {\"id\":\"R4\",\"description\":\"d4\","
+		"   \"match\":{\"env_pattern\":\"*_TOKEN\"},"
+		"   \"severity\":\"info\"}"
+		"]}";
+	JSON_Value *v = json_parse_string(src);
+	JSON_Object *root = json_value_get_object(v);
+	struct Policy p;
+
+	assert(policy_load_from_json(root, &p) == 0);
+	assert(strcmp(p.name, "test") == 0);
+	assert(p.rules_count == 4);
+
+	assert(strcmp(p.rules[0].id, "R1") == 0);
+	assert(p.rules[0].severity == SEV_HIGH);
+	assert(p.rules[0].func_exact != NULL);
+	assert(strcmp(p.rules[0].func_exact, "system") == 0);
+
+	assert(strcmp(p.rules[1].id, "R2") == 0);
+	assert(p.rules[1].severity == SEV_MEDIUM);
+	assert(p.rules[1].func_prefix != NULL);
+	assert(strcmp(p.rules[1].func_prefix, "get") == 0);
+
+	assert(strcmp(p.rules[2].id, "R3") == 0);
+	assert(p.rules[2].severity == SEV_CRITICAL);
+	assert(p.rules[2].path_contains != NULL);
+	assert(strcmp(p.rules[2].path_contains, "/etc/passwd") == 0);
+
+	assert(strcmp(p.rules[3].id, "R4") == 0);
+	assert(p.rules[3].severity == SEV_INFO);
+	assert(p.rules[3].env_pattern != NULL);
+	assert(strcmp(p.rules[3].env_pattern, "*_TOKEN") == 0);
+
+	policy_free(&p);
+	json_value_free(v);
+}
+
+static void test_load_missing_rules_array(void)
+{
+	const char *src = "{\"name\":\"empty\"}";
+	JSON_Value *v = json_parse_string(src);
+	JSON_Object *root = json_value_get_object(v);
+	struct Policy p;
+
+	assert(policy_load_from_json(root, &p) == 0);
+	assert(strcmp(p.name, "empty") == 0);
+	assert(p.rules == NULL);
+	assert(p.rules_count == 0);
+	policy_free(&p);
+	json_value_free(v);
+}
+
+static void test_load_unnamed_policy_uses_default(void)
+{
+	const char *src = "{}";
+	JSON_Value *v = json_parse_string(src);
+	JSON_Object *root = json_value_get_object(v);
+	struct Policy p;
+
+	assert(policy_load_from_json(root, &p) == 0);
+	assert(strcmp(p.name, "(unnamed)") == 0);
+	policy_free(&p);
+	json_value_free(v);
+}
+
+static void test_load_null_safety(void)
+{
+	struct Policy p;
+
+	assert(policy_load_from_json(NULL, &p) == -1);
+	assert(policy_load_from_json(NULL, NULL) == -1);
+}
+
+static void test_free_null_is_safe(void)
+{
+	policy_free(NULL);
+}
+
+/* ----- policy_rule_matches: func_exact ----- */
+
+static void test_func_exact_match(void)
+{
+	struct Rule r = {"R", "", .func_exact = "system"};
+	JSON_Object *m = msg_from_func("system");
+
+	assert(policy_rule_matches(&r, m) == 1);
+	msg_free(m);
+}
+
+static void test_func_exact_no_match(void)
+{
+	struct Rule r = {"R", "", .func_exact = "system"};
+	JSON_Object *m = msg_from_func("execve");
+
+	assert(policy_rule_matches(&r, m) == 0);
+	msg_free(m);
+}
+
+static void test_func_exact_no_func_in_msg(void)
+{
+	struct Rule r = {"R", "", .func_exact = "system"};
+	JSON_Object *m = msg_with_string("text", "no func here");
+
+	assert(policy_rule_matches(&r, m) == 0);
+	msg_free(m);
+}
+
+/* ----- policy_rule_matches: func_prefix ----- */
+
+static void test_func_prefix_match(void)
+{
+	struct Rule r = {"R", "", .func_prefix = "get"};
+	JSON_Object *m = msg_from_func("getenv");
+
+	assert(policy_rule_matches(&r, m) == 1);
+	msg_free(m);
+}
+
+static void test_func_prefix_no_match(void)
+{
+	struct Rule r = {"R", "", .func_prefix = "get"};
+	JSON_Object *m = msg_from_func("setenv");
+
+	assert(policy_rule_matches(&r, m) == 0);
+	msg_free(m);
+}
+
+/* ----- policy_rule_matches: path_contains ----- */
+
+static void test_path_contains_match_in_path(void)
+{
+	struct Rule r = {"R", "", .path_contains = "/etc/passwd"};
+	JSON_Object *m = msg_with_string("path", "/etc/passwd");
+
+	assert(policy_rule_matches(&r, m) == 1);
+	msg_free(m);
+}
+
+static void test_path_contains_match_in_any_string_field(void)
+{
+	struct Rule r = {"R", "", .path_contains = "secret"};
+	JSON_Object *m = msg_with_string("buf", "load the secret sauce");
+
+	assert(policy_rule_matches(&r, m) == 1);
+	msg_free(m);
+}
+
+static void test_path_contains_no_match(void)
+{
+	struct Rule r = {"R", "", .path_contains = "/etc/shadow"};
+	JSON_Object *m = msg_with_string("path", "/etc/passwd");
+
+	assert(policy_rule_matches(&r, m) == 0);
+	msg_free(m);
+}
+
+/* ----- policy_rule_matches: env_pattern ----- */
+
+static void test_env_pattern_suffix_match(void)
+{
+	struct Rule r = {"R", "", .env_pattern = "*_TOKEN"};
+	JSON_Object *m = msg_with_string("name", "API_TOKEN");
+
+	assert(policy_rule_matches(&r, m) == 1);
+	msg_free(m);
+}
+
+static void test_env_pattern_suffix_no_match(void)
+{
+	struct Rule r = {"R", "", .env_pattern = "*_TOKEN"};
+	JSON_Object *m = msg_with_string("name", "API_KEY");
+
+	assert(policy_rule_matches(&r, m) == 0);
+	msg_free(m);
+}
+
+static void test_env_pattern_prefix_match(void)
+{
+	struct Rule r = {"R", "", .env_pattern = "LD_*"};
+	JSON_Object *m = msg_with_string("name", "LD_PRELOAD");
+
+	assert(policy_rule_matches(&r, m) == 1);
+	msg_free(m);
+}
+
+static void test_env_pattern_prefix_no_match(void)
+{
+	struct Rule r = {"R", "", .env_pattern = "LD_*"};
+	JSON_Object *m = msg_with_string("name", "PATH");
+
+	assert(policy_rule_matches(&r, m) == 0);
+	msg_free(m);
+}
+
+static void test_env_pattern_exact_match(void)
+{
+	struct Rule r = {"R", "", .env_pattern = "IFS"};
+	JSON_Object *m = msg_with_string("name", "IFS");
+
+	assert(policy_rule_matches(&r, m) == 1);
+	msg_free(m);
+}
+
+static void test_env_pattern_null_name_in_msg(void)
+{
+	struct Rule r = {"R", "", .env_pattern = "*_TOKEN"};
+	JSON_Object *m = msg_from_func("getenv");  /* no "name" field */
+
+	assert(policy_rule_matches(&r, m) == 0);
+	msg_free(m);
+}
+
+/* ----- policy_rule_matches: AND semantics ----- */
+
+static void test_and_both_match(void)
+{
+	struct Rule r = {"R", "", .func_exact = "open",
+		.path_contains = "/etc"};
+	JSON_Object *m = msg_from_func("open");
+
+	json_object_set_string(m, "path", "/etc/passwd");
+	assert(policy_rule_matches(&r, m) == 1);
+	msg_free(m);
+}
+
+static void test_and_one_fails(void)
+{
+	struct Rule r = {"R", "", .func_exact = "open",
+		.path_contains = "/etc"};
+	JSON_Object *m = msg_from_func("open");
+
+	json_object_set_string(m, "path", "/var/log/foo");
+	assert(policy_rule_matches(&r, m) == 0);
+	msg_free(m);
+}
+
+/* ----- policy_rule_matches: edge cases ----- */
+
+static void test_empty_rule_matches_anything(void)
+{
+	struct Rule r = {"R", ""};  /* all predicates NULL */
+	JSON_Object *m = msg_from_func("anything");
+
+	assert(policy_rule_matches(&r, m) == 1);
+	msg_free(m);
+}
+
+static void test_null_inputs_safe(void)
+{
+	struct Rule r = {"R", ""};
+	JSON_Object *m = msg_from_func("x");
+
+	assert(policy_rule_matches(NULL, m) == 0);
+	assert(policy_rule_matches(&r, NULL) == 0);
+	msg_free(m);
+}
+
+int main(void)
+{
+	printf("-- severity_str --\n");
+	TEST(severity_str_round_trip);
+	TEST(severity_str_default_is_info);
+
+	printf("-- policy_load_from_json --\n");
+	TEST(load_all_predicate_types);
+	TEST(load_missing_rules_array);
+	TEST(load_unnamed_policy_uses_default);
+	TEST(load_null_safety);
+	TEST(free_null_is_safe);
+
+	printf("-- policy_rule_matches: func_exact --\n");
+	TEST(func_exact_match);
+	TEST(func_exact_no_match);
+	TEST(func_exact_no_func_in_msg);
+
+	printf("-- policy_rule_matches: func_prefix --\n");
+	TEST(func_prefix_match);
+	TEST(func_prefix_no_match);
+
+	printf("-- policy_rule_matches: path_contains --\n");
+	TEST(path_contains_match_in_path);
+	TEST(path_contains_match_in_any_string_field);
+	TEST(path_contains_no_match);
+
+	printf("-- policy_rule_matches: env_pattern --\n");
+	TEST(env_pattern_suffix_match);
+	TEST(env_pattern_suffix_no_match);
+	TEST(env_pattern_prefix_match);
+	TEST(env_pattern_prefix_no_match);
+	TEST(env_pattern_exact_match);
+	TEST(env_pattern_null_name_in_msg);
+
+	printf("-- policy_rule_matches: AND semantics --\n");
+	TEST(and_both_match);
+	TEST(and_one_fails);
+
+	printf("-- policy_rule_matches: edge cases --\n");
+	TEST(empty_rule_matches_anything);
+	TEST(null_inputs_safe);
+
+	printf("\nPass: %d, Fail: %d (of %d)\n",
+		tests_pass, tests_fail, tests_run);
+	return tests_fail == 0 ? 0 : 1;
+}

--- a/test/unit/test_policy.c
+++ b/test/unit/test_policy.c
@@ -19,6 +19,10 @@
  *   - policy_rule_matches AND semantics (all non-NULL constraints
  *     must match)
  *   - policy_rule_matches NULL safety
+ *
+ * Note: function calls live OUTSIDE assert() so the side-effecting
+ * call still happens under -DNDEBUG. Otherwise the test would
+ * operate on uninitialized memory.
  */
 
 #include "parson.h"
@@ -38,6 +42,15 @@ static int tests_fail;
 	test_##name(); \
 	tests_pass++; \
 	printf("OK\n"); \
+} while (0)
+
+/* Always-on check. assert() alone is compiled out by NDEBUG. */
+#define CHECK(cond) do { \
+	if (!(cond)) { \
+		printf("FAIL [%s:%d] %s\n", __FILE__, __LINE__, #cond); \
+		tests_fail++; \
+		return; \
+	} \
 } while (0)
 
 /* ----- Helpers ----- */
@@ -70,15 +83,15 @@ static void msg_free(JSON_Object *o)
 
 static void test_severity_str_round_trip(void)
 {
-	assert(strcmp(severity_str(SEV_INFO), "info") == 0);
-	assert(strcmp(severity_str(SEV_MEDIUM), "medium") == 0);
-	assert(strcmp(severity_str(SEV_HIGH), "high") == 0);
-	assert(strcmp(severity_str(SEV_CRITICAL), "critical") == 0);
+	CHECK(strcmp(severity_str(SEV_INFO), "info") == 0);
+	CHECK(strcmp(severity_str(SEV_MEDIUM), "medium") == 0);
+	CHECK(strcmp(severity_str(SEV_HIGH), "high") == 0);
+	CHECK(strcmp(severity_str(SEV_CRITICAL), "critical") == 0);
 }
 
 static void test_severity_str_default_is_info(void)
 {
-	assert(strcmp(severity_str((enum Severity)99), "info") == 0);
+	CHECK(strcmp(severity_str((enum Severity)99), "info") == 0);
 }
 
 /* ----- policy_load_from_json ----- */
@@ -101,30 +114,32 @@ static void test_load_all_predicate_types(void)
 	JSON_Value *v = json_parse_string(src);
 	JSON_Object *root = json_value_get_object(v);
 	struct Policy p;
+	int rc;
 
-	assert(policy_load_from_json(root, &p) == 0);
-	assert(strcmp(p.name, "test") == 0);
-	assert(p.rules_count == 4);
+	rc = policy_load_from_json(root, &p);
+	CHECK(rc == 0);
+	CHECK(strcmp(p.name, "test") == 0);
+	CHECK(p.rules_count == 4);
 
-	assert(strcmp(p.rules[0].id, "R1") == 0);
-	assert(p.rules[0].severity == SEV_HIGH);
-	assert(p.rules[0].func_exact != NULL);
-	assert(strcmp(p.rules[0].func_exact, "system") == 0);
+	CHECK(strcmp(p.rules[0].id, "R1") == 0);
+	CHECK(p.rules[0].severity == SEV_HIGH);
+	CHECK(p.rules[0].func_exact != NULL);
+	CHECK(strcmp(p.rules[0].func_exact, "system") == 0);
 
-	assert(strcmp(p.rules[1].id, "R2") == 0);
-	assert(p.rules[1].severity == SEV_MEDIUM);
-	assert(p.rules[1].func_prefix != NULL);
-	assert(strcmp(p.rules[1].func_prefix, "get") == 0);
+	CHECK(strcmp(p.rules[1].id, "R2") == 0);
+	CHECK(p.rules[1].severity == SEV_MEDIUM);
+	CHECK(p.rules[1].func_prefix != NULL);
+	CHECK(strcmp(p.rules[1].func_prefix, "get") == 0);
 
-	assert(strcmp(p.rules[2].id, "R3") == 0);
-	assert(p.rules[2].severity == SEV_CRITICAL);
-	assert(p.rules[2].path_contains != NULL);
-	assert(strcmp(p.rules[2].path_contains, "/etc/passwd") == 0);
+	CHECK(strcmp(p.rules[2].id, "R3") == 0);
+	CHECK(p.rules[2].severity == SEV_CRITICAL);
+	CHECK(p.rules[2].path_contains != NULL);
+	CHECK(strcmp(p.rules[2].path_contains, "/etc/passwd") == 0);
 
-	assert(strcmp(p.rules[3].id, "R4") == 0);
-	assert(p.rules[3].severity == SEV_INFO);
-	assert(p.rules[3].env_pattern != NULL);
-	assert(strcmp(p.rules[3].env_pattern, "*_TOKEN") == 0);
+	CHECK(strcmp(p.rules[3].id, "R4") == 0);
+	CHECK(p.rules[3].severity == SEV_INFO);
+	CHECK(p.rules[3].env_pattern != NULL);
+	CHECK(strcmp(p.rules[3].env_pattern, "*_TOKEN") == 0);
 
 	policy_free(&p);
 	json_value_free(v);
@@ -136,11 +151,13 @@ static void test_load_missing_rules_array(void)
 	JSON_Value *v = json_parse_string(src);
 	JSON_Object *root = json_value_get_object(v);
 	struct Policy p;
+	int rc;
 
-	assert(policy_load_from_json(root, &p) == 0);
-	assert(strcmp(p.name, "empty") == 0);
-	assert(p.rules == NULL);
-	assert(p.rules_count == 0);
+	rc = policy_load_from_json(root, &p);
+	CHECK(rc == 0);
+	CHECK(strcmp(p.name, "empty") == 0);
+	CHECK(p.rules == NULL);
+	CHECK(p.rules_count == 0);
 	policy_free(&p);
 	json_value_free(v);
 }
@@ -151,9 +168,11 @@ static void test_load_unnamed_policy_uses_default(void)
 	JSON_Value *v = json_parse_string(src);
 	JSON_Object *root = json_value_get_object(v);
 	struct Policy p;
+	int rc;
 
-	assert(policy_load_from_json(root, &p) == 0);
-	assert(strcmp(p.name, "(unnamed)") == 0);
+	rc = policy_load_from_json(root, &p);
+	CHECK(rc == 0);
+	CHECK(strcmp(p.name, "(unnamed)") == 0);
 	policy_free(&p);
 	json_value_free(v);
 }
@@ -162,8 +181,8 @@ static void test_load_null_safety(void)
 {
 	struct Policy p;
 
-	assert(policy_load_from_json(NULL, &p) == -1);
-	assert(policy_load_from_json(NULL, NULL) == -1);
+	CHECK(policy_load_from_json(NULL, &p) == -1);
+	CHECK(policy_load_from_json(NULL, NULL) == -1);
 }
 
 static void test_free_null_is_safe(void)
@@ -178,7 +197,7 @@ static void test_func_exact_match(void)
 	struct Rule r = {"R", "", .func_exact = "system"};
 	JSON_Object *m = msg_from_func("system");
 
-	assert(policy_rule_matches(&r, m) == 1);
+	CHECK(policy_rule_matches(&r, m) == 1);
 	msg_free(m);
 }
 
@@ -187,7 +206,7 @@ static void test_func_exact_no_match(void)
 	struct Rule r = {"R", "", .func_exact = "system"};
 	JSON_Object *m = msg_from_func("execve");
 
-	assert(policy_rule_matches(&r, m) == 0);
+	CHECK(policy_rule_matches(&r, m) == 0);
 	msg_free(m);
 }
 
@@ -196,7 +215,7 @@ static void test_func_exact_no_func_in_msg(void)
 	struct Rule r = {"R", "", .func_exact = "system"};
 	JSON_Object *m = msg_with_string("text", "no func here");
 
-	assert(policy_rule_matches(&r, m) == 0);
+	CHECK(policy_rule_matches(&r, m) == 0);
 	msg_free(m);
 }
 
@@ -207,7 +226,7 @@ static void test_func_prefix_match(void)
 	struct Rule r = {"R", "", .func_prefix = "get"};
 	JSON_Object *m = msg_from_func("getenv");
 
-	assert(policy_rule_matches(&r, m) == 1);
+	CHECK(policy_rule_matches(&r, m) == 1);
 	msg_free(m);
 }
 
@@ -216,7 +235,7 @@ static void test_func_prefix_no_match(void)
 	struct Rule r = {"R", "", .func_prefix = "get"};
 	JSON_Object *m = msg_from_func("setenv");
 
-	assert(policy_rule_matches(&r, m) == 0);
+	CHECK(policy_rule_matches(&r, m) == 0);
 	msg_free(m);
 }
 
@@ -227,7 +246,7 @@ static void test_path_contains_match_in_path(void)
 	struct Rule r = {"R", "", .path_contains = "/etc/passwd"};
 	JSON_Object *m = msg_with_string("path", "/etc/passwd");
 
-	assert(policy_rule_matches(&r, m) == 1);
+	CHECK(policy_rule_matches(&r, m) == 1);
 	msg_free(m);
 }
 
@@ -236,7 +255,7 @@ static void test_path_contains_match_in_any_string_field(void)
 	struct Rule r = {"R", "", .path_contains = "secret"};
 	JSON_Object *m = msg_with_string("buf", "load the secret sauce");
 
-	assert(policy_rule_matches(&r, m) == 1);
+	CHECK(policy_rule_matches(&r, m) == 1);
 	msg_free(m);
 }
 
@@ -245,7 +264,7 @@ static void test_path_contains_no_match(void)
 	struct Rule r = {"R", "", .path_contains = "/etc/shadow"};
 	JSON_Object *m = msg_with_string("path", "/etc/passwd");
 
-	assert(policy_rule_matches(&r, m) == 0);
+	CHECK(policy_rule_matches(&r, m) == 0);
 	msg_free(m);
 }
 
@@ -256,7 +275,7 @@ static void test_env_pattern_suffix_match(void)
 	struct Rule r = {"R", "", .env_pattern = "*_TOKEN"};
 	JSON_Object *m = msg_with_string("name", "API_TOKEN");
 
-	assert(policy_rule_matches(&r, m) == 1);
+	CHECK(policy_rule_matches(&r, m) == 1);
 	msg_free(m);
 }
 
@@ -265,7 +284,7 @@ static void test_env_pattern_suffix_no_match(void)
 	struct Rule r = {"R", "", .env_pattern = "*_TOKEN"};
 	JSON_Object *m = msg_with_string("name", "API_KEY");
 
-	assert(policy_rule_matches(&r, m) == 0);
+	CHECK(policy_rule_matches(&r, m) == 0);
 	msg_free(m);
 }
 
@@ -274,7 +293,7 @@ static void test_env_pattern_prefix_match(void)
 	struct Rule r = {"R", "", .env_pattern = "LD_*"};
 	JSON_Object *m = msg_with_string("name", "LD_PRELOAD");
 
-	assert(policy_rule_matches(&r, m) == 1);
+	CHECK(policy_rule_matches(&r, m) == 1);
 	msg_free(m);
 }
 
@@ -283,7 +302,7 @@ static void test_env_pattern_prefix_no_match(void)
 	struct Rule r = {"R", "", .env_pattern = "LD_*"};
 	JSON_Object *m = msg_with_string("name", "PATH");
 
-	assert(policy_rule_matches(&r, m) == 0);
+	CHECK(policy_rule_matches(&r, m) == 0);
 	msg_free(m);
 }
 
@@ -292,7 +311,7 @@ static void test_env_pattern_exact_match(void)
 	struct Rule r = {"R", "", .env_pattern = "IFS"};
 	JSON_Object *m = msg_with_string("name", "IFS");
 
-	assert(policy_rule_matches(&r, m) == 1);
+	CHECK(policy_rule_matches(&r, m) == 1);
 	msg_free(m);
 }
 
@@ -301,7 +320,7 @@ static void test_env_pattern_null_name_in_msg(void)
 	struct Rule r = {"R", "", .env_pattern = "*_TOKEN"};
 	JSON_Object *m = msg_from_func("getenv");  /* no "name" field */
 
-	assert(policy_rule_matches(&r, m) == 0);
+	CHECK(policy_rule_matches(&r, m) == 0);
 	msg_free(m);
 }
 
@@ -314,7 +333,7 @@ static void test_and_both_match(void)
 	JSON_Object *m = msg_from_func("open");
 
 	json_object_set_string(m, "path", "/etc/passwd");
-	assert(policy_rule_matches(&r, m) == 1);
+	CHECK(policy_rule_matches(&r, m) == 1);
 	msg_free(m);
 }
 
@@ -325,7 +344,7 @@ static void test_and_one_fails(void)
 	JSON_Object *m = msg_from_func("open");
 
 	json_object_set_string(m, "path", "/var/log/foo");
-	assert(policy_rule_matches(&r, m) == 0);
+	CHECK(policy_rule_matches(&r, m) == 0);
 	msg_free(m);
 }
 
@@ -336,7 +355,7 @@ static void test_empty_rule_matches_anything(void)
 	struct Rule r = {"R", ""};  /* all predicates NULL */
 	JSON_Object *m = msg_from_func("anything");
 
-	assert(policy_rule_matches(&r, m) == 1);
+	CHECK(policy_rule_matches(&r, m) == 1);
 	msg_free(m);
 }
 
@@ -345,8 +364,8 @@ static void test_null_inputs_safe(void)
 	struct Rule r = {"R", ""};
 	JSON_Object *m = msg_from_func("x");
 
-	assert(policy_rule_matches(NULL, m) == 0);
-	assert(policy_rule_matches(&r, NULL) == 0);
+	CHECK(policy_rule_matches(NULL, m) == 0);
+	CHECK(policy_rule_matches(&r, NULL) == 0);
 	msg_free(m);
 }
 

--- a/tools/audit-converter/audit.c
+++ b/tools/audit-converter/audit.c
@@ -37,98 +37,6 @@
 #include "pdf_writer.h"
 
 /*
- * Predicate evaluation. The entry is the log entry's "message"
- * object (the part that varies by action). For log_params
- * entries, "func" is the intercepted function name and other
- * fields are the parsed arguments (path, buf, etc.).
- *
- * Predicate semantics: a rule matches if ALL of its non-NULL
- * constraints match (AND). NULL constraints are wildcards.
- *
- * Returns 1 if the rule matches, 0 otherwise.
- */
-static int rule_matches(const struct Rule *rule, JSON_Object *msg)
-{
-	const char *func;
-	size_t nkeys, k;
-
-	if (rule == NULL || msg == NULL)
-		return 0;
-
-	func = json_object_get_string(msg, "func");
-
-	if (rule->func_exact != NULL) {
-		if (func == NULL || strcmp(func, rule->func_exact) != 0)
-			return 0;
-	}
-
-	if (rule->func_prefix != NULL) {
-		size_t plen = strlen(rule->func_prefix);
-
-		if (func == NULL || strncmp(func, rule->func_prefix, plen) != 0)
-			return 0;
-	}
-
-	/* path_contains: scan every string value in the message */
-	if (rule->path_contains != NULL) {
-		int found = 0;
-
-		nkeys = json_object_get_count(msg);
-		for (k = 0; k < nkeys; k++) {
-			JSON_Value *v = json_object_get_value_at(msg, k);
-			const char *s;
-
-			if (json_value_get_type(v) != JSONString)
-				continue;
-			s = json_value_get_string(v);
-			if (s != NULL && strstr(s, rule->path_contains) != NULL) {
-				found = 1;
-				break;
-			}
-		}
-		if (!found)
-			return 0;
-	}
-
-	/* env_pattern: glob match against getenv entries.
-	 * Patterns supported:
-	 *   *_TOKEN, *_KEY, *_PASSWORD  (suffix)
-	 *   LD_*, IFS                   (prefix)
-	 *   (anything else is exact)
-	 */
-	if (rule->env_pattern != NULL) {
-		const char *var = json_object_get_string(msg, "name");
-		size_t plen;
-		int match = 0;
-
-		if (var == NULL)
-			return 0;
-		plen = strlen(rule->env_pattern);
-		if (rule->env_pattern[0] == '*' && plen > 1) {
-			/* Suffix match: *_TOKEN */
-			size_t vlen = strlen(var);
-			size_t suffix_len = plen - 1;
-
-			if (vlen >= suffix_len &&
-			    strcmp(var + vlen - suffix_len,
-				   rule->env_pattern + 1) == 0)
-				match = 1;
-		} else if (plen > 0 && rule->env_pattern[plen - 1] == '*') {
-			/* Prefix match: LD_* */
-			if (strncmp(var, rule->env_pattern, plen - 1) == 0)
-				match = 1;
-		} else {
-			if (strcmp(var, rule->env_pattern) == 0)
-				match = 1;
-		}
-		if (!match)
-			return 0;
-	}
-
-	return 1;
-}
-
-/*
  * Internal finding representation. Decoupled from the on-disk
  * format so we can add formatters (default, SARIF, future PDF
  * text) without touching the matcher.
@@ -208,7 +116,7 @@ static void scan_trace(JSON_Array *trace, const struct Policy *policy,
 		for (r = 0; r < policy->rules_count; r++) {
 			const struct Rule *rule = &policy->rules[r];
 
-			if (rule_matches(rule, msg))
+			if (policy_rule_matches(rule, msg))
 				findings_append(out, rule, i, msg);
 		}
 	}

--- a/tools/audit-converter/policy.c
+++ b/tools/audit-converter/policy.c
@@ -163,3 +163,75 @@ int policy_load_from_file(const char *path, struct Policy *out)
 	json_value_free(v);
 	return rc;
 }
+
+int policy_rule_matches(const struct Rule *rule, JSON_Object *msg)
+{
+	const char *func;
+	size_t nkeys, k;
+
+	if (rule == NULL || msg == NULL)
+		return 0;
+
+	func = json_object_get_string(msg, "func");
+
+	if (rule->func_exact != NULL) {
+		if (func == NULL || strcmp(func, rule->func_exact) != 0)
+			return 0;
+	}
+
+	if (rule->func_prefix != NULL) {
+		size_t plen = strlen(rule->func_prefix);
+
+		if (func == NULL || strncmp(func, rule->func_prefix, plen) != 0)
+			return 0;
+	}
+
+	if (rule->path_contains != NULL) {
+		int found = 0;
+
+		nkeys = json_object_get_count(msg);
+		for (k = 0; k < nkeys; k++) {
+			JSON_Value *v = json_object_get_value_at(msg, k);
+			const char *s;
+
+			if (json_value_get_type(v) != JSONString)
+				continue;
+			s = json_value_get_string(v);
+			if (s != NULL && strstr(s, rule->path_contains) != NULL) {
+				found = 1;
+				break;
+			}
+		}
+		if (!found)
+			return 0;
+	}
+
+	if (rule->env_pattern != NULL) {
+		const char *var = json_object_get_string(msg, "name");
+		size_t plen;
+		int match = 0;
+
+		if (var == NULL)
+			return 0;
+		plen = strlen(rule->env_pattern);
+		if (rule->env_pattern[0] == '*' && plen > 1) {
+			size_t vlen = strlen(var);
+			size_t suffix_len = plen - 1;
+
+			if (vlen >= suffix_len &&
+			    strcmp(var + vlen - suffix_len,
+				   rule->env_pattern + 1) == 0)
+				match = 1;
+		} else if (plen > 0 && rule->env_pattern[plen - 1] == '*') {
+			if (strncmp(var, rule->env_pattern, plen - 1) == 0)
+				match = 1;
+		} else {
+			if (strcmp(var, rule->env_pattern) == 0)
+				match = 1;
+		}
+		if (!match)
+			return 0;
+	}
+
+	return 1;
+}

--- a/tools/audit-converter/policy.h
+++ b/tools/audit-converter/policy.h
@@ -98,4 +98,23 @@ int policy_load_from_file(const char *path, struct Policy *out);
  */
 const char *severity_str(enum Severity s);
 
+/*
+ * Predicate evaluation. The entry is the log entry's "message"
+ * object (the part that varies by action). For log_params
+ * entries, "func" is the intercepted function name and other
+ * fields are the parsed arguments (path, buf, etc.).
+ *
+ * Predicate semantics: a rule matches if ALL of its non-NULL
+ * constraints match (AND). NULL constraints are wildcards.
+ *
+ * env_pattern glob shapes:
+ *   *_TOKEN, *_KEY, *_PASSWORD  (suffix)
+ *   LD_*, IFS                   (prefix)
+ *   (anything else is exact)
+ *
+ * Returns 1 if the rule matches, 0 otherwise (including when
+ * either argument is NULL).
+ */
+int policy_rule_matches(const struct Rule *rule, JSON_Object *msg);
+
 #endif /* RETRACE_AUDIT_POLICY_H_ */


### PR DESCRIPTION
## Summary

Bumps retrace from v2.3.0 to **v2.3.1** (PATCH per ADR-0006). Behavior-preserving refactor + unit tests for the v2.3.0 tools.

## What changed

### Refactor (MECE)
- `audit-converter/rule_matches` → `policy_rule_matches`. Rule-matching semantics now live with the rule data model (`policy.c`); `audit.c` is purely trace-scanning + output formatting. Both the rule data and the rule matcher are in one module, testable in isolation.

### New unit tests (37 cases)
- `test/unit/test_policy.c` — 25 cases. `severity_str` round-trip across all enum values, `policy_load_from_json` parses all 4 predicate types + severity + missing rules + NULL safety + `(unnamed)` default, `policy_free` NULL safety, `policy_rule_matches` across every predicate (`func_exact`, `func_prefix`, `path_contains` in any string field, `env_pattern` suffix/prefix/exact), AND semantics, NULL inputs.
- `test/unit/test_normalize.c` — 12 cases. Call-count aggregation, duration sum, engine-noise skip (no `func` or no `call_duration_us`), `normalize_find` found/missing/NULL, `normalize_call_sequence` order preservation + noise filter + NULL safety, `normalize_free` idempotency.

### Version + packaging
- `include/retrace/version.h`, `src/cli/retrace_cli.c` banner: 2.3.0 → 2.3.1
- `packaging/{nix,debian,fedora}` bumped
- `CHANGELOG.md` entry

## Test plan

- [x] `cmake -B build -G Ninja -DRETRACE_BUILD_TESTS=ON`
- [x] `cmake --build build`
- [x] `ctest --test-dir build` — 48/48 pass (was 46)
- [x] `./build/test/unit/test_policy` — 25/25 pass
- [x] `./build/test/unit/test_normalize` — 12/12 pass
- [x] `./build/src/cli/retrace --help` banner reads `v2.3.1`
- [x] No AI attribution in commit message
- [ ] CI green on all matrix legs
- [ ] After merge: tag v2.3.1; release.yml produces binary artifacts

## Tagging plan

After PR rebase-merges, tag `v2.3.1` at the merge commit. release.yml will produce per-platform binary artifacts.
