### PR TITLE
v2.5.2: property tests for the audit policy matcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (see `docs/adr/0006-semantic-versioning.md`).
 
+## [2.5.2] - 2026-08-17
+
+### Added
+- `test/property/test_property_policy.c` — 6 property-based
+  tests for `policy_rule_matches` (the audit matcher), 2000
+  generated iterations each with a fixed seed (reproducible;
+  override via RETRACE_PROPERTY_SEED):
+  - **determinism**: same (rule, message) answers identically.
+  - **AND-loosening**: a matching rule still matches after any
+    single predicate is removed — fewer constraints cannot
+    un-match.
+  - **empty-matches-all**: a predicate-free rule matches every
+    generated message.
+  - **func_exact soundness**: a match implies the func equals
+    the pattern.
+  - **path_contains soundness**: a match implies some string
+    value contains the substring (non-matches vacuously sound).
+  - **env-glob iff**: suffix/prefix/exact shapes match exactly
+    the names that end with/start with/ equal the word.
+
 ## [2.5.1] - 2026-08-17
 
 ### Added

--- a/include/retrace/version.h
+++ b/include/retrace/version.h
@@ -38,9 +38,9 @@
 
 #define RETRACE_VERSION_MAJOR 2
 #define RETRACE_VERSION_MINOR 5
-#define RETRACE_VERSION_PATCH 1
+#define RETRACE_VERSION_PATCH 2
 
