### PR TITLE
v2.4.6: refresh architecture/development/faq for the v2.3.x–v2.4.x era

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (see `docs/adr/0006-semantic-versioning.md`).
 
+## [2.4.6] - 2026-08-17
+
+### Changed
+- `docs/architecture.md`: Logs section now documents the lock-free
+  SPSC ring + background flusher (v2.3.0) and
+  `RETRACE_LOGGER_RING`. New "The tooling ecosystem" section maps
+  the audit and diff module chains (policy→scan→format→pdf_writer;
+  normalize→threshold→lcs→stats) and the shared-JSON producer/
+  consumer contract. The backends section documents the ptrace
+  attach path (`retrace attach` / `retrace_attach_process`) and
+  why it bypasses the probe.
+- `docs/development.md`: new "Test conventions" (the CHECK-not-
+  assert rule with its Alpine war story, standalone tool-module
+  tests, per-commit checkpatch) and "Adding a new tool module"
+  (the pure-module → thin-CLI → standalone-test pattern).
+- `docs/faq.md`: four new answers — attach to a running process,
+  CI gating via `retrace-diff` exit codes, SARIF → GitHub Code
+  Scanning, logger overhead. Fixed stale counts (18→27 tutorials,
+  21→32 recipes) and the academic-citation version (2.1.0→2.4.5).
+
 ## [2.4.5] - 2026-08-16
 
 ### Fixed

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -320,8 +320,51 @@ The log goes to:
 Log entries include: timestamp, function name, parsed args, return
 value, `call_duration_us`.
 
+Since v2.3.0 the hot path is a **lock-free SPSC ring** per
+thread: the intercepting thread pushes an entry with two relaxed
+loads and one release store (no mutex on the write side), and a
+single background flusher thread drains all rings at a 1ms
+cadence and performs the actual I/O. The flusher disables
+interception for its own thread to avoid a feedback loop. Set
+`RETRACE_LOGGER_RING=0` for synchronous writes (OHOS/QEMU/debug
+builds where thread creation during init is fragile).
+
 `retrace pp <log.json>` pretty-prints a log as text.
 `retrace html <log.json>` converts it to an interactive HTML page.
+
+## The tooling ecosystem
+
+The standalone tools (`retrace-audit`, `retrace-diff`, ...) are
+consumers of the same JSON log the library produces. Each is
+decomposed into pure modules with the CLI as a thin driver —
+which is what makes them unit-testable without I/O:
+
+```
+tools/audit-converter/
+  policy.c     rules + matching        (policy_rule_matches)
+  scan.c       apply policy to trace   (audit_scan_trace)
+  format.c     render findings         (default JSON / SARIF 2.1.0)
+  pdf_writer.c PDF 1.4 deliverable    (cover + summary + findings)
+  audit.c      CLI: parse args, load, scan, format
+
+tools/trace-diff/
+  normalize.c  trace aggregation       (per-func counts + durations)
+  threshold.c  gating math             (diff_exceeds_threshold)
+  lcs.c        order alignment         (diff_lcs_len / diff_lcs_walk)
+  stats.c      z-score math            (diff_stats_compute)
+  diff.c       CLI: parse args, load, diff, print
+```
+
+Every module has a matching `test/unit/test_*.c` that links it
+standalone. The module chains are the reason that's possible:
+pure logic in small files, side effects (files, stdout)
+concentrated in the CLI driver.
+
+The output of every producer is byte-compatible with the input of
+every consumer — `retrace run`, `retrace attach`, the Frida
+bridge, and the eBPF bridge all emit the same JSON shape, and
+audit/diff/replay/ws/to-otlp all read it. Pipelines compose
+without format conversion.
 
 ## Per-platform backends
 
@@ -335,12 +378,24 @@ design.
 | `preload_macho` | macOS | x86_64, arm64 | `DYLD_INSERT_LIBRARIES` |
 | `preload_msvc` | Windows | x86_64, arm64 | Inline hook |
 | `preload_mingw` | Windows | x86_64 | Inline hook |
