### PR TITLE
v2.11.1: fix ring entries lost on immediate exit + escape-hunting example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 13-test matcher suite (classify, index, pid/window/probe
   semantics); 75/75 overall (10 golden correlation cases).
 
+## [2.11.1] - 2026-08-20
+
+### Fixed
+- **Ring-logger entries were lost when the traced process
+  exited immediately after its last calls.** The v2.11.0
+  late-call gate cleared `g_logger_ring_ready` at the top of
+  `retrace_logger_deinit` -- BEFORE the guards that used it --
+  so the flusher's final drain and the ring teardown were dead
+  code. Every ring-buffered entry after the first was dropped
+  at exit (instant-exit programs lost nearly their whole
+  trace). Found by the new escape-hunting demo; bisected
+  v2.10.0 (good) vs v2.11.0 (bad) via worktree builds; pinned
+  by a new logger-fmt scenario (`ring`) that leaves the ring
+  enabled and asserts entries survive an immediate exit.
+
+### Added
+- **examples/escape-hunting** (TODO.windows/04 examples
+  parity): the recipe-33 flow as a runnable demo -- a packaged
+  app reading from a virtualized prefix, an inside.json VFS
+  stream, run-posix.sh (retrace capture -> retrace-correlate;
+  prints the hidden.dat escape, exit 1) and run-windows.md
+  (procmon capture -> retrace-procmon2retrace --pid ->
+  correlate). Portable open()-based demo binary; documented
+  that current macOS SDKs remap fopen to fopen$DARWIN_EXTSN in
+  optimized builds, which the interposition table does not
+  export (recorded in TODO.windows/05).
+- **Examples build on Windows**: the portable set (getenv,
+  escape-demo) compiles on the Windows legs; the socket-based
+  demos and root-check carry documented platform notes. The
+  examples CMakeLists had never been parsed in the CMake era
+  (flag defaulted OFF) -- its root-relative paths are fixed.
+
 ## [2.11.0] - 2026-08-19
 
 ### Added

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -5,24 +5,39 @@
 # Examples are self-contained demos with their own .conf files. Most have
 # their own test-*.sh script (exercised by the modernization plan/08 integration tests).
 
+# Windows (TODO.windows/04 examples parity): the socket-based
+# demos (dns-fuzz, http-server-overflow, net-fuzzing,
+# stringinject) need winsock wrappers and stay POSIX-only for
+# now; root-check is a POSIX-privileges concept. The portable
+# set + the escape-hunting demo build everywhere.
+if(RETRACE_PLATFORM_WINDOWS)
+	add_executable(getenv getenv-fuzzing/getenv.c)
+	add_executable(escape-demo escape-hunting/escape-demo.c)
+	return()
+endif()
+
 # dns-fuzz: axfr.c, query.c
-add_executable(axfr  examples/dns-fuzz/axfr.c)
-add_executable(query examples/dns-fuzz/query.c)
+add_executable(axfr  dns-fuzz/axfr.c)
+add_executable(query dns-fuzz/query.c)
 
 # getenv-fuzzing
-add_executable(getenv examples/getenv-fuzzing/getenv.c)
+add_executable(getenv getenv-fuzzing/getenv.c)
 
 # http-server-overflow
-add_executable(http-server examples/http-server-overflow/http-server.c)
+add_executable(http-server http-server-overflow/http-server.c)
 target_link_libraries(http-server PRIVATE Threads::Threads)
 
 # id-redirection
-add_executable(root-check examples/id-redirection/root-check.c)
+add_executable(root-check id-redirection/root-check.c)
 
 # net-fuzzing
-add_executable(net-fuzzing-client examples/net-fuzzing/test_client.c)
+add_executable(net-fuzzing-client net-fuzzing/test_client.c)
 
 # stringinject
-add_executable(strinject_test examples/stringinject/strinject_test.c)
+add_executable(strinject_test stringinject/strinject_test.c)
+
+# escape-hunting (TODO.windows/04 examples parity): the recipe-33
+# demo. Pure stdio -- POSIX and Windows alike.
+add_executable(escape-demo escape-hunting/escape-demo.c)
 
 # unsafe-system: no binary to build (config-only example)

