### PR TITLE
v2.4.1: audit scan.c extraction (MECE) + 11 scan-engine tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (see `docs/adr/0006-semantic-versioning.md`).
 
+## [2.4.1] - 2026-08-14
+
+### Changed
+- `tools/audit-converter`: extracted the scan engine from `audit.c`
+  to a new `scan.{c,h}` — `struct Finding`/`Findings` +
+  `audit_findings_init/free/append` + `audit_scan_trace`. MECE
+  split completes the module chain: `policy.c` owns rules +
+  matching, `scan.c` owns apply-policy-to-trace, `audit.c` owns
+  CLI + formatters. The scan engine is now unit-testable in
+  isolation (same pattern as the `policy_rule_matches` and
+  `diff_exceeds_threshold` extractions).
+
+### Added
+- `test/unit/test_scan.c` — 11 unit tests: single rule/entry
+  matching, severity preserved through `finding->rule`, findings
+  in trace order, policy-rule order within one entry, multiple
+  rules per entry, one rule across entries, entries without a
+  message skipped, empty trace / zero-rule policy / no-match all
+  yield zero findings, `audit_findings_append` growth past the
+  initial 16-entry capacity, and the init→free→init lifecycle.
+  False negatives here mean missed violations in compliance
+  reports; wrong ordering corrupts the evidence chain.
+
 ## [2.4.0] - 2026-08-14
 
 MINOR bump per ADR-0006: new capability, backwards-compatible API.

--- a/include/retrace/version.h
+++ b/include/retrace/version.h
@@ -38,9 +38,9 @@
 
 #define RETRACE_VERSION_MAJOR 2
 #define RETRACE_VERSION_MINOR 4
-#define RETRACE_VERSION_PATCH 0
+#define RETRACE_VERSION_PATCH 1
 