-| `ptrace` | Linux | x86_64, aarch64 | `ptrace(2)` (for static binaries) |
+| `ptrace` | Linux | x86_64, aarch64 | `ptrace(2)` |
 
 Each backend implements `retrace_backend_t` from
 `include/retrace/backend.h` and self-registers via the constructor
 section. `retrace_backend_select` walks the registry and picks the
 highest-rank backend whose `probe()` succeeds.
+
+The `ptrace` backend owns two niches the preload backends
+structurally cannot: statically-linked binaries (their probe
+checks for a missing `PT_INTERP`) and, since v2.4.0, **attaching
+to an already-running process** — `retrace attach <pid>` calls the
+public `retrace_attach_process()`, which selects the ptrace
+backend explicitly (attach semantics bypass the probe: for a
+process you cannot exec, ptrace is the sole native mechanism
+regardless of how the binary was linked). Its trace loop
+synthesizes a frame per syscall stop and forwards it to the same
+process-global `retrace_engine_wrapper` the preload trampolines
+use, so the JSON config applies unchanged.
 
 Adding a new backend (e.g., `frida`, `ebpf`) = adding a new
 directory under `src/backends/<name>/` and implementing the

--- a/docs/development.md
+++ b/docs/development.md
@@ -75,6 +75,25 @@ Examples under `examples/*/` (dns-fuzz, getenv-fuzzing,
 http-server-overflow, id-redirection, net-fuzzing, stringinject,
 unsafe-system) are self-contained demos.
 
+### Test conventions
+
+- **Use `CHECK(cond)`, not `assert(cond)`, whenever the
+  expression contains a function call whose side effects later
+  code needs.** `assert()` compiles to `((void)0)` under
+  `-DNDEBUG` (the CMake Release default), eliding both the check
+  and the call — this class of bug once segfaulted the test
+  suite on Alpine/musl + gcc -O3 while passing on glibc/macOS.
+  `CHECK()` lives in `test/helpers/test_utils.h` (or a per-file
+  copy); it always evaluates, prints `FAIL [file:line]`, bumps
+  `tests_fail`, and returns from the test function.
+- Every tool module under `tools/` has a standalone
+  `test/unit/test_<module>.c` that links just that module — no
+  engine, no LD_PRELOAD. Keep new modules linkable that way
+  (pure logic in the module, I/O in the CLI driver).
+- Fix style issues in the commit that introduces them:
+  checkpatch runs per-commit over the whole PR range, so a
+  fixup commit does not clear the original warning.
+
 ## Code style
 
 `.clang-format` is Mozilla-based. Format manually if you want
@@ -222,6 +241,28 @@ Backends live in `src/backends/<name>/`. Each backend:
 See `src/backends/preload_elf/` for the canonical example. The
 registry walks the constructor section at startup and picks the
 highest-rank backend whose `probe()` succeeds.
+
+## Adding a new tool module
+
+The standalone tools follow one decomposition pattern (see
+[architecture.md](architecture.md#the-tooling-ecosystem) for the
+current module chains):
+
+1. **Pure module first.** Put the algorithm in its own
+   `<module>.c` with a small header — no `printf`, no file I/O,
+   no global CLI state. Think `threshold.c` (one predicate) or
+   `lcs.c` (compute + callback).
+2. **Thin CLI driver.** The tool's `main()` file owns argument
+   parsing, loading, and printing. It calls the modules.
+3. **Standalone test.** Add `test/unit/test_<module>.c` linking
+   only the module (+ parson via the `parson_stub` include if it
+   parses JSON), following the `TEST`/`CHECK` conventions above.
+   Copy the CMake block from an existing tool test.
+
+This pattern is why the audit and diff tools could be tested (and
+why testing them found seven real bugs): small pure files make
+wrong answers visible; monolithic CLI drivers make them
+invisible.
 
 ## Adding a new action
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -120,16 +120,72 @@ defensively); existing fields are not renamed or removed. See the
 [configuration reference](configuration.md) for the schema. The
 interactive HTML viewer handles whatever fields are present.
 