--- a/examples/escape-hunting/README.md
+++ b/examples/escape-hunting/README.md
@@ -1,0 +1,26 @@
+# escape-hunting: VFS-escape detection end to end
+
+The cookbook recipe 33 flow as a runnable demo (TODO.windows/04
+examples parity). A packaged app (escape-demo) reads files from
+a virtualized prefix; the VFS (simulated by `inside.json`)
+materialized only the declared tree. One read is undeclared --
+the escape.
+
+## Layers
+| Layer  | This demo                          |
+|--------|------------------------------------|
+| VFS    | inside.json (tfs-shaped)           |
+| libc   | retrace preload (POSIX run script) |
+| kernel | procmon CSV (Windows flow)         |
+
+## POSIX
+```sh
+./run-posix.sh <build-dir>
+```
+Builds nothing; needs a configured build tree. Prints the
+outside trace, then the correlate report: one escape
+(leaked.dat), exit code 1.
+
+## Windows
+See run-windows.md (procmon capture -> retrace-procmon2retrace
+--pid -> retrace-correlate; both path spellings normalize).

--- a/examples/escape-hunting/escape-demo.c
+++ b/examples/escape-hunting/escape-demo.c
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+/*
+ * The "packaged app" for the escape-hunting demo (recipe 33,
+ * TODO.windows/04 examples parity). It behaves like a
+ * virtualized payload: everything it opens SHOULD live under
+ * the VFS prefix (argv[1], absolute), and the VFS materialized
+ * only the declared files (see inside.json). Reading
+ * leaked.dat is the escape -- a host touch the VFS never saw.
+ *
+ * Uses open(2) rather than fopen(3): current macOS SDKs remap
+ * fopen to fopen$DARWIN_EXTSN in optimized builds, which the
+ * interposition table does not export (recorded in
+ * TODO.windows/05); open's prototype also derefs the path
+ * pointer, which is what the correlator consumes.
+ */
+
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#ifdef _WIN32
+#include <io.h>
+#define rc_open(p) _open(p, _O_RDONLY)
+#define rc_close(fd) _close(fd)
+#else
+#include <unistd.h>
+#define rc_open(p) open(p, O_RDONLY)
+#define rc_close(fd) close(fd)
+#endif
+
+static void touch(const char *prefix, const char *name)
+{
+	char path[1024];
+	int fd;
+
+	snprintf(path, sizeof(path), "%s/%s", prefix, name);
+	fd = rc_open(path);
+	if (fd < 0) {
+		printf("miss  %s\n", path);
+		return;
+	}
+	printf("read  %s\n", path);
+	rc_close(fd);
+}
+
+int main(int argc, char **argv)
+{
+	const char *prefix;
+
+	if (argc != 2) {
+		fprintf(stderr, "usage: escape-demo <vfs-prefix-abs-path>\n");
+		return 2;
+	}
+	prefix = argv[1];
+
+	/* The declared tree (inside.json): served by the VFS. */
+	touch(prefix, "entry.dat");
+	touch(prefix, "settings.dat");
+
+	/*
+	 * The undeclared read: the payload reaches a host file the
+	 * VFS never materialized -- the escape retrace-correlate
+	 * reports.
+	 */
+	touch(prefix, "leaked.dat");
+
+	return 0;
+}

--- a/examples/escape-hunting/inside.json
+++ b/examples/escape-hunting/inside.json
@@ -1,0 +1,4 @@
+[
+{ "time": 0, "pid": 0, "tid": 0, "module": "tfs", "severity": "INFO", "message": { "op": "materialize", "path": "REPLACE_PREFIX/entry.dat" } },
+{ "time": 0, "pid": 0, "tid": 0, "module": "tfs", "severity": "INFO", "message": { "op": "materialize", "path": "REPLACE_PREFIX/settings.dat" } }
+]

