### PR TITLE
v2.5.4: CI job timeouts on every workflow

### DIFF
--- a/.github/workflows/alpine.yml
+++ b/.github/workflows/alpine.yml
@@ -49,6 +49,7 @@ env:
 
 jobs:
   build-x86_64:
+    timeout-minutes: 45
     runs-on: ubuntu-latest
     container:
       image: alpine:3.21
@@ -96,6 +97,7 @@ jobs:
           LD_PRELOAD="$(pwd)/build/src/v2/libretrace.so" id
 
   build-aarch64:
+    timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,7 @@ env:
 
 jobs:
   build-and-test:
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -209,6 +210,7 @@ jobs:
   # finds no .gcda. --ignore-errors empty keeps the job green in that case;
   # once tests actually run, real coverage flows through.
   coverage:
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:

--- a/.github/workflows/checkpatch.yml
+++ b/.github/workflows/checkpatch.yml
@@ -37,6 +37,7 @@ concurrency:
 
 jobs:
   build:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     steps:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/msys.yml
+++ b/.github/workflows/msys.yml
@@ -49,6 +49,7 @@ env:
 
 jobs:
   build-and-smoke-test:
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -39,6 +39,7 @@ concurrency:
 
 jobs:
   build:
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -19,6 +19,7 @@ concurrency:
 
 jobs:
   build:
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -37,6 +38,7 @@ jobs:
           path: website/dist
 
   deploy:
+    timeout-minutes: 15
     needs: build
     runs-on: ubuntu-latest
     environment:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (see `docs/adr/0006-semantic-versioning.md`).
 
+## [2.5.4] - 2026-08-18
+
+### Changed
+- CI hardening: `timeout-minutes` on every workflow job that
+  lacked one (build.yml 60/30, alpine 45/60, msys 30, nix 30,
+  checkpatch 15, website 20/15, docker 30 — fuzz, ohos, coverity,
+  release already had them). Previously a hung runner (observed
+  during the v2.5.3 cycle: two Linux legs stuck on `apt install`)
+  waited out GitHub's 6-hour default before anyone could intervene.
+
 ## [2.5.3] - 2026-08-18
 
 ### Changed

--- a/include/retrace/version.h
+++ b/include/retrace/version.h
@@ -38,9 +38,9 @@
 
 #define RETRACE_VERSION_MAJOR 2
 #define RETRACE_VERSION_MINOR 5
-#define RETRACE_VERSION_PATCH 3
+#define RETRACE_VERSION_PATCH 4
 
-#define RETRACE_VERSION_STRING "2.5.3"
+#define RETRACE_VERSION_STRING "2.5.4"
 
 #define RETRACE_VERSION_ATLEAST(maj, min, pat)                  \
 	(RETRACE_VERSION_MAJOR > (maj) ||                       \

--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -1,3 +1,10 @@
+retrace (2.5.4-1) unstable; urgency=medium
+
+  * ci: timeout-minutes on every workflow job (bounded runner
+    hangs instead of GitHub's 6h default).
+
+ -- Ribose Inc <opensource@ribose.com>  Mon, 18 Aug 2026 00:00:00 +0000
+
 retrace (2.5.3-1) unstable; urgency=medium
 
   * ring logger: default capacity 64 -> 1024 (37x fewer drops at

--- a/packaging/fedora/retrace.spec
+++ b/packaging/fedora/retrace.spec
@@ -2,10 +2,10 @@
 #
 # Fedora RPM spec for retrace (TODO.complete/38).
 # Build: rpmbuild -ba retrace.spec
-# Install: dnf install retrace-2.5.3-1.*.rpm
+# Install: dnf install retrace-2.5.4-1.*.rpm
 
 Name:           retrace
-Version:        2.5.3
+Version:        2.5.4
 Release:        1%{?dist}
 Summary:        Userspace libc interceptor for security discovery
 
@@ -50,6 +50,9 @@ action, OTLP/JSON export, and a Python config builder.
 %{_includedir}/retrace/
 
 %changelog
+* Mon Aug 18 2026 Ribose Inc <opensource@ribose.com> - 2.5.4-1
+- CI job timeouts on every workflow
+
 * Tue Aug 18 2026 Ribose Inc <opensource@ribose.com> - 2.5.3-1
 - Ring logger capacity 64->1024 default; RETRACE_LOGGER_RING_CAP env override
 

--- a/packaging/nix/default.nix
+++ b/packaging/nix/default.nix
@@ -8,7 +8,7 @@
 
 stdenv.mkDerivation rec {
   pname = "retrace";
-  version = "2.5.3";
+  version = "2.5.4";
 
   src = ./.;
 

--- a/src/cli/retrace_cli.c
+++ b/src/cli/retrace_cli.c
@@ -63,7 +63,7 @@ typedef int retrace_status_t;
 static void usage(FILE *out)
 {
 	fprintf(out,
-"retrace v2.5.3 -- userspace libc interceptor\n"
+"retrace v2.5.4 -- userspace libc interceptor\n"
 "\n"
 "Usage:\n"
 "  retrace run [OPTIONS] -- <command> [args...]\n"


### PR DESCRIPTION
## Summary

PATCH per ADR-0006 (CI hardening only). During the v2.5.3 cycle two Linux CI legs hung on `apt install` with no progress; with no `timeout-minutes`, a hung runner waits GitHub's 6-hour default — and re-run is refused while the run is in_progress, forcing a cancel+rerun dance.

## What's in the bump

`timeout-minutes` bounded on every job that lacked one (values sized ~3–5× observed healthy runtimes):

| Workflow | Job | Timeout |
|----------|-----|---------|
| build.yml | build-and-test | 60 |
| build.yml | coverage | 30 |
| alpine.yml | build-x86_64 | 45 |
| alpine.yml | build-aarch64 | 60 |
| msys.yml | build-and-smoke-test | 30 |
| nix.yml | build | 30 |
| checkpatch.yml | build | 15 |
| website.yml | build / deploy | 20 / 15 |
| docker.yml | build-and-push | 30 |

fuzz/ohos/coverity/release already carried timeouts. All 11 workflow files re-validated as YAML after the edits. Version bumped to 2.5.4; CHANGELOG entry.

## Test plan

- [x] All 11 workflows parse as valid YAML
- [x] CI on this PR exercises the edited workflows (checkpatch/build/alpine/msys/nix legs run)
- [x] Banner reads v2.5.4
- [x] No AI attribution
- [ ] CI green
- [ ] After merge: tag v2.5.4