### PR TITLE
v2.4.2: audit format.c extraction (MECE) + 11 formatter tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (see `docs/adr/0006-semantic-versioning.md`).
 
+## [2.4.2] - 2026-08-14
+
+### Changed
+- `tools/audit-converter`: extracted the output formatters from
+  `audit.c` to a new `format.{c,h}` -- `audit_sarif_level`,
+  `audit_format_default`, `audit_format_sarif`. Completes the
+  tool's MECE chain: `policy.c` (rules + matching) -> `scan.c`
+  (apply-to-trace) -> `format.c` (render) -> `audit.c` (CLI).
+
+### Added
+- `test/unit/test_format.c` -- 11 unit tests. SARIF coverage pins
+  everything GitHub Code Scanning keys off: the 2.1.0 skeleton
+  (version, $schema, single run, driver name), per-result
+  ruleId/level/message.text, severity->level mapping
+  (critical/high -> error, medium -> warning, info -> note),
+  1-based region.startLine, artifactLocation.uri, and the
+  zero-findings empty-results contract. Default-format coverage
+  pins policy/trace fields, per-finding evidence (deep-copied
+  entry), summary counts per severity, and the zeroed summary.
+
 ## [2.4.1] - 2026-08-14
 
 ### Changed

--- a/include/retrace/version.h
+++ b/include/retrace/version.h
@@ -38,9 +38,9 @@
 
 #define RETRACE_VERSION_MAJOR 2
 #define RETRACE_VERSION_MINOR 4
-#define RETRACE_VERSION_PATCH 1
+#define RETRACE_VERSION_PATCH 2
 