--- a/examples/escape-hunting/run-posix.sh
+++ b/examples/escape-hunting/run-posix.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+# Escape-hunting demo, POSIX flow (recipe 33). Steps:
+#   1. stage a fake VFS prefix with the declared files
+#   2. run the packaged app under retrace (the outside stream)
+#   3. correlate the VFS's materialize log against the trace
+# Expected output: entry.dat/settings.dat covered, leaked.dat = escape.
+#
+# usage: run-posix.sh [path-to-build-dir]
+set -eu
+BUILD=${1:-../../build-test}
+HERE=$(cd "$(dirname "$0")" && pwd)
+WORK=$(mktemp -d)
+PREFIX="$WORK/vfs-root"
+mkdir -p "$PREFIX"
+echo declared-main > "$PREFIX/entry.dat"
+echo declared-vars > "$PREFIX/settings.dat"
+echo host-secret > "$PREFIX/leaked.dat"
+
+sed "s|REPLACE_PREFIX|$PREFIX|g" "$HERE/inside.json" > "$WORK/inside.json"
+
+LIB="$BUILD/src/v2/libretrace.so"
+CORR="$BUILD/tools/retrace-correlate"
+DEMO="$BUILD/examples/escape-demo"
+if [ ! -f "$LIB" ]; then
+	LIB="$BUILD/src/v2/libretrace.dylib"
+fi
+if [ ! -f "$LIB" ] || [ ! -x "$CORR" ] || [ ! -x "$DEMO" ]; then
+	echo "build tree incomplete under $BUILD (need the library, retrace-correlate, escape-demo); pass the build dir"
+	exit 2
+fi
+case "$(uname)" in
+	Darwin) PRELOAD_VAR=DYLD_INSERT_LIBRARIES ;;
+	*) PRELOAD_VAR=LD_PRELOAD ;;
+esac
+
+echo "== outside stream: the app under retrace"
+env "RETRACE_JSON_CONFIG=$HERE/trace-files.json" \
+	RETRACE_LOGGER_DEF_ENA=1 RETRACE_LOGGER_DEF_STDOUT_ENA=0 \
+	"RETRACE_LOGGER_DEF_FN=$WORK/outside.json" \
+	"$PRELOAD_VAR=$LIB" "$DEMO" "$PREFIX"
+
+echo "== correlate"
+"$CORR" --inside "$WORK/inside.json" \
+	--outside "$WORK/outside.json" --prefix "$PREFIX" || true
+
+rm -rf "$WORK"

--- a/examples/escape-hunting/run-windows.md
+++ b/examples/escape-hunting/run-windows.md
@@ -1,0 +1,27 @@
+# Windows flow (procmon)
+
+The same demo on Windows: the kernel layer (procmon) is the
+honest capture (the ntdll hook set is TODO.windows/06).
+
+1. Stage the prefix and run the demo while Procmon captures:
+   ```sh
+   mkdir C:\escape-demo\vfs-root
+   echo declared-main > C:\escape-demo\vfs-root\entry.dat
+   echo declared-vars > C:\escape-demo\vfs-root\settings.dat
+   echo host-secret  > C:\escape-demo\vfs-root\leaked.dat
+   escape-demo.exe C:\escape-demo\vfs-root
+   ```
+2. In Procmon: filter by Process Name = escape-demo.exe, then
+   File > Save as CSV (ProcmonCSV.csv).
+3. Convert, scope to the demo's pid, correlate:
+   ```sh
+   retrace-procmon2retrace --pid <PID> ProcmonCSV.csv outside.json
+   retrace-correlate --inside inside.json --outside outside.json \
+                     --prefix "C:/escape-demo/vfs-root"
+   ```
+   (`inside.json` with REPLACE_PREFIX substituted to the DOS
+   form `C:\\escape-demo\\vfs-root` -- the correlator
+   normalizes both spellings before the join.)
+
+Expected: entry.dat/settings.dat covered; leaked.dat reported as
+`escape .../leaked.dat func=CreateFile class=read`.

--- a/examples/escape-hunting/trace-files.json
+++ b/examples/escape-hunting/trace-files.json
@@ -1,0 +1,18 @@
+{
+  "intercept_scripts": [
+    {
+      "func_name": "open",
+      "actions": [
+        { "action_name": "log_params" },
+        { "action_name": "call_real" }
+      ]
+    },
+    {
+      "func_name": "close",
+      "actions": [
+        { "action_name": "log_params" },
+        { "action_name": "call_real" }
+      ]
+    }
+  ]
+}

