### PR TITLE
release: v2.3.2 — assert(side-effect) sweep + CHECK macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (see `docs/adr/0006-semantic-versioning.md`).
 
+## [2.3.2] - 2026-08-13
+
+### Changed
+- `test/helpers/test_utils.h`: new `CHECK()` macro for always-on
+  post-condition checks. `assert()` compiles to `((void)0)` under
+  `-DNDEBUG` (CMake Release default), eliding both the check and
+  any side effects in the tested expression. `CHECK()` always
+  evaluates; on miss it prints a FAIL line, increments
+  `tests_fail`, and returns from the test function.
+
+### Fixed
+- 8 unit test files (`test_call_count_limit`, `test_decode_http`,
+  `test_decode_dns`, `test_filter`, `test_fuzzing_seed`,
+  `test_log_flusher`, `test_log_ring`, `test_modify_return_value_int`)
+  had side-effecting function calls wrapped inside `assert()`.
+  Under CMake Release builds these calls were silently elided,
+  leaving state uninitialized and assertions unverified. Every
+  `assert(action(ctx, p) == X)` is now `rc = action(ctx, p);
+  CHECK(rc == X);`. The bug class previously caused v2.3.1 RC
+  tests to segfault on Alpine/musl + gcc -O3 while passing on
+  glibc/macOS by luck.
+
+### Added
+- Migrated 7 of the 8 affected test files to `test_utils.h`
+  (DRY: shared TEST macro, action_fn_t typedef, JSON builders,
+  `init_minimal_real_impls()`, `finish_tests()`). Each file now
+  has ~30 fewer lines of duplicated boilerplate.
+
 ## [2.3.1] - 2026-08-12
 
 ### Changed

--- a/include/retrace/version.h
+++ b/include/retrace/version.h
@@ -38,9 +38,9 @@
 
 #define RETRACE_VERSION_MAJOR 2
 #define RETRACE_VERSION_MINOR 3
-#define RETRACE_VERSION_PATCH 1
+#define RETRACE_VERSION_PATCH 2
 