-#define RETRACE_VERSION_STRING "2.4.1"
+#define RETRACE_VERSION_STRING "2.4.2"
 
 #define RETRACE_VERSION_ATLEAST(maj, min, pat)                  \
 	(RETRACE_VERSION_MAJOR > (maj) ||                       \

--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -1,3 +1,9 @@
+retrace (2.4.2-1) unstable; urgency=medium
+
+  * audit: extract format.c (MECE) + 11 formatter tests (SARIF + default).
+
+ -- Ribose Inc <opensource@ribose.com>  Fri, 14 Aug 2026 00:00:00 +0000
+
 retrace (2.4.1-1) unstable; urgency=medium
 
   * audit: extract scan.c (MECE) + 11 unit tests for the scan engine.

--- a/packaging/fedora/retrace.spec
+++ b/packaging/fedora/retrace.spec
@@ -2,10 +2,10 @@
 #
 # Fedora RPM spec for retrace (TODO.complete/38).
 # Build: rpmbuild -ba retrace.spec
-# Install: dnf install retrace-2.4.1-1.*.rpm
+# Install: dnf install retrace-2.4.2-1.*.rpm
 
 Name:           retrace
-Version:        2.4.1
+Version:        2.4.2
 Release:        1%{?dist}
 Summary:        Userspace libc interceptor for security discovery
 
@@ -50,6 +50,9 @@ action, OTLP/JSON export, and a Python config builder.
 %{_includedir}/retrace/
 
 %changelog
+* Fri Aug 14 2026 Ribose Inc <opensource@ribose.com> - 2.4.2-1
+- audit format.c extraction (MECE) + 11 formatter tests
+
 * Fri Aug 14 2026 Ribose Inc <opensource@ribose.com> - 2.4.1-1
 - audit scan.c extraction (MECE) + 11 scan-engine unit tests
 

--- a/packaging/nix/default.nix
+++ b/packaging/nix/default.nix
@@ -8,7 +8,7 @@
 
 stdenv.mkDerivation rec {
   pname = "retrace";
-  version = "2.4.1";
+  version = "2.4.2";
 
   src = ./.;
 

--- a/src/cli/retrace_cli.c
+++ b/src/cli/retrace_cli.c
@@ -63,7 +63,7 @@ typedef int retrace_status_t;
 static void usage(FILE *out)
 {
 	fprintf(out,
-"retrace v2.4.1 -- userspace libc interceptor\n"
+"retrace v2.4.2 -- userspace libc interceptor\n"
 "\n"
 "Usage:\n"
 "  retrace run [OPTIONS] -- <command> [args...]\n"

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -1147,3 +1147,28 @@ target_include_directories(retrace_test_scan PRIVATE
 add_test(NAME unit-test-scan
     COMMAND retrace_test_scan)
 set_tests_properties(unit-test-scan PROPERTIES LABELS "unit")
+
+#
+# Audit formatter unit tests (TODO.complete/26). audit_format_sarif
+# is what GitHub Code Scanning ingests -- a structural regression
+# breaks alert ingestion silently. Pins the SARIF 2.1.0 skeleton
+# and every field Code Scanning keys off, plus the default report.
+# Compiles format.c + scan.c + policy.c from tools/audit-converter/.
+#
+add_executable(retrace_test_format test_format.c
+    ${CMAKE_SOURCE_DIR}/tools/audit-converter/format.c
+    ${CMAKE_SOURCE_DIR}/tools/audit-converter/scan.c
+    ${_audit_policy_source}
+    ${_parson_for_tools})
+set_target_properties(retrace_test_format PROPERTIES
+    OUTPUT_NAME test_format
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/test/unit")
+
+target_include_directories(retrace_test_format PRIVATE
+    ${CMAKE_SOURCE_DIR}/tools/audit-converter
+    ${CMAKE_SOURCE_DIR}/src/config/json
+    ${CMAKE_SOURCE_DIR}/test/property/parson_stub)
+
+add_test(NAME unit-test-format
+    COMMAND retrace_test_format)
+set_tests_properties(unit-test-format PROPERTIES LABELS "unit")

--- a/test/unit/test_format.c
+++ b/test/unit/test_format.c
@@ -1,0 +1,461 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+/*
+ * Unit tests for the audit output formatters (TODO.complete/26).
+ *
+ * audit_format_sarif is what GitHub Code Scanning and Azure DevOps
+ * ingest natively -- a structural regression here breaks security
+ * alert ingestion silently (the upload succeeds; the alerts never
+ * render). These tests pin the SARIF 2.1.0 skeleton and every
+ * field Code Scanning keys off:
+ *   version, $schema, runs[0].tool.driver.name,
+ *   results[].ruleId / level / message.text / region.startLine.
+ *
+ * audit_format_default is the human report: policy name, trace
+ * path, per-finding evidence (deep-copied entry), and the summary
+ * counts. Pinned here for the same reason.
+ *
+ * Covers:
+ *   - audit_sarif_level: all four severities -> error/warning/note
+ *   - SARIF skeleton (version, $schema, single run, driver name)
+ *   - SARIF ruleId + level per finding
+ *   - SARIF message.text from rule description
+ *   - SARIF region.startLine = entry_index + 1 (1-based)
+ *   - SARIF artifactLocation.uri = trace path
+ *   - SARIF zero findings -> empty results array
+ *   - default: policy + trace fields
+ *   - default: finding fields incl. deep-copied entry evidence
+ *   - default: summary counts per severity
+ *   - default: zero findings -> zeroed summary
+ */
+
+#include "parson.h"
+#include "policy.h"
+#include "scan.h"
+#include "format.h"
+
+#include <stdio.h>
+#include <string.h>
+
+static int tests_run;
+static int tests_pass;
+static int tests_fail;
+
+#define TEST(name) do { \
+	tests_run++; \
+	printf("  TEST %s ... ", #name); \
+	test_##name(); \
+	tests_pass++; \
+	printf("OK\n"); \
+} while (0)
+
+#define CHECK(cond) do { \
+	if (!(cond)) { \
+		printf("FAIL [%s:%d] %s\n", __FILE__, __LINE__, #cond); \
+		tests_fail++; \
+		return; \
+	} \
+} while (0)
+
+/* Fixture: one policy with one rule per severity, and one trace
+ * entry that matches all of them (func_exact "open" + prefix
+ * "op" both hit a func named "open").
+ */
+static const char *policy_src =
+	"{\"name\":\"fmt-test\",\"rules\":["
+	"{\"id\":\"CRIT\",\"description\":\"crit rule\","
+	"\"match\":{\"func_exact\":\"open\"},\"severity\":\"critical\"},"
+	"{\"id\":\"HIGH\",\"description\":\"high rule\","
+	"\"match\":{\"func_prefix\":\"op\"},\"severity\":\"high\"},"
+	"{\"id\":\"MED\",\"description\":\"med rule\","
+	"\"match\":{\"path_contains\":\"secret\"},\"severity\":\"medium\"},"
+	"{\"id\":\"INFO\",\"description\":\"info rule\","
+	"\"match\":{\"env_pattern\":\"*_TOKEN\"},\"severity\":\"info\"}"
+	"]}";
+
+static const char *trace_src =
+	"[{\"message\":{\"func\":\"open\",\"path\":\"/etc/secret.key\"}}]";
+
+struct Fixture {
+	struct Policy policy;
+	JSON_Value *trace_v;
+	JSON_Array *trace;
+	struct Findings findings;
+};
+
+static int fixture_setup(struct Fixture *fx)
+{
+	JSON_Value *pv = json_parse_string(policy_src);
+	int rc;
+
+	memset(fx, 0, sizeof(*fx));
+	rc = policy_load_from_json(json_value_get_object(pv), &fx->policy);
+	json_value_free(pv);
+	if (rc != 0)
+		return -1;
+
+	fx->trace_v = json_parse_string(trace_src);
+	fx->trace = json_value_get_array(fx->trace_v);
+	if (fx->trace == NULL)
+		return -1;
+
+	audit_findings_init(&fx->findings);
+	audit_scan_trace(fx->trace, &fx->policy, &fx->findings);
+	return 0;
+}
+
+static void fixture_teardown(struct Fixture *fx)
+{
+	audit_findings_free(&fx->findings);
+	json_value_free(fx->trace_v);
+	policy_free(&fx->policy);
+}
+
+/* ----- audit_sarif_level ----- */
+
+static void test_sarif_level_mapping(void)
+{
+	CHECK(strcmp(audit_sarif_level(SEV_CRITICAL), "error") == 0);
+	CHECK(strcmp(audit_sarif_level(SEV_HIGH), "error") == 0);
+	CHECK(strcmp(audit_sarif_level(SEV_MEDIUM), "warning") == 0);
+	CHECK(strcmp(audit_sarif_level(SEV_INFO), "note") == 0);
+	CHECK(strcmp(audit_sarif_level((enum Severity)42), "note") == 0);
+}
+
+/* ----- SARIF skeleton ----- */
+
+static void test_sarif_skeleton(void)
+{
+	struct Fixture fx;
+	JSON_Value *out;
+	JSON_Object *root;
+	JSON_Array *runs;
+	JSON_Object *run;
+	JSON_Object *driver;
+
+	CHECK(fixture_setup(&fx) == 0);
+	out = audit_format_sarif(&fx.policy, "/t.json", &fx.findings);
+	CHECK(out != NULL);
+	root = json_value_get_object(out);
+
+	CHECK(strcmp(json_object_get_string(root, "version"), "2.1.0") == 0);
+	CHECK(strstr(json_object_get_string(root, "$schema"),
+		"sarif-2.1.0.json") != NULL);
+
+	runs = json_object_get_array(root, "runs");
+	CHECK(json_array_get_count(runs) == 1);
+	run = json_array_get_object(runs, 0);
+	CHECK(run != NULL);
+
+	driver = json_object_get_object(
+		json_object_get_object(run, "tool"), "driver");
+	CHECK(driver != NULL);
+	CHECK(strcmp(json_object_get_string(driver, "name"),
+		"retrace-audit") == 0);
+
+	json_value_free(out);
+	fixture_teardown(&fx);
+}
+
+/* ----- SARIF per-finding fields ----- */
+
+static void test_sarif_ruleid_and_level(void)
+{
+	struct Fixture fx;
+	JSON_Value *out;
+	JSON_Array *results;
+
+	CHECK(fixture_setup(&fx) == 0);
+	/* func "open" matches CRIT (exact) and HIGH (prefix);
+	 * path contains "secret" matches MED. INFO (env) does not.
+	 */
+	CHECK(fx.findings.count == 3);
+
+	out = audit_format_sarif(&fx.policy, "/t.json", &fx.findings);
+	{
+		JSON_Object *root = json_value_get_object(out);
+		JSON_Array *runs = json_object_get_array(root, "runs");
+		JSON_Object *run = json_array_get_object(runs, 0);
+		JSON_Array *results = json_object_get_array(run, "results");
+
+		CHECK(json_array_get_count(results) == 3);
+
+		CHECK(strcmp(json_object_get_string(
+			json_array_get_object(results, 0), "ruleId"),
+			"CRIT") == 0);
+		CHECK(strcmp(json_object_get_string(
+			json_array_get_object(results, 0), "level"),
+			"error") == 0);
+		CHECK(strcmp(json_object_get_string(
+			json_array_get_object(results, 1), "ruleId"),
+			"HIGH") == 0);
+		CHECK(strcmp(json_object_get_string(
+			json_array_get_object(results, 1), "level"),
+			"error") == 0);
+		CHECK(strcmp(json_object_get_string(
+			json_array_get_object(results, 2), "ruleId"),
+			"MED") == 0);
+		CHECK(strcmp(json_object_get_string(
+			json_array_get_object(results, 2), "level"),
+			"warning") == 0);
+	}
+
+	json_value_free(out);
+	fixture_teardown(&fx);
+}
+
+static void test_sarif_message_text(void)
+{
+	struct Fixture fx;
+	JSON_Value *out;
+	JSON_Object *root;
+	JSON_Array *runs;
+	JSON_Object *run;
+	JSON_Array *results;
+	JSON_Object *msg;
+
+	CHECK(fixture_setup(&fx) == 0);
+	out = audit_format_sarif(&fx.policy, "/t.json", &fx.findings);
+	root = json_value_get_object(out);
+	runs = json_object_get_array(root, "runs");
+	run = json_array_get_object(runs, 0);
+	results = json_object_get_array(run, "results");
+
+	msg = json_object_get_object(json_array_get_object(results, 0),
+		"message");
+	CHECK(msg != NULL);
+	CHECK(strcmp(json_object_get_string(msg, "text"),
+		"crit rule") == 0);
+
+	json_value_free(out);
+	fixture_teardown(&fx);
+}
+
+static void test_sarif_startline_is_one_based(void)
+{
+	struct Fixture fx;
+	JSON_Value *out;
+	JSON_Object *root;
+	JSON_Array *runs;
+	JSON_Object *run;
+	JSON_Array *results;
+	JSON_Object *loc;
+	JSON_Object *phys;
+	JSON_Object *region;
+	size_t i;
+
+	CHECK(fixture_setup(&fx) == 0);
+	out = audit_format_sarif(&fx.policy, "/t.json", &fx.findings);
+	root = json_value_get_object(out);
+	runs = json_object_get_array(root, "runs");
+	run = json_array_get_object(runs, 0);
+	results = json_object_get_array(run, "results");
+
+	for (i = 0; i < json_array_get_count(results); i++) {
+		loc = json_array_get_object(json_object_get_array(
+			json_array_get_object(results, i), "locations"), 0);
+		CHECK(loc != NULL);
+		phys = json_object_get_object(loc, "physicalLocation");
+		CHECK(phys != NULL);
+		region = json_object_get_object(phys, "region");
+		CHECK(region != NULL);
+		/* Entry index 0 -> startLine 1. */
+		CHECK(json_object_get_number(region, "startLine") == 1.0);
+	}
+
+	json_value_free(out);
+	fixture_teardown(&fx);
+}
+
+static void test_sarif_artifact_uri(void)
+{
+	struct Fixture fx;
+	JSON_Value *out;
+	JSON_Object *root;
+	JSON_Array *runs;
+	JSON_Object *run;
+	JSON_Array *results;
+	JSON_Object *loc;
+	JSON_Object *phys;
+	JSON_Object *art;
+
+	CHECK(fixture_setup(&fx) == 0);
+	out = audit_format_sarif(&fx.policy, "/my/trace.json", &fx.findings);
+	root = json_value_get_object(out);
+	runs = json_object_get_array(root, "runs");
+	run = json_array_get_object(runs, 0);
+	results = json_object_get_array(run, "results");
+	CHECK(json_array_get_count(results) > 0);
+
+	loc = json_array_get_object(json_object_get_array(
+		json_array_get_object(results, 0), "locations"), 0);
+	CHECK(loc != NULL);
+	phys = json_object_get_object(loc, "physicalLocation");
+	CHECK(phys != NULL);
+	art = json_object_get_object(phys, "artifactLocation");
+	CHECK(art != NULL);
+	CHECK(strcmp(json_object_get_string(art, "uri"),
+		"/my/trace.json") == 0);
+
+	json_value_free(out);
+	fixture_teardown(&fx);
+}
+
+static void test_sarif_zero_findings_empty_results(void)
+{
+	struct Fixture fx;
+	JSON_Value *out;
+	JSON_Object *root;
+	JSON_Array *runs;
+	JSON_Object *run;
+	JSON_Array *results;
+
+	CHECK(fixture_setup(&fx) == 0);
+	audit_findings_free(&fx.findings);
+	audit_findings_init(&fx.findings);
+
+	out = audit_format_sarif(&fx.policy, "/t.json", &fx.findings);
+	root = json_value_get_object(out);
+	runs = json_object_get_array(root, "runs");
+	run = json_array_get_object(runs, 0);
+	results = json_object_get_array(run, "results");
+	CHECK(json_array_get_count(results) == 0);
+
+	json_value_free(out);
+	fixture_teardown(&fx);
+}
+
+/* ----- default format ----- */
+
+static void test_default_policy_and_trace_fields(void)
+{
+	struct Fixture fx;
+	JSON_Value *out;
+	JSON_Object *root;
+
+	CHECK(fixture_setup(&fx) == 0);
+	out = audit_format_default(&fx.policy, "/t.json", &fx.findings);
+	root = json_value_get_object(out);
+
+	CHECK(strcmp(json_object_get_string(root, "policy"),
+		"fmt-test") == 0);
+	CHECK(strcmp(json_object_get_string(root, "trace"),
+		"/t.json") == 0);
+
+	json_value_free(out);
+	fixture_teardown(&fx);
+}
+
+static void test_default_finding_fields_and_evidence(void)
+{
+	struct Fixture fx;
+	JSON_Value *out;
+	JSON_Object *root;
+	JSON_Array *arr;
+	JSON_Object *f0;
+	JSON_Object *entry;
+
+	CHECK(fixture_setup(&fx) == 0);
+	out = audit_format_default(&fx.policy, "/t.json", &fx.findings);
+	root = json_value_get_object(out);
+	arr = json_object_get_array(root, "findings");
+	CHECK(json_array_get_count(arr) == 3);
+
+	f0 = json_array_get_object(arr, 0);
+	CHECK(strcmp(json_object_get_string(f0, "rule_id"), "CRIT") == 0);
+	CHECK(strcmp(json_object_get_string(f0, "severity"),
+		"critical") == 0);
+	CHECK(strcmp(json_object_get_string(f0, "description"),
+		"crit rule") == 0);
+	CHECK(json_object_get_number(f0, "entry_index") == 0.0);
+
+	/* Evidence: deep copy of the triggering entry. */
+	entry = json_object_get_object(f0, "entry");
+	CHECK(entry != NULL);
+	CHECK(strcmp(json_object_get_string(entry, "func"), "open") == 0);
+	CHECK(strstr(json_object_get_string(entry, "path"),
+		"secret") != NULL);
+
+	json_value_free(out);
+	fixture_teardown(&fx);
+}
+
+static void test_default_summary_counts(void)
+{
+	struct Fixture fx;
+	JSON_Value *out;
+	JSON_Object *root;
+	JSON_Object *summary;
+
+	CHECK(fixture_setup(&fx) == 0);
+	out = audit_format_default(&fx.policy, "/t.json", &fx.findings);
+	root = json_value_get_object(out);
+	summary = json_object_get_object(root, "summary");
+
+	CHECK(json_object_get_number(summary, "critical") == 1.0);
+	CHECK(json_object_get_number(summary, "high") == 1.0);
+	CHECK(json_object_get_number(summary, "medium") == 1.0);
+	CHECK(json_object_get_number(summary, "info") == 0.0);
+
+	json_value_free(out);
+	fixture_teardown(&fx);
+}
+
+static void test_default_zero_findings_zeroed_summary(void)
+{
+	struct Fixture fx;
+	JSON_Value *out;
+	JSON_Object *root;
+	JSON_Object *summary;
+	JSON_Array *arr;
+
+	CHECK(fixture_setup(&fx) == 0);
+	audit_findings_free(&fx.findings);
+	audit_findings_init(&fx.findings);
+
+	out = audit_format_default(&fx.policy, "/t.json", &fx.findings);
+	root = json_value_get_object(out);
+	arr = json_object_get_array(root, "findings");
+	CHECK(json_array_get_count(arr) == 0);
+
+	summary = json_object_get_object(root, "summary");
+	CHECK(json_object_get_number(summary, "critical") == 0.0);
+	CHECK(json_object_get_number(summary, "high") == 0.0);
+	CHECK(json_object_get_number(summary, "medium") == 0.0);
+	CHECK(json_object_get_number(summary, "info") == 0.0);
+
+	json_value_free(out);
+	fixture_teardown(&fx);
+}
+
+int main(void)
+{
+	printf("-- audit_sarif_level --\n");
+	TEST(sarif_level_mapping);
+
+	printf("-- SARIF skeleton --\n");
+	TEST(sarif_skeleton);
+
+	printf("-- SARIF per-finding fields --\n");
+	TEST(sarif_ruleid_and_level);
+	TEST(sarif_message_text);
+	TEST(sarif_startline_is_one_based);
+	TEST(sarif_artifact_uri);
+
+	printf("-- SARIF zero findings --\n");
+	TEST(sarif_zero_findings_empty_results);
+
+	printf("-- default format --\n");
+	TEST(default_policy_and_trace_fields);
+	TEST(default_finding_fields_and_evidence);
+	TEST(default_summary_counts);
+	TEST(default_zero_findings_zeroed_summary);
+
+	printf("\nPass: %d, Fail: %d (of %d)\n",
+		tests_pass, tests_fail, tests_run);
+	return tests_fail == 0 ? 0 : 1;
+}

--- a/tools/audit-converter/CMakeLists.txt
+++ b/tools/audit-converter/CMakeLists.txt
@@ -7,7 +7,7 @@
 
 set(_parson_source ${CMAKE_SOURCE_DIR}/src/config/json/parson.c)
 
-add_executable(retrace_audit audit.c policy.c scan.c pdf_writer.c ${_parson_source})
+add_executable(retrace_audit audit.c policy.c scan.c format.c pdf_writer.c ${_parson_source})
 set_target_properties(retrace_audit PROPERTIES
     OUTPUT_NAME retrace-audit
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tools")

--- a/tools/audit-converter/audit.c
+++ b/tools/audit-converter/audit.c
@@ -30,192 +30,13 @@
 #include "parson.h"
 #include "policy.h"
 #include "scan.h"
+#include "format.h"
 
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
 #include "pdf_writer.h"
-
-/* ----- Severity mappings for SARIF ----- */
-
-static const char *sarif_level(enum Severity s)
-{
-	switch (s) {
-	case SEV_CRITICAL:
-		return "error";
-	case SEV_HIGH:
-		return "error";
-	case SEV_MEDIUM:
-		return "warning";
-	case SEV_INFO:
-	default:
-		return "note";
-	}
-}
-
-/* ----- Formatters ----- */
-
-static JSON_Value *format_default(const struct Policy *policy,
-				  const char *trace_path,
-				  const struct Findings *findings)
-{
-	JSON_Value *root = json_value_init_object();
-	JSON_Object *obj = json_value_get_object(root);
-	JSON_Array *arr;
-	JSON_Object *summary;
-	size_t i;
-
-	json_object_set_string(obj, "policy", policy->name);
-	json_object_set_string(obj, "trace", trace_path);
-
-	arr = json_value_get_array(json_value_init_array());
-	json_object_set_value(obj, "findings",
-		json_array_get_wrapping_value(arr));
-
-	for (i = 0; i < findings->count; i++) {
-		const struct Finding *f = &findings->items[i];
-		JSON_Value *fv = json_value_init_object();
-		JSON_Object *fo = json_value_get_object(fv);
-		JSON_Value *entry_copy;
-
-		json_object_set_string(fo, "rule_id", f->rule->id);
-		json_object_set_string(fo, "severity",
-			severity_str(f->rule->severity));
-		json_object_set_string(fo, "description", f->rule->description);
-		json_object_set_number(fo, "entry_index",
-			(double)f->entry_index);
-		entry_copy = json_value_deep_copy(
-			json_object_get_wrapping_value(f->entry));
-		json_object_set_value(fo, "entry", entry_copy);
-		json_array_append_value(arr, fv);
-	}
-
-	summary = json_value_get_object(json_value_init_object());
-	json_object_set_value(obj, "summary",
-		json_object_get_wrapping_value(summary));
-	json_object_set_number(summary, "critical", 0);
-	json_object_set_number(summary, "high", 0);
-	json_object_set_number(summary, "medium", 0);
-	json_object_set_number(summary, "info", 0);
-	for (i = 0; i < findings->count; i++) {
-		const char *sev = severity_str(findings->items[i].rule->severity);
-		double cur = json_object_get_number(summary, sev);
-
-		json_object_set_number(summary, sev, cur + 1);
-	}
-
-	return root;
-}
-
-/*
- * SARIF 2.1.0 format. Schema:
- * https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html
- *
- * One run, one tool (retrace-audit). Each finding becomes a
- * result. ruleId is the policy rule's id; level is mapped from
- * severity (critical/high -> error, medium -> warning, info ->
- * note). The trace file is the artifactLocation; entry_index is
- * encoded as a region.startLine (1-based; SARIF doesn't have a
- * native "array index" concept, so we use line numbers as a
- * proxy).
- */
-static JSON_Value *format_sarif(const struct Policy *policy,
-				const char *trace_path,
-				const struct Findings *findings)
-{
-	JSON_Value *root = json_value_init_object();
-	JSON_Object *obj = json_value_get_object(root);
-	JSON_Array *runs;
-	JSON_Value *run_v;
-	JSON_Object *run;
-	JSON_Object *tool;
-	JSON_Object *driver;
-	JSON_Array *results;
-	size_t i;
-
-	json_object_set_string(obj, "$schema",
-		"https://json.schemastore.org/sarif-2.1.0.json");
-	json_object_set_string(obj, "version", "2.1.0");
-
-	runs = json_value_get_array(json_value_init_array());
-	json_object_set_value(obj, "runs",
-		json_array_get_wrapping_value(runs));
-
-	run_v = json_value_init_object();
-	run = json_value_get_object(run_v);
-	json_array_append_value(runs, run_v);
-
-	tool = json_value_get_object(json_value_init_object());
-	json_object_set_value(run, "tool",
-		json_object_get_wrapping_value(tool));
-
-	driver = json_value_get_object(json_value_init_object());
-	json_object_set_value(tool, "driver",
-		json_object_get_wrapping_value(driver));
-	json_object_set_string(driver, "name", "retrace-audit");
-	json_object_set_string(driver, "version", "0.1.0");
-	json_object_set_string(driver, "informationUri",
-		"https://github.com/riboseinc/retrace");
-
-	results = json_value_get_array(json_value_init_array());
-	json_object_set_value(run, "results",
-		json_array_get_wrapping_value(results));
-
-	for (i = 0; i < findings->count; i++) {
-		const struct Finding *f = &findings->items[i];
-		JSON_Value *rv = json_value_init_object();
-		JSON_Object *r = json_value_get_object(rv);
-		JSON_Object *msg;
-		JSON_Object *loc;
-		JSON_Object *phys;
-		JSON_Object *art;
-		JSON_Object *region;
-
-		json_object_set_string(r, "ruleId", f->rule->id);
-		json_object_set_string(r, "level", sarif_level(f->rule->severity));
-
-		msg = json_value_get_object(json_value_init_object());
-		json_object_set_value(r, "message",
-			json_object_get_wrapping_value(msg));
-		json_object_set_string(msg, "text", f->rule->description);
-
-		loc = json_value_get_object(json_value_init_object());
-		{
-			JSON_Array *locs = json_value_get_array(
-				json_value_init_array());
-
-			json_object_set_value(r, "locations",
-				json_array_get_wrapping_value(locs));
-			json_array_append_value(locs,
-				json_object_get_wrapping_value(loc));
-		}
-
-		phys = json_value_get_object(json_value_init_object());
-		json_object_set_value(loc, "physicalLocation",
-			json_object_get_wrapping_value(phys));
-
-		art = json_value_get_object(json_value_init_object());
-		json_object_set_value(phys, "artifactLocation",
-			json_object_get_wrapping_value(art));
-		json_object_set_string(art, "uri", trace_path);
-
-		region = json_value_get_object(json_value_init_object());
-		json_object_set_value(phys, "region",
-			json_object_get_wrapping_value(region));
-		/* SARIF region.startLine is 1-based; our entry_index
-		 * is 0-based. Bump by 1 so the first entry maps to
-		 * line 1.
-		 */
-		json_object_set_number(region, "startLine",
-			(double)f->entry_index + 1);
-
-		json_array_append_value(results, rv);
-	}
-
-	(void)policy;
-	return root;
-}
 
 /* ----- CLI ----- */
 
@@ -394,11 +215,11 @@ int main(int argc, char **argv)
 
 	switch (fmt) {
 	case OUT_SARIF:
-		out_root = format_sarif(&policy, trace_path, &findings);
+		out_root = audit_format_sarif(&policy, trace_path, &findings);
 		break;
 	case OUT_DEFAULT:
 	default:
-		out_root = format_default(&policy, trace_path, &findings);
+		out_root = audit_format_default(&policy, trace_path, &findings);
 		break;
 	}
 

--- a/tools/audit-converter/format.c
+++ b/tools/audit-converter/format.c
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+#include "format.h"
+
+#include <string.h>
+
+const char *audit_sarif_level(enum Severity s)
+{
+	switch (s) {
+	case SEV_CRITICAL:
+		return "error";
+	case SEV_HIGH:
+		return "error";
+	case SEV_MEDIUM:
+		return "warning";
+	case SEV_INFO:
+	default:
+		return "note";
+	}
+}
+
+JSON_Value *audit_format_default(const struct Policy *policy,
+				  const char *trace_path,
+				  const struct Findings *findings)
+{
+	JSON_Value *root = json_value_init_object();
+	JSON_Object *obj = json_value_get_object(root);
+	JSON_Array *arr;
+	JSON_Object *summary;
+	size_t i;
+
+	json_object_set_string(obj, "policy", policy->name);
+	json_object_set_string(obj, "trace", trace_path);
+
+	arr = json_value_get_array(json_value_init_array());
+	json_object_set_value(obj, "findings",
+		json_array_get_wrapping_value(arr));
+
+	for (i = 0; i < findings->count; i++) {
+		const struct Finding *f = &findings->items[i];
+		JSON_Value *fv = json_value_init_object();
+		JSON_Object *fo = json_value_get_object(fv);
+		JSON_Value *entry_copy;
+
+		json_object_set_string(fo, "rule_id", f->rule->id);
+		json_object_set_string(fo, "severity",
+			severity_str(f->rule->severity));
+		json_object_set_string(fo, "description", f->rule->description);
+		json_object_set_number(fo, "entry_index",
+			(double)f->entry_index);
+		entry_copy = json_value_deep_copy(
+			json_object_get_wrapping_value(f->entry));
+		json_object_set_value(fo, "entry", entry_copy);
+		json_array_append_value(arr, fv);
+	}
+
+	summary = json_value_get_object(json_value_init_object());
+	json_object_set_value(obj, "summary",
+		json_array_get_wrapping_value(summary));
+	json_object_set_number(summary, "critical", 0);
+	json_object_set_number(summary, "high", 0);
+	json_object_set_number(summary, "medium", 0);
+	json_object_set_number(summary, "info", 0);
+	for (i = 0; i < findings->count; i++) {
+		const char *sev = severity_str(findings->items[i].rule->severity);
+		double cur = json_object_get_number(summary, sev);
+
+		json_object_set_number(summary, sev, cur + 1);
+	}
+
+	return root;
+}
+
+JSON_Value *audit_format_sarif(const struct Policy *policy,
+			       const char *trace_path,
+			       const struct Findings *findings)
+{
+	JSON_Value *root = json_value_init_object();
+	JSON_Object *obj = json_value_get_object(root);
+	JSON_Array *runs;
+	JSON_Value *run_v;
+	JSON_Object *run;
+	JSON_Object *tool;
+	JSON_Object *driver;
+	JSON_Array *results;
+	size_t i;
+
+	json_object_set_string(obj, "$schema",
+		"https://json.schemastore.org/sarif-2.1.0.json");
+	json_object_set_string(obj, "version", "2.1.0");
+
+	runs = json_value_get_array(json_value_init_array());
+	json_object_set_value(obj, "runs",
+		json_array_get_wrapping_value(runs));
+
+	run_v = json_value_init_object();
+	run = json_value_get_object(run_v);
+	json_array_append_value(runs, run_v);
+
+	tool = json_value_get_object(json_value_init_object());
+	json_object_set_value(run, "tool",
+		json_object_get_wrapping_value(tool));
+
+	driver = json_value_get_object(json_value_init_object());
+	json_object_set_value(tool, "driver",
+		json_object_get_wrapping_value(driver));
+	json_object_set_string(driver, "name", "retrace-audit");
+	json_object_set_string(driver, "version", "0.1.0");
+	json_object_set_string(driver, "informationUri",
+		"https://github.com/riboseinc/retrace");
+
+	results = json_value_get_array(json_value_init_array());
+	json_object_set_value(run, "results",
+		json_array_get_wrapping_value(results));
+
+	for (i = 0; i < findings->count; i++) {
+		const struct Finding *f = &findings->items[i];
+		JSON_Value *rv = json_value_init_object();
+		JSON_Object *r = json_value_get_object(rv);
+		JSON_Object *msg;
+		JSON_Object *loc;
+		JSON_Object *phys;
+		JSON_Object *art;
+		JSON_Object *region;
+
+		json_object_set_string(r, "ruleId", f->rule->id);
+		json_object_set_string(r, "level",
+			audit_sarif_level(f->rule->severity));
+
+		msg = json_value_get_object(json_value_init_object());
+		json_object_set_value(r, "message",
+			json_object_get_wrapping_value(msg));
+		json_object_set_string(msg, "text", f->rule->description);
+
+		loc = json_value_get_object(json_value_init_object());
+		{
+			JSON_Array *locs = json_value_get_array(
+				json_value_init_array());
+
+			json_object_set_value(r, "locations",
+				json_array_get_wrapping_value(locs));
+			json_array_append_value(locs,
+				json_object_get_wrapping_value(loc));
+		}
+
+		phys = json_value_get_object(json_value_init_object());
+		json_object_set_value(loc, "physicalLocation",
+			json_object_get_wrapping_value(phys));
+
+		art = json_value_get_object(json_value_init_object());
+		json_object_set_value(phys, "artifactLocation",
+			json_object_get_wrapping_value(art));
+		json_object_set_string(art, "uri", trace_path);
+
+		region = json_value_get_object(json_value_init_object());
+		json_object_set_value(phys, "region",
+			json_object_get_wrapping_value(region));
+		/* SARIF region.startLine is 1-based; our entry_index
+		 * is 0-based. Bump by 1 so the first entry maps to
+		 * line 1.
+		 */
+		json_object_set_number(region, "startLine",
+			(double)f->entry_index + 1);
+
+		json_array_append_value(results, rv);
+	}
+
+	(void)policy;
+	return root;
+}

--- a/tools/audit-converter/format.h
+++ b/tools/audit-converter/format.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+#ifndef RETRACE_AUDIT_FORMAT_H_
+#define RETRACE_AUDIT_FORMAT_H_
+
+#include "parson.h"
+#include "scan.h"
+
+/*
+ * Audit output formatters (TODO.complete/26).
+ *
+ * Render a Findings set into a JSON document. Presentation only:
+ * no rule evaluation, no trace walking (those live in policy.c
+ * and scan.c). Each formatter returns a caller-owned JSON_Value.
+ */
+
+/*
+ * Maps a policy severity to the SARIF level vocabulary:
+ * critical/high -> "error", medium -> "warning", info -> "note".
+ */
+const char *audit_sarif_level(enum Severity s);
+
+/*
+ * Human-readable JSON: { policy, trace, findings[], summary }.
+ * Each finding carries rule_id, severity, description,
+ * entry_index, and a deep copy of the triggering log entry as
+ * evidence. summary counts findings per severity.
+ */
+JSON_Value *audit_format_default(const struct Policy *policy,
+				 const char *trace_path,
+				 const struct Findings *findings);
+
+/*
+ * SARIF 2.1.0 (OASIS standard; native input to GitHub Code
+ * Scanning, Azure DevOps, VS Code SARIF viewers). One run, one
+ * tool driver. Each finding becomes a result with ruleId, level
+ * (via audit_sarif_level), message.text, and a location whose
+ * region.startLine is entry_index+1 (SARIF lines are 1-based;
+ * entry_index is a 0-based array index used as a proxy).
+ */
+JSON_Value *audit_format_sarif(const struct Policy *policy,
+			       const char *trace_path,
+			       const struct Findings *findings);
+
+#endif /* RETRACE_AUDIT_FORMAT_H_ */


### PR DESCRIPTION
## Summary

Bumps retrace from v2.4.1 to **v2.4.2** (PATCH per ADR-0006). Refactor + tests, no behavior change. Completes the audit tool's MECE module chain and pins its SARIF output — the format GitHub Code Scanning ingests.

## What's in the bump

### Refactor (MECE)

- `tools/audit-converter/format.{c,h}` — extracted the output formatters from `audit.c`: `audit_sarif_level`, `audit_format_default`, `audit_format_sarif`. The chain is now: `policy.c` (rules + matching) → `scan.c` (apply-to-trace) → `format.c` (render) → `audit.c` (CLI). Each formatter returns a caller-owned `JSON_Value` — output is inspectable without stdout capture.

### Tests (11 new cases)

**SARIF** — pins everything Code Scanning keys off (a structural regression breaks alert ingestion *silently*: the upload succeeds, alerts never render):
- 2.1.0 skeleton: `version`, `$schema`, single run, driver name.
- Per-result `ruleId` + `level` ordering.
- `message.text` from rule description.
- Severity→level mapping: critical/high→`error`, medium→`warning`, info→`note` (+ unknown-enum default).
- `region.startLine = entry_index + 1` (1-based).
- `artifactLocation.uri` = trace path.
- Zero findings → empty `results` array.

**Default format** — pins the human report: policy/trace fields, per-finding evidence (deep-copied entry), summary counts per severity, zeroed summary on zero findings.

### Parson gotcha surfaced

`json_object_get_object` returns NULL for an array value — `"locations"` must be read via `json_object_get_array`. Cost one `strcmp(NULL, ...)` segfault to find; worth knowing when walking mixed-shape JSON.

### Version + packaging

- `version.h`, `retrace_cli.c` banner: 2.4.1 → 2.4.2
- `packaging/{nix,debian,fedora}` bumped
- `CHANGELOG.md` entry

## Test plan

- [x] `cmake -B build -G Ninja -DRETRACE_BUILD_TESTS=ON`
- [x] `cmake --build build`
- [x] `ctest --test-dir build` — 53/53 pass (was 52)
- [x] `./build/test/unit/test_format` — 11/11 pass
- [x] `./build/tools/retrace-audit` smoke in both formats (default + SARIF) — extraction is behavior-preserving
- [x] Single commit; verified committed content via `git show HEAD:` (no stale defs; `get_array` fix included)
- [x] No AI attribution in commit message
- [ ] CI green on all matrix legs
- [ ] After merge: tag v2.4.2; release.yml produces binary artifacts

## Tagging plan

After PR rebase-merges, tag `v2.4.2` at the merge commit. release.yml will produce per-platform binary artifacts.
