### PR TITLE
v2.4.5: audit PDF fixes — missing findings page + double-escape + 13 tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (see `docs/adr/0006-semantic-versioning.md`).
 
+## [2.4.5] - 2026-08-16
+
+### Fixed
+- `tools/audit-converter/pdf_writer.c` -- two real bugs, both
+  present since the PDF output shipped in v2.3.0 and both found
+  by the new tests:
+  1. **Missing findings page**: the findings-page loop's bound
+     (`obj_id < total_objects - 1`) was off by one, so whenever
+     the findings content fit exactly (1-40 findings) the page
+     was skipped entirely -- the PDF declared `/Count 3` with
+     only 2 page objects, and every finding was invisible.
+     Beyond 40 findings the last page was dropped. Now the page
+     count matches the objects for every case.
+  2. **Double-escaped cover text**: the cover pre-escaped the
+     policy name and trace path, then `build_page_content`
+     escaped them again -- parentheses rendered as literal
+     backslash-parens in viewers. The cover now passes raw
+     strings and is escaped exactly once (matching the findings
+     path).
+
+### Added
+- `test/unit/test_pdf.c` -- 13 unit tests: `pdf_escape_string`
+  rules (plain/parens/backslash/empty), document structure
+  (PDF 1.4 header, %%EOF trailer, xref + startxref,
+  Catalog/Pages/Font), page counts for 0/1/40/41 findings,
+  cover content, padded summary labels, findings rule ids,
+  special-character round trip, and the writer's return value.
+
 ## [2.4.4] - 2026-08-16
 
 ### Fixed

--- a/include/retrace/version.h
+++ b/include/retrace/version.h
@@ -38,9 +38,9 @@
 
 #define RETRACE_VERSION_MAJOR 2
 #define RETRACE_VERSION_MINOR 4
-#define RETRACE_VERSION_PATCH 4
+#define RETRACE_VERSION_PATCH 5
 
