### PR TITLE
v2.4.0: native process attach via ptrace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,40 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (see `docs/adr/0006-semantic-versioning.md`).
 
+## [2.4.0] - 2026-08-14
+
+MINOR bump per ADR-0006: new capability, backwards-compatible API.
+
+### Added
+- **Native process attach — `retrace attach <pid>`**. Attach to an
+  already-running process via ptrace and trace its syscalls until
+  it exits. No `LD_PRELOAD`, no restart, no control of the launch
+  required — reaches the targets the preload backends structurally
+  cannot (any running PID; static binaries after they started).
+  Output is the same JSON format as `retrace run` and feeds the
+  same downstream tools (audit, diff, replay). Linux only; reports
+  a clean error elsewhere.
+- **`retrace backends`** — lists the interposition backends
+  compiled into the library (preload-elf, preload-macho,
+  preload-msvc, ptrace, ...).
+- **New public API** (`include/retrace/retrace.h`):
+  `retrace_attach_process(pid)` — explicit ptrace lookup (bypasses
+  the static-binary probe: attach semantics differ from spawn; for
+  a process you cannot exec, ptrace is the sole native mechanism
+  regardless of how the binary was linked) — and
+  `retrace_list_backends(&names, &count)`.
+- **`test/unit/test_attach.c`** — 3 tests: backend enumeration,
+  invalid-pid rejection, and (on Linux) a real fork + PTRACE_ATTACH
+  + timeout-kill round trip verifying the trace loop runs to
+  completion. Non-Linux legs verify the clean-failure contract.
+
+### Changed
+- `src/backends/ptrace/trace_loop.c`: removed a NULL-engine early
+  return that defended an unsatisfiable contract —
+  `struct retrace_engine` is never instantiated; syscall dispatch
+  goes through the process-global `retrace_engine_wrapper`. The
+  handle survives in the signature for the backend API contract.
+
 ## [2.3.8] - 2026-08-14
 
 ### Added

--- a/README.adoc
+++ b/README.adoc
@@ -78,6 +78,21 @@ for 20+ recipes covering tracing, fuzzing, mocking, redirection,
 security auditing, and CI integration.
 
 
+== What's new in v2.4.0
+
+* **Native process attach &mdash; `retrace attach <pid>`** &mdash;
+  attach to an already-running process via ptrace and trace its
+  syscalls until it exits. No `LD_PRELOAD`, no restart, no control
+  of the launch required. This reaches the targets the preload
+  backends structurally cannot: any running PID (and static
+  binaries after they started). Output is the same JSON format and
+  feeds the same downstream tools. New public API:
+  `retrace_attach_process(pid)` and `retrace_list_backends()`.
+  See link:docs/cli.md[the CLI reference].
+* **`retrace backends`** &mdash; lists the interposition backends
+  compiled into the library (preload-elf, preload-macho,
+  preload-msvc, ptrace, ...).
+
 == What's new in v2.3.x
 
 The v2.3.x series turns retrace from a single CLI into a tools
@@ -569,6 +584,9 @@ match freely.
 | Tail a running trace and broadcast over WebSocket; built-in
   browser viewer at `http://localhost:8765/`.
 
+| `retrace attach <pid>`
+| Attach to a running process via ptrace and trace its syscalls
+  until it exits — no preload, no restart (Linux).
 | `retrace-to-otlp`
 | Convert a retrace JSON log to OTLP/JSON for Jaeger / Tempo /
   Honeycomb / Datadog.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -223,6 +223,53 @@ retrace fuzz-replay: running fuzz_action_run on crash-abc123 ...
 The fuzzer name must match a binary under `build/test/fuzz/`. To
 list available fuzzers, run `ls build/test/fuzz/`.
 
