### PR TITLE
v2.4.3: trace-diff lcs.c extraction (MECE) + 17 alignment tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (see `docs/adr/0006-semantic-versioning.md`).
 
+## [2.4.3] - 2026-08-15
+
+### Changed
+- `tools/trace-diff`: extracted the LCS alignment from `diff.c` to
+  a new `lcs.{c,h}` -- `diff_lcs_len` (pure length) and
+  `diff_lcs_walk` (alignment emitted as typed MATCH/DELETE/INSERT
+  items via callback). The tool chain is now: `normalize.c`
+  (aggregation) -> `threshold.c` (gating) -> `lcs.c` (order
+  alignment) -> `diff.c` (CLI + printing). Behavior-preserving,
+  including the both-empty early return before the header.
+
+### Added
+- `test/unit/test_lcs.c` -- 17 unit tests: classic LCS lengths
+  (identical/disjoint/interleaved/textbook ABCBDAB vs BDCABA),
+  empty inputs, prefix cases; walk semantics (all-MATCH for
+  identical, only-edits for disjoint, one-side-empty);
+  the identities `edits = alen + blen - 2*lcs` and `items =
+  alen + blen - lcs`; pointer provenance (MATCH/DELETE names from
+  the before sequence, INSERT from after); alignment shape for
+  reorderings; early-stop via callback; NULL-callback safety.
+
 ## [2.4.2] - 2026-08-14
 
 ### Changed

--- a/include/retrace/version.h
+++ b/include/retrace/version.h
@@ -38,9 +38,9 @@
 
 #define RETRACE_VERSION_MAJOR 2
 #define RETRACE_VERSION_MINOR 4
-#define RETRACE_VERSION_PATCH 2
+#define RETRACE_VERSION_PATCH 3
 