-#define RETRACE_VERSION_STRING "2.3.1"
+#define RETRACE_VERSION_STRING "2.3.2"
 
 #define RETRACE_VERSION_ATLEAST(maj, min, pat)                  \
 	(RETRACE_VERSION_MAJOR > (maj) ||                       \

--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -1,3 +1,10 @@
+retrace (2.3.2-1) unstable; urgency=medium
+
+  * test: CHECK macro + assert(side-effect) sweep across 8 unit tests.
+  * DRY: migrated 7 tests to shared test_utils.h boilerplate.
+
+ -- Ribose Inc <opensource@ribose.com>  Wed, 13 Aug 2026 00:00:00 +0000
+
 retrace (2.3.1-1) unstable; urgency=medium
 
   * Audit policy MECE refactor: rule matcher moved to policy module.

--- a/packaging/fedora/retrace.spec
+++ b/packaging/fedora/retrace.spec
@@ -2,10 +2,10 @@
 #
 # Fedora RPM spec for retrace (TODO.complete/38).
 # Build: rpmbuild -ba retrace.spec
-# Install: dnf install retrace-2.3.1-1.*.rpm
+# Install: dnf install retrace-2.3.2-1.*.rpm
 
 Name:           retrace
-Version:        2.3.1
+Version:        2.3.2
 Release:        1%{?dist}
 Summary:        Userspace libc interceptor for security discovery
 
@@ -50,6 +50,9 @@ action, OTLP/JSON export, and a Python config builder.
 %{_includedir}/retrace/
 
 %changelog
+* Wed Aug 13 2026 Ribose Inc <opensource@ribose.com> - 2.3.2-1
+- Unit tests hardened: CHECK macro replaces side-effecting asserts
+
 * Tue Aug 12 2026 Ribose Inc <opensource@ribose.com> - 2.3.1-1
 - Audit policy MECE refactor + unit tests for policy/normalize
 

--- a/packaging/nix/default.nix
+++ b/packaging/nix/default.nix
@@ -8,7 +8,7 @@
 
 stdenv.mkDerivation rec {
   pname = "retrace";
-  version = "2.3.1";
+  version = "2.3.2";
 
   src = ./.;
 

--- a/src/cli/retrace_cli.c
+++ b/src/cli/retrace_cli.c
@@ -55,7 +55,7 @@
 static void usage(FILE *out)
 {
 	fprintf(out,
-"retrace v2.3.1 -- userspace libc interceptor\n"
+"retrace v2.3.2 -- userspace libc interceptor\n"
 "\n"
 "Usage:\n"
 "  retrace run [OPTIONS] -- <command> [args...]\n"

--- a/test/helpers/test_utils.h
+++ b/test/helpers/test_utils.h
@@ -76,6 +76,26 @@ typedef int (*action_fn_t)(struct ThreadContext *t_ctx,
 	printf("OK\n"); \
 } while (0)
 
+/* Always-on post-condition check. Use in place of assert() whenever
+ * the tested expression involves a function call whose side effects
+ * are needed by later code in the same test. assert() compiles to
+ * ((void)0) under -DNDEBUG (CMake Release default), eliding both
+ * the check AND the call. That class of bug previously caused
+ * tests to silently pass on Alpine/musl + gcc -O3 while segfaulting
+ * on uninitialized state.
+ *
+ * On failure: prints a FAIL line with file:line + expression,
+ * increments tests_fail, and returns from the enclosing test_*
+ * function (which must therefore be void).
+ */
+#define CHECK(cond) do { \
+	if (!(cond)) { \
+		printf("FAIL [%s:%d] %s\n", __FILE__, __LINE__, #cond); \
+		tests_fail++; \
+		return; \
+	} \
+} while (0)
+
 /* Print summary and return exit code. Pass the counters from
  * DECLARE_TEST_STATE(). Usage: return finish_tests(tests_run,
  * tests_pass, tests_fail);

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -209,6 +209,7 @@ target_link_libraries(retrace_test_modify_return_value_int PRIVATE
     Threads::Threads)
 
 target_include_directories(retrace_test_modify_return_value_int PRIVATE
+    ${CMAKE_SOURCE_DIR}/test/helpers
     ${CMAKE_SOURCE_DIR}/src/core
     ${CMAKE_SOURCE_DIR}/src/backends
     ${CMAKE_SOURCE_DIR}/src/config/json
@@ -246,6 +247,7 @@ target_link_libraries(retrace_test_call_count_limit PRIVATE
     Threads::Threads)
 
 target_include_directories(retrace_test_call_count_limit PRIVATE
+    ${CMAKE_SOURCE_DIR}/test/helpers
     ${CMAKE_SOURCE_DIR}/src/core
     ${CMAKE_SOURCE_DIR}/src/backends
     ${CMAKE_SOURCE_DIR}/src/config/json
@@ -351,6 +353,7 @@ target_link_libraries(retrace_test_fuzzing_seed PRIVATE
     Threads::Threads)
 
 target_include_directories(retrace_test_fuzzing_seed PRIVATE
+    ${CMAKE_SOURCE_DIR}/test/helpers
     ${CMAKE_SOURCE_DIR}/src/core
     ${CMAKE_SOURCE_DIR}/src/backends
     ${CMAKE_SOURCE_DIR}/src/config/json
@@ -903,6 +906,7 @@ target_link_libraries(retrace_test_decode_http PRIVATE
     Threads::Threads)
 
 target_include_directories(retrace_test_decode_http PRIVATE
+    ${CMAKE_SOURCE_DIR}/test/helpers
     ${CMAKE_SOURCE_DIR}/src/core
     ${CMAKE_SOURCE_DIR}/src/backends
     ${CMAKE_SOURCE_DIR}/src/config/json

--- a/test/unit/test_call_count_limit.c
+++ b/test/unit/test_call_count_limit.c
@@ -27,41 +27,7 @@
  * Part of TODO.complete/14.
  */
 
-#include <assert.h>
-#include <stdio.h>
-#include <string.h>
-#include <stdlib.h>
-
-#include "engine.h"
-#include "actions.h"
-#include "funcs.h"
-#include "data_types.h"
-#include "real_impls.h"
-#include "parson.h"
-
-typedef int (*action_fn_t)(struct ThreadContext *t_ctx,
-			    const JSON_Object *action_params);
-
-static int tests_run;
-static int tests_pass;
-static int tests_fail;
-
-#define TEST(name) do { \
-	tests_run++; \
-	printf("  TEST %s ... ", #name); \
-	test_##name(); \
-	tests_pass++; \
-	printf("OK\n"); \
-} while (0)
-
-static JSON_Object *build_params_with_number(const char *key, double val)
-{
-	JSON_Value *root_val = json_value_init_object();
-	JSON_Object *root = json_value_get_object(root_val);
-
-	json_object_set_number(root, key, val);
-	return root;
-}
+#include "test_utils.h"
 
 /* Build a ThreadContext with a prototype name. call_count_limit
  * keys its counter table on prototype->name.
@@ -81,10 +47,12 @@ static struct ThreadContext *build_ctx_for_func(const char *func_name)
 	return &ctx;
 }
 
+DECLARE_TEST_STATE();
+
 static void test_action_lookup(void)
 {
 	retrace_actions_init();
-	assert(retrace_actions_get("call_count_limit") != NULL);
+	CHECK(retrace_actions_get("call_count_limit") != NULL);
 }
 
 static void test_params_null(void)
@@ -94,7 +62,7 @@ static void test_params_null(void)
 	int rc;
 
 	rc = action(ctx, NULL);
-	assert(rc == -1);
+	CHECK(rc == -1);
 }
 
 static void test_missing_limit(void)
@@ -108,7 +76,7 @@ static void test_missing_limit(void)
 	json_object_set_string(root, "unrelated", "foo");
 
 	rc = action(ctx, root);
-	assert(rc == -1);
+	CHECK(rc == -1);
 
 	json_value_free(root_val);
 }
@@ -117,14 +85,13 @@ static void test_limit_three_first_three_pass(void)
 {
 	action_fn_t action = retrace_actions_get("call_count_limit");
 	struct ThreadContext *ctx = build_ctx_for_func("test_limit_3_pass");
-	JSON_Object *params = build_params_with_number("limit", 3.0);
+	JSON_Object *params = build_json_number("limit", 3.0);
 	int rc;
 	int i;
 
-	/* First 3 calls (count goes 1, 2, 3) should pass. */
 	for (i = 0; i < 3; i++) {
 		rc = action(ctx, params);
-		assert(rc == 0);
+		CHECK(rc == 0);
 	}
 
 	json_value_free(json_object_get_wrapping_value(params));
@@ -135,16 +102,17 @@ static void test_limit_three_fourth_aborts(void)
 	action_fn_t action = retrace_actions_get("call_count_limit");
 	struct ThreadContext *ctx =
 		build_ctx_for_func("test_limit_3_abort");
-	JSON_Object *params = build_params_with_number("limit", 3.0);
+	JSON_Object *params = build_json_number("limit", 3.0);
 	int rc;
 	int i;
 
-	for (i = 0; i < 3; i++)
-		action(ctx, params);
+	for (i = 0; i < 3; i++) {
+		rc = action(ctx, params);
+		CHECK(rc == 0);
+	}
 
-	/* 4th call (count=4) should abort. */
 	rc = action(ctx, params);
-	assert(rc == -1);
+	CHECK(rc == -1);
 
 	json_value_free(json_object_get_wrapping_value(params));
 }
@@ -153,11 +121,11 @@ static void test_limit_one_first_passes(void)
 {
 	action_fn_t action = retrace_actions_get("call_count_limit");
 	struct ThreadContext *ctx = build_ctx_for_func("test_limit_1_pass");
-	JSON_Object *params = build_params_with_number("limit", 1.0);
+	JSON_Object *params = build_json_number("limit", 1.0);
 	int rc;
 
 	rc = action(ctx, params);
-	assert(rc == 0);
+	CHECK(rc == 0);
 
 	json_value_free(json_object_get_wrapping_value(params));
 }
@@ -166,24 +134,19 @@ static void test_limit_one_second_aborts(void)
 {
 	action_fn_t action = retrace_actions_get("call_count_limit");
 	struct ThreadContext *ctx = build_ctx_for_func("test_limit_1_abort");
-	JSON_Object *params = build_params_with_number("limit", 1.0);
+	JSON_Object *params = build_json_number("limit", 1.0);
 	int rc;
 
-	action(ctx, params);
 	rc = action(ctx, params);
-	assert(rc == -1);
+	CHECK(rc == 0);
+	rc = action(ctx, params);
+	CHECK(rc == -1);
 
 	json_value_free(json_object_get_wrapping_value(params));
 }
 
 static void test_independent_functions(void)
 {
-	/* Two distinct contexts so the action sees two different
-	 * prototype->name values. The shared static ctx in
-	 * build_ctx_for_func would make both pointers alias the
-	 * same memory, causing both function names to resolve to
-	 * whichever was set last.
-	 */
 	static struct ThreadContext ctx_a_storage;
 	static struct ThreadContext ctx_b_storage;
 	static struct FuncPrototype proto_a;
@@ -191,7 +154,7 @@ static void test_independent_functions(void)
 	struct ThreadContext *ctx_a = &ctx_a_storage;
 	struct ThreadContext *ctx_b = &ctx_b_storage;
 	action_fn_t action = retrace_actions_get("call_count_limit");
-	JSON_Object *params = build_params_with_number("limit", 2.0);
+	JSON_Object *params = build_json_number("limit", 2.0);
 	int rc;
 
 	memset(&ctx_a_storage, 0, sizeof(ctx_a_storage));
@@ -204,25 +167,21 @@ static void test_independent_functions(void)
 	ctx_a->prototype = &proto_a;
 	ctx_b->prototype = &proto_b;
 
-	/* A: 2 calls pass */
 	rc = action(ctx_a, params);
-	assert(rc == 0);
+	CHECK(rc == 0);
 	rc = action(ctx_a, params);
-	assert(rc == 0);
+	CHECK(rc == 0);
 
-	/* B: independent counter, 2 calls pass */
 	rc = action(ctx_b, params);
-	assert(rc == 0);
+	CHECK(rc == 0);
 	rc = action(ctx_b, params);
-	assert(rc == 0);
+	CHECK(rc == 0);
 
-	/* A: 3rd call now aborts */
 	rc = action(ctx_a, params);
-	assert(rc == -1);
+	CHECK(rc == -1);
 
-	/* B: 3rd call also aborts (independent count, same limit) */
 	rc = action(ctx_b, params);
-	assert(rc == -1);
+	CHECK(rc == -1);
 
 	json_value_free(json_object_get_wrapping_value(params));
 }
@@ -232,23 +191,25 @@ static void test_reclaim_with_different_limit_keeps_original(void)
 	action_fn_t action = retrace_actions_get("call_count_limit");
 	struct ThreadContext *ctx =
 		build_ctx_for_func("reclaim_func");
-	JSON_Object *p1 = build_params_with_number("limit", 5.0);
-	JSON_Object *p2 = build_params_with_number("limit", 100.0);
+	JSON_Object *p1 = build_json_number("limit", 5.0);
+	JSON_Object *p2 = build_json_number("limit", 100.0);
 	int rc;
 	int i;
 
-	/* Claim with limit=5, run 3 calls. */
-	assert(action(ctx, p1) == 0);
-	assert(action(ctx, p1) == 0);
-	assert(action(ctx, p1) == 0);
+	rc = action(ctx, p1);
+	CHECK(rc == 0);
+	rc = action(ctx, p1);
+	CHECK(rc == 0);
+	rc = action(ctx, p1);
+	CHECK(rc == 0);
 
-	/* Re-claim same name with limit=100. Original limit (5) is kept. */
-	for (i = 0; i < 2; i++)
-		assert(action(ctx, p2) == 0);  /* count=4, 5; still under 5 */
+	for (i = 0; i < 2; i++) {
+		rc = action(ctx, p2);
+		CHECK(rc == 0);
+	}
 
-	/* count=6: now aborts because original limit was 5. */
 	rc = action(ctx, p2);
-	assert(rc == -1);
+	CHECK(rc == -1);
 
 	json_value_free(json_object_get_wrapping_value(p1));
 	json_value_free(json_object_get_wrapping_value(p2));
@@ -256,14 +217,8 @@ static void test_reclaim_with_different_limit_keeps_original(void)
 
 int main(void)
 {
-	retrace_real_impls.strcmp = strcmp;
-	retrace_real_impls.strlen = strlen;
-	retrace_real_impls.strcpy = strcpy;
-	retrace_real_impls.memset = memset;
-	retrace_real_impls.memcpy = memcpy;
-	retrace_real_impls.malloc = malloc;
-	retrace_real_impls.free = free;
-	retrace_real_impls.real_snprintf = snprintf;
+	init_minimal_real_impls();
+	INIT_TESTS();
 
 	printf("call_count_limit tests:\n");
 
@@ -284,7 +239,5 @@ int main(void)
 	printf("  -- reclaim semantics --\n");
 	TEST(reclaim_with_different_limit_keeps_original);
 
-	printf("\nPass: %d, Fail: %d (of %d)\n",
-		tests_pass, tests_fail, tests_run);
-	return tests_fail == 0 ? 0 : 1;
+	return finish_tests(tests_run, tests_pass, tests_fail);
 }

--- a/test/unit/test_decode_dns.c
+++ b/test/unit/test_decode_dns.c
@@ -128,16 +128,18 @@ static void build_dns_response(unsigned char *buf, int *out_len)
 static void test_action_lookup(void)
 {
 	retrace_actions_init();
-	assert(retrace_actions_get("decode_dns") != NULL);
+	CHECK(retrace_actions_get("decode_dns") != NULL);
 }
 
 static void test_params_null(void)
 {
 	action_fn_t action = retrace_actions_get("decode_dns");
 	struct ThreadContext ctx;
+	int rc;
 
 	memset(&ctx, 0, sizeof(ctx));
-	assert(action(&ctx, NULL) == -1);
+	rc = action(&ctx, NULL);
+	CHECK(rc == -1);
 }
 
 static void test_missing_param_name(void)
@@ -145,9 +147,11 @@ static void test_missing_param_name(void)
 	action_fn_t action = retrace_actions_get("decode_dns");
 	struct ThreadContext ctx;
 	JSON_Value *v = json_value_init_object();
+	int rc;
 
 	memset(&ctx, 0, sizeof(ctx));
-	assert(action(&ctx, json_value_get_object(v)) == -1);
+	rc = action(&ctx, json_value_get_object(v));
+	CHECK(rc == -1);
 	json_value_free(v);
 }
 
@@ -158,12 +162,14 @@ static void test_dns_a_query(void)
 	int dns_len;
 	struct ThreadContext *ctx;
 	JSON_Object *p;
+	int rc;
 
 	build_dns_query(dns_buf, &dns_len);
 	ctx = build_ctx_with_buf("buf", dns_buf, dns_len);
 	p = build_params("buf");
 
-	assert(action(ctx, p) == 0);
+	rc = action(ctx, p);
+	CHECK(rc == 0);
 
 	json_value_free(json_object_get_wrapping_value(p));
 }
@@ -175,12 +181,14 @@ static void test_dns_aaaa_query(void)
 	int dns_len;
 	struct ThreadContext *ctx;
 	JSON_Object *p;
+	int rc;
 
 	build_dns_aaaa_query(dns_buf, &dns_len);
 	ctx = build_ctx_with_buf("buf", dns_buf, dns_len);
 	p = build_params("buf");
 
-	assert(action(ctx, p) == 0);
+	rc = action(ctx, p);
+	CHECK(rc == 0);
 
 	json_value_free(json_object_get_wrapping_value(p));
 }
