### PR TITLE
v2.5.3: ring capacity 64→1024 + RETRACE_LOGGER_RING_CAP (97.6% delivery)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (see `docs/adr/0006-semantic-versioning.md`).
 
+## [2.5.3] - 2026-08-18
+
+### Changed
+- **Ring logger default capacity 64 -> 1024** per thread. The
+  v2.5.1 contention benchmark showed the 64-slot ring engaging
+  drop-on-full at sustained rates above the flusher's drain
+  cadence (~64K entries/s/thread): a synthetic 1-thread producer
+  at ~500K entries/s delivered under 10% of entries. With 1024
+  slots (~1M entries/s/thread ceiling at the 1ms cadence, ~32KB
+  per logging thread) the same benchmark delivers **97.6%**
+  single-threaded (37x fewer drops) and 68% at 8 threads (was
+  17%). Accounting remains exact at every thread count
+  (delivered + dropped == pushed).
+
+### Added
+- `RETRACE_LOGGER_RING_CAP` env var: per-thread ring capacity,
+  power of two in [64, 65536]; anything else falls back to the
+  default. Documented in `docs/cli.md` and the README env table.
+- `test_env_cap_override` in the ring unit tests: valid override
+  (mask == cap-1), non-power-of-two and out-of-range fallbacks,
+  suite re-pinned to 64 via the env var so the wrap/drop tests
+  stay deterministic against any production default.
+
 ## [2.5.2] - 2026-08-17
 
 ### Added

--- a/README.adoc
+++ b/README.adoc
@@ -301,6 +301,7 @@ Environment variables:
 | `RETRACE_LOGGER_DEF_STDOUT_ENA` | `0` keeps retrace's log off stdout so it doesn't mix with the target's own output.
 | `RETRACE_LOGGER_DEF_FN` | Path to a log file (alternative to stderr).
 | `RETRACE_LOGGER_RING` | `1` (default): lock-free SPSC ring + background flusher. `0`: synchronous writes (OHOS/QEMU/debug).
+| `RETRACE_LOGGER_RING_CAP` | Per-thread ring capacity (power of 2 in 64..65536). Default 1024. |
 | `RETRACE_CALL_HASH` | `1` enables per-thread FNV-1a rolling hash surfaced to libFuzzer via `retrace_call_hash_last`. Default `0` (zero overhead).
 |===
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -289,6 +289,7 @@ Additional environment variables:
 | `RETRACE_LOGGER_ALLOWED_FUNCS`  | Comma-separated allowlist of function names to log.  |
 | `RETRACE_LOGGER_EXCLUDED_FUNCS` | Comma-separated denylist of function names to skip.  |
 | `RETRACE_LOGGER_RING`           | `1` (default): use lock-free SPSC ring + background flusher. `0`: synchronous writes (for OHOS / QEMU / debug builds where thread creation during init is fragile). |
+| `RETRACE_LOGGER_RING_CAP`        | Per-thread ring capacity in entries: power of two in `[64, 65536]`. Default `1024` (~1M entries/s/thread ceiling at the 1ms flusher cadence, ~32KB per logging thread). Larger = more headroom before drop-on-full engages. |
 | `RETRACE_CALL_HASH`             | `1` enables per-thread FNV-1a rolling hash of intercepted calls; exposed via `retrace_call_hash_last` for libFuzzer custom mutators (recipe 24). Default: `0` (off, zero overhead). |
 
 ## Library resolution

--- a/include/retrace/version.h
+++ b/include/retrace/version.h
@@ -38,9 +38,9 @@
 
 #define RETRACE_VERSION_MAJOR 2
 #define RETRACE_VERSION_MINOR 5
-#define RETRACE_VERSION_PATCH 2
+#define RETRACE_VERSION_PATCH 3
 
