### PR TITLE
v2.6.0: public registry introspection API + working list-* CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,35 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (see `docs/adr/0006-semantic-versioning.md`).
 
+## [2.6.0] - 2026-08-18
+
+MINOR bump per ADR-0006: public surface grows (ADR-0014's
+implementation-first path).
+
+### Added
+- **`retrace_list_functions()` / `retrace_list_actions()`** —
+  public registry introspection: enumerate every interceptable
+  libc function (the prototype registry) and every built-in
+  action. Same ownership contract as `retrace_list_backends`.
+  Implementation walks the `__retrace_funcs` / `__retrace_acts`
+  linker-section arrays; no init required. The section-walk
+  macro's block-scope externs are hoisted by clang, so each
+  listing lives in its own translation unit (mirroring
+  funcs.c/actions.c) with a shared inline builder in
+  `public_api_internal.h`.
+- Surface-guard test extended: the two new symbols join the
+  dlsym list, plus contract tests (counts, non-empty names,
+  well-known members: malloc/open/write among 322 functions;
+  log_params/call_real/memory_fuzz/capture_buffer among 17
+  actions).
+
+### Fixed
+- **`retrace list-functions` / `list-actions` actually work
+  now.** Both were stubs since the CLI landed ("TODO: link
+  against retrace_core"; list-actions printed a hardcoded list
+  of 9 actions that had drifted from the real 17). Both now
+  dlopen the installed library and print the live registry.
+
 ## [2.5.4] - 2026-08-18
 
 ### Changed

--- a/include/retrace/retrace.h
+++ b/include/retrace/retrace.h
@@ -122,6 +122,18 @@ RETRACE_API retrace_status_t retrace_attach_process(int pid);
 RETRACE_API retrace_status_t retrace_list_backends(
 		const char *const **out_names, size_t *out_count);
 
+/*
+ * Registry introspection: enumerate every interceptable libc
+ * function (the prototype registry) and every built-in action.
+ * Same ownership contract as retrace_list_backends: the array
+ * and strings are library-owned, valid until the next call to
+ * the same function.
+ */
+RETRACE_API retrace_status_t retrace_list_functions(
+		const char *const **out_names, size_t *out_count);
+RETRACE_API retrace_status_t retrace_list_actions(
+		const char *const **out_names, size_t *out_count);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/retrace/version.h
+++ b/include/retrace/version.h
@@ -37,10 +37,10 @@
 #define RETRACE_VERSION_H
 
 #define RETRACE_VERSION_MAJOR 2
-#define RETRACE_VERSION_MINOR 5
-#define RETRACE_VERSION_PATCH 4
+#define RETRACE_VERSION_MINOR 6
+#define RETRACE_VERSION_PATCH 0
 
