### PR TITLE
release: v2.3.4 — README.adoc + cli.md v2.3.x visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (see `docs/adr/0006-semantic-versioning.md`).
 
+## [2.3.4] - 2026-08-13
+
+### Changed
+- `README.adoc`: new "What's new in v2.3.x" section consolidating
+  highlights from v2.3.0–v2.3.3 (lock-free logger, capture_buffer,
+  call_hash, parson OOM hardening, the entire tools ecosystem,
+  fuzz-replay CLI, nightly fuzz workflow, website features). New
+  "Tooling ecosystem" section with one row per standalone tool.
+  "Supported platforms" header bumped from v2.2.0 to v2.3.3.
+
+### Added
+- `docs/cli.md`: `fuzz-replay` subcommand section. The subcommand
+  shipped in v2.3.0 but was undocumented in the CLI reference until
+  now.
+
 ## [2.3.3] - 2026-08-13
 
 ### Added

--- a/README.adoc
+++ b/README.adoc
@@ -22,7 +22,7 @@ incomplete I/O), redirecting network `connect()` calls, redirecting
 file `open()` paths, faking OpenSSL verify results, and more.
 
 
-== Supported platforms (v2.2.0)
+== Supported platforms (v2.3.3)
 
 [cols="1,1,1,1", frame=all, grid=all]
 |===
@@ -77,6 +77,70 @@ See the link:https://github.com/riboseinc/retrace/blob/main/docs/cookbook/README
 for 20+ recipes covering tracing, fuzzing, mocking, redirection,
 security auditing, and CI integration.
 
+
+== What's new in v2.3.x
+
+The v2.3.x series turns retrace from a single CLI into a tools
+ecosystem: one shared-library backend, plus standalone tools that
+all consume the same JSON log format.
+
+* **Lock-free SPSC ring logger** &mdash; per-thread ring with atomic
+  head/tail; a single background flusher thread drains at 1ms
+  cadence. Hot path is now a non-blocking push instead of a
+  mutexed `fwrite`. Env-gated via `RETRACE_LOGGER_RING` (default
+  on; disable for OHOS/QEMU).
+* **`capture_buffer` action** &mdash; post-call memory observation:
+  reads N bytes from a pointer param and logs as hex or string.
+* **`call_hash`** &mdash; per-thread FNV-1a rolling hash of
+  intercepted libc calls; surfaces as coverage feedback for
+  libFuzzer via a custom mutator.
+* **`retrace-audit`** &mdash; compliance audit tool. Apply a policy
+  file (baseline / PCI-DSS / HIPAA / ISO 27001 / custom) and emit
+  findings as JSON, SARIF 2.1.0 (GitHub Code Scanning / Azure
+  DevOps), or printable PDF. See
+  link:docs/cookbook/24-audit-compliance.md[cookbook 24].
+* **`retrace-diff`** &mdash; differential trace analysis. Per-function
+  count + duration diff with `--threshold pct=N` for CI gating,
+  LCS-based call-order diff (`--order`), and statistical
+  significance (`--stats` z-score against N baselines). See
+  link:docs/cookbook/25-diff-regression.md[cookbook 25] and
+  link:docs/cookbook/26-diff-call-order.md[cookbook 26].
+* **`retrace-replay`** &mdash; interactive TUI for traces. Step
+  forward/backward, jump to any index, regex search. See
+  link:docs/cookbook/27-replay-debug.md[cookbook 27].
+* **`retrace-ws`** &mdash; WebSocket streamer for live traces with a
+  built-in browser viewer at `http://localhost:8765/`. See
+  link:docs/cookbook/28-live-stream.md[cookbook 28].
+* **Frida bridge** (`frida-bridge/retrace-frida.js`) &mdash; emits
+  retrace-compatible JSON from inside Frida. The escape hatch when
+  `LD_PRELOAD` can't reach the target: iOS apps, static binaries,
+  attach to a running PID. See
+  link:docs/cookbook/29-frida-bridge.md[cookbook 29].
+* **eBPF bridge** (`ebpf-bridge/retrace-ebpf.bpf.c`) &mdash;
+  kernel-level observation of every `openat` / `close` syscall on
+  the system. Observation only (eBPF cannot modify calls). See
+  link:docs/cookbook/30-ebpf-system.md[cookbook 30].
+* **VS Code extension** &mdash; renders a retrace JSON log in a
+  webview pane inside the editor; doubles as a `retrace-ws`
+  client for live streams. See
+  link:docs/cookbook/31-vscode-viewer.md[cookbook 31].
+* **Grafana data source plugin** &mdash; loads a retrace JSON log
+  (over HTTP) and exposes events as a Grafana frame. Cache TTL
+  enables self-updating dashboards. See
+  link:docs/cookbook/32-grafana-dashboard.md[cookbook 32].
+* **`fuzz-replay` CLI subcommand** &mdash; replay a libFuzzer crash
+  input through the matching harness for quick triage.
+* **Nightly fuzz workflow** &mdash; matrix of 5 fuzzers, 5 minutes
+  each, against the seed corpus. Crash artifacts uploaded for
+  download.
+* **Parson OOM hardening** &mdash; allocation budget
+  (`input_len * 1000`) on the comment-stripping path; eliminates
+  the OOM vector found by the nightly fuzz workflow.
+* **Website features** &mdash; Decision Wizard, Recipe Builder,
+  Cmd-K search palette, Glossary, Community section, Back-to-top.
+
+See link:CHANGELOG.md[CHANGELOG.md] for the full diff per release
+(v2.3.0 / v2.3.1 / v2.3.2 / v2.3.3).
 
 == What's new in v2.2.0
 