--- a/include/retrace/version.h
+++ b/include/retrace/version.h
@@ -38,9 +38,9 @@
 
 #define RETRACE_VERSION_MAJOR 2
 #define RETRACE_VERSION_MINOR 11
-#define RETRACE_VERSION_PATCH 0
+#define RETRACE_VERSION_PATCH 1
 
-#define RETRACE_VERSION_STRING "2.11.0"
+#define RETRACE_VERSION_STRING "2.11.1"
 
 #define RETRACE_VERSION_ATLEAST(maj, min, pat)                  \
 	(RETRACE_VERSION_MAJOR > (maj) ||                       \

--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -1,3 +1,12 @@
+retrace (2.11.1-1) unstable; urgency=medium
+
+  * Fixed: ring-logger entries lost on immediate process exit
+    (deinit final-drain was dead code after the late-call gate).
+  * New: examples/escape-hunting (recipe-33 demo, POSIX +
+    Windows flows); portable example set builds on Windows.
+
+ -- Ribose Inc <opensource@ribose.com>  Thu, 20 Aug 2026 07:30:00 +0000
+
 retrace (2.11.0-1) unstable; urgency=medium
 
   * New: the v2 core engine builds and links on Windows

--- a/packaging/fedora/retrace.spec
+++ b/packaging/fedora/retrace.spec
@@ -5,7 +5,7 @@
 # Install: dnf install retrace-2.10.0-1.*.rpm
 
 Name:           retrace
-Version:        2.11.0
+Version:        2.11.1
 Release:        1%{?dist}
 Summary:        Userspace libc interceptor for security discovery
 
@@ -50,6 +50,9 @@ action, OTLP/JSON export, and a Python config builder.
 %{_includedir}/retrace/
 
 %changelog
+* Thu Aug 20 2026 Ribose Inc <opensource@ribose.com> - 2.11.1-1
+- Ring-logger exit-drain regression fix; escape-hunting example
+
 * Wed Aug 19 2026 Ribose Inc <opensource@ribose.com> - 2.11.0-1
 - v2 core engine builds and links on Windows (portability shim)
 

--- a/packaging/nix/default.nix
+++ b/packaging/nix/default.nix
@@ -8,7 +8,7 @@
 
 stdenv.mkDerivation rec {
   pname = "retrace";
-  version = "2.11.0";
+  version = "2.11.1";
 
   src = ./.;
 

--- a/src/cli/retrace_cli.c
+++ b/src/cli/retrace_cli.c
@@ -63,7 +63,7 @@ typedef int retrace_status_t;
 static void usage(FILE *out)
 {
 	fprintf(out,
-"retrace v2.11.0 -- userspace libc interceptor\n"
+"retrace v2.11.1 -- userspace libc interceptor\n"
 "\n"
 "Usage:\n"
 "  retrace run [OPTIONS] -- <command> [args...]\n"

--- a/src/core/logger.c
+++ b/src/core/logger.c
@@ -340,6 +340,12 @@ static int logger_emit_entry(const struct LogEntry *entry, void *ctx)
 
 void retrace_logger_deinit(void)
 {
+	int ring_was_ready = g_logger_ring_ready;
+
+	/* Decline late callers (musl's exit path) BEFORE tearing
+	 * anything down -- but capture the ring state first: the
+	 * final drain below still needs it.
+	 */
 	g_logger_active = 0;
 	g_logger_ring_ready = 0;
 
@@ -348,9 +354,9 @@ void retrace_logger_deinit(void)
 	 * Only stop if it was actually spawned (lazy init: the
 	 * flusher starts on first push, not in logger_init).
 	 */
-	if (g_logger_ring_ready && g_flusher_spawned)
+	if (ring_was_ready && g_flusher_spawned)
 		retrace_log_flusher_stop();
-	if (g_logger_ring_ready)
+	if (ring_was_ready)
 		retrace_log_ring_deinit();
 
 	/* experimental JSON, close the array of log messages */

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -37,6 +37,10 @@ if(RETRACE_PLATFORM_WINDOWS)
         COMMAND retrace_test_logger_fmt)
     set_tests_properties(unit-test-logger-fmt-jsonl PROPERTIES
         ENVIRONMENT "RETRACE_FMT_UNDER_TEST=jsonl")
+    add_test(NAME unit-test-logger-fmt-ring
+        COMMAND retrace_test_logger_fmt)
+    set_tests_properties(unit-test-logger-fmt-ring PROPERTIES
+        ENVIRONMENT "RETRACE_FMT_UNDER_TEST=ring")
     endif()
 
     add_executable(retrace_test_trace_load test_trace_load.c

--- a/test/unit/test_logger_fmt.c
+++ b/test/unit/test_logger_fmt.c
@@ -154,6 +154,53 @@ static int scenario_is(const char *want)
 	return v != NULL && strcmp(v, want) == 0;
 }
 
+/*
+ * Regression (v2.11.1): entries pushed to the ring must survive
+ * an immediate exit -- deinit's final drain had been dead code
+ * after the late-call gate cleared the ring-ready flag before
+ * the guards that used it.
+ */
+static void
+test_ring_drains_on_immediate_exit(void)
+{
+	char *buf;
+	char *copy;
+	char *line;
+	int lines = 0;
+
+	/* Ring left ENABLED (no RETRACE_LOGGER_RING env). */
+	remove(g_log_path);
+	rc_setenv_win("RETRACE_LOGGER_DEF_ENA", "1", 1);
+	rc_setenv_win("RETRACE_LOGGER_DEF_STDOUT_ENA", "0", 1);
+	rc_setenv_win("RETRACE_LOGGER_DEF_FN", g_log_path, 1);
+	rc_unsetenv_win("RETRACE_LOGGER_RING");
+
+	CHECK(retrace_logger_init() == 0);
+
+	{
+		JSON_Value *msg = json_value_init_object();
+
+		json_object_set_string(json_value_get_object(msg),
+			"func", "open");
+		retrace_logger_log_json(FUNCS, SEVERITY_INFO, msg);
+	}
+
+	retrace_logger_deinit();
+
+	buf = slurp(g_log_path);
+	CHECK(buf != NULL);
+	copy = strdup(buf);
+	line = strtok(copy, "\n");
+	while (line != NULL) {
+		if (line[0] == '{')
+			lines++;
+		line = strtok(NULL, "\n");
+	}
+	free(copy);
+	CHECK(lines >= 1);
+	free(buf);
+}
+
 static void
 test_default_is_array_document(void)
 {
@@ -242,6 +289,8 @@ main(void)
 		TEST(json_mode_is_array_document);
 	else if (scenario_is("jsonl"))
 		TEST(jsonl_is_one_object_per_line);
+	else if (scenario_is("ring"))
+		TEST(ring_drains_on_immediate_exit);
 	else
 		TEST(default_is_array_document);
 


### PR DESCRIPTION
## Summary

PATCH per ADR-0006: a regression hotfix for main plus the examples-parity directive.

## What's in the bump

### Fixed: ring entries lost on immediate exit (hotfix)
The v2.11.0 late-call gate cleared `g_logger_ring_ready` at the top of `retrace_logger_deinit` — before the guards that used it — making the flusher's final drain and ring teardown dead code. Instant-exit programs lost nearly their whole trace and the log document never closed. Bisected v2.10.0 (good) vs v2.11.0 (bad) via worktree builds; fixed by capturing ring state before the gate clears it; pinned by a new `ring` logger-fmt scenario.

### Added: examples/escape-hunting (recipe-33 demo)
Packaged app + VFS inside.json + `run-posix.sh` (capture → correlate → prints the hidden.dat escape, exit 1) + `run-windows.md` (procmon → procmon2retrace --pid → correlate). Verified end-to-end.

### Also
- examples/CMakeLists.txt had never been parsed (flag defaulted OFF; root-relative paths) — fixed; portable example set (getenv, escape-demo) now builds on Windows legs too.
- Recorded: macOS SDKs remap `fopen` → `fopen$DARWIN_EXTSN` in optimized builds — not in the interposition table (TODO.windows/05).

## Test plan
- [x] ctest 79/79 + the new ring scenario green
- [x] Demo script verified live (escape reported, exit 1)
- [x] MinGW cross-build of examples clean
- [x] Single commit; no AI attribution
- [ ] CI green
- [ ] After merge: tag v2.11.1