+### `attach` — trace a running process (Linux)
+
+```sh
+retrace attach [--config FILE] [--log FILE] <pid>
+```
+
+Attaches to an already-running process via `ptrace` and traces its
+syscalls until it exits — no `LD_PRELOAD`, no restart, no control of
+the launch required. This reaches the targets the preload backends
+structurally cannot: any running PID, and static binaries after they
+started. Output is the same JSON format as `retrace run` and feeds
+the same downstream tools (`retrace-audit`, `retrace-diff`,
+`retrace-replay`).
+
+```sh
+$ retrace attach --log /tmp/trace.json $(pidof my-server)
+retrace attach: tracing pid 4242 (ctrl-c to stop tracing, ...)
+... (JSON entries stream to /tmp/trace.json as syscalls happen)
+retrace attach: target exited
+```
+
+Permission errors mean one of:
+
+- not root, and the target is not your child process — run as root,
+  or relax `/proc/sys/kernel/kernel/yama/ptrace_scope` to `0`;
+- container hardening — attach to a process you spawned.
+
+On macOS and Windows the command reports
+`ptrace backend not available in this build` and exits 1.
+
+### `backends` — list interposition backends
+
+```sh
+retrace backends
+```
+
+Prints the backends compiled into the library
+(`preload-elf`, `preload-macho`, `preload-msvc`, `ptrace`, ...).
+Discoverability for which interposition mechanisms this build
+supports on this platform.
+
+```sh
+$ retrace backends
+1 backend registered:
+  preload-macho
+```
+
 ## Common options
 
 These apply to `run`, `trace`, `mock`, `fuzz`, and `slow`:

--- a/docs/cookbook/29-frida-bridge.md
+++ b/docs/cookbook/29-frida-bridge.md
@@ -136,6 +136,17 @@ $ frida -l retrace-frida.js -p 12345 > /tmp/trace.json
 Use this for incident response — no restart, no deployment, just
 attach and gather.
 
+**On Linux, retrace can attach natively** since v2.4.0:
+
+```sh
+$ retrace attach --log /tmp/trace.json 12345
+```
+
+Same JSON output, no Frida dependency, no JS runtime overhead.
+The Frida path remains the answer when the target is not a direct
+child and ptrace permissions are locked down, or on iOS/macOS
+where retrace's ptrace backend does not build.
+
 ### Custom function list for a specific investigation
 
 Edit `FUNC_LIST` to focus on what matters. For a crypto audit,