-#define RETRACE_VERSION_STRING "2.5.1"
+#define RETRACE_VERSION_STRING "2.5.2"
 
 #define RETRACE_VERSION_ATLEAST(maj, min, pat)                  \
 	(RETRACE_VERSION_MAJOR > (maj) ||                       \

--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -1,3 +1,10 @@
+retrace (2.5.2-1) unstable; urgency=medium
+
+  * property tests for the audit policy matcher (6 properties x
+    2000 iterations).
+
+ -- Ribose Inc <opensource@ribose.com>  Mon, 17 Aug 2026 00:00:00 +0000
+
 retrace (2.5.1-1) unstable; urgency=medium
 
   * perf: ring-logger contention benchmark (1/2/4/8 producers);

--- a/packaging/fedora/retrace.spec
+++ b/packaging/fedora/retrace.spec
@@ -2,10 +2,10 @@
 #
 # Fedora RPM spec for retrace (TODO.complete/38).
 # Build: rpmbuild -ba retrace.spec
-# Install: dnf install retrace-2.5.1-1.*.rpm
+# Install: dnf install retrace-2.5.2-1.*.rpm
 
 Name:           retrace
-Version:        2.5.1
+Version:        2.5.2
 Release:        1%{?dist}
 Summary:        Userspace libc interceptor for security discovery
 
@@ -50,6 +50,9 @@ action, OTLP/JSON export, and a Python config builder.
 %{_includedir}/retrace/
 
 %changelog
+* Mon Aug 17 2026 Ribose Inc <opensource@ribose.com> - 2.5.2-1
+- Property tests for the audit policy matcher
+
 * Mon Aug 17 2026 Ribose Inc <opensource@ribose.com> - 2.5.1-1
 - ring-logger contention benchmark (1/2/4/8 producer threads)
 

--- a/packaging/nix/default.nix
+++ b/packaging/nix/default.nix
@@ -8,7 +8,7 @@
 
 stdenv.mkDerivation rec {
   pname = "retrace";
-  version = "2.5.1";
+  version = "2.5.2";
 
   src = ./.;
 

--- a/src/cli/retrace_cli.c
+++ b/src/cli/retrace_cli.c
@@ -63,7 +63,7 @@ typedef int retrace_status_t;
 static void usage(FILE *out)
 {
 	fprintf(out,
-"retrace v2.5.1 -- userspace libc interceptor\n"
+"retrace v2.5.2 -- userspace libc interceptor\n"
 "\n"
 "Usage:\n"
 "  retrace run [OPTIONS] -- <command> [args...]\n"

--- a/test/property/CMakeLists.txt
+++ b/test/property/CMakeLists.txt
@@ -274,3 +274,31 @@ add_test(NAME property-caller-match
 set_tests_properties(property-caller-match PROPERTIES
     LABELS "property;unit"
     TIMEOUT 60)
+
+#
+# Property-based tests for the audit policy matcher (TODO.complete/26).
+# policy_rule_matches drives every compliance finding; these
+# properties (determinism, AND-loosening, empty-matches-all,
+# per-predicate soundness, env-glob iff-semantics) hold for any
+# generated rule + message. Links policy.c from tools/audit-converter/
+# plus parson via the stub.
+#
+add_executable(retrace_property_policy
+	test_property_policy.c
+	${CMAKE_SOURCE_DIR}/tools/audit-converter/policy.c
+	${_parson_sources})
+set_target_properties(retrace_property_policy PROPERTIES
+	OUTPUT_NAME property_policy
+	RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/test/property")
+
+target_include_directories(retrace_property_policy PRIVATE
+	${CMAKE_CURRENT_SOURCE_DIR}
+	${CMAKE_CURRENT_SOURCE_DIR}/parson_stub
+	${CMAKE_SOURCE_DIR}/tools/audit-converter
+	${CMAKE_SOURCE_DIR}/src/config/json)
+
+add_test(NAME property-policy
+	COMMAND retrace_property_policy)
+set_tests_properties(property-policy PROPERTIES
+	LABELS "property;unit"
+	TIMEOUT 60)

--- a/test/property/test_property_policy.c
+++ b/test/property/test_property_policy.c
@@ -1,0 +1,356 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+/*
+ * Property-based tests for the audit policy matcher (TODO.complete/26).
+ *
+ * policy_rule_matches drives every compliance finding; a logic
+ * inversion means missed violations or phantom findings. The unit
+ * tests pin hand-picked cases; these properties hold for ANY
+ * generated rule and message:
+ *
+ * P-POLICY-DETERMINISM: matching the same (rule, message) twice
+ * yields the same answer.
+ *
+ * P-POLICY-LOOSENING: if a rule matches, removing any single
+ * predicate from it (setting the field NULL) still matches.
+ * (AND-semantics: fewer constraints cannot un-match.)
+ *
+ * P-POLICY-EMPTY-MATCHES-ALL: a rule with no predicates matches
+ * every message with a valid object.
+ *
+ * P-POLICY-EXACT-SOUNDNESS: if func_exact matches, the message's
+ * func equals the pattern exactly.
+ *
+ * P-POLICY-CONTAINS-SOUNDNESS: if path_contains matches, some
+ * string value in the message contains the substring.
+ *
+ * P-POLICY-ENV-IFF: for the glob shapes the matcher supports,
+ * suffix (*_S), prefix (P*) and exact (E) match exactly the
+ * messages whose "name" ends with S / starts with P / equals E.
+ */
+
+#include "property_harness.h"
+#include "parson.h"
+#include "policy.h"
+
+#include <string.h>
+#include <stdlib.h>
+
+/* ----- generators (small alphabet, adversarial shapes) ----- */
+
+static const char *const words[] = {
+	"open", "openat", "system", "getenv", "connect",
+	"/etc/passwd", "/etc/shadow", "secret.key", "payload",
+	"API_TOKEN", "LD_PRELOAD", "PATH", "IFS",
+};
+
+#define NWORDS (sizeof(words) / sizeof(words[0]))
+
+static const char *gen_word(struct ret_prng *p)
+{
+	return words[ret_prng_u32(p, NWORDS)];
+}
+
+/* Build a rule with randomly-present predicates. Fields chosen
+ * NULL or a random word -- deliberately includes empty-string
+ * patterns ("" prefix matches everything with a func) and
+ * wildcard shapes for env_pattern.
+ */
+static void gen_rule(struct ret_prng *p, struct Rule *r)
+{
+	const char *env_shapes[] = {"suffix", "prefix", "exact", "bare"};
+	int shape;
+
+	memset(r, 0, sizeof(*r));
+	if (ret_prng_u32(p, 4) != 0)
+		r->func_exact = gen_word(p);
+	if (ret_prng_u32(p, 4) != 0)
+		r->func_prefix = ret_prng_u32(p, 8) == 0 ? "" :
+			gen_word(p);
+	if (ret_prng_u32(p, 4) != 0)
+		r->path_contains = ret_prng_u32(p, 8) == 0 ? "" :
+			gen_word(p);
+
+	shape = ret_prng_u32(p, 4);
+	if (ret_prng_u32(p, 4) != 0) {
+		static char buf[64];
+		const char *w = gen_word(p);
+
+		switch (shape) {
+		case 0:
+			snprintf(buf, sizeof(buf), "*_%s", w);
+			break;
+		case 1:
+			snprintf(buf, sizeof(buf), "%s*", w);
+			break;
+		case 2:
+			snprintf(buf, sizeof(buf), "%s", w);
+			break;
+		default:
+			snprintf(buf, sizeof(buf), "*");
+			break;
+		}
+		r->env_pattern = buf;
+	}
+	r->severity = (enum Severity)ret_prng_u32(p, 4);
+}
+
+/* Build a random message object: optional func, 0-3 extra string
+ * fields, optional name field. Returns a JSON_Value the caller
+ * frees; *out_obj borrows from it.
+ */
+static JSON_Value *gen_message(struct ret_prng *p, JSON_Object **out_obj)
+{
+	JSON_Value *v = json_value_init_object();
+	JSON_Object *o = json_value_get_object(v);
+	int extra = (int)ret_prng_u32(p, 4);
+	int i;
+
+	if (ret_prng_u32(p, 4) != 0)
+		json_object_set_string(o, "func", gen_word(p));
+	for (i = 0; i < extra; i++) {
+		char key[16];
+
+		snprintf(key, sizeof(key), "k%d", i);
+		json_object_set_string(o, key, gen_word(p));
+	}
+	if (ret_prng_u32(p, 3) != 0)
+		json_object_set_string(o, "name", gen_word(p));
+
+	*out_obj = o;
+	return v;
+}
+
+/* Deep-copy a rule's predicate set, then NULL one predicate. */
+static void rule_drop_one(const struct Rule *src, struct Rule *dst,
+			  int which)
+{
+	memcpy(dst, src, sizeof(*dst));
+	switch (which) {
+	case 0:
+		dst->func_exact = NULL;
+		break;
+	case 1:
+		dst->func_prefix = NULL;
+		break;
+	case 2:
+		dst->path_contains = NULL;
+		break;
+	default:
+		dst->env_pattern = NULL;
+		break;
+	}
+}
+
+/* ----- properties ----- */
+
+static int prop_determinism(uint64_t seed)
+{
+	struct ret_prng p;
+	struct Rule r;
+	JSON_Object *msg;
+	JSON_Value *mv;
+	int a, b;
+
+	ret_prng_seed(&p, seed);
+	gen_rule(&p, &r);
+	mv = gen_message(&p, &msg);
+
+	a = policy_rule_matches(&r, msg);
+	b = policy_rule_matches(&r, msg);
+
+	json_value_free(mv);
+	return a == b;
+}
+
+static int prop_loosening(uint64_t seed)
+{
+	struct ret_prng p;
+	struct Rule r, looser;
+	JSON_Object *msg;
+	JSON_Value *mv;
+	int which;
+
+	ret_prng_seed(&p, seed);
+	gen_rule(&p, &r);
+	mv = gen_message(&p, &msg);
+	which = (int)ret_prng_u32(&p, 4);
+	rule_drop_one(&r, &looser, which);
+
+	/* If the original matched, the loosened rule must match too.
+	 * (The converse does not hold: loosening can add matches.)
+	 */
+	if (policy_rule_matches(&r, msg) == 1 &&
+	    policy_rule_matches(&looser, msg) != 1) {
+		json_value_free(mv);
+		return 0;
+	}
+	json_value_free(mv);
+	return 1;
+}
+
+static int prop_empty_matches_all(uint64_t seed)
+{
+	struct ret_prng p;
+	struct Rule r = {"R", "", NULL, NULL, NULL, NULL, SEV_INFO};
+	JSON_Object *msg;
+	JSON_Value *mv;
+
+	(void)seed;
+	ret_prng_seed(&p, seed ? seed : 1);
+	mv = gen_message(&p, &msg);
+
+	if (policy_rule_matches(&r, msg) != 1) {
+		json_value_free(mv);
+		return 0;
+	}
+	json_value_free(mv);
+	return 1;
+}
+
+static int prop_exact_soundness(uint64_t seed)
+{
+	struct ret_prng p;
+	struct Rule r = {"R", "", NULL, NULL, NULL, NULL, SEV_INFO};
+	JSON_Object *msg;
+	JSON_Value *mv;
+	const char *func;
+
+	ret_prng_seed(&p, seed);
+	r.func_exact = gen_word(&p);
+	mv = gen_message(&p, &msg);
+	func = json_object_get_string(msg, "func");
+
+	if (policy_rule_matches(&r, msg) == 1) {
+		int sound = func != NULL &&
+			strcmp(func, r.func_exact) == 0;
+
+		json_value_free(mv);
+		return sound;
+	}
+	json_value_free(mv);
+	return 1;
+}
+
+static int prop_contains_soundness(uint64_t seed)
+{
+	struct ret_prng p;
+	struct Rule r = {"R", "", NULL, NULL, NULL, NULL, SEV_INFO};
+	JSON_Object *msg;
+	JSON_Value *mv;
+	size_t i, n;
+	int matched;
+
+	ret_prng_seed(&p, seed);
+	r.path_contains = gen_word(&p);
+	mv = gen_message(&p, &msg);
+
+	matched = policy_rule_matches(&r, msg);
+	if (matched == 1) {
+		int found = 0;
+
+		n = json_object_get_count(msg);
+		for (i = 0; i < n; i++) {
+			const char *s = json_value_get_string(
+				json_object_get_value_at(msg, i));
+
+			if (s != NULL && strstr(s, r.path_contains)) {
+				found = 1;
+				break;
+			}
+		}
+		json_value_free(mv);
+		return found;
+	}
+
+	json_value_free(mv);
+	/* Soundness only constrains the match case; a non-match is
+	 * vacuously sound.
+	 */
+	return 1;
+}
+
+static int prop_env_iff(uint64_t seed)
+{
+	struct ret_prng p;
+	struct Rule suffix_r = {"R", "", NULL, NULL, NULL, NULL, SEV_INFO};
+	struct Rule prefix_r = {"R", "", NULL, NULL, NULL, NULL, SEV_INFO};
+	struct Rule exact_r = {"R", "", NULL, NULL, NULL, NULL, SEV_INFO};
+	JSON_Object *msg;
+	JSON_Value *mv;
+	const char *name;
+	const char *word;
+	char pat[80];
+	size_t wl, pl;
+	int ok = 1;
+
+	ret_prng_seed(&p, seed);
+	word = gen_word(&p);
+	wl = strlen(word);
+
+	snprintf(pat, sizeof(pat), "*_%s", word);
+	suffix_r.env_pattern = pat;
+	{
+		/* prefix/exact rules need separate buffers */
+		static char ppre[80];
+		static char pex[80];
+
+		snprintf(ppre, sizeof(ppre), "%s*", word);
+		prefix_r.env_pattern = ppre;
+		snprintf(pex, sizeof(pex), "%s", word);
+		exact_r.env_pattern = pex;
+
+		mv = gen_message(&p, &msg);
+		name = json_object_get_string(msg, "name");
+		pl = name ? strlen(name) : 0;
+
+		/* Suffix: *_W matches iff name ends with W. */
+		if (suffix_r.env_pattern[0] == '*' &&
+		    policy_rule_matches(&suffix_r, msg) == 1) {
+			size_t sl = wl;
+
+			if (!(pl >= sl && strcmp(name + pl - sl, word) == 0))
+				ok = 0;
+		}
+		/* Prefix: W* matches iff name starts with W. */
+		if (ok && policy_rule_matches(&prefix_r, msg) == 1) {
+			if (!(name != NULL && strncmp(name, word, wl) == 0))
+				ok = 0;
+		}
+		/* Exact: W matches iff name equals W. */
+		if (ok && policy_rule_matches(&exact_r, msg) == 1) {
+			if (!(name != NULL && strcmp(name, word) == 0))
+				ok = 0;
+		}
+	}
+
+	json_value_free(mv);
+	return ok;
+}
+
+int main(void)
+{
+	int failures = 0;
+
+	failures += property_run(prop_determinism,
+				 "prop_policy_determinism", 2000, 1);
+	failures += property_run(prop_loosening,
+				 "prop_policy_loosening", 2000, 1);
+	failures += property_run(prop_empty_matches_all,
+				 "prop_policy_empty_matches_all", 2000, 1);
+	failures += property_run(prop_exact_soundness,
+				 "prop_policy_exact_soundness", 2000, 1);
+	failures += property_run(prop_contains_soundness,
+				 "prop_policy_contains_soundness", 2000, 1);
+	failures += property_run(prop_env_iff,
+				 "prop_policy_env_iff", 2000, 1);
+
+	printf("[property] %s\n",
+		failures ? "some properties FAILED" :
+		"all properties passed");
+	return failures ? 1 : 0;
+}


### PR DESCRIPTION
## Summary

Bumps retrace from v2.5.1 to **v2.5.2** (PATCH per ADR-0006: tests only). Property-based coverage for the audit policy matcher — the predicate that drives every compliance finding.

## What's in the bump

### `test/property/test_property_policy.c` — 6 properties × 2000 generated iterations

- **determinism**: the same (rule, message) answers identically.
- **AND-loosening**: a matching rule still matches after any single predicate is removed — fewer constraints cannot un-match.
- **empty-matches-all**: a predicate-free rule matches every generated message.
- **func_exact soundness**: a match implies the func equals the pattern exactly.
- **path_contains soundness**: a match implies some string value contains the substring (non-matches vacuously sound).
- **env-glob iff**: suffix (`*_W`) / prefix (`W*`) / exact (`W`) shapes match exactly the names ending with / starting with / equal to the word.

Deterministic seed, reproducible via `RETRACE_PROPERTY_SEED`. Generators build random rules (randomly-present predicates over a small adversarial word alphabet — including empty-string patterns and bare `*` env shapes) and messages (optional func, 0–3 string fields, optional name) via parson.

### Test-authoring lesson (captured in the property)

A soundness property must return PASS when the matcher correctly *declines* to match — only the match case is constrained. The first draft returned the found-flag unconditionally and failed on its first non-match (seed 2, iteration 1).

### Version + packaging

- `version.h`, `retrace_cli.c` banner: 2.5.1 → 2.5.2; packaging bumped; CHANGELOG entry.

## Test plan

- [x] `cmake -B build -G Ninja -DRETRACE_BUILD_TESTS=ON`
- [x] `cmake --build build`
- [x] `ctest --test-dir build` — 59/59 pass (was 58)
- [x] `./build/test/property/property_policy` — 6/6 properties PASS at 2000 iterations
- [x] Single commit; verified committed content via `git show HEAD:` (fix in, debug print out)
- [x] No AI attribution in commit message
- [ ] CI green on all matrix legs
- [ ] After merge: tag v2.5.2; release.yml produces binary artifacts

## Tagging plan

After PR rebase-merges, tag `v2.5.2` at the merge commit. release.yml will produce per-platform binary artifacts.
