### PR TITLE
v2.4.4: trace-diff stats.c extraction + 10 z-score tests + variance fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (see `docs/adr/0006-semantic-versioning.md`).
 
+## [2.4.4] - 2026-08-16
+
+### Fixed
+- `tools/trace-diff` stats mode: switched the variance from the
+  one-pass `E[x^2] - mean^2` form to the numerically stable
+  two-pass sum-of-squared-deviations. The one-pass form suffers
+  catastrophic cancellation for large call counts (values beyond
+  2^53 are not exactly representable in a double), producing
+  wrong stddevs and therefore wrong z-scores -- found by the new
+  large-counts unit test.
+
+### Changed
+- `tools/trace-diff`: extracted the z-score math from
+  `run_stats_mode` to a new `stats.{c,h}` -- `diff_stats_compute`
+  fills mean/stddev/z/no-variance/significance in one call. The
+  tool chain is now: `normalize.c` -> `threshold.c` -> `lcs.c` ->
+  `stats.c` -> `diff.c` (CLI + printing).
+
+### Added
+- `test/unit/test_stats.c` -- 10 unit tests: known distributions
+  ([10,12,14] -> 12 +- sqrt(8/3)), significant/not classification,
+  negative-direction |z|, zero-variance cases (constant baselines,
+  all-zero, single baseline), strict threshold semantics (exact
+  z == threshold is NOT significant), custom thresholds, invalid
+  inputs, and billion-scale counts.
+
 ## [2.4.3] - 2026-08-15
 
 ### Changed

--- a/include/retrace/version.h
+++ b/include/retrace/version.h
@@ -38,9 +38,9 @@
 
 #define RETRACE_VERSION_MAJOR 2
 #define RETRACE_VERSION_MINOR 4
-#define RETRACE_VERSION_PATCH 3
+#define RETRACE_VERSION_PATCH 4
 
