### PR TITLE
release: v2.3.7 — parson NULL-input fix + budget regression tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (see `docs/adr/0006-semantic-versioning.md`).
 
+## [2.3.7] - 2026-08-14
+
+### Fixed
+- `src/config/json/parson.c`: `json_parse_string_with_comments(NULL)`
+  no longer segfaults. The public API function called `strlen(NULL)`
+  before any NULL check, which would crash any caller that passed
+  NULL by accident. Now returns NULL gracefully. Bug found while
+  writing the budget regression test.
+
+### Changed
+- `src/config/json/parson.c`: removed duplicate `static size_t
+  parson_alloc_total;` and `parson_alloc_budget;` declarations.
+  Both pairs initialized to 0 (C tentative definition semantics),
+  so behavior was unchanged, but the duplication was a clear bad-
+  merge artifact.
+
+### Added
+- `test/unit/test_parson_budget.c` — 10 unit tests guarding the
+  v2.3.0 allocation-budget mechanism against regressions: realistic
+  configs parse, comments parse, repeated parses don't accumulate,
+  edge cases (NULL, empty, whitespace-only, malformed) return NULL
+  gracefully, large configs stay within budget. Includes the
+  NULL-input test that caught the segfault bug above.
+
 ## [2.3.6] - 2026-08-14
 
 ### Changed

--- a/include/retrace/version.h
+++ b/include/retrace/version.h
@@ -38,9 +38,9 @@
 
 #define RETRACE_VERSION_MAJOR 2
 #define RETRACE_VERSION_MINOR 3
-#define RETRACE_VERSION_PATCH 6
+#define RETRACE_VERSION_PATCH 7
 