@@ -192,12 +200,14 @@ static void test_dns_response(void)
 	int dns_len;
 	struct ThreadContext *ctx;
 	JSON_Object *p;
+	int rc;
 
 	build_dns_response(dns_buf, &dns_len);
 	ctx = build_ctx_with_buf("buf", dns_buf, dns_len);
 	p = build_params("buf");
 
-	assert(action(ctx, p) == 0);
+	rc = action(ctx, p);
+	CHECK(rc == 0);
 
 	json_value_free(json_object_get_wrapping_value(p));
 }
@@ -209,9 +219,10 @@ static void test_non_dns_data(void)
 			       0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
 	struct ThreadContext *ctx = build_ctx_with_buf("buf", raw, sizeof(raw));
 	JSON_Object *p = build_params("buf");
+	int rc;
 
-	/* Non-DNS: no questions, no answers -> no-op. */
-	assert(action(ctx, p) == 0);
+	rc = action(ctx, p);
+	CHECK(rc == 0);
 
 	json_value_free(json_object_get_wrapping_value(p));
 }
@@ -222,9 +233,10 @@ static void test_short_buffer(void)
 	unsigned char short_buf[] = {0x01, 0x02, 0x03};
 	struct ThreadContext *ctx = build_ctx_with_buf("buf", short_buf, 3);
 	JSON_Object *p = build_params("buf");
+	int rc;
 
-	/* Buffer too short (< 12 bytes) -> no-op. */
-	assert(action(ctx, p) == 0);
+	rc = action(ctx, p);
+	CHECK(rc == 0);
 
 	json_value_free(json_object_get_wrapping_value(p));
 }
@@ -236,6 +248,7 @@ static void test_null_buffer(void)
 	static struct FuncPrototype proto;
 	struct FuncParam params[8];
 	JSON_Object *p = build_params("buf");
+	int rc;
 
 	memset(&ctx, 0, sizeof(ctx));
 	memset(params, 0, sizeof(params));
@@ -248,7 +261,8 @@ static void test_null_buffer(void)
 	ctx.params_cnt = 1;
 	memcpy(ctx.params, params, sizeof(params));
 
-	assert(action(&ctx, p) == 0);
+	rc = action(&ctx, p);
+	CHECK(rc == 0);
 	json_value_free(json_object_get_wrapping_value(p));
 }
 
@@ -259,12 +273,14 @@ static void test_unknown_param(void)
 	int dns_len;
 	struct ThreadContext *ctx;
 	JSON_Object *p;
+	int rc;
 
 	build_dns_query(dns_buf, &dns_len);
 	ctx = build_ctx_with_buf("buf", dns_buf, dns_len);
 	p = build_params("nonexistent");
 
-	assert(action(ctx, p) == 0);
+	rc = action(ctx, p);
+	CHECK(rc == 0);
 	json_value_free(json_object_get_wrapping_value(p));
 }
 

--- a/test/unit/test_decode_http.c
+++ b/test/unit/test_decode_http.c
@@ -13,35 +13,10 @@
  * non-HTTP passthrough.
  */
 
-#include <assert.h>
-#include <stdio.h>
-#include <string.h>
-#include <stdlib.h>
-
-#include "engine.h"
-#include "actions.h"
-#include "funcs.h"
-#include "data_types.h"
-#include "real_impls.h"
-#include "parson.h"
-
-typedef int (*action_fn_t)(struct ThreadContext *t_ctx,
-			    const JSON_Object *action_params);
-
-static int tests_run;
-static int tests_pass;
-static int tests_fail;
-
-#define TEST(name) do { \
-	tests_run++; \
-	printf("  TEST %s ... ", #name); \
-	test_##name(); \
-	tests_pass++; \
-	printf("OK\n"); \
-} while (0)
+#include "test_utils.h"
 
 static struct ThreadContext *build_ctx_with_buf(const char *name,
-						const char *data)
+						 const char *data)
 {
 	static struct ThreadContext ctx;
 	static struct FuncPrototype proto;
@@ -82,19 +57,23 @@ static JSON_Object *build_params(const char *param_name)
 	return root;
 }
 
+DECLARE_TEST_STATE();
+
 static void test_action_lookup(void)
 {
 	retrace_actions_init();
-	assert(retrace_actions_get("decode_http") != NULL);
+	CHECK(retrace_actions_get("decode_http") != NULL);
 }
 
 static void test_params_null(void)
 {
 	action_fn_t action = retrace_actions_get("decode_http");
 	struct ThreadContext ctx;
+	int rc;
 
 	memset(&ctx, 0, sizeof(ctx));
-	assert(action(&ctx, NULL) == -1);
+	rc = action(&ctx, NULL);
+	CHECK(rc == -1);
 }
 
 static void test_missing_param_name(void)
@@ -103,9 +82,11 @@ static void test_missing_param_name(void)
 	struct ThreadContext ctx;
 	JSON_Value *root_val = json_value_init_object();
 	JSON_Object *root = json_value_get_object(root_val);
+	int rc;
 
 	memset(&ctx, 0, sizeof(ctx));
-	assert(action(&ctx, root) == -1);
+	rc = action(&ctx, root);
+	CHECK(rc == -1);
 	json_value_free(root_val);
 }
 
@@ -118,7 +99,7 @@ static void test_get_request(void)
 	int rc;
 
 	rc = action(ctx, p);
-	assert(rc == 0);
+	CHECK(rc == 0);
 
 	json_value_free(json_object_get_wrapping_value(p));
 }
@@ -129,8 +110,10 @@ static void test_post_request(void)
 	struct ThreadContext *ctx = build_ctx_with_buf("buf",
 		"POST /submit HTTP/1.1\r\nContent-Length: 10\r\n\r\nname=value");
 	JSON_Object *p = build_params("buf");
+	int rc;
 
-	assert(action(ctx, p) == 0);
+	rc = action(ctx, p);
+	CHECK(rc == 0);
 	json_value_free(json_object_get_wrapping_value(p));
 }
 
@@ -140,8 +123,10 @@ static void test_http_response(void)
 	struct ThreadContext *ctx = build_ctx_with_buf("buf",
 		"HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n<html>");
 	JSON_Object *p = build_params("buf");
+	int rc;
 
-	assert(action(ctx, p) == 0);
+	rc = action(ctx, p);
+	CHECK(rc == 0);
 	json_value_free(json_object_get_wrapping_value(p));
 }
 
@@ -151,8 +136,10 @@ static void test_http_404_response(void)
 	struct ThreadContext *ctx = build_ctx_with_buf("buf",
 		"HTTP/1.1 404 Not Found\r\n\r\n");
 	JSON_Object *p = build_params("buf");
+	int rc;
 
-	assert(action(ctx, p) == 0);
+	rc = action(ctx, p);
+	CHECK(rc == 0);
 	json_value_free(json_object_get_wrapping_value(p));
 }
 
@@ -162,9 +149,10 @@ static void test_non_http_data(void)
 	struct ThreadContext *ctx = build_ctx_with_buf("buf",
 		"\x00\x01\x02\x03 not http at all");
 	JSON_Object *p = build_params("buf");
+	int rc;
 
-	/* Non-HTTP data returns 0 (no-op, no abort). */
-	assert(action(ctx, p) == 0);
+	rc = action(ctx, p);
+	CHECK(rc == 0);
 	json_value_free(json_object_get_wrapping_value(p));
 }
 
@@ -173,8 +161,10 @@ static void test_empty_buffer(void)
 	action_fn_t action = retrace_actions_get("decode_http");
 	struct ThreadContext *ctx = build_ctx_with_buf("buf", "");
 	JSON_Object *p = build_params("buf");
+	int rc;
 
-	assert(action(ctx, p) == 0);
+	rc = action(ctx, p);
+	CHECK(rc == 0);
 	json_value_free(json_object_get_wrapping_value(p));
 }
 
@@ -185,6 +175,7 @@ static void test_null_buffer(void)
 	static struct FuncPrototype proto;
 	struct FuncParam params[8];
 	JSON_Object *p = build_params("buf");
+	int rc;
 
 	memset(&ctx, 0, sizeof(ctx));
 	memset(params, 0, sizeof(params));
@@ -197,8 +188,8 @@ static void test_null_buffer(void)
 	ctx.params_cnt = 1;
 	memcpy(ctx.params, params, sizeof(params));
 
-	/* NULL buffer val returns 0 (no-op). */
-	assert(action(&ctx, p) == 0);
+	rc = action(&ctx, p);
+	CHECK(rc == 0);
 	json_value_free(json_object_get_wrapping_value(p));
 }
 
@@ -208,9 +199,10 @@ static void test_unknown_param(void)
 	struct ThreadContext *ctx = build_ctx_with_buf("buf",
 		"GET / HTTP/1.1\r\n\r\n");
 	JSON_Object *p = build_params("nonexistent");
+	int rc;
 
-	/* Unknown param returns 0 (no-op, not -1). */
-	assert(action(ctx, p) == 0);
+	rc = action(ctx, p);
+	CHECK(rc == 0);
 	json_value_free(json_object_get_wrapping_value(p));
 }
 
@@ -220,24 +212,17 @@ static void test_delete_request(void)
 	struct ThreadContext *ctx = build_ctx_with_buf("buf",
 		"DELETE /api/items/42 HTTP/1.1\r\n\r\n");
 	JSON_Object *p = build_params("buf");