@@ -474,6 +538,60 @@ $ RETRACE_LOGGER_DEF_ENA=0 \
 | `examples/stringinject/` | File/string injection helper (paired with `tools/stringinjector`)
 | `examples/unsafe-system/` | Trace `system()` invocation paths
 |===
+
+
+== Tooling ecosystem
+
+retrace ships one shared-library backend plus standalone tools
+that consume the same JSON log format. Each owns one job; mix and
+match freely.
+
+[cols="1,4", frame=all, grid=all]
+|===
+| Tool | Job
+
+| `retrace-audit`
+| Apply a policy file (baseline / PCI-DSS / HIPAA / ISO 27001 /
+  custom) and emit findings as JSON, SARIF 2.1.0, or PDF.
+
+| `retrace-diff`
+| Per-function count + duration diff between two traces, with
+  `--threshold` for CI gating, `--order` for LCS call-sequence
+  diff, and `--stats` for z-score significance.
+
+| `retrace-replay`
+| Interactive TUI: step / rewind / jump / regex-search through
+  events.
+
+| `retrace-ws`
+| Tail a running trace and broadcast over WebSocket; built-in
+  browser viewer at `http://localhost:8765/`.
+
+| `retrace-to-otlp`
+| Convert a retrace JSON log to OTLP/JSON for Jaeger / Tempo /
+  Honeycomb / Datadog.
+
+| `frida-bridge/retrace-frida.js`
+| Frida script emitting retrace-compatible JSON. Use when
+  `LD_PRELOAD` can't reach the target (iOS, static binaries,
+  attach to running PID).
+
+| `ebpf-bridge/retrace-ebpf.bpf.c`
+| Linux kernel-level BPF program observing every `openat` /
+  `close` syscall on the system. Observation only.
+
+| `vscode-extension/`
+| VS Code extension: renders a trace in a webview pane, doubles
+  as a `retrace-ws` client for live streams.
+
+| `grafana-plugin/`
+| Grafana data source: load a trace over HTTP, expose events as
+  a frame for time series / bar gauge / state timeline panels.
+|===
+
+For task-driven recipes covering every tool, see
+link:docs/tools.md[the tools overview] and the
+link:docs/cookbook/README.html[cookbook] (32 recipes and counting).
 
 
 == Architecture

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -202,6 +202,27 @@ $ retrace validate bad-config.json
 error: unknown action 'modify_return_value' (did you mean modify_return_value_int?)
 ```
 
+### `fuzz-replay` — replay a libFuzzer crash
+
+```sh
+retrace fuzz-replay <fuzzer-name> <crash-input>
+```
+
+Replays a crash input through the matching libFuzzer harness for
+quick triage. Looks up the harness under `build/test/fuzz/` (built
+with `-DRETRACE_BUILD_FUZZERS=ON`). Useful when the nightly fuzz
+workflow reports a crash and you want to reproduce it locally with
+ASAN / gdb attached.
+
+```sh
+$ retrace fuzz-replay fuzz_action_run crash-abc123
+retrace fuzz-replay: running fuzz_action_run on crash-abc123 ...
+... (ASAN backtrace if the crash reproduces)
+```
+
+The fuzzer name must match a binary under `build/test/fuzz/`. To
+list available fuzzers, run `ls build/test/fuzz/`.
+
 ## Common options
 
 These apply to `run`, `trace`, `mock`, `fuzz`, and `slow`:

--- a/include/retrace/version.h
+++ b/include/retrace/version.h
@@ -38,9 +38,9 @@
 
 #define RETRACE_VERSION_MAJOR 2
 #define RETRACE_VERSION_MINOR 3
-#define RETRACE_VERSION_PATCH 3
+#define RETRACE_VERSION_PATCH 4
 
-#define RETRACE_VERSION_STRING "2.3.3"
+#define RETRACE_VERSION_STRING "2.3.4"
 
 #define RETRACE_VERSION_ATLEAST(maj, min, pat)                  \
 	(RETRACE_VERSION_MAJOR > (maj) ||                       \

--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -1,3 +1,9 @@
+retrace (2.3.4-1) unstable; urgency=medium
+
+  * docs: README.adoc + cli.md updated to mention v2.3.x tools and fuzz-replay.
+
+ -- Ribose Inc <opensource@ribose.com>  Wed, 13 Aug 2026 00:00:00 +0000
+
 retrace (2.3.3-1) unstable; urgency=medium
 
   * docs: cookbook recipes for every v2.3.0 tool + tools.md overview.

--- a/packaging/fedora/retrace.spec
+++ b/packaging/fedora/retrace.spec
@@ -2,10 +2,10 @@
 #
 # Fedora RPM spec for retrace (TODO.complete/38).
 # Build: rpmbuild -ba retrace.spec
-# Install: dnf install retrace-2.3.3-1.*.rpm
+# Install: dnf install retrace-2.3.4-1.*.rpm
 
 Name:           retrace
-Version:        2.3.3
+Version:        2.3.4
 Release:        1%{?dist}
 Summary:        Userspace libc interceptor for security discovery
 
@@ -50,6 +50,9 @@ action, OTLP/JSON export, and a Python config builder.
 %{_includedir}/retrace/
 
 %changelog
+* Wed Aug 13 2026 Ribose Inc <opensource@ribose.com> - 2.3.4-1
+- README.adoc + cli.md updated for v2.3.x tools and fuzz-replay subcommand
+
 * Wed Aug 13 2026 Ribose Inc <opensource@ribose.com> - 2.3.3-1
 - Cookbook recipes for every v2.3.0 tool + tools.md overview
 

--- a/packaging/nix/default.nix
+++ b/packaging/nix/default.nix
@@ -8,7 +8,7 @@
 
 stdenv.mkDerivation rec {
   pname = "retrace";
-  version = "2.3.3";
+  version = "2.3.4";
 
   src = ./.;
 

--- a/src/cli/retrace_cli.c
+++ b/src/cli/retrace_cli.c
@@ -55,7 +55,7 @@
 static void usage(FILE *out)
 {
 	fprintf(out,
-"retrace v2.3.3 -- userspace libc interceptor\n"
+"retrace v2.3.4 -- userspace libc interceptor\n"
 "\n"
 "Usage:\n"
 "  retrace run [OPTIONS] -- <command> [args...]\n"


### PR DESCRIPTION
## Summary

Bumps retrace from v2.3.3 to **v2.3.4** (PATCH per ADR-0006). Docs-only release closing the v2.3.x discoverability gap on the project's two highest-traffic surfaces: `README.adoc` (GitHub landing page) and `docs/cli.md` (CLI reference).

## What's in the bump

### README.adoc

- New **"What's new in v2.3.x"** section consolidating v2.3.0–v2.3.3 highlights (lock-free logger, capture_buffer, call_hash, parson OOM fix, tools ecosystem, fuzz-replay CLI, nightly fuzz workflow, website features), with cross-links to the cookbook recipes for each tool.
- New **"Tooling ecosystem"** section between End-to-end examples and Architecture: one row per standalone tool (`retrace-audit`, `retrace-diff`, `retrace-replay`, `retrace-ws`, `retrace-to-otlp`, Frida bridge, eBPF bridge, VS Code extension, Grafana plugin) with a one-line job description and a pointer to `docs/tools.md`.
- "Supported platforms" header bumped from `v2.2.0` to `v2.3.3`.

### docs/cli.md

- New `fuzz-replay` subcommand section. The subcommand shipped in v2.3.0 but was undocumented in the CLI reference until now.

### Version + packaging

- `version.h`, `retrace_cli.c` banner: 2.3.3 → 2.3.4
- `packaging/{nix,debian,fedora}` bumped
- `CHANGELOG.md` entry

## Why this matters

Pre-v2.3.4 README was a v2.2.0 snapshot — no mention of any of the v2.3.x tools. Combined with the v2.3.3 cookbook work, the project now has:
1. README → tools overview → cookbook recipe per tool (full discoverability chain from landing page).
2. CLI reference finally documents every subcommand (the `fuzz-replay` gap was a v2.3.0 oversight).

## Test plan

- [x] Docs only; no code change
- [x] `cmake --build build --target retrace` — clean
- [x] `./build/src/cli/retrace --help` banner reads `v2.3.4`
- [x] AsciiDoc structure verified (new section between End-to-end examples and Architecture)
- [x] No AI attribution in commit message
- [ ] CI green on all matrix legs
- [ ] After merge: tag v2.3.4; release.yml produces binary artifacts

## Tagging plan

After PR rebase-merges, tag `v2.3.4` at the merge commit. release.yml will produce per-platform binary artifacts.