-#define RETRACE_VERSION_STRING "2.5.4"
+#define RETRACE_VERSION_STRING "2.6.0"
 
 #define RETRACE_VERSION_ATLEAST(maj, min, pat)                  \
 	(RETRACE_VERSION_MAJOR > (maj) ||                       \

--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -1,3 +1,11 @@
+retrace (2.6.0-1) unstable; urgency=medium
+
+  * New: retrace_list_functions() / retrace_list_actions() public
+    API; CLI list-functions/list-actions now print the real
+    registry (was a stub + hardcoded list).
+
+ -- Ribose Inc <opensource@ribose.com>  Mon, 18 Aug 2026 00:00:00 +0000
+
 retrace (2.5.4-1) unstable; urgency=medium
 
   * ci: timeout-minutes on every workflow job (bounded runner

--- a/packaging/fedora/retrace.spec
+++ b/packaging/fedora/retrace.spec
@@ -2,10 +2,10 @@
 #
 # Fedora RPM spec for retrace (TODO.complete/38).
 # Build: rpmbuild -ba retrace.spec
-# Install: dnf install retrace-2.5.4-1.*.rpm
+# Install: dnf install retrace-2.6.0-1.*.rpm
 
 Name:           retrace
-Version:        2.5.4
+Version:        2.6.0
 Release:        1%{?dist}
 Summary:        Userspace libc interceptor for security discovery
 
@@ -50,6 +50,9 @@ action, OTLP/JSON export, and a Python config builder.
 %{_includedir}/retrace/
 
 %changelog
+* Mon Aug 18 2026 Ribose Inc <opensource@ribose.com> - 2.6.0-1
+- Public registry introspection API; CLI list-* un-stubbed
+
 * Mon Aug 18 2026 Ribose Inc <opensource@ribose.com> - 2.5.4-1
 - CI job timeouts on every workflow
 

--- a/packaging/nix/default.nix
+++ b/packaging/nix/default.nix
@@ -8,7 +8,7 @@
 
 stdenv.mkDerivation rec {
   pname = "retrace";
-  version = "2.5.4";
+  version = "2.6.0";
 
   src = ./.;
 

--- a/src/cli/retrace_cli.c
+++ b/src/cli/retrace_cli.c
@@ -63,7 +63,7 @@ typedef int retrace_status_t;
 static void usage(FILE *out)
 {
 	fprintf(out,
-"retrace v2.5.4 -- userspace libc interceptor\n"
+"retrace v2.6.0 -- userspace libc interceptor\n"
 "\n"
 "Usage:\n"
 "  retrace run [OPTIONS] -- <command> [args...]\n"
@@ -1165,6 +1165,64 @@ static int cmd_backends(void)
 	return 0;
 }
 
+/*
+ * retrace list-functions / list-actions
+ *
+ * Prints the registry the library actually carries (dlopen +
+ * dlsym of the public introspection API -- the names come from
+ * whatever library this build installed, not a hardcoded list).
+ */
+static int cmd_list_registry(const char *api_symbol)
+{
+	char lib_path[PATH_MAX];
+	char *found;
+	void *lib;
+	retrace_status_t (*list_fn)(const char *const **names,
+				    size_t *count);
+	const char *const *names = NULL;
+	size_t count = 0;
+	size_t i;
+
+	setenv("RETRACE_LOGGER_DEF_STDOUT_ENA", "0", 1);
+	found = find_library(lib_path, sizeof(lib_path));
+	if (!found) {
+		fprintf(stderr,
+			"retrace: cannot find %s. Set RETRACE_LIB.\n",
+			RETRACE_LIB_NAME);
+		return 1;
+	}
+
+	lib = dlopen(lib_path, RTLD_NOW);
+	if (lib == NULL) {
+		fprintf(stderr, "retrace: dlopen(%s): %s\n",
+			lib_path, dlerror());
+		return 1;
+	}
+
+	list_fn = (retrace_status_t(*)(const char *const **names,
+				       size_t *count))dlsym(lib, api_symbol);
+	if (list_fn == NULL) {
+		fprintf(stderr,
+			"retrace: library lacks %s (pre-v2.6.0 build?)\n",
+			api_symbol);
+		dlclose(lib);
+		return 1;
+	}
+
+	if (list_fn(&names, &count) != 0 || count == 0) {
+		fprintf(stderr, "retrace: registry empty\n");
+		dlclose(lib);
+		return 1;
+	}
+
+	printf("%zu entr%s:\n", count, count == 1 ? "y" : "ies");
+	for (i = 0; i < count; i++)
+		printf("  %s\n", names[i]);
+
+	dlclose(lib);
+	return 0;
+}
+
 int main(int argc, char **argv)
 {
 	if (argc < 2) {
@@ -1230,29 +1288,11 @@ int main(int argc, char **argv)
 		return 0;
 	}
 
-	if (strcmp(argv[1], "list-functions") == 0) {
-		/*
-		 * TODO: link against retrace_core and walk the registry.
-		 * For now, print a helpful message.
-		 */
-		printf("retrace list-functions requires the retrace_core library.\n");
-		printf("For now, see src/core/prototypes/ for the full list.\n");
-		return 0;
-	}
+	if (strcmp(argv[1], "list-functions") == 0)
+		return cmd_list_registry("retrace_list_functions");
 
-	if (strcmp(argv[1], "list-actions") == 0) {
-		printf("Built-in actions:\n");
-		printf("  log_params              Log call args to JSON\n");
-		printf("  call_real               Invoke real libc implementation\n");
-		printf("  modify_in_param_str     Rewrite a string argument\n");
-		printf("  modify_in_param_int     Rewrite an integer argument\n");
-		printf("  modify_in_param_arr     Rewrite a byte array argument\n");
-		printf("  modify_return_value_int Override the return value\n");
-		printf("  memory_fuzz             Randomly fail malloc/calloc/realloc\n");
-		printf("  incomplete_io           Partially fail I/O calls\n");
-		printf("  fuzzing_seed            Set deterministic seed for memory_fuzz\n");
-		return 0;
-	}
+	if (strcmp(argv[1], "list-actions") == 0)
+		return cmd_list_registry("retrace_list_actions");
 
 	if (strcmp(argv[1], "validate") == 0) {
 		if (argc < 3) {

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -18,7 +18,8 @@ set(_core_sources
 	log_ring.c
 	log_flusher.c
 	call_hash.c
-	public_api.c)
+	public_api.c
+	public_api_actions.c)
 
 # dlopen_guard.c is Linux-only: it exports dlopen/dlclose/dlsym/dlerror
 # as global symbols for LD_PRELOAD interposition. On macOS these symbols

--- a/src/core/public_api.c
+++ b/src/core/public_api.c
@@ -15,6 +15,12 @@
 #include <retrace/retrace.h>
 #include <retrace/version.h>
 
+#include "funcs.h"
+#include "actions.h"
+#include "real_impls.h"
+
+#include <stddef.h>
+
 RETRACE_API const char *retrace_version(void)
 {
 	return RETRACE_VERSION_STRING;
@@ -25,4 +31,29 @@ RETRACE_API const char *retrace_version_info(void)
 	return "retrace " RETRACE_VERSION_STRING
 	       " -- userspace libc interceptor"
 	       " (https://github.com/riboseinc/retrace)";
+}
+
+/*
+ * Registry listing: the section walk for __retrace_funcs must
+ * live in its own TU (see public_api_internal.h). The actions
+ * listing lives in public_api_actions.c for the same reason.
+ */
+#include "public_api_internal.h"
+#include "funcs.h"
+
+static const char *const *g_fn_names;
+static size_t g_fn_count;
+
+RETRACE_API retrace_status_t retrace_list_functions(
+		const char *const **out_names, size_t *out_count)
+{
+	struct FuncPrototype *p;
+	unsigned long size;
+
+	if (out_names == NULL || out_count == NULL)
+		return RETRACE_ERR_INVAL;
+
+	retrace_as_get_section_info("__DATA", "__retrace_funcs", &p, &size);
+	return retrace_names_from_section(p, size, sizeof(*p),
+		&g_fn_names, &g_fn_count, out_names, out_count);
 }

--- a/src/core/public_api_actions.c
+++ b/src/core/public_api_actions.c
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+/*
+ * The __retrace_acts half of the registry listing. Kept in its
+ * own TU: the section-walk macro's extern declarations cannot
+ * share a translation unit with another section's (see
+ * public_api_internal.h).
+ */
+
+#include "public_api_internal.h"
+#include "actions.h"
+
+static const char *const *g_act_names;
+static size_t g_act_count;
+
+RETRACE_API retrace_status_t retrace_list_actions(
+		const char *const **out_names, size_t *out_count)
+{
+	const struct Action *p;
+	unsigned long size;
+
+	if (out_names == NULL || out_count == NULL)
+		return RETRACE_ERR_INVAL;
+
+	retrace_as_get_section_info("__DATA", "__retrace_acts", &p, &size);
+	return retrace_names_from_section(p, size, sizeof(*p),
+		&g_act_names, &g_act_count, out_names, out_count);
+}

--- a/src/core/public_api_internal.h
+++ b/src/core/public_api_internal.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+#ifndef RETRACE_CORE_PUBLIC_API_INTERNAL_H_
+#define RETRACE_CORE_PUBLIC_API_INTERNAL_H_
+
+#include <retrace/retrace.h>
+
+#include <stddef.h>
+#include <stdlib.h>
+
+/*
+ * Shared builder for the registry-listing entry points. Both
+ * struct FuncPrototype and struct Action begin with a char name[]
+ * member, so the name array can be built generically from the
+ * section base + element size.
+ *
+ * The per-section walk itself (the retrace_as_get_section_info
+ * macro) must happen in the CALLING translation unit: the macro
+ * declares block-scope externs that clang hoists to file scope,
+ * so a single TU cannot walk two different sections. Hence one
+ * small TU per public listing, mirroring funcs.c/actions.c.
+ *
+ * Returns RETRACE_OK and fills *out/*count (array malloc'd once,
+ * cached in *cache; strings borrowed from static section data);
+ * RETRACE_ERR_NOMEM on allocation failure.
+ */
+static inline retrace_status_t retrace_names_from_section(
+		const void *base, size_t bytes, size_t elem_size,
+		const char ***cache, size_t *cached_count,
+		const char *const **out_names, size_t *out_count)
+{
+	size_t n = bytes / elem_size;
+
+	if (*cache == NULL) {
+		const char **names;
+		size_t i;
+
+		if (n == 0) {
+			static const char *const empty[] = { NULL };
+
+			*cache = empty;
+			*cached_count = 0;
+			*out_names = *cache;
+			*out_count = 0;
+			return RETRACE_OK;
+		}
+		names = (const char **)malloc(n * sizeof(char *));
+		if (names == NULL)
+			return RETRACE_ERR_NOMEM;
+		for (i = 0; i < n; i++) {
+			/* name is an embedded char[] at offset 0 of both
+			 * structs -- the string IS base + i*elem_size,
+			 * not a pointer stored there.
+			 */
+			names[i] = (const char *)base + i * elem_size;
+		}
+		*cache = names;
+		*cached_count = n;
+	}
+
+	*out_names = *cache;
+	*out_count = *cached_count;
+	return RETRACE_OK;
+}
+
+#endif /* RETRACE_CORE_PUBLIC_API_INTERNAL_H_ */

--- a/test/unit/test_public_api.c
+++ b/test/unit/test_public_api.c
@@ -56,6 +56,8 @@ static const char *const public_symbols[] = {
 	"retrace_version_info",
 	"retrace_attach_process",
 	"retrace_list_backends",
+	"retrace_list_functions",
+	"retrace_list_actions",
 };
 
 static void *g_lib;
@@ -120,6 +122,52 @@ static void test_list_backends_contract(void)
 	CHECK(names[0] != NULL && names[0][0] != '\0');
 }
 
+static int contains(const char *const *names, size_t count,
+		    const char *want)
+{
+	size_t i;
+
+	for (i = 0; i < count; i++)
+		if (names[i] != NULL && strcmp(names[i], want) == 0)
+			return 1;
+	return 0;
+}
+
+static void test_list_functions_contract(void)
+{
+	const char *const *names = NULL;
+	size_t count = 0;
+	size_t i;
+
+	CHECK(retrace_list_functions(NULL, NULL) == RETRACE_ERR_INVAL);
+	CHECK(retrace_list_functions(&names, &count) == RETRACE_OK);
+	CHECK(count > 100);  /* the prototype registry is large */
+	for (i = 0; i < count; i++)
+		CHECK(names[i] != NULL && names[i][0] != '\0');
+	/* Well-known interceptable functions must be present. */
+	CHECK(contains(names, count, "malloc"));
+	CHECK(contains(names, count, "open"));
+	CHECK(contains(names, count, "write"));
+}
+
+static void test_list_actions_contract(void)
+{
+	const char *const *names = NULL;
+	size_t count = 0;
+	size_t i;
+
+	CHECK(retrace_list_actions(NULL, NULL) == RETRACE_ERR_INVAL);
+	CHECK(retrace_list_actions(&names, &count) == RETRACE_OK);
+	CHECK(count >= 17);  /* built-in actions */
+	for (i = 0; i < count; i++)
+		CHECK(names[i] != NULL && names[i][0] != '\0');
+	/* Built-ins from every category. */
+	CHECK(contains(names, count, "log_params"));
+	CHECK(contains(names, count, "call_real"));
+	CHECK(contains(names, count, "memory_fuzz"));
+	CHECK(contains(names, count, "capture_buffer"));
+}
+
 int main(void)
 {
 	printf("-- surface guard --\n");
@@ -132,6 +180,8 @@ int main(void)
 	printf("-- behavior smoke --\n");
 	TEST(attach_invalid_pid);
 	TEST(list_backends_contract);
+	TEST(list_functions_contract);
+	TEST(list_actions_contract);
 
 	printf("\nPass: %d, Fail: %d (of %d)\n",
 		tests_pass, tests_fail, tests_run);


### PR DESCRIPTION
## Summary

MINOR per ADR-0006: public surface grows — the first slice of ADR-0014's implementation-first re-introduction.

## What's in the bump

### New public API

- **`retrace_list_functions()`** — every interceptable libc function (the prototype registry).
- **`retrace_list_actions()`** — every built-in action.
- Ownership contract matches `retrace_list_backends`. Declared with the definitions per ADR-0014; the dlsym surface guard now enforces both (8 symbols).

Implementation walks the `__retrace_funcs`/`__retrace_acts` linker-section arrays — no init required. The section macro's block-scope externs get hoisted by clang, so each listing lives in its own TU (mirroring funcs.c/actions.c) with a shared inline builder in `public_api_internal.h`.

### Fixed (user-visible): the list-* CLI works now

Both subcommands were stubs since the CLI landed: `list-functions` printed TODO text; `list-actions` printed a hardcoded list of 9 that had drifted from the real 17. Both now dlopen the installed library and print the live registry — **322 functions, 17 actions** verified.

### Tests

Surface guard extended + two contract tests (counts, non-empty names, well-known members). 7/7 in `test_public_api`; 59/59 overall.

## Test plan

- [x] `ctest --test-dir build` — 59/59
- [x] `retrace list-actions` → 17 entries; `retrace list-functions` → 322 entries (live registry)
- [x] Surface guard: 8/8 symbols resolve
- [x] Single commit; verified via `git show HEAD:` (stub text gone)
- [x] No AI attribution
- [ ] CI green
- [ ] After merge: tag v2.6.0