-#define RETRACE_VERSION_STRING "2.5.2"
+#define RETRACE_VERSION_STRING "2.5.3"
 
 #define RETRACE_VERSION_ATLEAST(maj, min, pat)                  \
 	(RETRACE_VERSION_MAJOR > (maj) ||                       \

--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -1,3 +1,10 @@
+retrace (2.5.3-1) unstable; urgency=medium
+
+  * ring logger: default capacity 64 -> 1024 (37x fewer drops at
+    sustained rates); new RETRACE_LOGGER_RING_CAP env override.
+
+ -- Ribose Inc <opensource@ribose.com>  Tue, 18 Aug 2026 00:00:00 +0000
+
 retrace (2.5.2-1) unstable; urgency=medium
 
   * property tests for the audit policy matcher (6 properties x

--- a/packaging/fedora/retrace.spec
+++ b/packaging/fedora/retrace.spec
@@ -2,10 +2,10 @@
 #
 # Fedora RPM spec for retrace (TODO.complete/38).
 # Build: rpmbuild -ba retrace.spec
-# Install: dnf install retrace-2.5.2-1.*.rpm
+# Install: dnf install retrace-2.5.3-1.*.rpm
 
 Name:           retrace
-Version:        2.5.2
+Version:        2.5.3
 Release:        1%{?dist}
 Summary:        Userspace libc interceptor for security discovery
 
@@ -50,6 +50,9 @@ action, OTLP/JSON export, and a Python config builder.
 %{_includedir}/retrace/
 
 %changelog
+* Tue Aug 18 2026 Ribose Inc <opensource@ribose.com> - 2.5.3-1
+- Ring logger capacity 64->1024 default; RETRACE_LOGGER_RING_CAP env override
+
 * Mon Aug 17 2026 Ribose Inc <opensource@ribose.com> - 2.5.2-1
 - Property tests for the audit policy matcher
 

--- a/packaging/nix/default.nix
+++ b/packaging/nix/default.nix
@@ -8,7 +8,7 @@
 
 stdenv.mkDerivation rec {
   pname = "retrace";
-  version = "2.5.2";
+  version = "2.5.3";
 
   src = ./.;
 

--- a/src/cli/retrace_cli.c
+++ b/src/cli/retrace_cli.c
@@ -63,7 +63,7 @@ typedef int retrace_status_t;
 static void usage(FILE *out)
 {
 	fprintf(out,
-"retrace v2.5.2 -- userspace libc interceptor\n"
+"retrace v2.5.3 -- userspace libc interceptor\n"
 "\n"
 "Usage:\n"
 "  retrace run [OPTIONS] -- <command> [args...]\n"

--- a/src/core/log_ring.c
+++ b/src/core/log_ring.c
@@ -156,9 +156,39 @@ static void ring_key_destructor(void *p)
 	retrace_real_impls.pthread_setspecific(g_ring_key, NULL);
 }
 
+static uint32_t g_ring_cap;
+
+/*
+ * Parse RETRACE_LOGGER_RING_CAP once at module init. Accepted:
+ * power-of-two values in [LOG_RING_CAP_MIN, LOG_RING_CAP_MAX].
+ * Anything else (unset, malformed, out of range) falls back to
+ * LOG_RING_DEFAULT_CAP. Returns the effective capacity.
+ */
+static uint32_t ring_configured_cap(void)
+{
+	const char *env = retrace_real_impls.getenv
+		? retrace_real_impls.getenv("RETRACE_LOGGER_RING_CAP")
+		: NULL;
+	long v;
+
+	if (env == NULL || *env == '\0')
+		return LOG_RING_DEFAULT_CAP;
+
+	if (retrace_real_impls.atoi == NULL)
+		return LOG_RING_DEFAULT_CAP;
+	v = (long)retrace_real_impls.atoi(env);
+	if (v < (long)LOG_RING_CAP_MIN || v > (long)LOG_RING_CAP_MAX)
+		return LOG_RING_DEFAULT_CAP;
+	if ((v & (v - 1)) != 0)
+		return LOG_RING_DEFAULT_CAP;
+	return (uint32_t)v;
+}
+
 int retrace_log_ring_init(void)
 {
 	int rc;
+
+	g_ring_cap = ring_configured_cap();
 
 	rc = retrace_real_impls.pthread_mutex_init(&g_registry.mtx, NULL);
 	if (rc != 0) {
@@ -205,7 +235,7 @@ struct LogRing *retrace_log_ring_get(void)
 	if (r != NULL)
 		return r;
 
-	r = ring_alloc(LOG_RING_DEFAULT_CAP);
+	r = ring_alloc(g_ring_cap ? g_ring_cap : LOG_RING_DEFAULT_CAP);
 	if (r == NULL)
 		return NULL;
 

--- a/src/core/log_ring.h
+++ b/src/core/log_ring.h
@@ -82,7 +82,19 @@ struct LogEntry {
 };
 
 /* Default capacity (power-of-2). 64 entries × 16 B = 1 KB per thread. */
-#define LOG_RING_DEFAULT_CAP 64
+/*
+ * Per-thread ring capacity (must be a power of two; the ring
+ * indexes with cap-1 masking). The default was raised from 64 to
+ * 1024 in v2.5.3: the contention benchmark showed the 64-slot
+ * ring engaging drop-on-full at sustained rates above the
+ * flusher's drain cadence (~64K entries/s/thread). 1024 slots
+ * (~1M entries/s/thread ceiling at the 1ms cadence) costs ~32KB
+ * per logging thread. Override via RETRACE_LOGGER_RING_CAP
+ * (power of two in [64, 65536]).
+ */
+#define LOG_RING_DEFAULT_CAP 1024
+#define LOG_RING_CAP_MIN 64
+#define LOG_RING_CAP_MAX 65536
 
 struct LogRing {
 	uint32_t mask;

--- a/test/unit/test_log_ring.c
+++ b/test/unit/test_log_ring.c
@@ -310,6 +310,40 @@ static void *thread_push_then_drain(void *p)
 	return NULL;
 }
 
+static void test_env_cap_override(void)
+{
+	struct LogRing *r;
+
+	/* Valid power-of-two override: 256 slots -> mask 255. */
+	setenv("RETRACE_LOGGER_RING_CAP", "256", 1);
+	retrace_log_ring_deinit();
+	retrace_log_ring_init();
+	r = retrace_log_ring_get();
+	CHECK(r != NULL);
+	CHECK(r->mask == 255);
+
+	/* Non-power-of-two: falls back to the default. */
+	setenv("RETRACE_LOGGER_RING_CAP", "100", 1);
+	retrace_log_ring_deinit();
+	retrace_log_ring_init();
+	r = retrace_log_ring_get();
+	CHECK(r != NULL);
+	CHECK(r->mask == LOG_RING_DEFAULT_CAP - 1);
+
+	/* Out-of-range: falls back to the default. */
+	setenv("RETRACE_LOGGER_RING_CAP", "999999", 1);
+	retrace_log_ring_deinit();
+	retrace_log_ring_init();
+	r = retrace_log_ring_get();
+	CHECK(r != NULL);
+	CHECK(r->mask == LOG_RING_DEFAULT_CAP - 1);
+
+	/* Restore the suite pin for subsequent tests. */
+	setenv("RETRACE_LOGGER_RING_CAP", "64", 1);
+	retrace_log_ring_deinit();
+	retrace_log_ring_init();
+}
+
 static void test_multi_thread_each_thread_drains_own(void)
 {
 	enum { NTHREADS = 4, PER_THREAD = 32 };
@@ -338,6 +372,13 @@ static void test_multi_thread_each_thread_drains_own(void)
 
 int main(void)
 {
+	/* The wrap/drop tests below assume the historical 64-slot
+	 * ring (63 usable + 1 sentinel). Pin RETRACE_LOGGER_RING_CAP
+	 * before the first module init so the suite is deterministic
+	 * regardless of the production default (1024 since v2.5.3).
+	 */
+	setenv("RETRACE_LOGGER_RING_CAP", "64", 1);
+
 	retrace_real_impls.strcmp = strcmp;
 	retrace_real_impls.strlen = strlen;
 	retrace_real_impls.strcpy = strcpy;
@@ -346,6 +387,8 @@ int main(void)
 	retrace_real_impls.malloc = malloc;
 	retrace_real_impls.free = free;
 	retrace_real_impls.real_snprintf = snprintf;
+	retrace_real_impls.atoi = atoi;
+	retrace_real_impls.getenv = getenv;
 	retrace_real_impls.pthread_mutex_lock = pthread_mutex_lock;
 	retrace_real_impls.pthread_mutex_unlock = pthread_mutex_unlock;
 	retrace_real_impls.pthread_mutex_init = pthread_mutex_init;
@@ -369,6 +412,9 @@ int main(void)
 
 	printf("  -- edge cases --\n");
 	TEST(null_inputs_safe);
+
+	printf("  -- capacity configuration --\n");
+	TEST(env_cap_override);
 
 	printf("  -- concurrency --\n");
 	TEST(multi_thread_each_thread_drains_own);


### PR DESCRIPTION
## Summary

Bumps retrace from v2.5.2 to **v2.5.3** (PATCH per ADR-0006: internal tuning, no API change). The v2.5.1 contention benchmark made the ring's old default measurable — and damning — so this fixes it.

## The problem, measured

A 64-slot ring drains at the flusher's 1ms cadence, capping sustained throughput at ~64K entries/s/thread. The contention benchmark's synthetic producer at ~500K entries/s had **90% of its log entries dropped** (by design, counted, but dropped).

## What's in the bump

### Default capacity 64 → 1024 per thread

Moves the ceiling to ~1M entries/s/thread for ~32KB per logging thread.

**Before/after on the contention benchmark (same machine):**

| Producers | Delivered before | Delivered after |
|-----------|------------------|-----------------|
| 1 | 9.8% | **97.6%** (drops 18049 → 485) |
| 2 | ~9% | 96.4% |
| 4 | ~2% | 90.8% |
| 8 | ~17% | 68% |

Accounting invariant (`delivered + dropped == pushed`) holds at every thread count in both configurations.

### `RETRACE_LOGGER_RING_CAP` env var

Power of two in [64, 65536]; anything else (unset/malformed/out-of-range/non-power-of-two) falls back to the default. Parsed once at module init. Documented in `docs/cli.md` + README env table.

### Tests

- `test_log_ring` re-pinned to the historical 64-slot semantics via the env var (the wrap/drop tests assume 63 usable slots), making the suite deterministic against any production default.
- New `test_env_cap_override`: valid override (mask == cap−1), non-power-of-two fallback, out-of-range fallback. 9/9.

## Test plan

- [x] `ctest --test-dir build` — 59/59 pass
- [x] Contention benchmark before/after run and recorded above
- [x] `./build/test/unit/test_log_ring` — 9/9
- [x] Single commit; verified via `git show HEAD:`
- [x] No AI attribution
- [ ] CI green
- [ ] After merge: tag v2.5.3; release.yml produces 28 assets

## Tagging plan

After PR rebase-merges, tag `v2.5.3` at the merge commit.