--- a/include/retrace/retrace.h
+++ b/include/retrace/retrace.h
@@ -133,6 +133,38 @@ RETRACE_API retrace_status_t retrace_engine_select_backend(
 		retrace_engine_t *eng, const char *name);
 
 /* ----------------------------------------------------------------- *
+ * Process attach
+ *
+ * Attach to an already-running process and trace its syscalls until
+ * it exits. This is the ptrace path: unlike the preload backends it
+ * needs no control of the process at exec time, so it works for
+ * targets LD_PRELOAD cannot reach (any running PID; also the only
+ * native option for static binaries after they started).
+ *
+ * Observation-oriented: the trace loop forwards each syscall to the
+ * engine, applying the JSON config like any other trace source.
+ *
+ * Requires the process-global engine (initialized by the library
+ * constructor on dlopen/load); no engine handle is needed.
+ *
+ * Linux only. Returns:
+ *   RETRACE_OK              trace loop ran to completion (target exited)
+ *   RETRACE_ERR_NOENT       ptrace backend not registered
+ *   RETRACE_ERR_PERMISSION  PTRACE_ATTACH denied (ptrace_scope / creds)
+ *   RETRACE_ERR_INVAL       pid <= 0
+ *   RETRACE_ERR_UNSUPPORTED non-Linux platform
+ */
+RETRACE_API retrace_status_t retrace_attach_process(int pid);
+
+/*
+ * Enumerate registered backend names (e.g. "preload_elf", "ptrace").
+ * The array and its strings are owned by the library and remain valid
+ * until the next call; callers must not free them.
+ */
+RETRACE_API retrace_status_t retrace_list_backends(
+		const char *const **out_names, size_t *out_count);
+
+/* ----------------------------------------------------------------- *
  * Programmatic script builder
  *
  * Build a script in C without parsing a file. Equivalent to the JSON path

--- a/include/retrace/version.h
+++ b/include/retrace/version.h
@@ -37,10 +37,10 @@
 #define RETRACE_VERSION_H
 
 #define RETRACE_VERSION_MAJOR 2
-#define RETRACE_VERSION_MINOR 3
-#define RETRACE_VERSION_PATCH 8
+#define RETRACE_VERSION_MINOR 4
+#define RETRACE_VERSION_PATCH 0
 
-#define RETRACE_VERSION_STRING "2.3.8"
+#define RETRACE_VERSION_STRING "2.4.0"
 
 #define RETRACE_VERSION_ATLEAST(maj, min, pat)                  \
 	(RETRACE_VERSION_MAJOR > (maj) ||                       \

--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -1,3 +1,12 @@
+retrace (2.4.0-1) unstable; urgency=medium
+
+  * New: native process attach via ptrace (`retrace attach <pid>`).
+  * New: `retrace backends` lists compiled interposition backends.
+  * New public API: retrace_attach_process() + retrace_list_backends().
+  * Tutorial 27 + cookbook 29 note native attach for running PIDs.
+
+ -- Ribose Inc <opensource@ribose.com>  Fri, 14 Aug 2026 00:00:00 +0000
+
 retrace (2.3.8-1) unstable; urgency=medium
 
   * docs: tutorials 23-27 covering the v2.3.0 tool ecosystem.

--- a/packaging/fedora/retrace.spec
+++ b/packaging/fedora/retrace.spec
@@ -2,10 +2,10 @@
 #
 # Fedora RPM spec for retrace (TODO.complete/38).
 # Build: rpmbuild -ba retrace.spec
-# Install: dnf install retrace-2.3.8-1.*.rpm
+# Install: dnf install retrace-2.4.0-1.*.rpm
 
 Name:           retrace
-Version:        2.3.8
+Version:        2.4.0
 Release:        1%{?dist}
 Summary:        Userspace libc interceptor for security discovery
 
@@ -50,6 +50,9 @@ action, OTLP/JSON export, and a Python config builder.
 %{_includedir}/retrace/
 
 %changelog
+* Fri Aug 14 2026 Ribose Inc <opensource@ribose.com> - 2.4.0-1
+- Native process attach via ptrace (retrace attach <pid>) + backends listing
+
 * Thu Aug 14 2026 Ribose Inc <opensource@ribose.com> - 2.3.8-1
 - Tutorials 23-27 covering the v2.3.0 tool ecosystem
 

--- a/packaging/nix/default.nix
+++ b/packaging/nix/default.nix
@@ -8,7 +8,7 @@
 
 stdenv.mkDerivation rec {
   pname = "retrace";
-  version = "2.3.8";
+  version = "2.4.0";
 
   src = ./.;
 

--- a/src/backends/ptrace/trace_loop.c
+++ b/src/backends/ptrace/trace_loop.c
@@ -139,8 +139,12 @@ retrace_ptrace_trace_loop(struct retrace_engine *eng, pid_t child_pid)
 	int in_syscall = 0; /* next stop is entry (0) or exit (1) */
 	int status;
 
-	if (eng == NULL)
-		return -1;
+	/* `eng` is not dereferenced here: syscall dispatch goes through
+	 * the process-global retrace_engine_wrapper (constructor-
+	 * initialized). The handle survives in the signature for the
+	 * backend API contract (spawn/attach both forward one).
+	 */
+	(void) eng;
 
 	/* Wait for the initial execve stop (Linux delivers SIGTRAP at that
 	 * point for a PTRACE_TRACEME child).

--- a/src/backends/registry.c
+++ b/src/backends/registry.c
@@ -33,6 +33,7 @@
  */
 
 #include <retrace/backend.h>
+#include <retrace/retrace.h>
 
 #include <stddef.h>
 #include <string.h>
@@ -41,6 +42,11 @@
 
 static const retrace_backend_t *registered[RETRACE_BACKEND_MAX];
 static size_t registered_count;
+
+/* Projection of registered[] into a name-only array for the public
+ * retrace_list_backends(). Rebuilt on each call; valid until next call.
+ */
+static const char *backend_names[RETRACE_BACKEND_MAX];
 
 RETRACE_BACKEND_API int
 retrace_backend_register(const retrace_backend_t *backend)
@@ -116,4 +122,54 @@ retrace_backend_select(struct retrace_engine *eng,
 	}
 
 	return best;