-#define RETRACE_VERSION_STRING "2.4.4"
+#define RETRACE_VERSION_STRING "2.4.5"
 
 #define RETRACE_VERSION_ATLEAST(maj, min, pat)                  \
 	(RETRACE_VERSION_MAJOR > (maj) ||                       \

--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -1,3 +1,10 @@
+retrace (2.4.5-1) unstable; urgency=medium
+
+  * audit PDF: fix missing findings page (1-40 findings) and
+    double-escaped cover text; + 13 pdf_writer unit tests.
+
+ -- Ribose Inc <opensource@ribose.com>  Sat, 15 Aug 2026 00:00:00 +0000
+
 retrace (2.4.4-1) unstable; urgency=medium
 
   * trace-diff: extract stats.c (MECE) + 10 z-score tests; fix

--- a/packaging/fedora/retrace.spec
+++ b/packaging/fedora/retrace.spec
@@ -2,10 +2,10 @@
 #
 # Fedora RPM spec for retrace (TODO.complete/38).
 # Build: rpmbuild -ba retrace.spec
-# Install: dnf install retrace-2.4.4-1.*.rpm
+# Install: dnf install retrace-2.4.5-1.*.rpm
 
 Name:           retrace
-Version:        2.4.4
+Version:        2.4.5
 Release:        1%{?dist}
 Summary:        Userspace libc interceptor for security discovery
 
@@ -50,6 +50,9 @@ action, OTLP/JSON export, and a Python config builder.
 %{_includedir}/retrace/
 
 %changelog
+* Sat Aug 15 2026 Ribose Inc <opensource@ribose.com> - 2.4.5-1
+- audit PDF: findings-page off-by-one + cover double-escape fixes; 13 tests
+
 * Sat Aug 15 2026 Ribose Inc <opensource@ribose.com> - 2.4.4-1
 - trace-diff stats.c extraction + 10 z-score tests; two-pass variance fix
 

--- a/packaging/nix/default.nix
+++ b/packaging/nix/default.nix
@@ -8,7 +8,7 @@
 
 stdenv.mkDerivation rec {
   pname = "retrace";
-  version = "2.4.4";
+  version = "2.4.5";
 
   src = ./.;
 

--- a/src/cli/retrace_cli.c
+++ b/src/cli/retrace_cli.c
@@ -63,7 +63,7 @@ typedef int retrace_status_t;
 static void usage(FILE *out)
 {
 	fprintf(out,
-"retrace v2.4.4 -- userspace libc interceptor\n"
+"retrace v2.4.5 -- userspace libc interceptor\n"
 "\n"
 "Usage:\n"
 "  retrace run [OPTIONS] -- <command> [args...]\n"

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -1212,3 +1212,22 @@ target_link_libraries(retrace_test_stats PRIVATE m)
 add_test(NAME unit-test-stats
     COMMAND retrace_test_stats)
 set_tests_properties(unit-test-stats PROPERTIES LABELS "unit")
+
+#
+# PDF writer unit tests (TODO.complete/26 P2). The PDF is a
+# compliance deliverable -- malformed structure fails viewers and
+# auditors' tooling. pdf_writer.c is decoupled from parson and
+# the Findings model (takes string arrays), so this links alone.
+#
+add_executable(retrace_test_pdf test_pdf.c
+    ${CMAKE_SOURCE_DIR}/tools/audit-converter/pdf_writer.c)
+set_target_properties(retrace_test_pdf PROPERTIES
+    OUTPUT_NAME test_pdf
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/test/unit")
+
+target_include_directories(retrace_test_pdf PRIVATE
+    ${CMAKE_SOURCE_DIR}/tools/audit-converter)
+
+add_test(NAME unit-test-pdf
+    COMMAND retrace_test_pdf)
+set_tests_properties(unit-test-pdf PROPERTIES LABELS "unit")

--- a/test/unit/test_pdf.c
+++ b/test/unit/test_pdf.c
@@ -1,0 +1,325 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+/*
+ * Unit tests for the audit PDF writer (TODO.complete/26 P2).
+ *
+ * The PDF is a compliance deliverable -- a malformed document
+ * (bad header, broken xref, wrong object count) fails to open in
+ * viewers and gets rejected by auditors' tooling. These tests
+ * pin the structural contract of pdf_write_audit_report and the
+ * escaping rules of pdf_escape_string.
+ *
+ * Covers:
+ *   - pdf_escape_string: plain unchanged; ( ) and \ escaped;
+ *     mixed strings; empty string yields ""
+ *   - pdf_write_audit_report: PDF 1.4 header; %%EOF trailer;
+ *     xref table + startxref present; Catalog/Pages/Font objects
+ *   - page counts: 0/1/40 findings -> 3 pages; 41/45 -> 4/5
+ *   - cover page carries policy name and trace path (escaped)
+ *   - summary page carries the four severity counts
+ *   - findings pages carry rule ids
+ *   - special characters in identifiers survive the escaping
+ */
+
+#include "pdf_writer.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int tests_run;
+static int tests_pass;
+static int tests_fail;
+
+#define TEST(name) do { \
+	tests_run++; \
+	printf("  TEST %s ... ", #name); \
+	test_##name(); \
+	tests_pass++; \
+	printf("OK\n"); \
+} while (0)
+
+#define CHECK(cond) do { \
+	if (!(cond)) { \
+		printf("FAIL [%s:%d] %s\n", __FILE__, __LINE__, #cond); \
+		tests_fail++; \
+		return; \
+	} \
+} while (0)
+
+/* Read an entire file into a malloc'd NUL-terminated buffer. */
+static char *slurp(FILE *f)
+{
+	long sz;
+	char *buf;
+
+	fseek(f, 0, SEEK_END);
+	sz = ftell(f);
+	rewind(f);
+	buf = (char *)malloc((size_t)sz + 1);
+	if (buf == NULL)
+		return NULL;
+	if (fread(buf, 1, (size_t)sz, f) != (size_t)sz) {
+		free(buf);
+		return NULL;
+	}
+	buf[sz] = '\0';
+	return buf;
+}
+
+/* Render a report with the given findings to a tmpfile; return
+ * the PDF bytes (caller frees) and the writer's return value.
+ */
+static char *render(const char *policy, const char *trace,
+		    int n_findings, int *rc_out)
+{
+	const char *sev0[] = {"critical", "high", "medium", "info"};
+	const char *sev[64];
+	const char *ids[64];
+	const char *descs[64];
+	FILE *f;
+	char *pdf;
+	int rc;
+	int i;
+
+	if (n_findings > 64)
+		n_findings = 64;
+	for (i = 0; i < n_findings; i++) {
+		sev[i] = sev0[i % 4];
+		ids[i] = "R-001";
+		descs[i] = "finding description";
+	}
+
+	f = tmpfile();
+	if (f == NULL)
+		return NULL;
+	rc = pdf_write_audit_report(f, policy, trace,
+		n_findings > 0 ? sev : NULL,
+		n_findings > 0 ? ids : NULL,
+		n_findings > 0 ? descs : NULL,
+		n_findings,
+		1, 2, 3, 4);
+	if (rc_out != NULL)
+		*rc_out = rc;
+	rewind(f);
+	pdf = slurp(f);
+	fclose(f);
+	return pdf;
+}
+
+static int count_str(const char *hay, const char *needle)
+{
+	int n = 0;
+	const char *p = hay;
+
+	while ((p = strstr(p, needle)) != NULL) {
+		n++;
+		p += strlen(needle);
+	}
+	return n;
+}
+
+/* ----- pdf_escape_string ----- */
+
+static void test_escape_plain_unchanged(void)
+{
+	char *e = pdf_escape_string("hello world");
+
+	CHECK(e != NULL);
+	CHECK(strcmp(e, "hello world") == 0);
+	free(e);
+}
+
+static void test_escape_parens_and_backslash(void)
+{
+	char *e = pdf_escape_string("a(b)c\\d");
+
+	CHECK(e != NULL);
+	CHECK(strcmp(e, "a\\(b\\)c\\\\d") == 0);
+	free(e);
+}
+
+static void test_escape_only_specials(void)
+{
+	char *e1 = pdf_escape_string("(");
+	char *e2 = pdf_escape_string(")");
+	char *e3 = pdf_escape_string("\\");
+
+	CHECK(strcmp(e1, "\\(") == 0);
+	CHECK(strcmp(e2, "\\)") == 0);
+	CHECK(strcmp(e3, "\\\\") == 0);
+	free(e1);
+	free(e2);
+	free(e3);
+}
+
+static void test_escape_empty_string(void)
+{
+	char *e = pdf_escape_string("");
+
+	CHECK(e != NULL);
+	CHECK(strcmp(e, "") == 0);
+	free(e);
+}
+
+/* ----- document structure ----- */
+
+static void test_header_and_trailer(void)
+{
+	char *pdf = render("pol", "/t.json", 1, NULL);
+	size_t len;
+
+	CHECK(pdf != NULL);
+	len = strlen(pdf);
+	CHECK(strncmp(pdf, "%PDF-1.4", 8) == 0);
+	/* Trailer: %%EOF at the very end (allow trailing newline). */
+	CHECK(strstr(pdf, "%%EOF") != NULL);
+	CHECK(strstr(pdf + len - 16, "%%EOF") != NULL);
+	free(pdf);
+}
+
+static void test_xref_and_core_objects(void)
+{
+	char *pdf = render("pol", "/t.json", 1, NULL);
+
+	CHECK(pdf != NULL);
+	CHECK(strstr(pdf, "xref") != NULL);
+	CHECK(strstr(pdf, "startxref") != NULL);
+	CHECK(strstr(pdf, "/Type /Catalog") != NULL);
+	CHECK(strstr(pdf, "/Type /Pages") != NULL);
+	CHECK(strstr(pdf, "/Type /Font") != NULL);
+	CHECK(strstr(pdf, "/BaseFont /Helvetica") != NULL);
+	/* The free entry of the xref table. */
+	CHECK(strstr(pdf, "65535 f") != NULL);
+	free(pdf);
+}
+
+/* ----- page counts ----- */
+
+static void check_page_count(int n_findings, int want_pages,
+			     const char *label)
+{
+	char *pdf = render("pol", "/t.json", n_findings, NULL);
+	int pages;
+
+	pages = pdf ? count_str(pdf, "/Type /Page ") : -1;
+	printf("[%s: %d pages] ", label, pages);
+	free(pdf);
+	CHECK(pages == want_pages);
+}
+
+static void test_page_counts(void)
+{
+	/* cover + summary + >=1 findings page; 40 findings still
+	 * fit on one findings page ((40+39)/40 == 1).
+	 */
+	check_page_count(0, 3, "0 findings");
+	check_page_count(1, 3, "1 finding");
+	check_page_count(40, 3, "40 findings");
+}
+
+static void test_page_counts_overflow_pages(void)
+{
+	/* 41 spills onto a second findings page. */
+	check_page_count(41, 4, "41 findings");
+}
+
+/* ----- content ----- */
+
+static void test_cover_carries_policy_and_trace(void)
+{
+	char *pdf = render("pci-dss", "/var/log/trace.json", 1, NULL);
+
+	CHECK(pdf != NULL);
+	CHECK(strstr(pdf, "pci-dss") != NULL);
+	CHECK(strstr(pdf, "/var/log/trace.json") != NULL);
+	CHECK(strstr(pdf, "retrace Compliance Audit Report") != NULL);
+	free(pdf);
+}
+
+static void test_summary_carries_counts(void)
+{
+	char *pdf = render("pol", "/t.json", 1, NULL);
+
+	CHECK(pdf != NULL);
+	/* The writer pads the labels for column alignment. */
+	CHECK(strstr(pdf, "Critical: 1") != NULL);
+	CHECK(strstr(pdf, "High:     2") != NULL);
+	CHECK(strstr(pdf, "Medium:   3") != NULL);
+	CHECK(strstr(pdf, "Info:     4") != NULL);
+	free(pdf);
+}
+
+static void test_findings_carry_rule_ids(void)
+{
+	char *pdf = render("pol", "/t.json", 5, NULL);
+	int n;
+
+	CHECK(pdf != NULL);
+	n = count_str(pdf, "R-001");
+	CHECK(n >= 5);
+	free(pdf);
+}
+
+static void test_special_chars_survive_escaping(void)
+{
+	char *pdf;
+	FILE *f;
+	const char *sev[] = {"high"};
+	const char *ids[] = {"R(1)\\x"};
+	const char *descs[] = {"desc"};
+
+	f = tmpfile();
+	CHECK(f != NULL);
+	pdf_write_audit_report(f, "pol(name)", "/t.json",
+		sev, ids, descs, 1, 0, 1, 0, 0);
+	rewind(f);
+	pdf = slurp(f);
+	fclose(f);
+
+	CHECK(pdf != NULL);
+	/* Escaped forms embedded in the content streams. */
+	CHECK(strstr(pdf, "R\\(1\\)\\\\x") != NULL);
+	CHECK(strstr(pdf, "pol\\(name\\)") != NULL);
+	free(pdf);
+}
+
+static void test_writer_returns_zero(void)
+{
+	int rc = -99;
+
+	render("pol", "/t.json", 3, &rc);
+	CHECK(rc == 0);
+}
+
+int main(void)
+{
+	printf("-- pdf_escape_string --\n");
+	TEST(escape_plain_unchanged);
+	TEST(escape_parens_and_backslash);
+	TEST(escape_only_specials);
+	TEST(escape_empty_string);
+
+	printf("-- document structure --\n");
+	TEST(header_and_trailer);
+	TEST(xref_and_core_objects);
+
+	printf("-- page counts --\n");
+	TEST(page_counts);
+	TEST(page_counts_overflow_pages);
+
+	printf("-- content --\n");
+	TEST(cover_carries_policy_and_trace);
+	TEST(summary_carries_counts);
+	TEST(findings_carry_rule_ids);
+	TEST(special_chars_survive_escaping);
+	TEST(writer_returns_zero);
+
+	printf("\nPass: %d, Fail: %d (of %d)\n",
+		tests_pass, tests_fail, tests_run);
+	return tests_fail == 0 ? 0 : 1;
+}

--- a/tools/audit-converter/pdf_writer.c
+++ b/tools/audit-converter/pdf_writer.c
@@ -173,18 +173,20 @@ int pdf_write_audit_report(FILE *out, const char *policy_name,
 
 	/* Page 1: Cover */
 	{
-		char *esc_policy = pdf_escape_string(policy_name);
-		char *esc_trace = pdf_escape_string(trace_path);
+		/* build_page_content escapes each line exactly once;
+		 * pass the raw strings (pre-escaping here would
+		 * double-escape and render literal backslashes).
+		 */
 		const char *lines[] = {
 			"retrace Compliance Audit Report",
 			"",
 			"Policy:",
 			"",
-			esc_policy,
+			policy_name,
 			"",
 			"Trace:",
 			"",
-			esc_trace,
+			trace_path,
 			"",
 			"Date:",
 			"",
@@ -204,8 +206,6 @@ int pdf_write_audit_report(FILE *out, const char *policy_name,
 			obj_id, strlen(content), content);
 		obj_id++;
 		free(content);
-		free(esc_policy);
-		free(esc_trace);
 	}
 
 	/* Page 2: Summary */
@@ -267,7 +267,15 @@ int pdf_write_audit_report(FILE *out, const char *policy_name,
 	{
 		int finding_idx = 0;
 
-		while (finding_idx < n_findings && obj_id < total_objects - 1) {
+		/* Object numbering: 3 core + 2 per page. After cover
+		 * and summary the next findings page starts at obj_id
+		 * and consumes exactly the remaining budget, so the
+		 * guard is obj_id < total_objects (the historical
+		 * "- 1" skipped the findings page whenever it fit
+		 * exactly -- 1..40 findings produced a /Count of 3
+		 * with only 2 page objects).
+		 */
+		while (finding_idx < n_findings && obj_id < total_objects) {
 			const char *lines[42];
 			int n_lines = 0;
 


### PR DESCRIPTION
## Summary

Bumps retrace from v2.4.4 to **v2.4.5** (PATCH per ADR-0006). Two real bug fixes in the audit PDF deliverable plus its first test coverage. Both bugs shipped in v2.3.0 and were found by the new tests.

## What's in the bump

### Fixed — real bugs found by the new tests

1. **Missing findings page**: the findings-page loop's bound (`obj_id < total_objects - 1`) was off by one, so whenever the findings content fit exactly (1–40 findings) the page was skipped entirely — the PDF declared `/Count 3` with only 2 page objects, and every finding was invisible. Beyond 40 findings the last page was dropped. Verified end-to-end: `file(1)` now reports "3 pages" for a 1-finding report (previously 2).
2. **Double-escaped cover text**: the cover pre-escaped the policy name and trace path, then `build_page_content` escaped them again — parentheses rendered as literal backslash-parens in viewers. The cover now passes raw strings and is escaped exactly once (matching the findings path).

### Added — 13 unit tests

`test/unit/test_pdf.c`: `pdf_escape_string` rules (plain/parens/backslash/empty); document structure (PDF 1.4 header, `%%EOF` trailer, xref + startxref, Catalog/Pages/Font, the xref free entry); page counts for 0/1/40/41 findings; cover content; padded summary labels; findings rule ids; special-character round trip; writer return value. Links `pdf_writer.c` alone (it's decoupled from parson and the Findings model).

### Test-harness note

The render helper originally passed a fixed 4-element severities array for any finding count — the writer indexes it per finding, so 40 findings read past it (ASan stack-buffer-overflow). Sized it like the ids/descs arrays.

### Version + packaging

- `version.h`, `retrace_cli.c` banner: 2.4.4 → 2.4.5
- `packaging/{nix,debian,fedora}` bumped
- `CHANGELOG.md` entry

## Test plan

- [x] `cmake -B build -G Ninja -DRETRACE_BUILD_TESTS=ON`
- [x] `cmake --build build`
- [x] `ctest --test-dir build` — 56/56 pass (was 55)
- [x] `./build/test/unit/test_pdf` — 13/13 pass
- [x] `retrace-audit --format pdf` end-to-end: `file` reports "PDF document, version 1.4, 3 pages", `%%EOF` trailer present
- [x] Single commit; verified committed content via `git show HEAD:`
- [x] No AI attribution in commit message
- [ ] CI green on all matrix legs
- [ ] After merge: tag v2.4.5; release.yml produces binary artifacts

## Tagging plan

After PR rebase-merges, tag `v2.4.5` at the merge commit. release.yml will produce per-platform binary artifacts.