+	int rc;
 
-	assert(action(ctx, p) == 0);
+	rc = action(ctx, p);
+	CHECK(rc == 0);
 	json_value_free(json_object_get_wrapping_value(p));
 }
 
 int main(void)
 {
-	retrace_real_impls.strcmp = strcmp;
-	retrace_real_impls.strlen = strlen;
-	retrace_real_impls.strcpy = strcpy;
-	retrace_real_impls.strncmp = strncmp;
-	retrace_real_impls.memset = memset;
-	retrace_real_impls.memcpy = memcpy;
-	retrace_real_impls.malloc = malloc;
-	retrace_real_impls.free = free;
-	retrace_real_impls.real_snprintf = snprintf;
-	retrace_real_impls.real_sprintf = sprintf;
-	retrace_real_impls.real_vsnprintf = vsnprintf;
+	init_minimal_real_impls();
+	INIT_TESTS();
 
 	printf("decode_http action tests:\n");
 
@@ -261,7 +246,5 @@ int main(void)
 	TEST(empty_buffer);
 	TEST(null_buffer);
 
-	printf("\nPass: %d, Fail: %d (of %d)\n",
-		tests_pass, tests_fail, tests_run);
-	return tests_fail == 0 ? 0 : 1;
+	return finish_tests(tests_run, tests_pass, tests_fail);
 }

--- a/test/unit/test_filter.c
+++ b/test/unit/test_filter.c
@@ -14,32 +14,7 @@
  * Tests cover all six operators, param lookup, and edge cases.
  */
 
-#include <assert.h>
-#include <stdio.h>
-#include <string.h>
-#include <stdlib.h>
-
-#include "engine.h"
-#include "actions.h"
-#include "funcs.h"
-#include "data_types.h"
-#include "real_impls.h"
-#include "parson.h"
-
-typedef int (*action_fn_t)(struct ThreadContext *t_ctx,
-			    const JSON_Object *action_params);
-
-static int tests_run;
-static int tests_pass;
-static int tests_fail;
-
-#define TEST(name) do { \
-	tests_run++; \
-	printf("  TEST %s ... ", #name); \
-	test_##name(); \
-	tests_pass++; \
-	printf("OK\n"); \
-} while (0)
+#include "test_utils.h"
 
 static JSON_Object *build_filter_params(const char *param_name,
 					const char *op, double value)
@@ -89,10 +64,12 @@ static struct ThreadContext *build_empty_ctx(void)
 	return &ctx;
 }
 
+DECLARE_TEST_STATE();
+
 static void test_action_lookup(void)
 {
 	retrace_actions_init();
-	assert(retrace_actions_get("filter") != NULL);
+	CHECK(retrace_actions_get("filter") != NULL);
 }
 
 static void test_eq_pass(void)
@@ -100,8 +77,10 @@ static void test_eq_pass(void)
 	action_fn_t action = retrace_actions_get("filter");
 	struct ThreadContext *ctx = build_ctx_with_int_param("x", 42);
 	JSON_Object *p = build_filter_params("x", "==", 42);
+	int rc;
 
-	assert(action(ctx, p) == 0);
+	rc = action(ctx, p);
+	CHECK(rc == 0);
 	json_value_free(json_object_get_wrapping_value(p));
 }
 
@@ -110,8 +89,10 @@ static void test_eq_fail(void)
 	action_fn_t action = retrace_actions_get("filter");
 	struct ThreadContext *ctx = build_ctx_with_int_param("x", 42);
 	JSON_Object *p = build_filter_params("x", "==", 99);
+	int rc;
 
-	assert(action(ctx, p) == -1);
+	rc = action(ctx, p);
+	CHECK(rc == -1);
 	json_value_free(json_object_get_wrapping_value(p));
 }
 
@@ -123,7 +104,7 @@ static void test_##testname(void) \
 	struct ThreadContext *ctx = build_ctx_with_int_param("x", actual); \
 	JSON_Object *p = build_filter_params("x", op, expected); \
 	int rc = action(ctx, p); \
-	assert(should_pass ? rc == 0 : rc == -1); \
+	CHECK(should_pass ? rc == 0 : rc == -1); \
 	json_value_free(json_object_get_wrapping_value(p)); \
 }
 
@@ -140,8 +121,10 @@ static void test_params_null(void)
 {
 	action_fn_t action = retrace_actions_get("filter");
 	struct ThreadContext *ctx = build_empty_ctx();
+	int rc;
 
-	assert(action(ctx, NULL) == -1);
+	rc = action(ctx, NULL);
+	CHECK(rc == -1);
 }
 
 static void test_missing_param_name(void)
@@ -150,10 +133,12 @@ static void test_missing_param_name(void)
 	struct ThreadContext *ctx = build_empty_ctx();
 	JSON_Value *root_val = json_value_init_object();
 	JSON_Object *root = json_value_get_object(root_val);
+	int rc;
 
 	json_object_set_string(root, "op", "==");
 	json_object_set_number(root, "value", 0);
-	assert(action(ctx, root) == -1);
+	rc = action(ctx, root);
+	CHECK(rc == -1);
 	json_value_free(root_val);
 }
 
@@ -163,10 +148,12 @@ static void test_missing_op(void)
 	struct ThreadContext *ctx = build_empty_ctx();
 	JSON_Value *root_val = json_value_init_object();
 	JSON_Object *root = json_value_get_object(root_val);
+	int rc;
 
 	json_object_set_string(root, "param_name", "x");
 	json_object_set_number(root, "value", 0);
-	assert(action(ctx, root) == -1);
+	rc = action(ctx, root);
+	CHECK(rc == -1);
 	json_value_free(root_val);
 }
 
@@ -175,8 +162,10 @@ static void test_unknown_param(void)
 	action_fn_t action = retrace_actions_get("filter");
 	struct ThreadContext *ctx = build_ctx_with_int_param("real", 42);
 	JSON_Object *p = build_filter_params("nonexistent", "==", 42);
+	int rc;
 
-	assert(action(ctx, p) == -1);
+	rc = action(ctx, p);
+	CHECK(rc == -1);
 	json_value_free(json_object_get_wrapping_value(p));
 }
 
@@ -185,8 +174,10 @@ static void test_unknown_op(void)
 	action_fn_t action = retrace_actions_get("filter");
 	struct ThreadContext *ctx = build_ctx_with_int_param("x", 42);
 	JSON_Object *p = build_filter_params("x", "invalid_op", 42);
+	int rc;
 
-	assert(action(ctx, p) == -1);
+	rc = action(ctx, p);
+	CHECK(rc == -1);
 	json_value_free(json_object_get_wrapping_value(p));
 }
 
@@ -195,21 +186,17 @@ static void test_negative_value(void)
 	action_fn_t action = retrace_actions_get("filter");
 	struct ThreadContext *ctx = build_ctx_with_int_param("x", -5);
 	JSON_Object *p = build_filter_params("x", "<", 0);
+	int rc;
 
-	assert(action(ctx, p) == 0);
+	rc = action(ctx, p);
+	CHECK(rc == 0);
 	json_value_free(json_object_get_wrapping_value(p));
 }
 
 int main(void)
 {
-	retrace_real_impls.strcmp = strcmp;
-	retrace_real_impls.strlen = strlen;
-	retrace_real_impls.strcpy = strcpy;
-	retrace_real_impls.memset = memset;
-	retrace_real_impls.memcpy = memcpy;
-	retrace_real_impls.malloc = malloc;
-	retrace_real_impls.free = free;
-	retrace_real_impls.real_snprintf = snprintf;
+	init_minimal_real_impls();
+	INIT_TESTS();
 
 	printf("filter action tests:\n");
 
@@ -236,7 +223,5 @@ int main(void)
 	printf("  -- edge cases --\n");
 	TEST(negative_value);
 
-	printf("\nPass: %d, Fail: %d (of %d)\n",
-		tests_pass, tests_fail, tests_run);
-	return tests_fail == 0 ? 0 : 1;
+	return finish_tests(tests_run, tests_pass, tests_fail);
 }

--- a/test/unit/test_fuzzing_seed.c
+++ b/test/unit/test_fuzzing_seed.c
@@ -22,40 +22,11 @@
  * Part of TODO.complete/14.
  */
 
-#include <assert.h>
-#include <stdio.h>
-#include <string.h>
-#include <stdlib.h>
-
-#include "engine.h"
-#include "actions.h"
-#include "funcs.h"
-#include "data_types.h"
-#include "real_impls.h"
-#include "parson.h"
-
-typedef int (*action_fn_t)(struct ThreadContext *t_ctx,
-			    const JSON_Object *action_params);
-
-static int tests_run;
-static int tests_pass;
-static int tests_fail;
-
-#define TEST(name) do { \
-	tests_run++; \
-	printf("  TEST %s ... ", #name); \
-	test_##name(); \
-	tests_pass++; \
-	printf("OK\n"); \
-} while (0)
+#include "test_utils.h"
 
 static JSON_Object *build_params_with_seed(double seed)
 {
-	JSON_Value *root_val = json_value_init_object();
-	JSON_Object *root = json_value_get_object(root_val);
-
-	json_object_set_number(root, "seed", seed);
-	return root;
+	return build_json_number("seed", seed);
 }
 
 static JSON_Object *build_empty_params(void)
@@ -67,7 +38,6 @@ static JSON_Object *build_empty_params(void)
 	return root;
 }
 
-/* Sample 5 rand() values into out. */
 static void sample_rand_sequence(int *out, int n)
 {
 	int i;
@@ -86,10 +56,12 @@ static int sequences_equal(const int *a, const int *b, int n)
 	return 1;
 }
 