-#define RETRACE_VERSION_STRING "2.4.2"
+#define RETRACE_VERSION_STRING "2.4.3"
 
 #define RETRACE_VERSION_ATLEAST(maj, min, pat)                  \
 	(RETRACE_VERSION_MAJOR > (maj) ||                       \

--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -1,3 +1,9 @@
+retrace (2.4.3-1) unstable; urgency=medium
+
+  * trace-diff: extract lcs.c (MECE) + 17 LCS alignment tests.
+
+ -- Ribose Inc <opensource@ribose.com>  Fri, 14 Aug 2026 00:00:00 +0000
+
 retrace (2.4.2-1) unstable; urgency=medium
 
   * audit: extract format.c (MECE) + 11 formatter tests (SARIF + default).

--- a/packaging/fedora/retrace.spec
+++ b/packaging/fedora/retrace.spec
@@ -2,10 +2,10 @@
 #
 # Fedora RPM spec for retrace (TODO.complete/38).
 # Build: rpmbuild -ba retrace.spec
-# Install: dnf install retrace-2.4.2-1.*.rpm
+# Install: dnf install retrace-2.4.3-1.*.rpm
 
 Name:           retrace
-Version:        2.4.2
+Version:        2.4.3
 Release:        1%{?dist}
 Summary:        Userspace libc interceptor for security discovery
 
@@ -50,6 +50,9 @@ action, OTLP/JSON export, and a Python config builder.
 %{_includedir}/retrace/
 
 %changelog
+* Sat Aug 15 2026 Ribose Inc <opensource@ribose.com> - 2.4.3-1
+- trace-diff lcs.c extraction (MECE) + 17 LCS alignment tests
+
 * Fri Aug 14 2026 Ribose Inc <opensource@ribose.com> - 2.4.2-1
 - audit format.c extraction (MECE) + 11 formatter tests
 

--- a/packaging/nix/default.nix
+++ b/packaging/nix/default.nix
@@ -8,7 +8,7 @@
 
 stdenv.mkDerivation rec {
   pname = "retrace";
-  version = "2.4.2";
+  version = "2.4.3";
 
   src = ./.;
 

--- a/src/cli/retrace_cli.c
+++ b/src/cli/retrace_cli.c
@@ -63,7 +63,7 @@ typedef int retrace_status_t;
 static void usage(FILE *out)
 {
 	fprintf(out,
-"retrace v2.4.2 -- userspace libc interceptor\n"
+"retrace v2.4.3 -- userspace libc interceptor\n"
 "\n"
 "Usage:\n"
 "  retrace run [OPTIONS] -- <command> [args...]\n"

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -1060,6 +1060,25 @@ add_test(NAME unit-test-threshold
 set_tests_properties(unit-test-threshold PROPERTIES LABELS "unit")
 
 #
+# LCS alignment unit tests (TODO.complete/27 P1). diff_lcs_walk
+# drives the call-order diff (cookbook 26): the edit count is what
+# CI gates on and the alignment is what users read. Pure algorithm,
+# no parson/normalize deps.
+#
+add_executable(retrace_test_lcs test_lcs.c
+    ${CMAKE_SOURCE_DIR}/tools/trace-diff/lcs.c)
+set_target_properties(retrace_test_lcs PROPERTIES
+    OUTPUT_NAME test_lcs
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/test/unit")
+
+target_include_directories(retrace_test_lcs PRIVATE
+    ${CMAKE_SOURCE_DIR}/tools/trace-diff)
+
+add_test(NAME unit-test-lcs
+    COMMAND retrace_test_lcs)
+set_tests_properties(unit-test-lcs PROPERTIES LABELS "unit")
+
+#
 # Parson allocation-budget regression tests (TODO.complete/33 P0).
 # Guards against regressions where someone tightens the budget
 # (breaking real configs) or fails to reset it between calls

--- a/test/unit/test_lcs.c
+++ b/test/unit/test_lcs.c
@@ -1,0 +1,365 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+/*
+ * Unit tests for the LCS alignment (TODO.complete/27 P1).
+ *
+ * diff_lcs_walk drives the call-order diff (cookbook 26): the
+ * edit count is what CI gates on and the alignment is what users
+ * read. Wrong LCS = false "behavior changed" alarms or missed
+ * reorderings.
+ *
+ * Covers:
+ *   - diff_lcs_len: identical / disjoint / interleaved / classic
+ *     LCS examples, empty inputs, prefix/suffix cases
+ *   - diff_lcs_walk: identical sequences emit all MATCH, 0 edits
+ *   - disjoint sequences emit only DELETE + INSERT
+ *   - one-side-empty emits only that side's items
+ *   - edit count = len(a) + len(b) - 2*lcs_len (identity)
+ *   - emitted item count = len(a) + len(b) - lcs_len
+ *   - early-stop: callback returning non-zero halts the walk
+ *   - MATCH items carry the before-side name; INSERT carry the
+ *     after-side name
+ *
+ * Items arrive in back-walk (tail-first) order by design -- the
+ * tests record then reverse where head-first assertions are
+ * clearer.
+ */
+
+#include "lcs.h"
+
+#include <stdio.h>
+#include <string.h>
+
+static int tests_run;
+static int tests_pass;
+static int tests_fail;
+
+#define TEST(name) do { \
+	tests_run++; \
+	printf("  TEST %s ... ", #name); \
+	test_##name(); \
+	tests_pass++; \
+	printf("OK\n"); \
+} while (0)
+
+#define CHECK(cond) do { \
+	if (!(cond)) { \
+		printf("FAIL [%s:%d] %s\n", __FILE__, __LINE__, #cond); \
+		tests_fail++; \
+		return; \
+	} \
+} while (0)
+
+/* Recording callback: captures items into a fixed array. */
+#define MAX_ITEMS 64
+struct Record {
+	struct diff_lcs_item items[MAX_ITEMS];
+	int count;
+	int stop_after;  /* if > 0, stop after this many items */
+};
+
+static int record_cb(const struct diff_lcs_item *item, void *p)
+{
+	struct Record *r = (struct Record *)p;
+
+	if (r->count < MAX_ITEMS)
+		r->items[r->count++] = *item;
+	if (r->stop_after > 0 && r->count >= r->stop_after)
+		return 1;
+	return 0;
+}
+
+static void record_init(struct Record *r)
+{
+	memset(r, 0, sizeof(*r));
+}
+
+static int count_type(const struct Record *r, enum diff_lcs_type t)
+{
+	int i, n = 0;
+
+	for (i = 0; i < r->count; i++)
+		if (r->items[i].type == t)
+			n++;
+	return n;
+}
+
+/* Reverse a record in place (back-walk -> head-first). */
+static void record_reverse(struct Record *r)
+{
+	int i;
+
+	for (i = 0; i < r->count / 2; i++) {
+		struct diff_lcs_item tmp = r->items[i];
+
+		r->items[i] = r->items[r->count - 1 - i];
+		r->items[r->count - 1 - i] = tmp;
+	}
+}
+
+/* ----- diff_lcs_len ----- */
+
+static void test_len_identical(void)
+{
+	const char *a[] = {"open", "read", "close"};
+
+	CHECK(diff_lcs_len(a, 3, a, 3) == 3);
+}
+
+static void test_len_disjoint(void)
+{
+	const char *a[] = {"open", "read"};
+	const char *b[] = {"send", "recv"};
+
+	CHECK(diff_lcs_len(a, 2, b, 2) == 0);
+}
+
+static void test_len_interleaved(void)
+{
+	const char *a[] = {"a", "b", "c", "d"};
+	const char *b[] = {"b", "d", "a", "c"};
+
+	/* LCS is "b","c" or "b","d" or "a","c" -- length 2. */
+	CHECK(diff_lcs_len(a, 4, b, 4) == 2);
+}
+
+static void test_len_classic(void)
+{
+	const char *a[] = {"a", "b", "c", "b", "d", "a", "b"};
+	const char *b[] = {"b", "d", "c", "a", "b", "a"};
+
+	/* Classic textbook LCS: "b","d","a","b" length 4
+	 * (also "b","c","a","b" length 4).
+	 */
+	CHECK(diff_lcs_len(a, 7, b, 6) == 4);
+}
+
+static void test_len_empty_inputs(void)
+{
+	const char *a[] = {"open"};
+
+	CHECK(diff_lcs_len(a, 1, a, 0) == 0);
+	CHECK(diff_lcs_len(a, 0, a, 1) == 0);
+	CHECK(diff_lcs_len(a, 0, a, 0) == 0);
+}
+
+static void test_len_prefix_suffix(void)
+{
+	const char *a[] = {"open", "read", "write", "close"};
+	const char *prefix[] = {"open", "read"};
+
+	CHECK(diff_lcs_len(a, 4, prefix, 2) == 2);
+	/* Same elements, same relative order -> full LCS. */
+	CHECK(diff_lcs_len(a, 4, a, 4) == 4);
+}
+
+static void test_len_reordering_only(void)
+{
+	/* Same multiset, different order: LCS is the longest
+	 * increasing subsequence mapping -- for abc vs acb it's 2.
+	 */
+	const char *a[] = {"a", "b", "c"};
+	const char *b[] = {"a", "c", "b"};
+
+	CHECK(diff_lcs_len(a, 3, b, 3) == 2);
+}
+
+/* ----- diff_lcs_walk ----- */
+
+static void test_walk_identical_all_match_zero_edits(void)
+{
+	const char *a[] = {"open", "read", "close"};
+	struct Record r;
+
+	record_init(&r);
+	CHECK(diff_lcs_walk(a, 3, a, 3, record_cb, &r) == 3);
+	CHECK(r.count == 3);
+	CHECK(count_type(&r, DIFF_LCS_MATCH) == 3);
+	CHECK(count_type(&r, DIFF_LCS_DELETE) == 0);
+	CHECK(count_type(&r, DIFF_LCS_INSERT) == 0);
+}
+
+static void test_walk_disjoint_only_edits(void)
+{
+	const char *a[] = {"open", "read"};
+	const char *b[] = {"send", "recv"};
+	struct Record r;
+
+	record_init(&r);
+	CHECK(diff_lcs_walk(a, 2, b, 2, record_cb, &r) == 4);
+	CHECK(count_type(&r, DIFF_LCS_MATCH) == 0);
+	CHECK(count_type(&r, DIFF_LCS_DELETE) == 2);
+	CHECK(count_type(&r, DIFF_LCS_INSERT) == 2);
+}
+
+static void test_walk_empty_before_all_insert(void)
+{
+	const char *b[] = {"send", "recv", "close"};
+	struct Record r;
+
+	record_init(&r);
+	CHECK(diff_lcs_walk(NULL, 0, b, 3, record_cb, &r) == 3);
+	CHECK(count_type(&r, DIFF_LCS_INSERT) == 3);
+	CHECK(count_type(&r, DIFF_LCS_MATCH) == 0);
+}
+
+static void test_walk_empty_after_all_delete(void)
+{
+	const char *a[] = {"open", "read", "close"};
+	struct Record r;
+
+	record_init(&r);
+	CHECK(diff_lcs_walk(a, 3, NULL, 0, record_cb, &r) == 3);
+	CHECK(count_type(&r, DIFF_LCS_DELETE) == 3);
+	CHECK(count_type(&r, DIFF_LCS_MATCH) == 0);
+}
+
+static void test_walk_edit_count_identity(void)
+{
+	/* edits = alen + blen - 2*lcs_len, for several shapes. */
+	const char *a1[] = {"open", "read", "close"};
+	const char *b1[] = {"open", "close", "read"};
+	const char *a2[] = {"a", "b", "c", "d"};
+	const char *b2[] = {"b", "d", "a", "c"};
+	const char *a3[] = {"x"};
+	const char *b3[] = {"x", "y"};
+	struct Record r;
+
+	record_init(&r);
+	diff_lcs_walk(a1, 3, b1, 3, record_cb, &r);
+	CHECK(count_type(&r, DIFF_LCS_DELETE) +
+	      count_type(&r, DIFF_LCS_INSERT) ==
+	      3 + 3 - 2 * diff_lcs_len(a1, 3, b1, 3));
+
+	record_init(&r);
+	diff_lcs_walk(a2, 4, b2, 4, record_cb, &r);
+	CHECK(count_type(&r, DIFF_LCS_DELETE) +
+	      count_type(&r, DIFF_LCS_INSERT) ==
+	      4 + 4 - 2 * diff_lcs_len(a2, 4, b2, 4));
+
+	record_init(&r);
+	diff_lcs_walk(a3, 1, b3, 2, record_cb, &r);
+	CHECK(count_type(&r, DIFF_LCS_DELETE) +
+	      count_type(&r, DIFF_LCS_INSERT) ==
+	      1 + 2 - 2 * diff_lcs_len(a3, 1, b3, 2));
+}
+
+static void test_walk_item_count_identity(void)
+{
+	/* items = alen + blen - lcs_len. */
+	const char *a[] = {"open", "read", "close"};
+	const char *b[] = {"open", "close", "read"};
+	struct Record r;
+
+	record_init(&r);
+	CHECK(diff_lcs_walk(a, 3, b, 3, record_cb, &r) ==
+		3 + 3 - (int)diff_lcs_len(a, 3, b, 3));
+	CHECK(r.count == 3 + 3 - (int)diff_lcs_len(a, 3, b, 3));
+}
+
+static void test_walk_names_come_from_correct_side(void)
+{
+	/* MATCH and DELETE names are pointers into the before
+	 * sequence; INSERT names point into the after sequence.
+	 */
+	const char *before[] = {"shared", "onlybefore"};
+	const char *after[] = {"shared", "onlyafter"};
+	struct Record r;
+	int i;
+	int saw_shared_match = 0;
+	int saw_before_delete = 0;
+	int saw_after_insert = 0;
+
+	record_init(&r);
+	diff_lcs_walk(before, 2, after, 2, record_cb, &r);
+	CHECK(r.count == 3);
+
+	for (i = 0; i < r.count; i++) {
+		if (r.items[i].type == DIFF_LCS_MATCH &&
+		    strcmp(r.items[i].name, "shared") == 0)
+			saw_shared_match = 1;
+		if (r.items[i].type == DIFF_LCS_DELETE &&
+		    r.items[i].name == before[1])
+			saw_before_delete = 1;
+		if (r.items[i].type == DIFF_LCS_INSERT &&
+		    r.items[i].name == after[1])
+			saw_after_insert = 1;
+	}
+	CHECK(saw_shared_match == 1);
+	CHECK(saw_before_delete == 1);
+	CHECK(saw_after_insert == 1);
+}
+
+static void test_walk_alignment_shape_reordering(void)
+{
+	/* before: open read close / after: open close read.
+	 * LCS length 2 ("open" plus one of read/close). Head-first
+	 * alignment: MATCH open, then 2 more matches? No -- exactly
+	 * 2 matches total, 1 delete, 1 insert.
+	 */
+	const char *a[] = {"open", "read", "close"};
+	const char *b[] = {"open", "close", "read"};
+	struct Record r;
+
+	record_init(&r);
+	diff_lcs_walk(a, 3, b, 3, record_cb, &r);
+	record_reverse(&r);
+
+	CHECK(r.count == 4);
+	CHECK(count_type(&r, DIFF_LCS_MATCH) == 2);
+	CHECK(count_type(&r, DIFF_LCS_DELETE) == 1);
+	CHECK(count_type(&r, DIFF_LCS_INSERT) == 1);
+	CHECK(r.items[0].type == DIFF_LCS_MATCH);
+	CHECK(strcmp(r.items[0].name, "open") == 0);
+}
+
+static void test_walk_early_stop(void)
+{
+	const char *a[] = {"a", "b", "c", "d"};
+	struct Record r;
+
+	record_init(&r);
+	r.stop_after = 2;
+	CHECK(diff_lcs_walk(a, 4, a, 4, record_cb, &r) == 2);
+	CHECK(r.count == 2);
+}
+
+static void test_walk_null_callback_ok(void)
+{
+	const char *a[] = {"a", "b"};
+
+	/* NULL cb must not crash; returns the item count. */
+	CHECK(diff_lcs_walk(a, 2, a, 2, NULL, NULL) == 2);
+}
+
+int main(void)
+{
+	printf("-- diff_lcs_len --\n");
+	TEST(len_identical);
+	TEST(len_disjoint);
+	TEST(len_interleaved);
+	TEST(len_classic);
+	TEST(len_empty_inputs);
+	TEST(len_prefix_suffix);
+	TEST(len_reordering_only);
+
+	printf("-- diff_lcs_walk --\n");
+	TEST(walk_identical_all_match_zero_edits);
+	TEST(walk_disjoint_only_edits);
+	TEST(walk_empty_before_all_insert);
+	TEST(walk_empty_after_all_delete);
+	TEST(walk_edit_count_identity);
+	TEST(walk_item_count_identity);
+	TEST(walk_names_come_from_correct_side);
+	TEST(walk_alignment_shape_reordering);
+	TEST(walk_early_stop);
+	TEST(walk_null_callback_ok);
+
+	printf("\nPass: %d, Fail: %d (of %d)\n",
+		tests_pass, tests_fail, tests_run);
+	return tests_fail == 0 ? 0 : 1;
+}

--- a/tools/trace-diff/CMakeLists.txt
+++ b/tools/trace-diff/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 set(_parson_source ${CMAKE_SOURCE_DIR}/src/config/json/parson.c)
 
-add_executable(retrace_diff diff.c normalize.c threshold.c ${_parson_source})
+add_executable(retrace_diff diff.c normalize.c threshold.c lcs.c ${_parson_source})
 set_target_properties(retrace_diff PROPERTIES
     OUTPUT_NAME retrace-diff
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tools")

--- a/tools/trace-diff/diff.c
+++ b/tools/trace-diff/diff.c
@@ -39,6 +39,7 @@
 #include "parson.h"
 #include "normalize.h"
 #include "threshold.h"
+#include "lcs.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -213,87 +214,55 @@ static int print_all_diffs(const struct NormalizedLog *before,
 /*
  * Order diff via longest common subsequence (TODO.complete/27 P1).
  *
- * Computes the LCS of two function-name sequences and prints
- * the differences as unified-diff-style insertions / deletions.
- * Each entry in the LCS appears as a context line ("  func");
- * each before-only entry appears as a deletion ("- func"); each
- * after-only entry appears as an insertion ("+ func").
- *
- * Returns the number of insertions + deletions (i.e. the
- * "edit distance"). 0 means identical order.
- *
- * Standard DP. O(N*M) memory for the table; bounded by trace
- * length. For typical retrace runs (< 10K calls) this is fine.
+ * Prints the alignment computed by lcs.c as unified-diff-style
+ * lines: "  func" for entries in both, "- func" for before-only,
+ * "+ func" for after-only. Returns the number of insertions +
+ * deletions (the "edit distance"); 0 means identical order.
  */
+struct print_ctx {
+	int edits;
+};
+
+static int print_item(const struct diff_lcs_item *item, void *p)
+{
+	struct print_ctx *ctx = (struct print_ctx *)p;
+
+	switch (item->type) {
+	case DIFF_LCS_MATCH:
+		printf("  %s\n", item->name);
+		break;
+	case DIFF_LCS_DELETE:
+		printf("- %s\n", item->name);
+		ctx->edits++;
+		break;
+	case DIFF_LCS_INSERT:
+		printf("+ %s\n", item->name);
+		ctx->edits++;
+		break;
+	}
+	return 0;
+}
+
 static int print_order_diff(char **before_seq, size_t before_len,
 			    char **after_seq, size_t after_len)
 {
-	size_t i, j;
-	size_t *dp;
-	size_t dp_rows = before_len + 1;
-	size_t dp_cols = after_len + 1;
-	int edits = 0;
+	struct print_ctx ctx = {0};
+	int rc;
 
 	if (before_len == 0 && after_len == 0)
 		return 0;
 
-	/* Allocate the (before_len+1) x (after_len+1) table. */
-	dp = (size_t *)calloc(dp_rows * dp_cols, sizeof(size_t));
-	if (dp == NULL) {
+	printf("\n--- order diff (LCS) ---\n");
+	rc = diff_lcs_walk((const char *const *)before_seq, before_len,
+			   (const char *const *)after_seq, after_len,
+			   print_item, &ctx);
+	if (rc < 0) {
 		fprintf(stderr,
 			"retrace-diff: OOM in LCS (sizes %zu x %zu)\n",
 			before_len, after_len);
 		return -1;
 	}
-
-	/* Fill the table. */
-	for (i = 1; i < dp_rows; i++) {
-		for (j = 1; j < dp_cols; j++) {
-			if (strcmp(before_seq[i - 1], after_seq[j - 1]) == 0)
-				dp[i * dp_cols + j] =
-					dp[(i - 1) * dp_cols + (j - 1)] + 1;
-			else
-				dp[i * dp_cols + j] =
-					(dp[(i - 1) * dp_cols + j] >
-					 dp[i * dp_cols + (j - 1)])
-					? dp[(i - 1) * dp_cols + j]
-					: dp[i * dp_cols + (j - 1)];
-		}
-	}
-
-	/* Walk back from [before_len][after_len] to reconstruct. */
-	printf("\n--- order diff (LCS) ---\n");
-	i = before_len;
-	j = after_len;
-	while (i > 0 && j > 0) {
-		if (strcmp(before_seq[i - 1], after_seq[j - 1]) == 0) {
-			printf("  %s\n", before_seq[i - 1]);
-			i--;
-			j--;
-		} else if (dp[(i - 1) * dp_cols + j] >=
-			   dp[i * dp_cols + (j - 1)]) {
-			printf("- %s\n", before_seq[i - 1]);
-			i--;
-			edits++;
-		} else {
-			printf("+ %s\n", after_seq[j - 1]);
-			j--;
-			edits++;
-		}
-	}
-	while (i > 0) {
-		printf("- %s\n", before_seq[i - 1]);
-		i--;
-		edits++;
-	}
-	while (j > 0) {
-		printf("+ %s\n", after_seq[j - 1]);
-		j--;
-		edits++;
-	}
-
-	free(dp);
-	return edits;
+	return ctx.edits;
 }
 
 /*

--- a/tools/trace-diff/lcs.c
+++ b/tools/trace-diff/lcs.c
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+#include "lcs.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+/*
+ * Shared DP-table builder. Returns a calloc'd (alen+1) x (blen+1)
+ * size_t table (caller frees), or NULL on OOM. dp[i*cols + j] is
+ * the LCS length of the first i of a and the first j of b.
+ */
+static size_t *lcs_build_table(const char *const *a, size_t alen,
+			       const char *const *b, size_t blen)
+{
+	size_t rows = alen + 1;
+	size_t cols = blen + 1;
+	size_t *dp;
+	size_t i, j;
+
+	dp = (size_t *)calloc(rows * cols, sizeof(size_t));
+	if (dp == NULL)
+		return NULL;
+
+	for (i = 1; i < rows; i++) {
+		for (j = 1; j < cols; j++) {
+			if (strcmp(a[i - 1], b[j - 1]) == 0)
+				dp[i * cols + j] =
+					dp[(i - 1) * cols + (j - 1)] + 1;
+			else
+				dp[i * cols + j] =
+					(dp[(i - 1) * cols + j] >
+					 dp[i * cols + (j - 1)])
+					? dp[(i - 1) * cols + j]
+					: dp[i * cols + (j - 1)];
+		}
+	}
+
+	return dp;
+}
+
+size_t diff_lcs_len(const char *const *a, size_t alen,
+		    const char *const *b, size_t blen)
+{
+	size_t cols = blen + 1;
+	size_t *dp;
+	size_t len;
+
+	if (alen == 0 || blen == 0)
+		return 0;
+
+	dp = lcs_build_table(a, alen, b, blen);
+	if (dp == NULL)
+		return 0;
+
+	len = dp[alen * cols + blen];
+	free(dp);
+	return len;
+}
+
+int diff_lcs_walk(const char *const *a, size_t alen,
+		  const char *const *b, size_t blen,
+		  diff_lcs_cb cb, void *ctx)
+{
+	size_t cols = blen + 1;
+	size_t *dp;
+	size_t i, j;
+	int emitted = 0;
+	struct diff_lcs_item item;
+
+	if (alen == 0 && blen == 0)
+		return 0;
+
+	dp = lcs_build_table(a, alen, b, blen);
+	if (dp == NULL)
+		return -1;
+
+	i = alen;
+	j = blen;
+	while (i > 0 && j > 0) {
+		if (strcmp(a[i - 1], b[j - 1]) == 0) {
+			item.type = DIFF_LCS_MATCH;
+			item.name = a[i - 1];
+			i--;
+			j--;
+		} else if (dp[(i - 1) * cols + j] >=
+			   dp[i * cols + (j - 1)]) {
+			item.type = DIFF_LCS_DELETE;
+			item.name = a[i - 1];
+			i--;
+		} else {
+			item.type = DIFF_LCS_INSERT;
+			item.name = b[j - 1];
+			j--;
+		}
+		emitted++;
+		if (cb != NULL && cb(&item, ctx) != 0)
+			goto out;
+	}
+	while (i > 0) {
+		item.type = DIFF_LCS_DELETE;
+		item.name = a[i - 1];
+		i--;
+		emitted++;
+		if (cb != NULL && cb(&item, ctx) != 0)
+			goto out;
+	}
+	while (j > 0) {
+		item.type = DIFF_LCS_INSERT;
+		item.name = b[j - 1];
+		j--;
+		emitted++;
+		if (cb != NULL && cb(&item, ctx) != 0)
+			goto out;
+	}
+
+out:
+	free(dp);
+	return emitted;
+}

--- a/tools/trace-diff/lcs.h
+++ b/tools/trace-diff/lcs.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+#ifndef RETRACE_DIFF_LCS_H_
+#define RETRACE_DIFF_LCS_H_
+
+#include <stddef.h>
+
+/*
+ * Longest-common-subsequence alignment for call-order diffing
+ * (TODO.complete/27 P1).
+ *
+ * Owns the pure algorithm: given two sequences of names, compute
+ * the LCS table and reconstruct the alignment. Presentation (the
+ * "  / - / +" rendering) lives in diff.c; this module only emits
+ * typed alignment items via a callback.
+ */
+
+enum diff_lcs_type {
+	DIFF_LCS_MATCH = 0,   /* present in both, same relative order */
+	DIFF_LCS_DELETE = 1,  /* only in the before sequence */
+	DIFF_LCS_INSERT = 2   /* only in the after sequence */
+};
+
+struct diff_lcs_item {
+	enum diff_lcs_type type;
+
+	/* The name. For MATCH/DELETE: from the before sequence; for
+	 * INSERT: from the after sequence. Borrowed, not copied.
+	 */
+	const char *name;
+};
+
+/*
+ * Callback invoked once per alignment item. Items are emitted
+ * tail-first by the back-walk, so callers that need head-first
+ * order must reverse (diff.c prints as it goes -- for a
+ * unified-diff look it emits in reverse and the terminal shows
+ * the natural order). Return non-zero from the callback to stop
+ * the walk early.
+ */
+typedef int (*diff_lcs_cb)(const struct diff_lcs_item *item,
+			   void *ctx);
+
+/*
+ * Returns the length of the longest common subsequence of the two
+ * name sequences (compared with strcmp). O(a*b) time, O(a*b)
+ * space. Returns 0 if either sequence is empty.
+ */
+size_t diff_lcs_len(const char *const *a, size_t alen,
+		    const char *const *b, size_t blen);
+
+/*
+ * Walks the alignment, invoking `cb` once per item (MATCH, DELETE
+ * or INSERT). The number of non-MATCH items is the edit count.
+ * Returns the number of items emitted, or -1 on OOM.
+ */
+int diff_lcs_walk(const char *const *a, size_t alen,
+		  const char *const *b, size_t blen,
+		  diff_lcs_cb cb, void *ctx);
+
+#endif /* RETRACE_DIFF_LCS_H_ */


### PR DESCRIPTION
## Summary

Bumps retrace from v2.4.2 to **v2.4.3** (PATCH per ADR-0006). Refactor + tests, no behavior change. Completes the diff tool's MECE chain and pins its order-alignment algorithm.

## What's in the bump

### Refactor (MECE)

- `tools/trace-diff/lcs.{c,h}` — extracted the LCS alignment from `print_order_diff`: `diff_lcs_len` (pure length) + `diff_lcs_walk` (alignment emitted as typed `MATCH`/`DELETE`/`INSERT` items via callback). The tool chain is now: `normalize.c` (aggregation) → `threshold.c` (gating) → `lcs.c` (order alignment) → `diff.c` (CLI + printing). Behavior-preserving down to the both-empty early return before the header line; `--order` output verified on a reorder smoke test.

### Tests (17 new cases)

- `diff_lcs_len`: identical / disjoint / interleaved / textbook `ABCBDAB` vs `BDCABA` (= 4) / empty inputs / prefix / 3-element reordering (= 2).
- `diff_lcs_walk`: identical → all MATCH (0 edits); disjoint → only DELETE+INSERT; one-side-empty; the identities `edits = alen + blen − 2·lcs` and `items = alen + blen − lcs`; pointer provenance (MATCH/DELETE names from the before sequence, INSERT from after); alignment shape for reorderings; early-stop via callback; NULL-callback safety.

**Why it matters**: the edit count is what cookbook 26's CI gate keys on and the alignment is what users read — a wrong LCS means false "behavior changed" alarms or missed reorderings.

### Nice check on my own understanding

The shape test initially assumed a 3-element reordering has LCS 1 — the len tests proved it's 2 (two of three elements always keep relative order). Fixed; the identity tests (`edits = a + b − 2·lcs`) now enforce consistency.

### Version + packaging

- `version.h`, `retrace_cli.c` banner: 2.4.2 → 2.4.3
- `packaging/{nix,debian,fedora}` bumped
- `CHANGELOG.md` entry

## Test plan

- [x] `cmake -B build -G Ninja -DRETRACE_BUILD_TESTS=ON`
- [x] `cmake --build build`
- [x] `ctest --test-dir build` — 54/54 pass (was 53)
- [x] `./build/test/unit/test_lcs` — 17/17 pass
- [x] `./build/tools/retrace-diff --order` smoke test — output shape unchanged (behavior-preserving)
- [x] Single commit; verified committed content via `git show HEAD:`
- [x] No AI attribution in commit message
- [ ] CI green on all matrix legs
- [ ] After merge: tag v2.4.3; release.yml produces binary artifacts

## Tagging plan

After PR rebase-merges, tag `v2.4.3` at the merge commit. release.yml will produce per-platform binary artifacts.
