### PR TITLE
release: v2.3.5 — capture_buffer action + env var reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (see `docs/adr/0006-semantic-versioning.md`).
 
+## [2.3.5] - 2026-08-13
+
+### Added
+- `docs/configuration.md`: `capture_buffer` action reference.
+  Covers `param_name` (required), `size_param`, `max_bytes`
+  (default 4096, hard cap 4096), `format` (`hex` default vs
+  `string`), and the non-printable byte replacement behavior.
+  Cross-references recipe 22 (`decode_http` / `decode_dns`) for
+  the structured-fields alternative.
+- `docs/cli.md` + `README.adoc` env var tables: `RETRACE_LOGGER_RING`
+  (lock-free ring + background flusher vs synchronous writes) and
+  `RETRACE_CALL_HASH` (per-thread FNV-1a coverage hash for
+  libFuzzer custom mutators). Both shipped in v2.3.0 but were
+  absent from the env var reference until now.
+
 ## [2.3.4] - 2026-08-13
 
 ### Changed

--- a/README.adoc
+++ b/README.adoc
@@ -285,6 +285,8 @@ Environment variables:
 | `RETRACE_LOGGER_DEF_ENA` | `0` disables the logger entirely.
 | `RETRACE_LOGGER_DEF_STDOUT_ENA` | `0` keeps retrace's log off stdout so it doesn't mix with the target's own output.
 | `RETRACE_LOGGER_DEF_FN` | Path to a log file (alternative to stderr).
+| `RETRACE_LOGGER_RING` | `1` (default): lock-free SPSC ring + background flusher. `0`: synchronous writes (OHOS/QEMU/debug).
+| `RETRACE_CALL_HASH` | `1` enables per-thread FNV-1a rolling hash surfaced to libFuzzer via `retrace_call_hash_last`. Default `0` (zero overhead).
 |===
 
 [NOTE]

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -241,6 +241,8 @@ Additional environment variables:
 | `RETRACE_LOGGER_DEF_STDOUT_ENA` | `0` to suppress stdout mirroring of the log.          |
 | `RETRACE_LOGGER_ALLOWED_FUNCS`  | Comma-separated allowlist of function names to log.  |
 | `RETRACE_LOGGER_EXCLUDED_FUNCS` | Comma-separated denylist of function names to skip.  |
+| `RETRACE_LOGGER_RING`           | `1` (default): use lock-free SPSC ring + background flusher. `0`: synchronous writes (for OHOS / QEMU / debug builds where thread creation during init is fragile). |
+| `RETRACE_CALL_HASH`             | `1` enables per-thread FNV-1a rolling hash of intercepted calls; exposed via `retrace_call_hash_last` for libFuzzer custom mutators (recipe 24). Default: `0` (off, zero overhead). |
 
 ## Library resolution
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -112,6 +112,38 @@ the top of the first script you want to seed.
 Without this action, the seed defaults to `getpid()`, so each run
 gets different failures.
 
+#### `capture_buffer`
+
+Reads N bytes from a pointer parameter **after** the real call
+returns and logs the contents (post-call memory observation). Use
+this to capture what `recv` filled, what `read` loaded, what
+`snprintf` wrote &mdash; not just the return value.
+
+```json
+{ "action_name": "capture_buffer",
+  "action_params": {
+    "param_name": "buf",
+    "size_param": "len",
+    "format": "hex"
+  } }
+```
+
+| Param           | Type   | Required | Notes                                                          |
+|-----------------|--------|----------|----------------------------------------------------------------|
+| `param_name`    | string | yes      | Name of the pointer parameter to read.                         |
+| `size_param`    | string | no       | Name of the integer parameter holding the buffer length.       |
+| `max_bytes`     | number | no       | Cap on bytes to read. Default 4096; hard cap 4096.             |
+| `format`        | string | no       | `hex` (default) or `string`. String replaces non-printable    |
+|                 |        |          | bytes with `.` (preserves `\n`/`\r`/`\t`).                     |
+
+If `size_param` is omitted, captures `max_bytes` bytes. If
+`size_param` exceeds `max_bytes`, truncates to `max_bytes`. The
+action never aborts the script (always returns 0); it logs the
+captured bytes as a `capture_buffer: <param>[N]=<value>` entry.
+
+Pair with `decode_http` / `decode_dns` (recipe 22) when you want
+structured fields instead of raw bytes.
+
 ### Modify
 
 Actions that rewrite the call's arguments or return value.

--- a/include/retrace/version.h
+++ b/include/retrace/version.h
@@ -38,9 +38,9 @@
 
 #define RETRACE_VERSION_MAJOR 2
 #define RETRACE_VERSION_MINOR 3
-#define RETRACE_VERSION_PATCH 4
+#define RETRACE_VERSION_PATCH 5
 