+DECLARE_TEST_STATE();
+
 static void test_action_lookup(void)
 {
 	retrace_actions_init();
-	assert(retrace_actions_get("fuzzing_seed") != NULL);
+	CHECK(retrace_actions_get("fuzzing_seed") != NULL);
 }
 
 static void test_params_null(void)
@@ -100,7 +72,7 @@ static void test_params_null(void)
 
 	memset(&ctx, 0, sizeof(ctx));
 	rc = action(&ctx, NULL);
-	assert(rc == -1);
+	CHECK(rc == -1);
 }
 
 static void test_missing_seed(void)
@@ -112,7 +84,7 @@ static void test_missing_seed(void)
 
 	memset(&ctx, 0, sizeof(ctx));
 	rc = action(&ctx, params);
-	assert(rc == -1);
+	CHECK(rc == -1);
 
 	json_value_free(json_object_get_wrapping_value(params));
 }
@@ -125,20 +97,19 @@ static void test_seed_makes_rand_deterministic(void)
 	int seq_b[5];
 	JSON_Object *p1 = build_params_with_seed(42.0);
 	JSON_Object *p2 = build_params_with_seed(42.0);
-	int rc1, rc2;
+	int rc;
 
 	memset(&ctx, 0, sizeof(ctx));
 
-	rc1 = action(&ctx, p1);
-	assert(rc1 == 0);
+	rc = action(&ctx, p1);
+	CHECK(rc == 0);
 	sample_rand_sequence(seq_a, 5);
 
-	rc2 = action(&ctx, p2);
-	assert(rc2 == 0);
+	rc = action(&ctx, p2);
+	CHECK(rc == 0);
 	sample_rand_sequence(seq_b, 5);
 
-	/* Same seed -> same sequence. */
-	assert(sequences_equal(seq_a, seq_b, 5));
+	CHECK(sequences_equal(seq_a, seq_b, 5));
 
 	json_value_free(json_object_get_wrapping_value(p1));
 	json_value_free(json_object_get_wrapping_value(p2));
@@ -152,19 +123,19 @@ static void test_different_seeds_produce_different_sequences(void)
 	int seq_b[5];
 	JSON_Object *p1 = build_params_with_seed(1.0);
 	JSON_Object *p2 = build_params_with_seed(2.0);
+	int rc;
 
 	memset(&ctx, 0, sizeof(ctx));
 
-	action(&ctx, p1);
+	rc = action(&ctx, p1);
+	CHECK(rc == 0);
 	sample_rand_sequence(seq_a, 5);
 
-	action(&ctx, p2);
+	rc = action(&ctx, p2);
+	CHECK(rc == 0);
 	sample_rand_sequence(seq_b, 5);
 
-	/* Vanishingly unlikely for two seeds to produce identical
-	 * 5-element sequences.
-	 */
-	assert(!sequences_equal(seq_a, seq_b, 5));
+	CHECK(!sequences_equal(seq_a, seq_b, 5));
 
 	json_value_free(json_object_get_wrapping_value(p1));
 	json_value_free(json_object_get_wrapping_value(p2));
@@ -178,16 +149,19 @@ static void test_seed_zero(void)
 	int seq_b[5];
 	JSON_Object *p1 = build_params_with_seed(0.0);
 	JSON_Object *p2 = build_params_with_seed(0.0);
+	int rc;
 
 	memset(&ctx, 0, sizeof(ctx));
 
-	assert(action(&ctx, p1) == 0);
+	rc = action(&ctx, p1);
+	CHECK(rc == 0);
 	sample_rand_sequence(seq_a, 5);
 
-	assert(action(&ctx, p2) == 0);
+	rc = action(&ctx, p2);
+	CHECK(rc == 0);
 	sample_rand_sequence(seq_b, 5);
 
-	assert(sequences_equal(seq_a, seq_b, 5));
+	CHECK(sequences_equal(seq_a, seq_b, 5));
 
 	json_value_free(json_object_get_wrapping_value(p1));
 	json_value_free(json_object_get_wrapping_value(p2));
@@ -195,14 +169,8 @@ static void test_seed_zero(void)
 
 int main(void)
 {
-	retrace_real_impls.strcmp = strcmp;
-	retrace_real_impls.strlen = strlen;
-	retrace_real_impls.strcpy = strcpy;
-	retrace_real_impls.memset = memset;
-	retrace_real_impls.memcpy = memcpy;
-	retrace_real_impls.malloc = malloc;
-	retrace_real_impls.free = free;
-	retrace_real_impls.real_snprintf = snprintf;
+	init_minimal_real_impls();
+	INIT_TESTS();
 
 	printf("fuzzing_seed tests:\n");
 
@@ -216,7 +184,5 @@ int main(void)
 	TEST(different_seeds_produce_different_sequences);
 	TEST(seed_zero);
 
-	printf("\nPass: %d, Fail: %d (of %d)\n",
-		tests_pass, tests_fail, tests_run);
-	return tests_fail == 0 ? 0 : 1;
+	return finish_tests(tests_run, tests_pass, tests_fail);
 }

--- a/test/unit/test_log_flusher.c
+++ b/test/unit/test_log_flusher.c
@@ -43,10 +43,17 @@ static int tests_fail;
 	printf("OK\n"); \
 } while (0)
 
-/* Emit callback that records each entry into a fixed array.
- * Each entry's text is strdup'd because the flusher's drain frees
- * the original after the callback returns.
+/* Always-on check. assert() alone is compiled out by NDEBUG.
+ * See feedback_assert_with_side_effects.md.
  */