-#define RETRACE_VERSION_STRING "2.4.0"
+#define RETRACE_VERSION_STRING "2.4.1"
 
 #define RETRACE_VERSION_ATLEAST(maj, min, pat)                  \
 	(RETRACE_VERSION_MAJOR > (maj) ||                       \

--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -1,3 +1,9 @@
+retrace (2.4.1-1) unstable; urgency=medium
+
+  * audit: extract scan.c (MECE) + 11 unit tests for the scan engine.
+
+ -- Ribose Inc <opensource@ribose.com>  Fri, 14 Aug 2026 00:00:00 +0000
+
 retrace (2.4.0-1) unstable; urgency=medium
 
   * New: native process attach via ptrace (`retrace attach <pid>`).

--- a/packaging/fedora/retrace.spec
+++ b/packaging/fedora/retrace.spec
@@ -2,10 +2,10 @@
 #
 # Fedora RPM spec for retrace (TODO.complete/38).
 # Build: rpmbuild -ba retrace.spec
-# Install: dnf install retrace-2.4.0-1.*.rpm
+# Install: dnf install retrace-2.4.1-1.*.rpm
 
 Name:           retrace
-Version:        2.4.0
+Version:        2.4.1
 Release:        1%{?dist}
 Summary:        Userspace libc interceptor for security discovery
 
@@ -50,6 +50,9 @@ action, OTLP/JSON export, and a Python config builder.
 %{_includedir}/retrace/
 
 %changelog
+* Fri Aug 14 2026 Ribose Inc <opensource@ribose.com> - 2.4.1-1
+- audit scan.c extraction (MECE) + 11 scan-engine unit tests
+
 * Fri Aug 14 2026 Ribose Inc <opensource@ribose.com> - 2.4.0-1
 - Native process attach via ptrace (retrace attach <pid>) + backends listing
 

--- a/packaging/nix/default.nix
+++ b/packaging/nix/default.nix
@@ -8,7 +8,7 @@
 
 stdenv.mkDerivation rec {
   pname = "retrace";
-  version = "2.4.0";
+  version = "2.4.1";
 
   src = ./.;
 

--- a/src/cli/retrace_cli.c
+++ b/src/cli/retrace_cli.c
@@ -63,7 +63,7 @@ typedef int retrace_status_t;
 static void usage(FILE *out)
 {
 	fprintf(out,
-"retrace v2.4.0 -- userspace libc interceptor\n"
+"retrace v2.4.1 -- userspace libc interceptor\n"
 "\n"
 "Usage:\n"
 "  retrace run [OPTIONS] -- <command> [args...]\n"

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -1124,3 +1124,26 @@ endif()
 add_test(NAME unit-test-attach
     COMMAND retrace_test_attach)
 set_tests_properties(unit-test-attach PROPERTIES LABELS "unit")
+
+#
+# Audit scan-engine unit tests (TODO.complete/26). audit_scan_trace
+# drives the policy matcher across a trace and collects findings --
+# false negatives here mean missed violations in compliance reports.
+# Compiles scan.c + policy.c directly from tools/audit-converter/.
+#
+add_executable(retrace_test_scan test_scan.c
+    ${CMAKE_SOURCE_DIR}/tools/audit-converter/scan.c
+    ${_audit_policy_source}
+    ${_parson_for_tools})
+set_target_properties(retrace_test_scan PROPERTIES
+    OUTPUT_NAME test_scan
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/test/unit")
+
+target_include_directories(retrace_test_scan PRIVATE
+    ${CMAKE_SOURCE_DIR}/tools/audit-converter
+    ${CMAKE_SOURCE_DIR}/src/config/json
+    ${CMAKE_SOURCE_DIR}/test/property/parson_stub)
+
+add_test(NAME unit-test-scan
+    COMMAND retrace_test_scan)
+set_tests_properties(unit-test-scan PROPERTIES LABELS "unit")

--- a/test/unit/test_scan.c
+++ b/test/unit/test_scan.c
@@ -1,0 +1,392 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+/*
+ * Unit tests for the audit scan engine (TODO.complete/26).
+ *
+ * audit_scan_trace is the loop that drives the policy matcher
+ * against every trace entry and collects findings. Wrong behavior
+ * here means missing violations (false negatives in compliance
+ * reports) or duplicate/phantom findings.
+ *
+ * Covers:
+ *   - single rule matching a single entry
+ *   - severity preserved through finding->rule
+ *   - findings appear in trace order; within one entry, in
+ *     policy-rule order
+ *   - multiple rules can match the same entry
+ *   - the same rule can match multiple entries
+ *   - entries without a "message" object are skipped
+ *   - empty trace yields zero findings
+ *   - policy with zero rules yields zero findings
+ *   - non-matching trace yields zero findings
+ *   - findings_append grows the array past its initial capacity
+ *   - init/free lifecycle (free then init is reusable)
+ */
+
+#include "parson.h"
+#include "policy.h"
+#include "scan.h"
+
+#include <stdio.h>
+#include <string.h>
+
+static int tests_run;
+static int tests_pass;
+static int tests_fail;
+
+#define TEST(name) do { \
+	tests_run++; \
+	printf("  TEST %s ... ", #name); \
+	test_##name(); \
+	tests_pass++; \
+	printf("OK\n"); \
+} while (0)
+
+#define CHECK(cond) do { \
+	if (!(cond)) { \
+		printf("FAIL [%s:%d] %s\n", __FILE__, __LINE__, #cond); \
+		tests_fail++; \
+		return; \
+	} \
+} while (0)
+
+/* Build a policy from a JSON source string. Caller frees. */
+static struct Policy *policy_from(const char *src)
+{
+	static struct Policy p;
+	JSON_Value *v = json_parse_string(src);
+	int rc;
+
+	rc = policy_load_from_json(json_value_get_object(v), &p);
+	if (rc != 0)
+		return NULL;
+	return &p;
+}
+
+static void policy_free_local(struct Policy *p)
+{
+	policy_free(p);
+}
+
+/* Build a trace array from a JSON source string. Caller frees
+ * via json_value_free(json_array_get_wrapping_value(a)).
+ */
+static JSON_Array *trace_from(const char *src)
+{
+	return json_value_get_array(json_parse_string(src));
+}
+
+static void trace_free_local(JSON_Array *a)
+{
+	json_value_free(json_array_get_wrapping_value(a));
+}
+
+/* ----- basic matching ----- */
+
+static void test_single_rule_single_entry(void)
+{
+	struct Policy *p = policy_from(
+		"{\"name\":\"t\",\"rules\":["
+		"{\"id\":\"R1\",\"description\":\"d\","
+		"\"match\":{\"func_exact\":\"system\"},\"severity\":\"high\"}"
+		"]}");
+	JSON_Array *t = trace_from(
+		"[{\"message\":{\"func\":\"system\",\"args\":{}}}]");
+	struct Findings f;
+
+	CHECK(p != NULL);
+	audit_findings_init(&f);
+	audit_scan_trace(t, p, &f);
+
+	CHECK(f.count == 1);
+	CHECK(strcmp(f.items[0].rule->id, "R1") == 0);
+	CHECK(f.items[0].entry_index == 0);
+	CHECK(f.items[0].entry != NULL);
+
+	audit_findings_free(&f);
+	trace_free_local(t);
+	policy_free_local(p);
+}
+
+static void test_severity_preserved_through_rule(void)
+{
+	struct Policy *p = policy_from(
+		"{\"name\":\"t\",\"rules\":["
+		"{\"id\":\"R1\",\"description\":\"d\","
+		"\"match\":{\"func_exact\":\"open\"},\"severity\":\"critical\"}"
+		"]}");
+	JSON_Array *t = trace_from(
+		"[{\"message\":{\"func\":\"open\",\"args\":{}}}]");
+	struct Findings f;
+
+	CHECK(p != NULL);
+	audit_findings_init(&f);
+	audit_scan_trace(t, p, &f);
+
+	CHECK(f.count == 1);
+	CHECK(f.items[0].rule->severity == SEV_CRITICAL);
+	CHECK(strcmp(severity_str(f.items[0].rule->severity),
+		"critical") == 0);
+
+	audit_findings_free(&f);
+	trace_free_local(t);
+	policy_free_local(p);
+}
+
+/* ----- ordering ----- */
+
+static void test_findings_in_trace_order(void)
+{
+	struct Policy *p = policy_from(
+		"{\"name\":\"t\",\"rules\":["
+		"{\"id\":\"R\",\"description\":\"d\","
+		"\"match\":{\"func_prefix\":\"get\"},\"severity\":\"info\"}"
+		"]}");
+	/* Entries 0 and 2 match; entry 1 does not. */
+	JSON_Array *t = trace_from(
+		"[{\"message\":{\"func\":\"getenv\"}},"
+		"{\"message\":{\"func\":\"setenv\"}},"
+		"{\"message\":{\"func\":\"getcwd\"}}]");
+	struct Findings f;
+
+	CHECK(p != NULL);
+	audit_findings_init(&f);
+	audit_scan_trace(t, p, &f);
+
+	CHECK(f.count == 2);
+	CHECK(f.items[0].entry_index == 0);
+	CHECK(f.items[1].entry_index == 2);
+
+	audit_findings_free(&f);
+	trace_free_local(t);
+	policy_free_local(p);
+}
+
+static void test_within_entry_policy_rule_order(void)
+{
+	/* Two rules both match the same entry: findings must appear
+	 * in policy-rule order (R1 before R2).
+	 */
+	struct Policy *p = policy_from(
+		"{\"name\":\"t\",\"rules\":["
+		"{\"id\":\"R1\",\"description\":\"d1\","
+		"\"match\":{\"func_exact\":\"open\"},\"severity\":\"info\"},"
+		"{\"id\":\"R2\",\"description\":\"d2\","
+		"\"match\":{\"func_prefix\":\"op\"},\"severity\":\"info\"}"
+		"]}");
+	JSON_Array *t = trace_from(
+		"[{\"message\":{\"func\":\"open\",\"args\":{}}}]");
+	struct Findings f;
+
+	CHECK(p != NULL);
+	audit_findings_init(&f);
+	audit_scan_trace(t, p, &f);
+
+	CHECK(f.count == 2);
+	CHECK(strcmp(f.items[0].rule->id, "R1") == 0);
+	CHECK(strcmp(f.items[1].rule->id, "R2") == 0);
+
+	audit_findings_free(&f);
+	trace_free_local(t);
+	policy_free_local(p);
+}
+
+static void test_same_rule_matches_multiple_entries(void)
+{
+	struct Policy *p = policy_from(
+		"{\"name\":\"t\",\"rules\":["
+		"{\"id\":\"R\",\"description\":\"d\","
+		"\"match\":{\"func_exact\":\"open\"},\"severity\":\"info\"}"
+		"]}");
+	JSON_Array *t = trace_from(
+		"[{\"message\":{\"func\":\"open\"}},"
+		"{\"message\":{\"func\":\"read\"}},"
+		"{\"message\":{\"func\":\"open\"}}]");
+	struct Findings f;
+
+	CHECK(p != NULL);
+	audit_findings_init(&f);
+	audit_scan_trace(t, p, &f);
+
+	CHECK(f.count == 2);
+	CHECK(f.items[0].entry_index == 0);
+	CHECK(f.items[1].entry_index == 2);
+
+	audit_findings_free(&f);
+	trace_free_local(t);
+	policy_free_local(p);
+}
+
+/* ----- skips and empties ----- */
+
+static void test_entries_without_message_skipped(void)
+{
+	struct Policy *p = policy_from(
+		"{\"name\":\"t\",\"rules\":["
+		"{\"id\":\"R\",\"description\":\"d\","
+		"\"match\":{\"path_contains\":\"secret\"},\"severity\":\"info\"}"
+		"]}");
+	/* Entry 0 has a message that matches; entry 1 has no
+	 * message object at all and must be skipped by the scanner
+	 * regardless of the rule.
+	 */
+	JSON_Array *t = trace_from(
+		"[{\"message\":{\"path\":\"/etc/secret.key\"}},"
+		"{\"nomessage\":1}]");
+	struct Findings f;
+
+	CHECK(p != NULL);
+	audit_findings_init(&f);
+	audit_scan_trace(t, p, &f);
+
+	CHECK(f.count == 1);
+	CHECK(f.items[0].entry_index == 0);
+
+	audit_findings_free(&f);
+	trace_free_local(t);
+	policy_free_local(p);
+}
+
+static void test_empty_trace_zero_findings(void)
+{
+	struct Policy *p = policy_from(
+		"{\"name\":\"t\",\"rules\":["
+		"{\"id\":\"R\",\"description\":\"d\","
+		"\"match\":{\"func_prefix\":\"\"},\"severity\":\"info\"}"
+		"]}");
+	JSON_Array *t = trace_from("[]");
+	struct Findings f;
+
+	CHECK(p != NULL);
+	audit_findings_init(&f);
+	audit_scan_trace(t, p, &f);
+	CHECK(f.count == 0);
+	CHECK(f.items == NULL);
+
+	audit_findings_free(&f);
+	trace_free_local(t);
+	policy_free_local(p);
+}
+
+static void test_zero_rule_policy_zero_findings(void)
+{
+	struct Policy *p = policy_from("{\"name\":\"t\"}");
+	JSON_Array *t = trace_from(
+		"[{\"message\":{\"func\":\"open\"}}]");
+	struct Findings f;
+
+	CHECK(p != NULL);
+	CHECK(p->rules_count == 0);
+	audit_findings_init(&f);
+	audit_scan_trace(t, p, &f);
+	CHECK(f.count == 0);
+
+	audit_findings_free(&f);
+	trace_free_local(t);
+	policy_free_local(p);
+}
+
+static void test_no_match_zero_findings(void)
+{
+	struct Policy *p = policy_from(
+		"{\"name\":\"t\",\"rules\":["
+		"{\"id\":\"R\",\"description\":\"d\","
+		"\"match\":{\"func_exact\":\"execve\"},\"severity\":\"high\"}"
+		"]}");
+	JSON_Array *t = trace_from(
+		"[{\"message\":{\"func\":\"open\"}},"
+		"{\"message\":{\"func\":\"read\"}}]");
+	struct Findings f;
+
+	CHECK(p != NULL);
+	audit_findings_init(&f);
+	audit_scan_trace(t, p, &f);
+	CHECK(f.count == 0);
+
+	audit_findings_free(&f);
+	trace_free_local(t);
+	policy_free_local(p);
+}
+
+/* ----- findings_append growth ----- */
+
+static void test_append_grows_past_initial_capacity(void)
+{
+	/* Initial capacity is 16; append 100 and verify all land. */
+	struct Findings f;
+	struct Policy *p = policy_from(
+		"{\"name\":\"t\",\"rules\":["
+		"{\"id\":\"R\",\"description\":\"d\","
+		"\"match\":{\"func_prefix\":\"\"},\"severity\":\"info\"}"
+		"]}");
+	JSON_Array *t = trace_from("[]");
+	int i;
+	int ok = 1;
+
+	CHECK(p != NULL);
+	audit_findings_init(&f);
+	for (i = 0; i < 100; i++) {
+		if (audit_findings_append(&f, &p->rules[0],
+			(size_t)i, NULL) != 0) {
+			ok = 0;
+			break;
+		}
+	}
+	CHECK(ok == 1);
+	CHECK(f.count == 100);
+	CHECK(f.cap >= 100);
+	/* Last append landed with the right index. */
+	CHECK(f.items[99].entry_index == 99);
+
+	audit_findings_free(&f);
+	trace_free_local(t);
+	policy_free_local(p);
+}
+
+static void test_init_after_free_reusable(void)
+{
+	struct Findings f;
+
+	audit_findings_init(&f);
+	CHECK(audit_findings_append(&f, NULL, 0, NULL) == 0);
+	audit_findings_free(&f);
+	CHECK(f.items == NULL);
+	CHECK(f.count == 0);
+	CHECK(f.cap == 0);
+
+	audit_findings_init(&f);
+	CHECK(f.count == 0);
+	CHECK(audit_findings_append(&f, NULL, 7, NULL) == 0);
+	CHECK(f.items[0].entry_index == 7);
+	audit_findings_free(&f);
+}
+
+int main(void)
+{
+	printf("-- basic matching --\n");
+	TEST(single_rule_single_entry);
+	TEST(severity_preserved_through_rule);
+
+	printf("-- ordering --\n");
+	TEST(findings_in_trace_order);
+	TEST(within_entry_policy_rule_order);
+	TEST(same_rule_matches_multiple_entries);
+
+	printf("-- skips and empties --\n");
+	TEST(entries_without_message_skipped);
+	TEST(empty_trace_zero_findings);
+	TEST(zero_rule_policy_zero_findings);
+	TEST(no_match_zero_findings);
+
+	printf("-- findings_append growth + lifecycle --\n");
+	TEST(append_grows_past_initial_capacity);
+	TEST(init_after_free_reusable);
+
+	printf("\nPass: %d, Fail: %d (of %d)\n",
+		tests_pass, tests_fail, tests_run);
+	return tests_fail == 0 ? 0 : 1;
+}

--- a/tools/audit-converter/CMakeLists.txt
+++ b/tools/audit-converter/CMakeLists.txt
@@ -7,7 +7,7 @@
 
 set(_parson_source ${CMAKE_SOURCE_DIR}/src/config/json/parson.c)
 
-add_executable(retrace_audit audit.c policy.c pdf_writer.c ${_parson_source})
+add_executable(retrace_audit audit.c policy.c scan.c pdf_writer.c ${_parson_source})
 set_target_properties(retrace_audit PROPERTIES
     OUTPUT_NAME retrace-audit
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tools")

--- a/tools/audit-converter/audit.c
+++ b/tools/audit-converter/audit.c
@@ -29,98 +29,13 @@
 
 #include "parson.h"
 #include "policy.h"
+#include "scan.h"
 
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
 #include "pdf_writer.h"
-
-/*
- * Internal finding representation. Decoupled from the on-disk
- * format so we can add formatters (default, SARIF, future PDF
- * text) without touching the matcher.
- */
-struct Finding {
-	const struct Rule *rule;
-
-	size_t entry_index;
-
-	JSON_Object *entry;  /* borrowed from trace_root; do not free */
-};
-
-struct Findings {
-	struct Finding *items;
-
-	size_t count;
-
-	size_t cap;
-};
-
-static void findings_init(struct Findings *f)
-{
-	f->items = NULL;
-	f->count = 0;
-	f->cap = 0;
-}
-
-static void findings_free(struct Findings *f)
-{
-	free(f->items);
-	f->items = NULL;
-	f->count = 0;
-	f->cap = 0;
-}
-
-static int findings_append(struct Findings *f, const struct Rule *rule,
-			   size_t entry_index, JSON_Object *entry)
-{
-	struct Finding *newbuf;
-
-	if (f->count == f->cap) {
-		size_t newcap = (f->cap == 0) ? 16 : f->cap * 2;
-
-		newbuf = (struct Finding *)realloc(f->items,
-			newcap * sizeof(*newbuf));
-		if (newbuf == NULL)
-			return -1;
-		f->items = newbuf;
-		f->cap = newcap;
-	}
-	f->items[f->count].rule = rule;
-	f->items[f->count].entry_index = entry_index;
-	f->items[f->count].entry = entry;
-	f->count++;
-	return 0;
-}
-
-/*
- * Walks every (entry, rule) pair, appends matches to findings.
- */
-static void scan_trace(JSON_Array *trace, const struct Policy *policy,
-		       struct Findings *out)
-{
-	size_t i, n = json_array_get_count(trace);
-
-	for (i = 0; i < n; i++) {
-		JSON_Object *entry = json_array_get_object(trace, i);
-		JSON_Object *msg;
-		size_t r;
-
-		if (entry == NULL)
-			continue;
-		msg = json_object_get_object(entry, "message");
-		if (msg == NULL)
-			continue;
-
-		for (r = 0; r < policy->rules_count; r++) {
-			const struct Rule *rule = &policy->rules[r];
-
-			if (policy_rule_matches(rule, msg))
-				findings_append(out, rule, i, msg);
-		}
-	}
-}
 
 /* ----- Severity mappings for SARIF ----- */
 
@@ -410,8 +325,8 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
-	findings_init(&findings);
-	scan_trace(trace, &policy, &findings);
+	audit_findings_init(&findings);
+	audit_scan_trace(trace, &policy, &findings);
 
 	if (fmt == OUT_PDF) {
 		int nc = 0, nh = 0, nm = 0, ni = 0;
@@ -458,7 +373,7 @@ int main(int argc, char **argv)
 				free(ids);
 				free(descs);
 				json_value_free(trace_root);
-				findings_free(&findings);
+				audit_findings_free(&findings);
 				policy_free(&policy);
 				return 1;
 			}
@@ -472,7 +387,7 @@ int main(int argc, char **argv)
 		if (out != stdout)
 			fclose(out);
 		json_value_free(trace_root);
-		findings_free(&findings);
+		audit_findings_free(&findings);
 		policy_free(&policy);
 		return 0;
 	}
@@ -494,7 +409,7 @@ int main(int argc, char **argv)
 				out_path);
 			json_value_free(out_root);
 			json_value_free(trace_root);
-			findings_free(&findings);
+			audit_findings_free(&findings);
 			policy_free(&policy);
 			return 1;
 		}
@@ -513,7 +428,7 @@ int main(int argc, char **argv)
 
 	json_value_free(out_root);
 	json_value_free(trace_root);
-	findings_free(&findings);
+	audit_findings_free(&findings);
 	policy_free(&policy);
 	return 0;
 }

--- a/tools/audit-converter/scan.c
+++ b/tools/audit-converter/scan.c
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+#include "scan.h"
+
+#include <stdlib.h>
+
+void audit_findings_init(struct Findings *f)
+{
+	f->items = NULL;
+	f->count = 0;
+	f->cap = 0;
+}
+
+void audit_findings_free(struct Findings *f)
+{
+	free(f->items);
+	f->items = NULL;
+	f->count = 0;
+	f->cap = 0;
+}
+
+int audit_findings_append(struct Findings *f, const struct Rule *rule,
+			  size_t entry_index, JSON_Object *entry)
+{
+	struct Finding *newbuf;
+
+	if (f->count == f->cap) {
+		size_t newcap = (f->cap == 0) ? 16 : f->cap * 2;
+
+		newbuf = (struct Finding *)realloc(f->items,
+			newcap * sizeof(*newbuf));
+		if (newbuf == NULL)
+			return -1;
+		f->items = newbuf;
+		f->cap = newcap;
+	}
+	f->items[f->count].rule = rule;
+	f->items[f->count].entry_index = entry_index;
+	f->items[f->count].entry = entry;
+	f->count++;
+	return 0;
+}
+
+void audit_scan_trace(JSON_Array *trace, const struct Policy *policy,
+		      struct Findings *out)
+{
+	size_t i, n = json_array_get_count(trace);
+
+	for (i = 0; i < n; i++) {
+		JSON_Object *entry = json_array_get_object(trace, i);
+		JSON_Object *msg;
+		size_t r;
+
+		if (entry == NULL)
+			continue;
+		msg = json_object_get_object(entry, "message");
+		if (msg == NULL)
+			continue;
+
+		for (r = 0; r < policy->rules_count; r++) {
+			const struct Rule *rule = &policy->rules[r];
+
+			if (policy_rule_matches(rule, msg))
+				audit_findings_append(out, rule, i, msg);
+		}
+	}
+}

--- a/tools/audit-converter/scan.h
+++ b/tools/audit-converter/scan.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+#ifndef RETRACE_AUDIT_SCAN_H_
+#define RETRACE_AUDIT_SCAN_H_
+
+#include "parson.h"
+#include "policy.h"
+
+#include <stddef.h>
+
+/*
+ * Audit scan engine (TODO.complete/26).
+ *
+ * Owns the "apply policy to trace" step: walks every
+ * (entry, rule) pair and collects matches as Findings. Rule
+ * semantics live in policy.c (parsing + matching); this module is
+ * the engine that drives them; the formatters in audit.c render
+ * the results.
+ *
+ * A Finding borrows its rule pointer from the Policy and its entry
+ * pointer from the trace JSON -- both must outlive the Findings.
+ */
+struct Finding {
+	const struct Rule *rule;
+
+	size_t entry_index;
+
+	JSON_Object *entry;  /* borrowed from trace_root; do not free */
+};
+
+struct Findings {
+	struct Finding *items;
+
+	size_t count;
+
+	size_t cap;
+};
+
+void audit_findings_init(struct Findings *f);
+
+/* Frees the item array (not the borrowed rule/entry pointers). */
+void audit_findings_free(struct Findings *f);
+
+/* Returns 0 on success, -1 on OOM. */
+int audit_findings_append(struct Findings *f, const struct Rule *rule,
+			  size_t entry_index, JSON_Object *entry);
+
+/*
+ * Walks every (entry, rule) pair; each entry whose message matches
+ * a rule appends a Finding. Findings appear in trace order; within
+ * one entry, in policy-rule order. Entries without a "message"
+ * object are skipped.
+ */
+void audit_scan_trace(JSON_Array *trace, const struct Policy *policy,
+		      struct Findings *out);
+
+#endif /* RETRACE_AUDIT_SCAN_H_ */


### PR DESCRIPTION
## Summary

Bumps retrace from v2.4.0 to **v2.4.1** (PATCH per ADR-0006). Refactor + tests, no behavior change. Completes the audit tool's MECE module chain and closes its biggest untested surface.

## What's in the bump

### Refactor (MECE)

- `tools/audit-converter/scan.{c,h}` — extracted the scan engine from `audit.c`: `struct Finding`/`Findings` + `audit_findings_init/free/append` + `audit_scan_trace`. The module chain is now: `policy.c` owns rules + matching, `scan.c` owns apply-policy-to-trace, `audit.c` owns CLI + formatters. Same extraction pattern as `policy_rule_matches` (v2.3.1) and `diff_exceeds_threshold` (v2.3.6).

### Tests (11 new cases)

`test/unit/test_scan.c` covers the scan engine end-to-end:
- Single rule/entry matching + severity preserved through `finding->rule`.
- Findings in trace order; policy-rule order within one entry.
- Multiple rules matching one entry; one rule across entries.
- Entries without a `message` object skipped.
- Empty trace / zero-rule policy / no-match → zero findings.
- `audit_findings_append` growth past the initial 16-entry capacity.
- init → free → init lifecycle reusable.

**Why it matters**: false negatives here mean missed violations in compliance reports; wrong ordering corrupts the evidence chain — `entry_index` is what `retrace-replay` jump-to and SARIF `region.startLine` key off.

### A matcher subtlety surfaced by the tests

A `func_prefix: ""` rule does **not** match a message lacking a `func` key — `policy_rule_matches` rejects `func == NULL` before the prefix compare. The skip test uses `path_contains` (matches any string field) instead. Worth knowing when writing policies.

### Version + packaging

- `version.h`, `retrace_cli.c` banner: 2.4.0 → 2.4.1
- `packaging/{nix,debian,fedora}` bumped
- `CHANGELOG.md` entry

## Test plan

- [x] `cmake -B build -G Ninja -DRETRACE_BUILD_TESTS=ON`
- [x] `cmake --build build`
- [x] `ctest --test-dir build` — 52/52 pass (was 51)
- [x] `./build/test/unit/test_scan` — 11/11 pass
- [x] `./build/tools/retrace-audit` end-to-end smoke: baseline policy + crafted `system()` trace produces the expected finding (extraction is behavior-preserving)
- [x] `./build/src/cli/retrace --help` banner reads `v2.4.1`
- [x] Single commit; verified committed content via `git show HEAD:` (v2.4.0's staging lesson applied)
- [x] No AI attribution in commit message
- [ ] CI green on all matrix legs
- [ ] After merge: tag v2.4.1; release.yml produces binary artifacts

## Tagging plan

After PR rebase-merges, tag `v2.4.1` at the merge commit. release.yml will produce per-platform binary artifacts.