+}
+
+RETRACE_API retrace_status_t
+retrace_list_backends(const char *const **out_names, size_t *out_count)
+{
+	size_t i;
+
+	if (out_names == NULL || out_count == NULL)
+		return RETRACE_ERR_INVAL;
+
+	for (i = 0; i < registered_count; i++)
+		backend_names[i] = registered[i]->name;
+
+	*out_names = backend_names;
+	*out_count = registered_count;
+	return RETRACE_OK;
+}
+
+RETRACE_API retrace_status_t
+retrace_attach_process(int pid)
+{
+	const retrace_backend_t *ptrace;
+	retrace_pid_t rc;
+
+	if (pid <= 0)
+		return RETRACE_ERR_INVAL;
+
+	/* Explicit lookup, not select(): attach semantics differ from
+	 * spawn. The ptrace probe checks whether a target path is a
+	 * static ELF — meaningless for an already-running pid. For a
+	 * process we cannot exec (the only kind attach targets),
+	 * ptrace is the sole native mechanism regardless of how the
+	 * binary was linked.
+	 */
+	ptrace = retrace_backend_find("ptrace");
+	if (ptrace == NULL || ptrace->attach == NULL)
+		return RETRACE_ERR_NOENT;
+
+	/* ptrace_attach ignores the engine handle: the process-global
+	 * engine (constructor-initialized) serves the trace loop.
+	 */
+	rc = ptrace->attach(NULL, (retrace_pid_t)pid);
+
+	if (rc == (retrace_pid_t)pid)
+		return RETRACE_OK;
+	if (rc == (retrace_pid_t)RETRACE_BACKEND_PERMISSION)
+		return RETRACE_ERR_PERMISSION;
+	if (rc == (retrace_pid_t)RETRACE_BACKEND_UNSUPPORTED)
+		return RETRACE_ERR_UNSUPPORTED;
+	return RETRACE_ERR_INTERNAL;
 }

--- a/src/cli/retrace_cli.c
+++ b/src/cli/retrace_cli.c
@@ -37,6 +37,7 @@
 #include <errno.h>
 #include <sys/wait.h>
 #include <signal.h>
+#include <dlfcn.h>
 
 #include "parson.h"
 #include "config_builder.h"
@@ -52,10 +53,17 @@
 #define RETRACE_LIB_NAME "libretrace.so"
 #endif
 