-#define RETRACE_VERSION_STRING "2.4.3"
+#define RETRACE_VERSION_STRING "2.4.4"
 
 #define RETRACE_VERSION_ATLEAST(maj, min, pat)                  \
 	(RETRACE_VERSION_MAJOR > (maj) ||                       \

--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -1,3 +1,10 @@
+retrace (2.4.4-1) unstable; urgency=medium
+
+  * trace-diff: extract stats.c (MECE) + 10 z-score tests; fix
+    catastrophic-cancellation variance for large counts.
+
+ -- Ribose Inc <opensource@ribose.com>  Sat, 15 Aug 2026 00:00:00 +0000
+
 retrace (2.4.3-1) unstable; urgency=medium
 
   * trace-diff: extract lcs.c (MECE) + 17 LCS alignment tests.

--- a/packaging/fedora/retrace.spec
+++ b/packaging/fedora/retrace.spec
@@ -2,10 +2,10 @@
 #
 # Fedora RPM spec for retrace (TODO.complete/38).
 # Build: rpmbuild -ba retrace.spec
-# Install: dnf install retrace-2.4.3-1.*.rpm
+# Install: dnf install retrace-2.4.4-1.*.rpm
 
 Name:           retrace
-Version:        2.4.3
+Version:        2.4.4
 Release:        1%{?dist}
 Summary:        Userspace libc interceptor for security discovery
 
@@ -50,6 +50,9 @@ action, OTLP/JSON export, and a Python config builder.
 %{_includedir}/retrace/
 
 %changelog
+* Sat Aug 15 2026 Ribose Inc <opensource@ribose.com> - 2.4.4-1
+- trace-diff stats.c extraction + 10 z-score tests; two-pass variance fix
+
 * Sat Aug 15 2026 Ribose Inc <opensource@ribose.com> - 2.4.3-1
 - trace-diff lcs.c extraction (MECE) + 17 LCS alignment tests
 

--- a/packaging/nix/default.nix
+++ b/packaging/nix/default.nix
@@ -8,7 +8,7 @@
 
 stdenv.mkDerivation rec {
   pname = "retrace";
-  version = "2.4.3";
+  version = "2.4.4";
 
   src = ./.;
 

--- a/src/cli/retrace_cli.c
+++ b/src/cli/retrace_cli.c
@@ -63,7 +63,7 @@ typedef int retrace_status_t;
 static void usage(FILE *out)
 {
 	fprintf(out,
-"retrace v2.4.3 -- userspace libc interceptor\n"
+"retrace v2.4.4 -- userspace libc interceptor\n"
 "\n"
 "Usage:\n"
 "  retrace run [OPTIONS] -- <command> [args...]\n"

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -1191,3 +1191,24 @@ target_include_directories(retrace_test_format PRIVATE
 add_test(NAME unit-test-format
     COMMAND retrace_test_format)
 set_tests_properties(unit-test-format PROPERTIES LABELS "unit")
+
+#
+# Z-score stats unit tests (TODO.complete/27 P2). diff_stats_compute
+# drives the --stats CI gate (cookbook 25) -- wrong mean/stddev/z
+# means missed regressions or false alarms on every PR. Needs -lm
+# for sqrt/fabs (part of libSystem on macOS).
+#
+add_executable(retrace_test_stats test_stats.c
+    ${CMAKE_SOURCE_DIR}/tools/trace-diff/stats.c)
+set_target_properties(retrace_test_stats PROPERTIES
+    OUTPUT_NAME test_stats
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/test/unit")
+
+target_include_directories(retrace_test_stats PRIVATE
+    ${CMAKE_SOURCE_DIR}/tools/trace-diff)
+
+target_link_libraries(retrace_test_stats PRIVATE m)
+
+add_test(NAME unit-test-stats
+    COMMAND retrace_test_stats)
+set_tests_properties(unit-test-stats PROPERTIES LABELS "unit")

--- a/test/unit/test_stats.c
+++ b/test/unit/test_stats.c
@@ -1,0 +1,230 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+/*
+ * Unit tests for the z-score stats (TODO.complete/27 P2).
+ *
+ * diff_stats_compute drives the --stats CI gate (cookbook 25):
+ * a wrong mean/stddev/z means missed regressions or false
+ * alarms on every PR.
+ *
+ * Covers:
+ *   - mean and population stddev for known distributions
+ *     ([10,12,14] -> 12 +- sqrt(8/3))
+ *   - zero-variance detection + the any-deviation rule
+ *   - all-zero baselines are a zero-variance case with mean 0
+ *   - z threshold is STRICT (exactly-at-threshold not significant)
+ *   - negative-direction z is absolute-valued for the decision
+ *   - single baseline (n=1) is zero-variance
+ *   - invalid input (n=0, NULL) returns -1
+ *   - large counts do not lose the deviation
+ *   - typical significant / not-significant classifications
+ */
+
+#include "stats.h"
+
+#include <math.h>
+#include <stdio.h>
+
+static int tests_run;
+static int tests_pass;
+static int tests_fail;
+
+#define TEST(name) do { \
+	tests_run++; \
+	printf("  TEST %s ... ", #name); \
+	test_##name(); \
+	tests_pass++; \
+	printf("OK\n"); \
+} while (0)
+
+#define CHECK(cond) do { \
+	if (!(cond)) { \
+		printf("FAIL [%s:%d] %s\n", __FILE__, __LINE__, #cond); \
+		tests_fail++; \
+		return; \
+	} \
+} while (0)
+
+static int approx(double a, double b)
+{
+	return fabs(a - b) < 1e-9;
+}
+
+/* ----- basic distribution stats ----- */
+
+static void test_mean_and_stddev_known_distribution(void)
+{
+	const uint64_t base[] = {10, 12, 14};
+	struct diff_stats st;
+
+	CHECK(diff_stats_compute(base, 3, 13, 2.0, &st) == 0);
+	CHECK(approx(st.mean, 12.0));
+	/* variance = (100+144+196)/3 - 144 = 440/3 - 144 = 8/3 */
+	CHECK(approx(st.stddev, sqrt(8.0 / 3.0)));
+	CHECK(approx(st.z, (13.0 - 12.0) / sqrt(8.0 / 3.0)));
+	CHECK(st.no_variance == 0);
+	/* z ~ 0.61 -> not significant at 2.0. */
+	CHECK(st.significant == 0);
+}
+
+static void test_significant_above_threshold(void)
+{
+	const uint64_t base[] = {10, 12, 14};
+	struct diff_stats st;
+
+	CHECK(diff_stats_compute(base, 3, 16, 2.0, &st) == 0);
+	/* z = 4 / 1.633 ~ 2.449 > 2.0 */
+	CHECK(st.significant == 1);
+	CHECK(st.z > 2.0);
+}
+
+static void test_negative_direction_absolute(void)
+{
+	const uint64_t base[] = {10, 12, 14};
+	struct diff_stats st;
+
+	CHECK(diff_stats_compute(base, 3, 8, 2.0, &st) == 0);
+	/* z = -4 / 1.633 ~ -2.449; |z| > 2.0 -> significant. */
+	CHECK(approx(st.z, -4.0 / sqrt(8.0 / 3.0)));
+	CHECK(st.significant == 1);
+}
+
+/* ----- zero variance ----- */
+
+static void test_zero_variance_any_deviation_flags(void)
+{
+	const uint64_t base[] = {10, 10, 10};
+	struct diff_stats st;
+
+	CHECK(diff_stats_compute(base, 3, 10, 2.0, &st) == 0);
+	CHECK(st.no_variance == 1);
+	CHECK(approx(st.mean, 10.0));
+	CHECK(approx(st.stddev, 0.0));
+	/* Equal to the constant -> not flagged. */
+	CHECK(st.significant == 0);
+
+	CHECK(diff_stats_compute(base, 3, 11, 2.0, &st) == 0);
+	CHECK(st.no_variance == 1);
+	/* Any deviation (even 1) flags with no variance. */
+	CHECK(st.significant == 1);
+}
+
+static void test_all_zero_baselines(void)
+{
+	const uint64_t base[] = {0, 0, 0, 0};
+	struct diff_stats st;
+
+	CHECK(diff_stats_compute(base, 4, 0, 2.0, &st) == 0);
+	CHECK(st.no_variance == 1);
+	CHECK(approx(st.mean, 0.0));
+	CHECK(st.significant == 0);
+
+	CHECK(diff_stats_compute(base, 4, 1, 2.0, &st) == 0);
+	CHECK(st.significant == 1);
+}
+
+static void test_single_baseline_is_zero_variance(void)
+{
+	const uint64_t base[] = {5};
+	struct diff_stats st;
+
+	CHECK(diff_stats_compute(base, 1, 5, 2.0, &st) == 0);
+	CHECK(st.no_variance == 1);
+	CHECK(st.significant == 0);
+
+	CHECK(diff_stats_compute(base, 1, 100, 2.0, &st) == 0);
+	CHECK(st.significant == 1);
+}
+
+/* ----- threshold semantics ----- */
+
+static void test_threshold_is_strict(void)
+{
+	/* Craft a distribution where |z| lands exactly on the
+	 * threshold: baselines [0, 2] -> mean 1, stddev 1; test 3
+	 * -> z = 2 exactly. Strict > means NOT significant at 2.0.
+	 */
+	const uint64_t base[] = {0, 2};
+	struct diff_stats st;
+
+	CHECK(diff_stats_compute(base, 2, 3, 2.0, &st) == 0);
+	CHECK(approx(st.mean, 1.0));
+	CHECK(approx(st.stddev, 1.0));
+	CHECK(approx(st.z, 2.0));
+	CHECK(st.significant == 0);
+
+	/* Just above the threshold flags. */
+	CHECK(diff_stats_compute(base, 2, 4, 2.0, &st) == 0);
+	CHECK(st.z > 2.0);
+	CHECK(st.significant == 1);
+}
+
+static void test_custom_threshold_widens_gate(void)
+{
+	const uint64_t base[] = {10, 12, 14};
+	struct diff_stats st;
+
+	/* z ~ 2.449: significant at 2.0, not at 3.0. */
+	CHECK(diff_stats_compute(base, 3, 16, 2.0, &st) == 0);
+	CHECK(st.significant == 1);
+	CHECK(diff_stats_compute(base, 3, 16, 3.0, &st) == 0);
+	CHECK(st.significant == 0);
+}
+
+/* ----- input validation + extremes ----- */
+
+static void test_invalid_inputs_rejected(void)
+{
+	const uint64_t base[] = {1, 2};
+	struct diff_stats st;
+
+	CHECK(diff_stats_compute(NULL, 2, 1, 2.0, &st) == -1);
+	CHECK(diff_stats_compute(base, 0, 1, 2.0, &st) == -1);
+	CHECK(diff_stats_compute(base, 2, 1, 2.0, NULL) == -1);
+}
+
+static void test_large_counts(void)
+{
+	const uint64_t base[] = {1000000000ULL, 1000000002ULL};
+	struct diff_stats st;
+
+	CHECK(diff_stats_compute(base, 2, 1000000000ULL, 2.0, &st) == 0);
+	/* mean 1e9+1, stddev 1; test at the mean -> z -1, not sig. */
+	CHECK(approx(st.mean, 1000000001.0));
+	CHECK(approx(st.stddev, 1.0));
+	CHECK(st.significant == 0);
+
+	/* +4 -> z ~ 3 -> significant. */
+	CHECK(diff_stats_compute(base, 2, 1000000005ULL, 2.0, &st) == 0);
+	CHECK(st.z > 3.0);
+	CHECK(st.significant == 1);
+}
+
+int main(void)
+{
+	printf("-- distribution stats --\n");
+	TEST(mean_and_stddev_known_distribution);
+	TEST(significant_above_threshold);
+	TEST(negative_direction_absolute);
+
+	printf("-- zero variance --\n");
+	TEST(zero_variance_any_deviation_flags);
+	TEST(all_zero_baselines);
+	TEST(single_baseline_is_zero_variance);
+
+	printf("-- threshold semantics --\n");
+	TEST(threshold_is_strict);
+	TEST(custom_threshold_widens_gate);
+
+	printf("-- validation + extremes --\n");
+	TEST(invalid_inputs_rejected);
+	TEST(large_counts);
+
+	printf("\nPass: %d, Fail: %d (of %d)\n",
+		tests_pass, tests_fail, tests_run);
+	return tests_fail == 0 ? 0 : 1;
+}

--- a/tools/trace-diff/CMakeLists.txt
+++ b/tools/trace-diff/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 set(_parson_source ${CMAKE_SOURCE_DIR}/src/config/json/parson.c)
 
-add_executable(retrace_diff diff.c normalize.c threshold.c lcs.c ${_parson_source})
+add_executable(retrace_diff diff.c normalize.c threshold.c lcs.c stats.c ${_parson_source})
 set_target_properties(retrace_diff PROPERTIES
     OUTPUT_NAME retrace-diff
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tools")

--- a/tools/trace-diff/diff.c
+++ b/tools/trace-diff/diff.c
@@ -40,6 +40,7 @@
 #include "normalize.h"
 #include "threshold.h"
 #include "lcs.h"
+#include "stats.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -315,6 +316,8 @@ static int load_trace(const char *path, struct NormalizedLog *out,
  */
 #include <math.h>
 
+#define MAX_BASELINES 64
+
 static int run_stats_mode(const char *baseline_list,
 			  const char *test_path, double zscore)
 {
@@ -387,47 +390,40 @@ static int run_stats_mode(const char *baseline_list,
 	/* For each function in the test trace, compute z-score. */
 	for (i = 0; i < test.count; i++) {
 		const char *name = test.funcs[i].name;
-		uint64_t test_count = test.funcs[i].call_count;
-		double sum = 0, sum_sq = 0;
-		double mean, variance, stddev;
+		uint64_t counts[MAX_BASELINES];
+		struct diff_stats st;
 		int j;
 
 		for (j = 0; j < n_baselines; j++) {
 			const struct FuncStat *s = normalize_find(
 				&baselines[j], name);
-			double c = s ? (double)s->call_count : 0;
 
-			sum += c;
-			sum_sq += c * c;
+			counts[j] = s ? s->call_count : 0;
 		}
 
-		mean = sum / n_baselines;
-		variance = (sum_sq / n_baselines) - (mean * mean);
-		stddev = sqrt(variance > 0 ? variance : 0);
+		if (diff_stats_compute(counts, (size_t)n_baselines,
+			    test.funcs[i].call_count, zscore, &st) != 0)
+			continue;
 
-		if (stddev == 0) {
+		if (st.no_variance) {
 			/* No variance in baselines. Flag if test
 			 * differs from the constant value at all.
 			 */
-			if ((double)test_count != mean) {
+			if (st.significant) {
 				printf("  %s: test=%llu baseline=%.1f+0.0"
 				       " (NO VARIANCE -- manual review)\n",
 					name,
-					(unsigned long long)test_count,
-					mean);
+					(unsigned long long)test.funcs[i].call_count,
+					st.mean);
 				significant++;
 			}
-		} else {
-			double z = ((double)test_count - mean) / stddev;
-
-			if (fabs(z) > zscore) {
-				printf("  %s: test=%llu baseline=%.1f+%.1f"
-				       " (z=%.2f ***)\n",
-					name,
-					(unsigned long long)test_count,
-					mean, stddev, z);
-				significant++;
-			}
+		} else if (st.significant) {
+			printf("  %s: test=%llu baseline=%.1f+%.1f"
+			       " (z=%.2f ***)\n",
+				name,
+				(unsigned long long)test.funcs[i].call_count,
+				st.mean, st.stddev, st.z);
+			significant++;
 		}
 	}
 

--- a/tools/trace-diff/stats.c
+++ b/tools/trace-diff/stats.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+#include "stats.h"
+
+#include <math.h>
+
+int diff_stats_compute(const uint64_t *baseline_counts, size_t n,
+		       uint64_t test_count, double threshold,
+		       struct diff_stats *out)
+{
+	double sum = 0;
+	double ssd = 0;  /* sum of squared deviations from the mean */
+	size_t i;
+
+	if (baseline_counts == NULL || n == 0 || out == NULL)
+		return -1;
+
+	for (i = 0; i < n; i++)
+		sum += (double)baseline_counts[i];
+
+	out->mean = sum / (double)n;
+
+	/* Two-pass variance: numerically stable where the one-pass
+	 * E[x^2] - mean^2 form suffers catastrophic cancellation for
+	 * large counts (call counts can exceed 2^53 precision).
+	 */
+	for (i = 0; i < n; i++) {
+		double d = (double)baseline_counts[i] - out->mean;
+
+		ssd += d * d;
+	}
+	out->stddev = sqrt(ssd / (double)n);
+
+	if (out->stddev == 0) {
+		out->no_variance = 1;
+		out->z = 0;
+		out->significant = ((double)test_count != out->mean);
+	} else {
+		out->no_variance = 0;
+		out->z = ((double)test_count - out->mean) / out->stddev;
+		out->significant = fabs(out->z) > threshold;
+	}
+
+	return 0;
+}

--- a/tools/trace-diff/stats.h
+++ b/tools/trace-diff/stats.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+#ifndef RETRACE_DIFF_STATS_H_
+#define RETRACE_DIFF_STATS_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+/*
+ * Statistical significance for the differential trace analysis
+ * (TODO.complete/27 P2).
+ *
+ * Owns the per-function z-score math: given N baseline call
+ * counts and one test count, decide whether the test deviates
+ * from the baseline distribution by more than a threshold of
+ * standard deviations. Loading traces, iterating functions and
+ * printing live in diff.c.
+ */
+
+struct diff_stats {
+	double mean;         /* baseline mean */
+	double stddev;       /* baseline stddev (population) */
+	double z;            /* (test - mean) / stddev; 0 when no variance */
+
+	/* Baselines had zero variance (all equal). The decision rule
+	 * degrades to "any deviation from the constant is notable"
+	 * because a real z is undefined (divide by zero).
+	 */
+	int no_variance;
+
+	/* The decision: test deviates by more than `threshold`
+	 * stddevs. With no_variance, true for any deviation from
+	 * the constant mean. Strict inequality -- exactly at the
+	 * threshold is NOT significant.
+	 */
+	int significant;
+};
+
+/*
+ * One-pass population statistics over `n` baseline counts
+ * (missing-function baselines contribute 0 -- the caller folds
+ * that in before calling).
+ *
+ * Returns 0 and fills `out`; -1 on invalid input (n == 0 or
+ * out == NULL).
+ */
+int diff_stats_compute(const uint64_t *baseline_counts, size_t n,
+		       uint64_t test_count, double threshold,
+		       struct diff_stats *out);
+
+#endif /* RETRACE_DIFF_STATS_H_ */


### PR DESCRIPTION
## Summary

Bumps retrace from v2.4.3 to **v2.4.4** (PATCH per ADR-0006). Refactor + tests + a real numerical fix the new tests surfaced. Completes the diff tool's MECE chain.

## What's in the bump

### Fixed — real defect found by the new tests

The stats mode's variance used the one-pass `E[x²] − mean²` form, which suffers **catastrophic cancellation** for large call counts: values beyond 2^53 aren't exactly representable in a double, so `sum_sq` loses precision and the subtraction amplifies it — wrong stddev, wrong z-score, wrong CI verdict. Switched to the numerically stable two-pass sum-of-squared-deviations. Small-magnitude output is unchanged (smoke z identical); billion-scale counts are now correct where they were previously garbage.

### Refactor (MECE)

- `tools/trace-diff/stats.{c,h}` — `diff_stats_compute`: mean/stddev/z/no-variance/significance in one call, extracted from `run_stats_mode`. The tool chain is now: `normalize.c` → `threshold.c` → `lcs.c` → `stats.c` → `diff.c` (CLI + printing).

### Tests (10 new cases)

- Known distributions: `[10,12,14]` → mean 12, stddev √(8/3).
- Significant / not-significant classification; negative-direction |z|.
- Zero-variance cases: constant baselines, all-zero, single baseline.
- Strict threshold semantics: crafted `[0,2]` + test 3 gives z exactly 2.0 → NOT significant at 2.0 (the `>` is strict).
- Custom thresholds widen the gate.
- Invalid inputs (NULL, n=0) rejected.
- Billion-scale counts (the case that caught the cancellation bug).

### Version + packaging

- `version.h`, `retrace_cli.c` banner: 2.4.3 → 2.4.4
- `packaging/{nix,debian,fedora}` bumped
- `CHANGELOG.md` entry

## Test plan

- [x] `cmake -B build -G Ninja -DRETRACE_BUILD_TESTS=ON`
- [x] `cmake --build build`
- [x] `ctest --test-dir build` — 55/55 pass (was 54)
- [x] `./build/test/unit/test_stats` — 10/10 pass
- [x] `--stats` smoke run — printed output identical to pre-refactor (same z, same format)
- [x] Single commit; verified committed content via `git show HEAD:`
- [x] No AI attribution in commit message
- [ ] CI green on all matrix legs
- [ ] After merge: tag v2.4.4; release.yml produces binary artifacts

## Tagging plan

After PR rebase-merges, tag `v2.4.4` at the merge commit. release.yml will produce per-platform binary artifacts.