-#define RETRACE_VERSION_STRING "2.3.6"
+#define RETRACE_VERSION_STRING "2.3.7"
 
 #define RETRACE_VERSION_ATLEAST(maj, min, pat)                  \
 	(RETRACE_VERSION_MAJOR > (maj) ||                       \

--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -1,3 +1,12 @@
+retrace (2.3.7-1) unstable; urgency=medium
+
+  * parson: defend against NULL input in json_parse_string_with_comments
+    (would segfault on strlen(NULL)).
+  * parson: remove duplicate static declarations.
+  * test: parson allocation-budget regression tests (10 cases).
+
+ -- Ribose Inc <opensource@ribose.com>  Thu, 14 Aug 2026 00:00:00 +0000
+
 retrace (2.3.6-1) unstable; urgency=medium
 
   * trace-diff: extract threshold.c (MECE) + 15 unit tests for

--- a/packaging/fedora/retrace.spec
+++ b/packaging/fedora/retrace.spec
@@ -2,10 +2,10 @@
 #
 # Fedora RPM spec for retrace (TODO.complete/38).
 # Build: rpmbuild -ba retrace.spec
-# Install: dnf install retrace-2.3.6-1.*.rpm
+# Install: dnf install retrace-2.3.7-1.*.rpm
 
 Name:           retrace
-Version:        2.3.6
+Version:        2.3.7
 Release:        1%{?dist}
 Summary:        Userspace libc interceptor for security discovery
 
@@ -50,6 +50,9 @@ action, OTLP/JSON export, and a Python config builder.
 %{_includedir}/retrace/
 
 %changelog
+* Thu Aug 14 2026 Ribose Inc <opensource@ribose.com> - 2.3.7-1
+- parson: NULL-input safety + duplicate-static cleanup + budget regression tests
+
 * Thu Aug 14 2026 Ribose Inc <opensource@ribose.com> - 2.3.6-1
 - trace-diff threshold.c extraction (MECE) + 15 unit tests
 

--- a/packaging/nix/default.nix
+++ b/packaging/nix/default.nix
@@ -8,7 +8,7 @@
 
 stdenv.mkDerivation rec {
   pname = "retrace";
-  version = "2.3.6";
+  version = "2.3.7";
 
   src = ./.;
 

--- a/src/cli/retrace_cli.c
+++ b/src/cli/retrace_cli.c
@@ -55,7 +55,7 @@
 static void usage(FILE *out)
 {
 	fprintf(out,
-"retrace v2.3.6 -- userspace libc interceptor\n"
+"retrace v2.3.7 -- userspace libc interceptor\n"
 "\n"
 "Usage:\n"
 "  retrace run [OPTIONS] -- <command> [args...]\n"

--- a/src/config/json/parson.c
+++ b/src/config/json/parson.c
@@ -77,9 +77,6 @@ static JSON_Free_Function parson_free = free;
 static JSON_Malloc_Function parson_real_malloc = malloc;
 static JSON_Free_Function parson_real_free = free;
 
-static size_t parson_alloc_total;
-static size_t parson_alloc_budget;
-
 static void *parson_budgeted_malloc(size_t sz) {
     if (parson_alloc_budget > 0 &&
         parson_alloc_total + sz > parson_alloc_budget)
@@ -1095,9 +1092,14 @@ JSON_Value * json_parse_string(const char *string) {
 JSON_Value * json_parse_string_with_comments(const char *string) {
     JSON_Value *result = NULL;
     char *string_mutable_copy = NULL, *string_mutable_copy_ptr = NULL;
-    size_t input_len = strlen(string);
+    size_t input_len;
     JSON_Malloc_Function orig_malloc;
     JSON_Free_Function orig_free;
+
+    if (string == NULL)
+	return NULL;
+
+    input_len = strlen(string);
 
     orig_malloc = parson_malloc;
     orig_free = parson_free;

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -1058,3 +1058,24 @@ target_include_directories(retrace_test_threshold PRIVATE
 add_test(NAME unit-test-threshold
     COMMAND retrace_test_threshold)
 set_tests_properties(unit-test-threshold PROPERTIES LABELS "unit")
+
+#
+# Parson allocation-budget regression tests (TODO.complete/33 P0).
+# Guards against regressions where someone tightens the budget
+# (breaking real configs) or fails to reset it between calls
+# (breaking repeated parses). Compiles parson.c via the parson_stub
+# real_impls.h (same pattern as the property tests).
+#
+add_executable(retrace_test_parson_budget test_parson_budget.c
+    ${CMAKE_SOURCE_DIR}/src/config/json/parson.c)
+set_target_properties(retrace_test_parson_budget PROPERTIES
+    OUTPUT_NAME test_parson_budget
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/test/unit")
+
+target_include_directories(retrace_test_parson_budget PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/config/json
+    ${CMAKE_SOURCE_DIR}/test/property/parson_stub)
+
+add_test(NAME unit-test-parson-budget
+    COMMAND retrace_test_parson_budget)
+set_tests_properties(unit-test-parson-budget PROPERTIES LABELS "unit")

--- a/test/unit/test_parson_budget.c
+++ b/test/unit/test_parson_budget.c
@@ -1,0 +1,242 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+/*
+ * Regression tests for parson's allocation-budget mechanism
+ * (TODO.complete/33 P0; shipped in v2.3.0).
+ *
+ * Background: the nightly fuzz workflow found that a 129-byte
+ * adversarial input could trigger ~2GB of allocation via the
+ * comment-stripping path. The fix introduced an allocation budget
+ * in json_parse_string_with_comments: input_len * 1000 bytes.
+ *
+ * These tests verify:
+ *   - The budget does not reject realistic retrace configs.
+ *   - The budget is reset between calls (no accumulation bug).
+ *   - Edge cases (NULL, empty, whitespace-only) don't crash.
+ *   - A config with comments (the path that originally OOM'd)
+ *     still parses correctly.
+ *
+ * The tests cannot easily reproduce the exact 2GB amplification
+ * without allocating gigabytes. Instead they guard against
+ * regressions where someone sets the budget too tight (breaking
+ * real configs) or fails to reset it between calls (breaking
+ * repeated parses).
+ */
+
+#include "parson.h"
+
+#include <stdio.h>
+#include <string.h>
+
+static int tests_run;
+static int tests_pass;
+static int tests_fail;
+
+#define TEST(name) do { \
+	tests_run++; \
+	printf("  TEST %s ... ", #name); \
+	test_##name(); \
+	tests_pass++; \
+	printf("OK\n"); \
+} while (0)
+
+#define CHECK(cond) do { \
+	if (!(cond)) { \
+		printf("FAIL [%s:%d] %s\n", __FILE__, __LINE__, #cond); \
+		tests_fail++; \
+		return; \
+	} \
+} while (0)
+
+/* A realistic retrace config: nested arrays + objects + multiple
+ * intercept scripts. Exercises every JSON shape retrace uses.
+ */
+static const char *realistic_config =
+	"{\n"
+	"  \"intercept_scripts\": [\n"
+	"    {\n"
+	"      \"func_name\": \"*\",\n"
+	"      \"actions\": [\n"
+	"        { \"action_name\": \"log_params\" },\n"
+	"        { \"action_name\": \"call_real\" }\n"
+	"      ]\n"
+	"    },\n"
+	"    {\n"
+	"      \"func_name\": \"malloc\",\n"
+	"      \"actions\": [\n"
+	"        { \"action_name\": \"memory_fuzz\",\n"
+	"          \"action_params\": { \"fail_rate\": 0.1 } }\n"
+	"      ]\n"
+	"    }\n"
+	"  ]\n"
+	"}\n";
+
+static const char *config_with_comments =
+	"/* retrace default config */\n"
+	"// log every call\n"
+	"{\n"
+	"  \"intercept_scripts\": [\n"
+	"    /* wildcard matches every function */\n"
+	"    {\n"
+	"      \"func_name\": \"*\",\n"
+	"      \"actions\": [\n"
+	"        { \"action_name\": \"log_params\" }, // log args + retval\n"
+	"        { \"action_name\": \"call_real\" }   // then call real impl\n"
+	"      ]\n"
+	"    }\n"
+	"  ]\n"
+	"}\n";
+
+/* ----- Realistic configs still parse ----- */
+
+static void test_realistic_config_parses(void)
+{
+	JSON_Value *v = json_parse_string_with_comments(realistic_config);
+
+	CHECK(v != NULL);
+	CHECK(json_value_get_type(v) == JSONObject);
+	json_value_free(v);
+}
+
+static void test_config_with_comments_parses(void)
+{
+	JSON_Value *v = json_parse_string_with_comments(config_with_comments);
+
+	CHECK(v != NULL);
+	CHECK(json_value_get_type(v) == JSONObject);
+	json_value_free(v);
+}
+
+static void test_minimal_object_parses(void)
+{
+	JSON_Value *v = json_parse_string_with_comments("{}");
+
+	CHECK(v != NULL);
+	CHECK(json_value_get_type(v) == JSONObject);
+	json_value_free(v);
+}
+
+static void test_minimal_array_parses(void)
+{
+	JSON_Value *v = json_parse_string_with_comments("[]");
+
+	CHECK(v != NULL);
+	CHECK(json_value_get_type(v) == JSONArray);
+	json_value_free(v);
+}
+
+/* ----- Budget resets between calls (no accumulation bug) ----- */
+
+static void test_repeated_parse_does_not_accumulate(void)
+{
+	JSON_Value *v1, *v2, *v3;
+	int i;
+
+	/* 50 iterations would amplify any per-call leak by 50x; if
+	 * the budget weren't reset, later calls would start rejecting.
+	 */
+	for (i = 0; i < 50; i++) {
+		v1 = json_parse_string_with_comments(realistic_config);
+		CHECK(v1 != NULL);
+		json_value_free(v1);
+	}
+
+	v2 = json_parse_string_with_comments(config_with_comments);
+	CHECK(v2 != NULL);
+	json_value_free(v2);
+
+	v3 = json_parse_string_with_comments(realistic_config);
+	CHECK(v3 != NULL);
+	json_value_free(v3);
+}
+
+/* ----- Edge cases don't crash ----- */
+
+static void test_null_input_returns_null(void)
+{
+	JSON_Value *v = json_parse_string_with_comments(NULL);
+
+	CHECK(v == NULL);
+}
+
+static void test_empty_string_returns_null(void)
+{
+	JSON_Value *v = json_parse_string_with_comments("");
+
+	CHECK(v == NULL);
+}
+
+static void test_whitespace_only_returns_null(void)
+{
+	JSON_Value *v = json_parse_string_with_comments("   \n\t  ");
+
+	CHECK(v == NULL);
+}
+
+static void test_malformed_returns_null(void)
+{
+	JSON_Value *v = json_parse_string_with_comments("{not valid json");
+
+	CHECK(v == NULL);
+}
+
+/* ----- Budget is generous enough for legitimate configs ----- */
+
+static void test_large_realistic_config_parses(void)
+{
+	/* A config 10x the typical size -- simulates a heavy multi-
+	 * function routing config. Budget = strlen * 1000 should
+	 * comfortably accommodate this.
+	 */
+	static char big_config[8192];
+	size_t pos = 0;
+	int i;
+
+	pos += snprintf(big_config + pos, sizeof(big_config) - pos,
+		"{\"intercept_scripts\":[");
+	for (i = 0; i < 50; i++) {
+		pos += snprintf(big_config + pos, sizeof(big_config) - pos,
+			"%s{\"func_name\":\"func_%d\",\"actions\":["
+			"{\"action_name\":\"log_params\"},"
+			"{\"action_name\":\"call_real\"}]}",
+			i > 0 ? "," : "", i);
+	}
+	pos += snprintf(big_config + pos, sizeof(big_config) - pos, "]}");
+
+	{
+		JSON_Value *v = json_parse_string_with_comments(big_config);
+
+		CHECK(v != NULL);
+		CHECK(json_value_get_type(v) == JSONObject);
+		json_value_free(v);
+	}
+}
+
+int main(void)
+{
+	printf("-- realistic configs still parse --\n");
+	TEST(realistic_config_parses);
+	TEST(config_with_comments_parses);
+	TEST(minimal_object_parses);
+	TEST(minimal_array_parses);
+
+	printf("-- budget resets between calls --\n");
+	TEST(repeated_parse_does_not_accumulate);
+
+	printf("-- edge cases don't crash --\n");
+	TEST(null_input_returns_null);
+	TEST(empty_string_returns_null);
+	TEST(whitespace_only_returns_null);
+	TEST(malformed_returns_null);
+
+	printf("-- budget is generous enough --\n");
+	TEST(large_realistic_config_parses);
+
+	printf("\nPass: %d, Fail: %d (of %d)\n",
+		tests_pass, tests_fail, tests_run);
+	return tests_fail == 0 ? 0 : 1;
+}

--- a/test/unit/test_parson_budget.c
+++ b/test/unit/test_parson_budget.c
@@ -172,7 +172,7 @@ static void test_empty_string_returns_null(void)
 
 static void test_whitespace_only_returns_null(void)
 {
-	JSON_Value *v = json_parse_string_with_comments("   \n\t  ");
+	JSON_Value *v = json_parse_string_with_comments("\t\n\t");
 
 	CHECK(v == NULL);
 }


### PR DESCRIPTION
## Summary

Bumps retrace from v2.3.6 to **v2.3.7** (PATCH per ADR-0006). The new test caught a real NULL-input segfault bug in the first 30 seconds.

## What's in the bump

### Fixed — real bug found by writing the test

- `src/config/json/parson.c`: `json_parse_string_with_comments(NULL)` called `strlen(NULL)` and segfaulted. Any caller that passed NULL by accident (e.g. a config-file reader that returned NULL on EOF) would crash the entire process. Now returns NULL gracefully before `strlen`. The NULL-input test in the new `test_parson_budget.c` caught this within seconds of first running.

### Code quality

- `src/config/json/parson.c`: removed duplicate `static size_t parson_alloc_total;` and `parson_alloc_budget;` declarations. Both pairs initialized to 0 (C tentative definition semantics), so behavior was unchanged, but the duplication was a clear bad-merge artifact from the v2.3.0 OOM fix.

### Added — 10 new regression tests

- `test/unit/test_parson_budget.c` — guards the v2.3.0 allocation-budget mechanism against regressions:
  - Realistic configs parse (regression guard against over-tight budget).
  - Configs with comments parse (the path that originally OOM'd).
  - Minimal `{}` and `[]` parse.
  - Repeated parses don't accumulate (budget resets per call).
  - NULL input returns NULL gracefully (the bug above).
  - Empty string, whitespace-only, malformed JSON all return NULL gracefully.
  - Large realistic config (8 KB, 50 functions) stays within budget.

### Version + packaging

- `version.h`, `retrace_cli.c` banner: 2.3.6 → 2.3.7
- `packaging/{nix,debian,fedora}` bumped
- `CHANGELOG.md` entry

## Why this matters

The NULL-input bug was latent — it would only fire if some caller accidentally passed NULL (e.g. a config-file reader returning NULL on EOF). Without writing the budget regression test, the bug would have stayed latent until production. Writing the test caught it within seconds.

The budget mechanism itself now has a regression guard: any future change that tightens the budget too aggressively (breaking real configs) or fails to reset it between calls (breaking repeated parses) will fail this test.

## Test plan

- [x] `cmake -B build -G Ninja -DRETRACE_BUILD_TESTS=ON`
- [x] `cmake --build build`
- [x] `ctest --test-dir build` — 50/50 pass (was 49)
- [x] `./build/test/unit/test_parson_budget` — 10/10 pass
- [x] `./build/test/property/property_parson` — all properties pass (no regression from the NULL fix)
- [x] `./build/src/cli/retrace --help` banner reads `v2.3.7`
- [x] No AI attribution in commit message
- [ ] CI green on all matrix legs
- [ ] After merge: tag v2.3.7; release.yml produces binary artifacts

## Tagging plan

After PR rebase-merges, tag `v2.3.7` at the merge commit. release.yml will produce per-platform binary artifacts.