-#define RETRACE_VERSION_STRING "2.3.4"
+#define RETRACE_VERSION_STRING "2.3.5"
 
 #define RETRACE_VERSION_ATLEAST(maj, min, pat)                  \
 	(RETRACE_VERSION_MAJOR > (maj) ||                       \

--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -1,3 +1,10 @@
+retrace (2.3.5-1) unstable; urgency=medium
+
+  * docs: capture_buffer action reference + RETRACE_CALL_HASH and
+    RETRACE_LOGGER_RING env var reference.
+
+ -- Ribose Inc <opensource@ribose.com>  Wed, 13 Aug 2026 00:00:00 +0000
+
 retrace (2.3.4-1) unstable; urgency=medium
 
   * docs: README.adoc + cli.md updated to mention v2.3.x tools and fuzz-replay.

--- a/packaging/fedora/retrace.spec
+++ b/packaging/fedora/retrace.spec
@@ -2,10 +2,10 @@
 #
 # Fedora RPM spec for retrace (TODO.complete/38).
 # Build: rpmbuild -ba retrace.spec
-# Install: dnf install retrace-2.3.4-1.*.rpm
+# Install: dnf install retrace-2.3.5-1.*.rpm
 
 Name:           retrace
-Version:        2.3.4
+Version:        2.3.5
 Release:        1%{?dist}
 Summary:        Userspace libc interceptor for security discovery
 
@@ -50,6 +50,9 @@ action, OTLP/JSON export, and a Python config builder.
 %{_includedir}/retrace/
 
 %changelog
+* Wed Aug 13 2026 Ribose Inc <opensource@ribose.com> - 2.3.5-1
+- Reference docs for capture_buffer action and CALL_HASH / LOGGER_RING env vars
+
 * Wed Aug 13 2026 Ribose Inc <opensource@ribose.com> - 2.3.4-1
 - README.adoc + cli.md updated for v2.3.x tools and fuzz-replay subcommand
 

--- a/packaging/nix/default.nix
+++ b/packaging/nix/default.nix
@@ -8,7 +8,7 @@
 
 stdenv.mkDerivation rec {
   pname = "retrace";
-  version = "2.3.4";
+  version = "2.3.5";
 
   src = ./.;
 

--- a/src/cli/retrace_cli.c
+++ b/src/cli/retrace_cli.c
@@ -55,7 +55,7 @@
 static void usage(FILE *out)
 {
 	fprintf(out,
-"retrace v2.3.4 -- userspace libc interceptor\n"
+"retrace v2.3.5 -- userspace libc interceptor\n"
 "\n"
 "Usage:\n"
 "  retrace run [OPTIONS] -- <command> [args...]\n"


### PR DESCRIPTION
## Summary

Bumps retrace from v2.3.4 to **v2.3.5** (PATCH per ADR-0006). Docs-only release closing three v2.3.0 reference gaps: the `capture_buffer` action, `RETRACE_LOGGER_RING` env var, and `RETRACE_CALL_HASH` env var all shipped in v2.3.0 but were missing from the reference docs.

## What's in the bump

### `docs/configuration.md` — `capture_buffer` action reference

New section under the Observe category. Covers:
- `param_name` (required) — the buffer parameter to read.
- `size_param` (optional) — integer parameter holding buffer length.
- `max_bytes` (optional, default 4096, hard cap 4096) — read cap.
- `format` (optional, `"hex"` default | `"string"`) — output format. `string` replaces non-printable bytes with `.` (preserves `\n`/`\r`/`\t`).
- Post-call timing — reads after the real call returns.
- Always returns 0 (never aborts the script).
- Cross-link to recipe 22 (`decode_http` / `decode_dns`) for the structured-fields alternative.

### `docs/cli.md` + `README.adoc` — env var reference

Two new rows in each env var table:
- `RETRACE_LOGGER_RING` — `1` (default): lock-free SPSC ring + background flusher. `0`: synchronous writes for OHOS/QEMU/debug.
- `RETRACE_CALL_HASH` — `1` enables per-thread FNV-1a rolling hash surfaced to libFuzzer via `retrace_call_hash_last`. Default `0` (zero overhead).

### Version + packaging

- `version.h`, `retrace_cli.c` banner: 2.3.4 → 2.3.5
- `packaging/{nix,debian,fedora}` bumped
- `CHANGELOG.md` entry

## Why this matters

Anyone who installed v2.3.x had to read source code to learn about `capture_buffer`, `RETRACE_LOGGER_RING`, or `RETRACE_CALL_HASH`. Now they're in the reference docs next to the existing actions and env vars.

## Test plan

- [x] Docs only; no code change
- [x] `cmake --build build --target retrace` — clean
- [x] `./build/src/cli/retrace --help` banner reads `v2.3.5`
- [x] `capture_buffer` param table matches the actual implementation in `src/core/actions/capture_buffer.c`
- [x] Env var descriptions match the actual env var semantics
- [x] No AI attribution in commit message
- [ ] CI green on all matrix legs
- [ ] After merge: tag v2.3.5; release.yml produces binary artifacts

## Tagging plan

After PR rebase-merges, tag `v2.3.5` at the merge commit. release.yml will produce per-platform binary artifacts.