+## Can I attach to an already-running process?
+
+On Linux, yes — since v2.4.0:
+
+```sh
+retrace attach --log /tmp/trace.json $(pidof my-server)
+```
+
+This uses ptrace: no `LD_PRELOAD`, no restart, no control of the
+launch required. Output is the same JSON log as `retrace run` and
+feeds the same tools. Permission errors usually mean ptrace_scope
+restrictions — attach to your own child, run as root, or see the
+troubleshooting notes in the [CLI reference](cli.md#attach--trace-a-running-process-linux).
+
+Elsewhere (macOS, Windows, iOS), use the
+[Frida bridge](cookbook/29-frida-bridge.md) — same JSON output,
+different injection point.
+
+## How do I fail CI when a change makes my program slower?
+
+`retrace-diff` compares two traces and its exit code doubles as a
+gate: 0 = no diff above threshold, 1 = regression found, 2 = setup
+error. Suppress noise with a percentage threshold:
+
+```sh
+retrace-diff --threshold pct=10 before.json after.json
+```
+
+For statistical gating across flaky runs, feed it multiple
+baselines: `--stats base1.json,base2.json,base3.json test.json`
+flags functions deviating by more than N standard deviations.
+See [tutorial 24](tutorials.md) for the full workflow.
+
+## Can retrace findings appear in GitHub Code Scanning?
+
+Yes. `retrace-audit` emits SARIF 2.1.0 — upload the file as a
+SARIF artifact and each finding (rule ID, severity, evidence)
+becomes an alert in **Security → Code scanning**, with Azure
+DevOps support as well:
+
+```sh
+retrace-audit --policy share/policies/pci-dss.json \
+  --trace trace.json --format sarif -o findings.sarif
+```
+
+## Does the logger add much overhead to the target?
+
+Since v2.3.0 the hot path is a lock-free per-thread ring: the
+intercepting thread does two relaxed loads and one release store
+per entry — no mutex — and a single background thread performs
+the actual I/O at 1ms cadence. The throughput-critical part of
+your program never blocks on the log writer. For targets where
+even the flusher thread is unwanted (QEMU, OHOS), set
+`RETRACE_LOGGER_RING=0` for synchronous writes.
+
 ## How do I cite retrace in academic work?
 
-Cite the repository: `riboseinc/retrace`, version 2.1.0,
+Cite the repository: `riboseinc/retrace`, version 2.4.5,
 BSD-2-Clause license, available at
 <https://github.com/riboseinc/retrace>. There is no formal paper
 yet; if you'd like one, open an issue.
 
 ## See also
 
-- [Tutorials](tutorials.md) — 18 scenario-driven walkthroughs.
-- [Cookbook](cookbook/README.md) — 21 recipe-style recipes.
+- [Tutorials](tutorials.md) — 27 scenario-driven walkthroughs.
+- [Cookbook](cookbook/README.md) — 32 recipe-style recipes.
+- [Tools overview](tools.md) — which tool for which job.
 - [CLI reference](cli.md) — every subcommand.
 - [Configuration reference](configuration.md) — full JSON schema.

--- a/include/retrace/version.h
+++ b/include/retrace/version.h
@@ -38,9 +38,9 @@
 
 #define RETRACE_VERSION_MAJOR 2
 #define RETRACE_VERSION_MINOR 4
-#define RETRACE_VERSION_PATCH 5
+#define RETRACE_VERSION_PATCH 6
 
-#define RETRACE_VERSION_STRING "2.4.5"
+#define RETRACE_VERSION_STRING "2.4.6"
 
 #define RETRACE_VERSION_ATLEAST(maj, min, pat)                  \
 	(RETRACE_VERSION_MAJOR > (maj) ||                       \

--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -1,3 +1,11 @@
+retrace (2.4.6-1) unstable; urgency=medium
+
+  * docs: architecture/development/faq refreshed for v2.3.x-v2.4.x
+    (tool ecosystem module chains, ptrace attach, CHECK convention,
+    new FAQ entries).
+
+ -- Ribose Inc <opensource@ribose.com>  Sun, 16 Aug 2026 00:00:00 +0000
+
 retrace (2.4.5-1) unstable; urgency=medium
 
   * audit PDF: fix missing findings page (1-40 findings) and

--- a/packaging/fedora/retrace.spec
+++ b/packaging/fedora/retrace.spec
@@ -2,10 +2,10 @@
 #
 # Fedora RPM spec for retrace (TODO.complete/38).
 # Build: rpmbuild -ba retrace.spec
-# Install: dnf install retrace-2.4.5-1.*.rpm
+# Install: dnf install retrace-2.4.6-1.*.rpm
 
 Name:           retrace
-Version:        2.4.5
+Version:        2.4.6
 Release:        1%{?dist}
 Summary:        Userspace libc interceptor for security discovery
 
@@ -50,6 +50,9 @@ action, OTLP/JSON export, and a Python config builder.
 %{_includedir}/retrace/
 
 %changelog
+* Sun Aug 16 2026 Ribose Inc <opensource@ribose.com> - 2.4.6-1
+- architecture/development/faq docs refreshed for the v2.3.x-v2.4.x era
+
 * Sat Aug 15 2026 Ribose Inc <opensource@ribose.com> - 2.4.5-1
 - audit PDF: findings-page off-by-one + cover double-escape fixes; 13 tests
 

--- a/packaging/nix/default.nix
+++ b/packaging/nix/default.nix
@@ -8,7 +8,7 @@
 
 stdenv.mkDerivation rec {
   pname = "retrace";
-  version = "2.4.5";
+  version = "2.4.6";
 
   src = ./.;
 

--- a/src/cli/retrace_cli.c
+++ b/src/cli/retrace_cli.c
@@ -63,7 +63,7 @@ typedef int retrace_status_t;
 static void usage(FILE *out)
 {
 	fprintf(out,
-"retrace v2.4.5 -- userspace libc interceptor\n"
+"retrace v2.4.6 -- userspace libc interceptor\n"
 "\n"
 "Usage:\n"
 "  retrace run [OPTIONS] -- <command> [args...]\n"


### PR DESCRIPTION
## Summary

Bumps retrace from v2.4.5 to **v2.4.6** (PATCH per ADR-0006). Docs-only: refreshes the last three reference docs still describing the v2.2-era codebase. This closes the final item on the gap list.

## What's in the bump

### `docs/architecture.md`

- **Logs**: documents the lock-free SPSC ring + background flusher (v2.3.0) and `RETRACE_LOGGER_RING`.
- **New "The tooling ecosystem" section**: the audit module chain (policy → scan → format → pdf_writer) and the diff chain (normalize → threshold → lcs → stats), each module's responsibility, why the decomposition makes them unit-testable, and the shared-JSON producer/consumer contract (run/attach/frida/ebpf → audit/diff/replay/ws/to-otlp; pipelines compose without format conversion).
- **Backends**: the ptrace row plus a paragraph on `retrace attach` / `retrace_attach_process()` and why attach bypasses the probe.

### `docs/development.md`

- **New "Test conventions"**: the CHECK-not-assert rule (with the Alpine/musl NDEBUG war story as the why), standalone tool-module tests, per-commit checkpatch semantics.
- **New "Adding a new tool module"**: the pure-module → thin-CLI → standalone-test pattern that produced the module chains (and surfaced seven real bugs).

### `docs/faq.md`

- Four new answers: attach to a running process (Linux native + Frida elsewhere), CI gating via `retrace-diff` exit codes, SARIF → GitHub Code Scanning, logger overhead.
- Fixed stale counts (18→27 tutorials, 21→32 recipes) and the academic-citation version (2.1.0→2.4.5).

### Version + packaging

- `version.h`, `retrace_cli.c` banner: 2.4.5 → 2.4.6; packaging bumped; CHANGELOG entry.

## Test plan

- [x] Docs only; no code change
- [x] `ctest --test-dir build` — 56/56 pass
- [x] Banner reads `v2.4.6`
- [x] Cross-references resolve (architecture ↔ development ↔ faq ↔ cli.md)
- [x] Single commit; verified committed content via `git show HEAD:`
- [x] No AI attribution in commit message
- [ ] CI green on all matrix legs
- [ ] After merge: tag v2.4.6; release.yml produces binary artifacts

## Tagging plan

After PR rebase-merges, tag `v2.4.6` at the merge commit. release.yml will produce per-platform binary artifacts.