+/* Mirror of retrace_status_t (include/retrace/retrace.h). The CLI
+ * stays a standalone binary: it dlsyms library functions but cannot
+ * include the full public header without dragging in the build's
+ * include paths. Values must stay in sync with the public header.
+ */
+typedef int retrace_status_t;
+
 static void usage(FILE *out)
 {
 	fprintf(out,
-"retrace v2.3.8 -- userspace libc interceptor\n"
+"retrace v2.4.0 -- userspace libc interceptor\n"
 "\n"
 "Usage:\n"
 "  retrace run [OPTIONS] -- <command> [args...]\n"
@@ -67,6 +75,8 @@ static void usage(FILE *out)
 "  retrace list-actions\n"
 "  retrace validate <config.json>\n"
 "  retrace fuzz-replay <fuzzer-name> <crash-input>\n"
+"  retrace attach [OPTIONS] <pid>\n"
+"  retrace backends\n"
 "\n"
 "Quick subcommands (no JSON needed):\n"
 "  retrace trace malloc,free -- /bin/ls\n"
@@ -957,6 +967,204 @@ static int cmd_run(int argc, char **argv)
 	return 0;
 }
 
+/*
+ * retrace attach [OPTIONS] <pid>
+ *
+ * Attach to an already-running process and trace its syscalls until
+ * it exits. Uses the ptrace backend — no LD_PRELOAD, no restart.
+ * The trace output follows the same JSON format as `retrace run`
+ * and feeds the same downstream tools.
+ */
+static int cmd_attach(int argc, char **argv)
+{
+	const char *config = NULL;
+	const char *logfile = NULL;
+	const char *lib_override = NULL;
+	int quiet = 0;
+	int pid = -1;
+	int i;
+	char lib_path[PATH_MAX];
+	char *found;
+	void *lib;
+	retrace_status_t (*attach_fn)(int pid);
+	retrace_status_t rc;
+
+	for (i = 0; i < argc; i++) {
+		if (strcmp(argv[i], "--config") == 0 && i + 1 < argc) {
+			config = argv[++i];
+		} else if (strcmp(argv[i], "--log") == 0 && i + 1 < argc) {
+			logfile = argv[++i];
+		} else if (strcmp(argv[i], "--lib") == 0 && i + 1 < argc) {
+			lib_override = argv[++i];
+		} else if (strcmp(argv[i], "--quiet") == 0) {
+			quiet = 1;
+		} else if (strcmp(argv[i], "--help") == 0 ||
+			   strcmp(argv[i], "-h") == 0) {
+			usage(stdout);
+			return 0;
+		} else if (pid < 0) {
+			char *end = NULL;
+			long v = strtol(argv[i], &end, 10);
+
+			if (end == argv[i] || *end != '\0' || v <= 0) {
+				fprintf(stderr,
+					"retrace attach: invalid pid '%s'\n",
+					argv[i]);
+				return 1;
+			}
+			pid = (int)v;
+		} else {
+			fprintf(stderr, "retrace attach: unknown option '%s'\n",
+				argv[i]);
+			return 1;
+		}
+	}
+
+	if (pid < 0) {
+		fprintf(stderr,
+			"retrace attach: usage: retrace attach [--config FILE] "
+			"[--log FILE] <pid>\n");
+		return 1;
+	}
+
+	if (lib_override)
+		setenv("RETRACE_LIB", lib_override, 1);
+
+	found = find_library(lib_path, sizeof(lib_path));
+	if (!found) {
+		fprintf(stderr,
+			"retrace attach: cannot find %s. Set RETRACE_LIB.\n",
+			RETRACE_LIB_NAME);
+		return 1;
+	}
+
+	/* The library constructor reads these at dlopen time. */
+	if (config)
+		setenv("RETRACE_JSON_CONFIG", config, 1);
+	if (logfile) {
+		setenv("RETRACE_LOGGER_DEF_FN", logfile, 1);
+		setenv("RETRACE_LOGGER_DEF_STDOUT_ENA", "0", 1);
+	}
+	if (quiet)
+		setenv("RETRACE_LOGGER_DEF_ENA", "0", 1);
+
+	lib = dlopen(lib_path, RTLD_NOW);
+	if (lib == NULL) {
+		fprintf(stderr, "retrace attach: dlopen(%s): %s\n",
+			lib_path, dlerror());
+		return 1;
+	}
+
+	attach_fn = (retrace_status_t (*)(int pid))dlsym(lib,
+		"retrace_attach_process");
+	if (attach_fn == NULL) {
+		fprintf(stderr,
+			"retrace attach: library lacks retrace_attach_process "
+			"(pre-v2.4.0 build?)\n");
+		dlclose(lib);
+		return 1;
+	}
+
+	fprintf(stderr, "retrace attach: tracing pid %d (ctrl-c to stop "
+		"tracing, target exits when it exits)\n", pid);
+
+	rc = attach_fn(pid);
+
+	switch (rc) {
+	case 0:
+		fprintf(stderr, "retrace attach: target exited\n");
+		break;
+	case -7: /* RETRACE_ERR_PERMISSION */
+		fprintf(stderr,
+			"retrace attach: permission denied (ptrace).\n"
+			"  - run as root, or\n"
+			"  - attach to a child process, or\n"
+			"  - set /proc/sys/kernel/yama/ptrace_scope to 0 "
+			"(security tradeoff)\n");
+		break;
+	case -6: /* RETRACE_ERR_UNSUPPORTED */
+		fprintf(stderr,
+			"retrace attach: unsupported on this platform "
+			"(Linux only)\n");
+		break;
+	case -3: /* RETRACE_ERR_NOENT */
+		fprintf(stderr,
+			"retrace attach: ptrace backend not available in "
+			"this build\n");
+		break;
+	default:
+		fprintf(stderr, "retrace attach: failed (status %d)\n",
+			(int)rc);
+		break;
+	}
+
+	dlclose(lib);
+	return rc == 0 ? 0 : 1;
+}
+
+/*
+ * retrace backends
+ *
+ * List the backends compiled into this build (preload_elf, preload_macho,
+ * ptrace, ...). Discoverability for the interposition mechanisms
+ * available on this platform.
+ */
+static int cmd_backends(void)
+{
+	char lib_path[PATH_MAX];
+	char *found;
+	void *lib;
+	retrace_status_t (*list_fn)(const char *const **names,
+				    size_t *count);
+	const char *const *names;
+	size_t count;
+	size_t i;
+
+	/* Pure listing: keep the library's constructor log out of the
+	 * way (it would otherwise emit a JSON banner to stdout).
+	 */
+	setenv("RETRACE_LOGGER_DEF_STDOUT_ENA", "0", 1);
+
+	found = find_library(lib_path, sizeof(lib_path));
+	if (!found) {
+		fprintf(stderr,
+			"retrace backends: cannot find %s. Set RETRACE_LIB.\n",
+			RETRACE_LIB_NAME);
+		return 1;
+	}
+
+	lib = dlopen(lib_path, RTLD_NOW);
+	if (lib == NULL) {
+		fprintf(stderr, "retrace backends: dlopen(%s): %s\n",
+			lib_path, dlerror());
+		return 1;
+	}
+
+	list_fn = (retrace_status_t(*)(const char *const **names,
+				       size_t *count))
+		dlsym(lib, "retrace_list_backends");
+	if (list_fn == NULL) {
+		fprintf(stderr,
+			"retrace backends: library lacks "
+			"retrace_list_backends (pre-v2.4.0 build?)\n");
+		dlclose(lib);
+		return 1;
+	}
+
+	if (list_fn(&names, &count) != 0 || count == 0) {
+		fprintf(stderr, "retrace backends: none registered\n");
+		dlclose(lib);
+		return 1;
+	}
+
+	printf("%zu backend%s registered:\n", count, count == 1 ? "" : "s");
+	for (i = 0; i < count; i++)
+		printf("  %s\n", names[i]);
+
+	dlclose(lib);
+	return 0;
+}
+
 int main(int argc, char **argv)
 {
 	if (argc < 2) {
@@ -966,6 +1174,14 @@ int main(int argc, char **argv)
 
 	if (strcmp(argv[1], "run") == 0) {
 		return cmd_run(argc - 2, &argv[2]);
+	}
+
+	if (strcmp(argv[1], "attach") == 0) {
+		return cmd_attach(argc - 2, &argv[2]);
+	}
+
+	if (strcmp(argv[1], "backends") == 0) {
+		return cmd_backends();
 	}
 
 	if (strcmp(argv[1], "trace") == 0) {

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -1079,3 +1079,48 @@ target_include_directories(retrace_test_parson_budget PRIVATE
 add_test(NAME unit-test-parson-budget
     COMMAND retrace_test_parson_budget)
 set_tests_properties(unit-test-parson-budget PROPERTIES LABELS "unit")
+
+#
+# Native process attach tests (v2.4.0). Exercises the public
+# retrace_attach_process / retrace_list_backends APIs. On Linux the
+# attach leg forks a child and PTRACE_ATTACHes to it (permitted for
+# a direct child under default yama); elsewhere it verifies the
+# clean-failure contract. Needs the full engine + backends because
+# the ptrace trace loop dispatches through retrace_engine_wrapper.
+#
+add_executable(retrace_test_attach test_attach.c)
+set_target_properties(retrace_test_attach PROPERTIES
+    OUTPUT_NAME test_attach
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/test/unit")
+
+target_link_libraries(retrace_test_attach PRIVATE
+    retrace_core
+    retrace_config_json
+    retrace_backends
+    ${_unit_backend_lib}
+    retrace_preload_common
+    retrace_headers
+    ${CMAKE_DL_LIBS}
+    Threads::Threads)
+
+target_include_directories(retrace_test_attach PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/core
+    ${CMAKE_SOURCE_DIR}/src/backends
+    ${CMAKE_SOURCE_DIR}/src/config/json
+    ${_unit_arch_include})
+
+if(RETRACE_PLATFORM_LINUX OR RETRACE_PLATFORM_FREEBSD)
+    target_compile_definitions(retrace_test_attach PRIVATE _GNU_SOURCE _DEFAULT_SOURCE)
+elseif(RETRACE_PLATFORM_DARWIN)
+    target_compile_definitions(retrace_test_attach PRIVATE _DARWIN_C_SOURCE)
+endif()
+
+# The ptrace backend only exists on Linux; link it in so the real
+# attach path (not just the failure path) is exercised there.
+if(RETRACE_PLATFORM_LINUX)
+    target_link_libraries(retrace_test_attach PRIVATE retrace_backend_ptrace)
+endif()
+
+add_test(NAME unit-test-attach
+    COMMAND retrace_test_attach)
+set_tests_properties(unit-test-attach PROPERTIES LABELS "unit")

--- a/test/unit/test_attach.c
+++ b/test/unit/test_attach.c
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+/*
+ * Integration test for native process attach (v2.4.0).
+ *
+ * Exercises the public retrace_attach_process() API end-to-end on
+ * Linux: forks a child, attaches to it while it runs, arms a
+ * timeout to terminate the child, and verifies the trace loop ran
+ * to completion (attach returns 0 when the target exits).
+ *
+ * Also verifies retrace_list_backends(): at least one backend must
+ * be registered, and on Linux the ptrace backend must be present.
+ *
+ * The attach leg requires PTRACE_ATTACH on a direct child, which
+ * is permitted in default container/CI configurations (ptrace of
+ * your own child; no yama relaxation needed).
+ *
+ * The trace output itself goes wherever RETRACE_LOGGER_DEF_FN
+ * points; ctest sets it to a temp file. We assert the loop
+ * completed, not specific syscalls -- the exact syscall set of a
+ * pause()-ing child varies by libc.
+ */
+
+#include <retrace/retrace.h>
+#include <retrace/backend.h>
+
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+static int tests_run;
+static int tests_pass;
+static int tests_fail;
+
+#define TEST(name) do { \
+	tests_run++; \
+	printf("  TEST %s ... ", #name); \
+	test_##name(); \
+	tests_pass++; \
+	printf("OK\n"); \
+} while (0)
+
+#define CHECK(cond) do { \
+	if (!(cond)) { \
+		printf("FAIL [%s:%d] %s\n", __FILE__, __LINE__, #cond); \
+		tests_fail++; \
+		return; \
+	} \
+} while (0)
+
+static void test_list_backends_returns_entries(void)
+{
+	const char *const *names = NULL;
+	size_t count = 0;
+	retrace_status_t rc;
+	size_t i;
+
+	rc = retrace_list_backends(NULL, NULL);
+	CHECK(rc != 0);
+
+	rc = retrace_list_backends(&names, &count);
+	CHECK(rc == 0);
+	CHECK(count > 0);
+	CHECK(names != NULL);
+
+	/* Every name non-NULL, non-empty. */
+	for (i = 0; i < count; i++) {
+		CHECK(names[i] != NULL);
+		CHECK(names[i][0] != '\0');
+	}
+
+	printf("[%zu: ", count);
+	for (i = 0; i < count; i++)
+		printf("%s%s", i > 0 ? " " : "", names[i]);
+	printf("] ");
+}
+
+static void test_attach_invalid_pid_rejected(void)
+{
+	CHECK(retrace_attach_process(0) != 0);
+	CHECK(retrace_attach_process(-1) != 0);
+}
+
+#ifdef __linux__
+#include <sys/ptrace.h>
+
+static pid_t g_child_pid;
+static sig_atomic_t g_kill_sent;
+
+/*
+ * Timeout: if attach has not returned within ATTACH_TIMEOUT_SEC
+ * (child failed to exit), kill the child so the trace loop's
+ * waitpid observes the exit and retrace_attach_process returns.
+ */
+#define ATTACH_TIMEOUT_SEC 10
+
+static void on_alarm(int sig)
+{
+	(void) sig;
+	if (!g_kill_sent) {
+		g_kill_sent = 1;
+		kill(g_child_pid, SIGKILL);
+	}
+}
+
+static void test_attach_to_running_child(void)
+{
+	pid_t child;
+	retrace_status_t rc;
+
+	child = fork();
+	if (child == 0) {
+		/* Child: park until the parent kills us. */
+		pause();
+		_exit(0);
+	}
+	CHECK(child > 0);
+	g_child_pid = child;
+	g_kill_sent = 0;
+
+	signal(SIGALRM, on_alarm);
+	alarm(ATTACH_TIMEOUT_SEC);
+
+	rc = retrace_attach_process((int)child);
+
+	alarm(0);
+	signal(SIGALRM, SIG_DFL);
+
+	if (!g_kill_sent) {
+		/* The child should still be alive post-attach only if
+		 * something went wrong; clean up either way.
+		 */
+		kill(child, SIGKILL);
+	}
+	waitpid(child, NULL, 0);
+
+	/* PTRACE_ATTACH of a direct child is permitted under default
+	 * yama (ptrace_scope 1) and in CI containers. If permission
+	 * was denied, report distinctly rather than as a hard fail.
+	 */
+	if (rc == RETRACE_ERR_PERMISSION) {
+		printf("(SKIPPED: ptrace permission denied) ");
+		return;
+	}
+
+	CHECK(rc == RETRACE_OK);
+}
+#else
+static void test_attach_to_running_child(void)
+{
+	/* Non-Linux: the API must fail cleanly, never return OK.
+	 * NOENT = no ptrace backend compiled in (typical macOS/Windows
+	 * build); UNSUPPORTED = backend present but platform-refuses.
+	 */
+	retrace_status_t rc = retrace_attach_process(12345);
+
+	CHECK(rc == RETRACE_ERR_NOENT || rc == RETRACE_ERR_UNSUPPORTED);
+}
+#endif
+
+int main(void)
+{
+	printf("-- retrace_list_backends --\n");
+	TEST(list_backends_returns_entries);
+
+	printf("-- attach input validation --\n");
+	TEST(attach_invalid_pid_rejected);
+
+	printf("-- attach to a running process --\n");
+	TEST(attach_to_running_child);
+
+	printf("\nPass: %d, Fail: %d (of %d)\n",
+		tests_pass, tests_fail, tests_run);
+	return tests_fail == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Bumps retrace from v2.3.8 to **v2.4.0** (MINOR per ADR-0006: new capability, backwards-compatible). Native process attach — `retrace attach <pid>` — reaching the targets `LD_PRELOAD` structurally cannot: any running PID, no restart, no control of the launch.

## What's in the bump

### `retrace attach <pid>` (Linux)

Attaches via ptrace and traces syscalls until the target exits. Same JSON output as `retrace run`; feeds the same downstream tools (audit, diff, replay). Clean failure elsewhere: NOENT when the ptrace backend isn't compiled in; PERMISSION with ptrace_scope guidance.

### `retrace backends`

Lists the interposition backends compiled into the library (`preload-elf`, `preload-macho`, `preload-msvc`, `ptrace`, ...).

### New public API (`include/retrace/retrace.h`)

- `retrace_attach_process(pid)` — explicit ptrace lookup, bypassing the static-binary probe. Attach semantics differ from spawn: for a process you cannot exec, ptrace is the sole native mechanism regardless of how the binary was linked.
- `retrace_list_backends(&names, &count)`.

### Implementation notes

- `registry.c` owns both new entry points (it owns backend lookup).
- `trace_loop.c`: removed a NULL-engine early return that defended an unsatisfiable contract — `struct retrace_engine` is never instantiated; syscall dispatch goes through the process-global `retrace_engine_wrapper`. The handle survives in the signature for the backend API contract.
- CLI dlopens the library it already locates (`find_library`) and dlsyms the new symbols; config env set before dlopen so the constructor picks it up — same contract as `run`.

### Tests (`test/unit/test_attach.c`, 3 cases)

- Backend enumeration returns ≥ 1 registered, names valid.
- Invalid pid (0, -1) rejected.
- **Linux**: fork child + PTRACE_ATTACH + alarm-kill round trip verifying the trace loop runs to completion; skips gracefully on ptrace-permission denial. **Non-Linux**: the API fails cleanly (NOENT/UNSUPPORTED), never OK. Verified 3/3 on macOS locally; the Linux legs of the CI matrix exercise the real attach path.

### Docs

- `cli.md`: sections for both subcommands (with ptrace-permission troubleshooting).
- `README.adoc`: What's-new v2.4.0 + ecosystem table row.
- Cookbook 29 (Frida): notes native attach next to the Frida path — Frida remains the answer for non-child processes under locked-down ptrace, iOS/macOS.

## Test plan

- [x] `cmake -B build -G Ninja -DRETRACE_BUILD_TESTS=ON`
- [x] `cmake --build build`
- [x] `ctest --test-dir build` — 51/51 pass (was 50)
- [x] `./build/test/unit/test_attach` — 3/3 pass on macOS (Linux attach leg runs in CI)
- [x] `retrace backends` — clean output, lists `preload-macho` on macOS
- [x] `retrace attach <pid>` — clean "ptrace backend not available" on macOS, exit 1
- [x] `./build/src/cli/retrace --help` banner reads `v2.4.0`
- [x] No AI attribution in commit message
- [ ] CI green on all matrix legs (Linux legs exercise the real attach)
- [ ] After merge: tag v2.4.0; release.yml produces binary artifacts

## Tagging plan

After PR rebase-merges, tag `v2.4.0` at the merge commit. release.yml will produce per-platform binary artifacts.