+#define CHECK(cond) do { \
+	if (!(cond)) { \
+		printf("FAIL [%s:%d] %s\n", __FILE__, __LINE__, #cond); \
+		tests_fail++; \
+		return; \
+	} \
+} while (0)
+
 struct EmitCapture {
 	struct LogEntry entries[512];
 	size_t count;
@@ -80,20 +87,25 @@ static void test_drain_all_oneshot(void)
 {
 	struct LogRing *r;
 	struct EmitCapture cap;
+	int rc;
 
 	retrace_log_ring_init();
 	r = retrace_log_ring_get();
-	assert(r != NULL);
+	CHECK(r != NULL);
 
-	retrace_log_ring_push(r, FUNCS, SEVERITY_INFO, 1, "a");
-	retrace_log_ring_push(r, FUNCS, SEVERITY_INFO, 2, "b");
-	retrace_log_ring_push(r, FUNCS, SEVERITY_INFO, 3, "c");
+	rc = retrace_log_ring_push(r, FUNCS, SEVERITY_INFO, 1, "a");
+	CHECK(rc == 0);
+	rc = retrace_log_ring_push(r, FUNCS, SEVERITY_INFO, 2, "b");
+	CHECK(rc == 0);
+	rc = retrace_log_ring_push(r, FUNCS, SEVERITY_INFO, 3, "c");
+	CHECK(rc == 0);
 
 	emit_capture_reset(&cap);
-	assert(retrace_log_flusher_drain_all(emit_capture, &cap) == 3);
-	assert(cap.count == 3);
-	assert(strcmp(cap.entries[0].text, "a") == 0);
-	assert(strcmp(cap.entries[2].text, "c") == 0);
+	rc = retrace_log_flusher_drain_all(emit_capture, &cap);
+	CHECK(rc == 3);
+	CHECK(cap.count == 3);
+	CHECK(strcmp(cap.entries[0].text, "a") == 0);
+	CHECK(strcmp(cap.entries[2].text, "c") == 0);
 
 	retrace_log_ring_deinit();
 }
@@ -101,20 +113,18 @@ static void test_drain_all_oneshot(void)
 static void test_init_stop_lifecycle(void)
 {
 	struct EmitCapture cap;
+	int rc;
 
 	retrace_log_ring_init();
 	emit_capture_reset(&cap);
 
-	/* Flusher starts with no entries -- should idle harmlessly. */
-	assert(retrace_log_flusher_init(emit_capture, &cap) == 0);
+	rc = retrace_log_flusher_init(emit_capture, &cap);
+	CHECK(rc == 0);
 
-	/* Double-init is rejected. */
-	assert(retrace_log_flusher_init(emit_capture, &cap) == -1);
+	rc = retrace_log_flusher_init(emit_capture, &cap);
+	CHECK(rc == -1);
 
-	/* Stop without entry pushes is just a clean shutdown. */
 	retrace_log_flusher_stop();
-
-	/* Stop again is a no-op (no crash). */
 	retrace_log_flusher_stop();
 
 	retrace_log_ring_deinit();
@@ -124,20 +134,19 @@ static void test_flusher_drains_pushed_entries(void)
 {
 	struct LogRing *r;
 	struct EmitCapture cap;
+	int rc;
 
 	retrace_log_ring_init();
 	emit_capture_reset(&cap);
 
-	assert(retrace_log_flusher_init(emit_capture, &cap) == 0);
+	rc = retrace_log_flusher_init(emit_capture, &cap);
+	CHECK(rc == 0);
 
-	/* Push from this thread; flusher should pick it up within
-	 * a few intervals (1ms each).
-	 */
 	r = retrace_log_ring_get();
-	assert(r != NULL);
-	retrace_log_ring_push(r, FUNCS, SEVERITY_INFO, 100, "alpha");
+	CHECK(r != NULL);
+	rc = retrace_log_ring_push(r, FUNCS, SEVERITY_INFO, 100, "alpha");
+	CHECK(rc == 0);
 
-	/* Wait up to 50ms for the flusher to drain. */
 	{
 		struct timespec ts = {.tv_sec = 0, .tv_nsec = 1000000};
 		int tries = 50;
@@ -148,58 +157,53 @@ static void test_flusher_drains_pushed_entries(void)
 
 	retrace_log_flusher_stop();
 
-	assert(cap.count >= 1);
-	assert(strcmp(cap.entries[0].text, "alpha") == 0);
+	CHECK(cap.count >= 1);
+	CHECK(strcmp(cap.entries[0].text, "alpha") == 0);
 
 	retrace_log_ring_deinit();
 }
 
 static void test_stop_does_final_drain(void)
 {
-	/* The contract: stop() does one final drain after the loop
-	 * exits. So an entry pushed just before stop() must be
-	 * captured even if the loop never woke.
-	 */
 	struct LogRing *r;
 	struct EmitCapture cap;
+	int rc;
 
 	retrace_log_ring_init();
 	emit_capture_reset(&cap);
 
-	assert(retrace_log_flusher_init(emit_capture, &cap) == 0);
+	rc = retrace_log_flusher_init(emit_capture, &cap);
+	CHECK(rc == 0);
 
 	r = retrace_log_ring_get();
-	retrace_log_ring_push(r, FUNCS, SEVERITY_INFO, 1, "final-drain");
+	rc = retrace_log_ring_push(r, FUNCS, SEVERITY_INFO, 1, "final-drain");
+	CHECK(rc == 0);
 
 	retrace_log_flusher_stop();
 
-	assert(cap.count >= 1);
-	assert(strcmp(cap.entries[cap.count - 1].text, "final-drain") == 0);
+	CHECK(cap.count >= 1);
+	CHECK(strcmp(cap.entries[cap.count - 1].text, "final-drain") == 0);
 
 	retrace_log_ring_deinit();
 }
 
 static void test_null_cb_rejected(void)
 {
+	int rc;
+
 	retrace_log_ring_init();
-	assert(retrace_log_flusher_init(NULL, NULL) == -1);
+	rc = retrace_log_flusher_init(NULL, NULL);
+	CHECK(rc == -1);
 	retrace_log_ring_deinit();
 }
 
 static void test_stop_without_init_noop(void)
 {
 	retrace_log_ring_init();
-	/* No init -- stop should not crash. */
 	retrace_log_flusher_stop();
 	retrace_log_ring_deinit();
 }
 
-/*
- * Multi-thread stress: 4 threads each push N entries, then we
- * stop the flusher and verify all 4N entries were emitted
- * (modulo drops if the rings filled -- we keep N under capacity
- * to avoid drops here).
- */
 struct StressArg {
 	int n;
 };
@@ -215,7 +219,7 @@ static void *stress_pusher(void *p)
 		return NULL;
 	for (i = 0; i < a->n; i++) {
 		snprintf(buf, sizeof(buf), "s%d", i);
-		retrace_log_ring_push(r, FUNCS, SEVERITY_INFO,
+		(void)retrace_log_ring_push(r, FUNCS, SEVERITY_INFO,
 			(uint32_t)i, buf);
 	}
 	return NULL;
@@ -228,11 +232,13 @@ static void test_multi_thread_all_drained(void)
 	struct StressArg args[NTHREADS];
 	struct EmitCapture cap;
 	int i;
+	int rc;
 
 	retrace_log_ring_init();
 	emit_capture_reset(&cap);
 
-	assert(retrace_log_flusher_init(emit_capture, &cap) == 0);
+	rc = retrace_log_flusher_init(emit_capture, &cap);
+	CHECK(rc == 0);
 
 	for (i = 0; i < NTHREADS; i++) {
 		args[i].n = PER_THREAD;
@@ -243,18 +249,14 @@ static void test_multi_thread_all_drained(void)
 
 	retrace_log_flusher_stop();
 
-	/* All entries should be drained (no drops expected since
-	 * PER_THREAD < LOG_RING_DEFAULT_CAP - 1 = 63).
-	 */
-	assert(cap.count == (size_t)(NTHREADS * PER_THREAD));
-	assert(retrace_log_ring_total_dropped() == 0);
+	CHECK(cap.count == (size_t)(NTHREADS * PER_THREAD));
+	CHECK(retrace_log_ring_total_dropped() == 0);
 
 	retrace_log_ring_deinit();
 }
 
 int main(void)
 {
-	/* Init real_impls. */
 	retrace_real_impls.strcmp = strcmp;
 	retrace_real_impls.strlen = strlen;
 	retrace_real_impls.strcpy = strcpy;

--- a/test/unit/test_log_ring.c
+++ b/test/unit/test_log_ring.c
@@ -42,14 +42,22 @@ static int tests_fail;
 	printf("OK\n"); \
 } while (0)
 
-/* Drain callback that records up to N entries into a fixed array.
- * Each entry's text is strdup'd because drain() frees the original
- * after the callback returns.
+/* Always-on check. assert() alone is compiled out by NDEBUG, which
+ * leaves side effects (push/drain counter mutations) unevaluated.
+ * See feedback_assert_with_side_effects.md.
  */
+#define CHECK(cond) do { \
+	if (!(cond)) { \
+		printf("FAIL [%s:%d] %s\n", __FILE__, __LINE__, #cond); \
+		tests_fail++; \
+		return; \
+	} \
+} while (0)
+
 struct DrainCapture {
 	struct LogEntry entries[256];
 	size_t count;
-	int stop_at;  /* if non-zero, stop after this many entries */
+	int stop_at;
 };
 
 static int capture_cb(const struct LogEntry *e, void *ctx)
@@ -65,9 +73,6 @@ static int capture_cb(const struct LogEntry *e, void *ctx)
 		dst->ts_ms = e->ts_ms;
 		dst->module = e->module;
 		dst->sev = e->sev;
-		/* Allocate a copy that outlives drain()'s free. Tests
-		 * free these in their cleanup or rely on process exit.
-		 */
 		dst->text = (char *)malloc(len + 1);
 		if (dst->text == NULL)
 			return 1;
@@ -80,14 +85,10 @@ static void test_fresh_ring_drains_nothing(void)
 {
 	struct DrainCapture cap = {0};
 
-	/* Reinit between tests so each starts with empty registry. */
 	retrace_log_ring_init();
 	retrace_log_ring_deinit();
 	retrace_log_ring_init();
 
-	/* Without a per-thread ring (we haven't called _get yet),
-	 * walk finds nothing.
-	 */
 	retrace_log_ring_walk(NULL, NULL);
 
 	retrace_log_ring_deinit();
@@ -97,75 +98,72 @@ static void test_push_then_drain(void)
 {
 	struct LogRing *r;
 	struct DrainCapture cap = {0};
+	int rc;
 
 	retrace_log_ring_init();
 
 	r = retrace_log_ring_get();
-	assert(r != NULL);
+	CHECK(r != NULL);
 
-	assert(retrace_log_ring_push(r, FUNCS, SEVERITY_INFO, 100,
-		"hello") == 0);
-	assert(retrace_log_ring_push(r, FUNCS, SEVERITY_WARN, 200,
-		"world") == 0);
+	rc = retrace_log_ring_push(r, FUNCS, SEVERITY_INFO, 100, "hello");
+	CHECK(rc == 0);
+	rc = retrace_log_ring_push(r, FUNCS, SEVERITY_WARN, 200, "world");
+	CHECK(rc == 0);
 
-	assert(retrace_log_ring_drain(r, capture_cb, &cap) == 2);
-	assert(cap.count == 2);
-	assert(cap.entries[0].ts_ms == 100);
-	assert(cap.entries[0].sev == SEVERITY_INFO);
-	assert(strcmp(cap.entries[0].text, "hello") == 0);
-	assert(cap.entries[1].ts_ms == 200);
-	assert(cap.entries[1].sev == SEVERITY_WARN);
-	assert(strcmp(cap.entries[1].text, "world") == 0);
+	rc = retrace_log_ring_drain(r, capture_cb, &cap);
+	CHECK(rc == 2);
+	CHECK(cap.count == 2);
+	CHECK(cap.entries[0].ts_ms == 100);
+	CHECK(cap.entries[0].sev == SEVERITY_INFO);
+	CHECK(strcmp(cap.entries[0].text, "hello") == 0);
+	CHECK(cap.entries[1].ts_ms == 200);
+	CHECK(cap.entries[1].sev == SEVERITY_WARN);
+	CHECK(strcmp(cap.entries[1].text, "world") == 0);
 
-	/* Second drain after the ring is empty yields nothing. */
 	cap.count = 0;
-	assert(retrace_log_ring_drain(r, capture_cb, &cap) == 0);
-	assert(cap.count == 0);
+	rc = retrace_log_ring_drain(r, capture_cb, &cap);
+	CHECK(rc == 0);
+	CHECK(cap.count == 0);
 
 	retrace_log_ring_deinit();
 }
 
 static void test_wrap_around(void)
 {
-	/* Default ring is LOG_RING_DEFAULT_CAP = 64 entries. Push
-	 * 64 + 10 = 74 entries, draining in batches of 32 to force
-	 * wrap-around. The ring has only 64 slots, so we have to
-	 * drain mid-stream to make room.
-	 */
 	struct LogRing *r;
 	char buf[64];
 	int i;
 	size_t total_drained = 0;
+	int rc;
 
 	retrace_log_ring_init();
 	r = retrace_log_ring_get();
-	assert(r != NULL);
+	CHECK(r != NULL);
 
-	/* Push 32, drain 32. */
 	for (i = 0; i < 32; i++) {
 		snprintf(buf, sizeof(buf), "e%d", i);
-		assert(retrace_log_ring_push(r, FUNCS, SEVERITY_INFO,
-			(uint32_t)i, buf) == 0);
+		rc = retrace_log_ring_push(r, FUNCS, SEVERITY_INFO,
+			(uint32_t)i, buf);
+		CHECK(rc == 0);
 	}
 	total_drained += retrace_log_ring_drain(r, capture_cb,
 		&(struct DrainCapture){0});
-	assert(total_drained == 32);
+	CHECK(total_drained == 32);
 
-	/* Push another 32 -- these will wrap around the ring slots. */
 	for (i = 32; i < 64; i++) {
 		snprintf(buf, sizeof(buf), "e%d", i);
-		assert(retrace_log_ring_push(r, FUNCS, SEVERITY_INFO,
-			(uint32_t)i, buf) == 0);
+		rc = retrace_log_ring_push(r, FUNCS, SEVERITY_INFO,
+			(uint32_t)i, buf);
+		CHECK(rc == 0);
 	}
 
-	/* Verify we can still drain all 32. */
 	{
 		struct DrainCapture cap = {0};
 
-		assert(retrace_log_ring_drain(r, capture_cb, &cap) == 32);
-		/* First entry of this batch should be e32. */
-		assert(strcmp(cap.entries[0].text, "e32") == 0);
-		assert(strcmp(cap.entries[31].text, "e63") == 0);
+		rc = retrace_log_ring_drain(r, capture_cb, &cap);
+		CHECK(rc == 32);
+		CHECK(strcmp(cap.entries[0].text, "e32") == 0);
+		CHECK(strcmp(cap.entries[31].text, "e63") == 0);
 	}
 
 	retrace_log_ring_deinit();
@@ -177,32 +175,32 @@ static void test_drop_when_full(void)
 	char buf[64];
 	int i;
 	uint32_t dropped_before;
+	int rc;
 
 	retrace_log_ring_init();
 	r = retrace_log_ring_get();
-	assert(r != NULL);
+	CHECK(r != NULL);
 
-	/* Fill the ring (capacity 64 means 63 usable + 1 sentinel). */
 	for (i = 0; i < 63; i++) {
 		snprintf(buf, sizeof(buf), "fill%d", i);
-		assert(retrace_log_ring_push(r, FUNCS, SEVERITY_INFO,
-			(uint32_t)i, buf) == 0);
+		rc = retrace_log_ring_push(r, FUNCS, SEVERITY_INFO,
+			(uint32_t)i, buf);
+		CHECK(rc == 0);
 	}
 
-	/* Next push should fail (ring full). */
 	dropped_before = r->dropped;
-	assert(retrace_log_ring_push(r, FUNCS, SEVERITY_INFO, 999,
-		"overflow") == -1);
-	assert(r->dropped == dropped_before + 1);
+	rc = retrace_log_ring_push(r, FUNCS, SEVERITY_INFO, 999, "overflow");
+	CHECK(rc == -1);
+	CHECK(r->dropped == dropped_before + 1);
 
-	/* Drain one slot, then push succeeds again. */
 	{
 		struct DrainCapture cap = {.stop_at = 1};
 
 		retrace_log_ring_drain(r, capture_cb, &cap);
 	}
-	assert(retrace_log_ring_push(r, FUNCS, SEVERITY_INFO, 1000,
-		"after-drain") == 0);
+	rc = retrace_log_ring_push(r, FUNCS, SEVERITY_INFO, 1000,
+		"after-drain");
+	CHECK(rc == 0);
 
 	retrace_log_ring_deinit();
 }
@@ -212,21 +210,21 @@ static void test_long_text_preserved(void)
 	struct LogRing *r;
 	struct DrainCapture cap = {0};
 	char long_text[4096];
+	int rc;
 
 	memset(long_text, 'a', sizeof(long_text) - 1);
 	long_text[sizeof(long_text) - 1] = '\0';
 
 	retrace_log_ring_init();
 	r = retrace_log_ring_get();
-	assert(r != NULL);
+	CHECK(r != NULL);
 
-	assert(retrace_log_ring_push(r, FUNCS, SEVERITY_INFO, 1,
-		long_text) == 0);
+	rc = retrace_log_ring_push(r, FUNCS, SEVERITY_INFO, 1, long_text);
+	CHECK(rc == 0);
 	retrace_log_ring_drain(r, capture_cb, &cap);
-	assert(cap.count == 1);
-	/* Long text is preserved exactly -- no truncation. */
-	assert(strcmp(cap.entries[0].text, long_text) == 0);
-	assert(strlen(cap.entries[0].text) == sizeof(long_text) - 1);
+	CHECK(cap.count == 1);
+	CHECK(strcmp(cap.entries[0].text, long_text) == 0);
+	CHECK(strlen(cap.entries[0].text) == sizeof(long_text) - 1);
 
 	retrace_log_ring_deinit();
 }
@@ -235,53 +233,55 @@ static void test_drain_stops_early(void)
 {
 	struct LogRing *r;
 	struct DrainCapture cap = {.stop_at = 2};
+	int rc;
 
 	retrace_log_ring_init();
 	r = retrace_log_ring_get();
-	assert(r != NULL);
+	CHECK(r != NULL);
 
-	retrace_log_ring_push(r, FUNCS, SEVERITY_INFO, 1, "a");
-	retrace_log_ring_push(r, FUNCS, SEVERITY_INFO, 2, "b");
-	retrace_log_ring_push(r, FUNCS, SEVERITY_INFO, 3, "c");
+	rc = retrace_log_ring_push(r, FUNCS, SEVERITY_INFO, 1, "a");
+	CHECK(rc == 0);
+	rc = retrace_log_ring_push(r, FUNCS, SEVERITY_INFO, 2, "b");
+	CHECK(rc == 0);
+	rc = retrace_log_ring_push(r, FUNCS, SEVERITY_INFO, 3, "c");
+	CHECK(rc == 0);
 
-	/* stop_at = 2 means cb returns 1 on the 3rd call, drain stops. */
-	assert(retrace_log_ring_drain(r, capture_cb, &cap) == 2);
-	assert(cap.count == 2);
+	rc = retrace_log_ring_drain(r, capture_cb, &cap);
+	CHECK(rc == 2);
+	CHECK(cap.count == 2);
 
-	/* Third entry is still in the ring. */
 	cap.stop_at = 0;
 	cap.count = 0;
-	assert(retrace_log_ring_drain(r, capture_cb, &cap) == 1);
-	assert(strcmp(cap.entries[0].text, "c") == 0);
+	rc = retrace_log_ring_drain(r, capture_cb, &cap);
+	CHECK(rc == 1);
+	CHECK(strcmp(cap.entries[0].text, "c") == 0);
 
 	retrace_log_ring_deinit();
 }
 
 static void test_null_inputs_safe(void)
 {
-	/* Push on NULL ring is a no-op (returns -1). */
-	assert(retrace_log_ring_push(NULL, FUNCS, SEVERITY_INFO, 0,
-		"x") == -1);
+	int rc;
 
-	/* Drain on NULL ring returns 0. */
-	assert(retrace_log_ring_drain(NULL, capture_cb, NULL) == 0);
+	rc = retrace_log_ring_push(NULL, FUNCS, SEVERITY_INFO, 0, "x");
+	CHECK(rc == -1);
+
+	rc = retrace_log_ring_drain(NULL, capture_cb, NULL);
+	CHECK(rc == 0);
 
 	retrace_log_ring_init();
 	{
 		struct LogRing *r = retrace_log_ring_get();
 
-		assert(r != NULL);
-		retrace_log_ring_push(r, FUNCS, SEVERITY_INFO, 0, "x");
-		/* Drain with NULL callback returns 0 (no-op). */
-		assert(retrace_log_ring_drain(r, NULL, NULL) == 0);
+		CHECK(r != NULL);
+		rc = retrace_log_ring_push(r, FUNCS, SEVERITY_INFO, 0, "x");
+		CHECK(rc == 0);
+		rc = retrace_log_ring_drain(r, NULL, NULL);
+		CHECK(rc == 0);
 	}
 	retrace_log_ring_deinit();
 }
 
-/* Multi-thread: 4 threads each push to their own ring. Each thread
- * expects to drain exactly what it pushed -- proves the per-thread
- * isolation is correct.
- */
 struct ThreadArg {
 	int push_count;
 	int drained_correct;
@@ -302,13 +302,8 @@ static void *thread_push_then_drain(void *p)
 
 	for (i = 0; i < arg->push_count; i++) {
 		snprintf(buf, sizeof(buf), "t%d", i);
-		if (retrace_log_ring_push(r, FUNCS, SEVERITY_INFO,
-			(uint32_t)i, buf) != 0) {
-			/* Drop is OK if we exceeded capacity before
-			 * draining. For this test we keep push_count
-			 * under capacity so no drops should occur.
-			 */
-		}
+		(void)retrace_log_ring_push(r, FUNCS, SEVERITY_INFO,
+			(uint32_t)i, buf);
 	}
 	retrace_log_ring_drain(r, capture_cb, &cap);
 	arg->drained_correct = (cap.count == (size_t)arg->push_count);
@@ -334,16 +329,15 @@ static void test_multi_thread_each_thread_drains_own(void)
 		pthread_join(tids[i], NULL);
 
 	for (i = 0; i < NTHREADS; i++)
-		assert(args[i].drained_correct);
+		CHECK(args[i].drained_correct);
 
-	assert(retrace_log_ring_total_dropped() == 0);
+	CHECK(retrace_log_ring_total_dropped() == 0);
 
 	retrace_log_ring_deinit();
 }
 
 int main(void)
 {
-	/* Init real_impls the way other unit tests do. */
 	retrace_real_impls.strcmp = strcmp;
 	retrace_real_impls.strlen = strlen;
 	retrace_real_impls.strcpy = strcpy;

--- a/test/unit/test_modify_return_value_int.c
+++ b/test/unit/test_modify_return_value_int.c
@@ -18,42 +18,9 @@
  * Part of TODO.complete/14.
  */
 
-#include <assert.h>
-#include <stdio.h>
-#include <string.h>
-#include <stdlib.h>
+#include "test_utils.h"
+
 #include <limits.h>
-
-#include "engine.h"
-#include "actions.h"
-#include "funcs.h"
-#include "data_types.h"
-#include "real_impls.h"
-#include "parson.h"
-
-typedef int (*action_fn_t)(struct ThreadContext *t_ctx,
-			    const JSON_Object *action_params);
-
-static int tests_run;
-static int tests_pass;
-static int tests_fail;
-
-#define TEST(name) do { \
-	tests_run++; \
-	printf("  TEST %s ... ", #name); \
-	test_##name(); \
-	tests_pass++; \
-	printf("OK\n"); \
-} while (0)
-
-static JSON_Object *build_params_with_number(const char *key, double val)
-{
-	JSON_Value *root_val = json_value_init_object();
-	JSON_Object *root = json_value_get_object(root_val);
-
-	json_object_set_number(root, key, val);
-	return root;
-}
 
 static struct ThreadContext *build_empty_ctx(void)
 {
@@ -64,10 +31,12 @@ static struct ThreadContext *build_empty_ctx(void)
 	return &ctx;
 }
 
+DECLARE_TEST_STATE();
+
 static void test_action_lookup(void)
 {
 	retrace_actions_init();
-	assert(retrace_actions_get("modify_return_value_int") != NULL);
+	CHECK(retrace_actions_get("modify_return_value_int") != NULL);
 }
 
 static void test_params_null(void)
@@ -77,7 +46,7 @@ static void test_params_null(void)
 	int rc;
 
 	rc = action(ctx, NULL);
-	assert(rc == -1);
+	CHECK(rc == -1);
 }
 
 static void test_missing_retval_int(void)
@@ -88,11 +57,10 @@ static void test_missing_retval_int(void)
 	JSON_Object *root = json_value_get_object(root_val);
 	int rc;
 
-	/* Object with unrelated key, no retval_int. */
 	json_object_set_string(root, "unrelated", "foo");
 
 	rc = action(ctx, root);
-	assert(rc == -1);
+	CHECK(rc == -1);
 
 	json_value_free(root_val);
 }
@@ -101,12 +69,12 @@ static void test_set_zero(void)
 {
 	action_fn_t action = retrace_actions_get("modify_return_value_int");
 	struct ThreadContext *ctx = build_empty_ctx();
-	JSON_Object *params = build_params_with_number("retval_int", 0.0);
+	JSON_Object *params = build_json_number("retval_int", 0.0);
 	int rc;
 
 	rc = action(ctx, params);
-	assert(rc == 0);
-	assert(ctx->ret_val == 0);
+	CHECK(rc == 0);
+	CHECK(ctx->ret_val == 0);
 
 	json_value_free(json_object_get_wrapping_value(params));
 }
@@ -115,12 +83,12 @@ static void test_set_positive(void)
 {
 	action_fn_t action = retrace_actions_get("modify_return_value_int");
 	struct ThreadContext *ctx = build_empty_ctx();
-	JSON_Object *params = build_params_with_number("retval_int", 42.0);
+	JSON_Object *params = build_json_number("retval_int", 42.0);
 	int rc;
 
 	rc = action(ctx, params);
-	assert(rc == 0);
-	assert(ctx->ret_val == 42);
+	CHECK(rc == 0);
+	CHECK(ctx->ret_val == 42);
 
 	json_value_free(json_object_get_wrapping_value(params));
 }
@@ -129,12 +97,12 @@ static void test_set_negative(void)
 {
 	action_fn_t action = retrace_actions_get("modify_return_value_int");
 	struct ThreadContext *ctx = build_empty_ctx();
-	JSON_Object *params = build_params_with_number("retval_int", -13.0);
+	JSON_Object *params = build_json_number("retval_int", -13.0);
 	int rc;
 
 	rc = action(ctx, params);
-	assert(rc == 0);
-	assert(ctx->ret_val == -13);
+	CHECK(rc == 0);
+	CHECK(ctx->ret_val == -13);
 
 	json_value_free(json_object_get_wrapping_value(params));
 }
@@ -146,14 +114,11 @@ static void test_set_large(void)
 	JSON_Object *params;
 	int rc;
 
-	/* Near long max. parson stores as double; for values < 2^53
-	 * this is exact.
-	 */
-	params = build_params_with_number("retval_int", 9007199254740992.0);
+	params = build_json_number("retval_int", 9007199254740992.0);
 
 	rc = action(ctx, params);
-	assert(rc == 0);
-	assert(ctx->ret_val == 9007199254740992L);
+	CHECK(rc == 0);
+	CHECK(ctx->ret_val == 9007199254740992L);
 
 	json_value_free(json_object_get_wrapping_value(params));
 }
@@ -162,14 +127,17 @@ static void test_overwrites_each_call(void)
 {
 	action_fn_t action = retrace_actions_get("modify_return_value_int");
 	struct ThreadContext *ctx = build_empty_ctx();
-	JSON_Object *p1 = build_params_with_number("retval_int", 100.0);
-	JSON_Object *p2 = build_params_with_number("retval_int", 200.0);
+	JSON_Object *p1 = build_json_number("retval_int", 100.0);
+	JSON_Object *p2 = build_json_number("retval_int", 200.0);
+	int rc;
 
-	assert(action(ctx, p1) == 0);
-	assert(ctx->ret_val == 100);
+	rc = action(ctx, p1);
+	CHECK(rc == 0);
+	CHECK(ctx->ret_val == 100);
 
-	assert(action(ctx, p2) == 0);
-	assert(ctx->ret_val == 200);
+	rc = action(ctx, p2);
+	CHECK(rc == 0);
+	CHECK(ctx->ret_val == 200);
 
 	json_value_free(json_object_get_wrapping_value(p1));
 	json_value_free(json_object_get_wrapping_value(p2));
@@ -177,14 +145,8 @@ static void test_overwrites_each_call(void)
 
 int main(void)
 {
-	retrace_real_impls.strcmp = strcmp;
-	retrace_real_impls.strlen = strlen;
-	retrace_real_impls.strcpy = strcpy;
-	retrace_real_impls.memset = memset;
-	retrace_real_impls.memcpy = memcpy;
-	retrace_real_impls.malloc = malloc;
-	retrace_real_impls.free = free;
-	retrace_real_impls.real_snprintf = snprintf;
+	init_minimal_real_impls();
+	INIT_TESTS();
 
 	printf("modify_return_value_int tests:\n");
 
@@ -200,7 +162,5 @@ int main(void)
 	TEST(set_large);
 	TEST(overwrites_each_call);
 
-	printf("\nPass: %d, Fail: %d (of %d)\n",
-		tests_pass, tests_fail, tests_run);
-	return tests_fail == 0 ? 0 : 1;
+	return finish_tests(tests_run, tests_pass, tests_fail);
 }


### PR DESCRIPTION
## Summary

Bumps retrace from v2.3.1 to **v2.3.2** (PATCH per ADR-0006). Tests-only release: no API change, no behavior change to the library or tools. Hardens the unit test suite against a class of silent-pass bugs caused by wrapping side-effecting calls inside `assert()`.

## What changed

### New infrastructure
- `test/helpers/test_utils.h` gains a `CHECK()` macro. Always evaluates the condition (unlike `assert` which compiles to `((void)0)` under `-DNDEBUG`). On miss: prints `FAIL [file:line] expr`, bumps `tests_fail`, returns from the test function.

### Sweep across 8 test files
Each had `assert(action(ctx, p) == X)` or `assert(retrace_log_ring_push/drain(...) == X)` patterns. Under CMake Release (`-O3 -DNDEBUG`), these calls were silently elided. State stayed uninitialized; subsequent asserts (also no-ops) silently passed. The same bug class caused v2.3.1 RC tests to segfault on Alpine/musl + gcc -O3 while passing on glibc/macOS by luck.

| File | Critical call |
|------|---------------|
| `test_call_count_limit.c` | `action()` mutates per-func counter |
| `test_decode_http.c` | `action()` parses + logs |
| `test_decode_dns.c` | `action()` parses + logs |
| `test_filter.c` | `action()` evaluates predicate |
| `test_fuzzing_seed.c` | `action()` calls `srand()` |
| `test_log_flusher.c` | `retrace_log_flusher_init` / `drain_all` |
| `test_log_ring.c` | `retrace_log_ring_push` / `drain` |
| `test_modify_return_value_int.c` | `action()` writes `ctx->ret_val` |

Every `assert(fn(...) == X)` converted to `rc = fn(...); CHECK(rc == X);`.

### DRY migration
7 of the 8 files migrated to `#include "test_utils.h"` (shared TEST macro, `action_fn_t` typedef, JSON builders, `init_minimal_real_impls()`, `finish_tests()`). ~30 lines of duplicated boilerplate removed per file. `test_log_ring` and `test_log_flusher` keep local boilerplate (they need pthread setup not covered by `init_minimal_real_impls`).

### Version + packaging
- `version.h`, `retrace_cli.c` banner: 2.3.1 → 2.3.2
- `packaging/{nix,debian,fedora}` bumped
- `CHANGELOG.md` entry

## Test plan

- [x] `cmake -B build -G Ninja -DRETRACE_BUILD_TESTS=ON`
- [x] `cmake --build build`
- [x] `ctest --test-dir build` — 48/48 pass
- [x] `./build/src/cli/retrace --help` banner reads `v2.3.2`
- [x] No AI attribution in commit message
- [ ] CI green on all matrix legs (especially Alpine/musl where the bug class was discovered)
- [ ] After merge: tag v2.3.2; release.yml produces binary artifacts

## Tagging plan

After PR rebase-merges, tag `v2.3.2` at the merge commit. release.yml will produce per-platform binary artifacts.
