### PR TITLE
v2.11.2: interpose fopen$DARWIN_EXTSN (macOS _DARWIN_C_SOURCE builds)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 13-test matcher suite (classify, index, pid/window/probe
   semantics); 75/75 overall (10 golden correlation cases).
 
+## [2.11.2] - 2026-08-20
+
+### Fixed
+- **fopen interception was silently bypassed on macOS for every
+  target compiled with `_DARWIN_C_SOURCE`** — which includes
+  everything built by this project's CMake (it adds the define
+  to all Darwin targets). Modern macOS SDKs remap `fopen` to
+  `fopen$DARWIN_EXTSN` under that define in optimized builds,
+  and the interposition table had no entry for the variant —
+  calls went straight to libc, unlogged. Notably, the CI's own
+  test/file binary was affected: the macOS legs had zero real
+  fopen coverage until now.
+  - The Mach-O backends (arm64 + the shared x86_64 table)
+    interpose `fopen$DARWIN_EXTSN`.
+  - The engine strips the `$DARWIN_EXTSN` suffix at the single
+    normalization point (`strip_darwin_extsn`), so prototype
+    lookup, config scripts, real-impl resolution, and log
+    output all use the clean name — user configs need no
+    changes.
+  - Verified end to end: a `_DARWIN_C_SOURCE` -O3 binary's
+    EXTSN call is interposed, logged as plain `fopen` with the
+    dereferenced `*filename` param, and `call_real` executes
+    (the CI file test's 2 fopen calls now appear in traces).
+
 ## [2.11.1] - 2026-08-20
 
 ### Fixed

--- a/examples/escape-hunting/escape-demo.c
+++ b/examples/escape-hunting/escape-demo.c
@@ -12,11 +12,11 @@
  * only the declared files (see inside.json). Reading
  * leaked.dat is the escape -- a host touch the VFS never saw.
  *
- * Uses open(2) rather than fopen(3): current macOS SDKs remap
- * fopen to fopen$DARWIN_EXTSN in optimized builds, which the
- * interposition table does not export (recorded in
- * TODO.windows/05); open's prototype also derefs the path
- * pointer, which is what the correlator consumes.
+ * Uses open(2): its prototype derefs the path pointer (the
+ * correlator consumes *path), and it maps 1:1 to _open on
+ * Windows. fopen is interposed too -- including the
+ * fopen$DARWIN_EXTSN variant macOS SDKs emit in optimized
+ * _DARWIN_C_SOURCE builds (v2.12.0).
  */
 
 #include <fcntl.h>

--- a/include/retrace/version.h
+++ b/include/retrace/version.h
@@ -38,9 +38,9 @@
 
 #define RETRACE_VERSION_MAJOR 2
 #define RETRACE_VERSION_MINOR 11
-#define RETRACE_VERSION_PATCH 1
+#define RETRACE_VERSION_PATCH 2
 
-#define RETRACE_VERSION_STRING "2.11.1"
+#define RETRACE_VERSION_STRING "2.11.2"
 
 #define RETRACE_VERSION_ATLEAST(maj, min, pat)                  \
 	(RETRACE_VERSION_MAJOR > (maj) ||                       \

--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -1,3 +1,14 @@
+retrace (2.11.2-1) unstable; urgency=medium
+
+  * Fixed: fopen interception silently bypassed on macOS for
+    every target compiled with _DARWIN_C_SOURCE (the project's
+    own CMake adds it to all Darwin targets): modern SDKs emit
+    fopen$DARWIN_EXTSN in optimized builds. The variant symbol
+    is now interposed; the engine strips the suffix so configs,
+    prototypes, and logs use the plain name.
+
+ -- Ribose Inc <opensource@ribose.com>  Thu, 20 Aug 2026 09:40:00 +0000
+
 retrace (2.11.1-1) unstable; urgency=medium
 
   * Fixed: ring-logger entries lost on immediate process exit

--- a/packaging/fedora/retrace.spec
+++ b/packaging/fedora/retrace.spec
@@ -5,7 +5,7 @@
 # Install: dnf install retrace-2.10.0-1.*.rpm
 
 Name:           retrace
-Version:        2.11.1
+Version:        2.11.2
 Release:        1%{?dist}
 Summary:        Userspace libc interceptor for security discovery
 
@@ -50,6 +50,9 @@ action, OTLP/JSON export, and a Python config builder.
 %{_includedir}/retrace/
 
 %changelog
+* Thu Aug 20 2026 Ribose Inc <opensource@ribose.com> - 2.11.2-1
+- fopen$DARWIN_EXTSN interposition (macOS _DARWIN_C_SOURCE builds)
+
 * Thu Aug 20 2026 Ribose Inc <opensource@ribose.com> - 2.11.1-1
 - Ring-logger exit-drain regression fix; escape-hunting example
 

--- a/packaging/nix/default.nix
+++ b/packaging/nix/default.nix
@@ -8,7 +8,7 @@
 
 stdenv.mkDerivation rec {
   pname = "retrace";
-  version = "2.11.1";
+  version = "2.11.2";
 
   src = ./.;
 

--- a/src/backends/preload_macho/aarch64/funcs_symbols.S
+++ b/src/backends/preload_macho/aarch64/funcs_symbols.S
@@ -46,5 +46,15 @@
  * recursion. On Darwin, the constructor uses a different resolution
  * path (dyld interpose section walk), so dlsym interception is safe.
  */
+/*
+ * macOS SDKs with _DARWIN_C_SOURCE remap fopen to
+ * fopen$DARWIN_EXTSN in optimized builds (the project's CMake
+ * adds _DARWIN_C_SOURCE to every Darwin target). Interpose the
+ * variant symbol; the engine strips the suffix (engine.c,
+ * strip_darwin_extsn) so configs, prototypes, and logs all
+ * use the plain name.
+ */
+WRAPPER_ENTRY_AARCH64 fopen$DARWIN_EXTSN
+
 WRAPPER_ENTRY_AARCH64 dlerror
 WRAPPER_ENTRY_AARCH64 dlsym

--- a/src/cli/retrace_cli.c
+++ b/src/cli/retrace_cli.c
@@ -63,7 +63,7 @@ typedef int retrace_status_t;
 static void usage(FILE *out)
 {
 	fprintf(out,
-"retrace v2.11.1 -- userspace libc interceptor\n"
+"retrace v2.11.2 -- userspace libc interceptor\n"
 "\n"
 "Usage:\n"
 "  retrace run [OPTIONS] -- <command> [args...]\n"

--- a/src/core/engine.c
+++ b/src/core/engine.c
@@ -36,6 +36,7 @@
 #define _GNU_SOURCE
 #endif
 #include <stdio.h>
+#include <string.h>
 
 #include "engine.h"
 #include "real_impls.h"
@@ -73,6 +74,41 @@
  * Steps 3, 11, 12 live in their own modules (ADR-0013); this function
  * is the orchestrator that calls them in order.
  */
+/*
+ * macOS SDKs with _DARWIN_C_SOURCE remap some libc names (fopen)
+ * to $DARWIN_EXTSN variants in optimized builds. The Mach-O
+ * backends interpose the variant symbols too; stripping the
+ * suffix here makes every downstream lookup -- prototype,
+ * config script, real-impl resolution, log output -- see the
+ * clean name. Single normalization point (SSOT).
+ *
+ * Deliberately libc-free (manual loops): a plain strlen/strcmp
+ * here is an interposed call -- the wrapper would re-enter the
+ * engine and recurse (every preload test died to this on Linux).
+ */
+static char *strip_darwin_extsn(char *name, char *buf, size_t bufsz)
+{
+	static const char suffix[] = "$DARWIN_EXTSN";
+	const size_t slen = sizeof(suffix) - 1;
+	size_t n = 0;
+	size_t i;
+
+	while (name[n] != '\0')
+		n++;
+	if (n <= slen)
+		return name;
+	for (i = 0; i < slen; i++) {
+		if (name[n - slen + i] != suffix[i])
+			return name;
+	}
+	if (n - slen >= bufsz)
+		return name;
+	for (i = 0; i < n - slen; i++)
+		buf[i] = name[i];
+	buf[n - slen] = '\0';
+	return buf;
+}
+
 void retrace_engine_wrapper(char *func_name,
 	void *arch_spec_ctx)
 {
@@ -80,6 +116,10 @@ void retrace_engine_wrapper(char *func_name,
 	struct ThreadContext *thread_ctx;
 	const JSON_Object *i_script;
 	const JSON_Array *i_scripts;
+	char clean_name[64]; /* MAXLEN_FUNC_NAME; funcs.h not included here */
+
+	func_name = strip_darwin_extsn(func_name, clean_name,
+		sizeof(clean_name));
 
 	real_impl = retrace_as_get_real_safe(func_name);
 	if (!retrace_inited) {

--- a/src/v2/funcs_symbols.S
+++ b/src/v2/funcs_symbols.S
@@ -37,6 +37,17 @@
 #undef RETRACE_WRAP
 
 /*
+ * macOS (x86_64 path -- this file is the fallback when no
+ * arch-specific funcs_symbols.S exists): SDKs with
+ * _DARWIN_C_SOURCE remap fopen to fopen$DARWIN_EXTSN in
+ * optimized builds. Interpose the variant symbol; the engine
+ * strips the suffix (engine.c, strip_darwin_extsn).
+ */
+#ifdef __MACH__
+WRAPPER_ENTRY_SYSTEM_V fopen$DARWIN_EXTSN
+#endif
+
+/*
  * glibc-specific: __isoc99_* scanf variants.
  *
  * Modern gcc + glibc redirects scanf/fscanf/sscanf/v*scanf to


### PR DESCRIPTION
## Summary

PATCH per ADR-0006 (interception coverage fix on macOS). Closes the gap recorded in TODO.windows/05 during v2.11.1.

## The bug
macOS SDKs remap `fopen` → `fopen$DARWIN_EXTSN` in optimized builds compiled with `_DARWIN_C_SOURCE` — which this project's CMake adds to **every** Darwin target. The interposition table had no entry for the variant: those calls went straight to libc (unlogged, unmodified). The CI's own test/file binary is compiled that way — the macOS legs had zero real fopen coverage.

## The fix (SSOT)
- Mach-O backends interpose `fopen$DARWIN_EXTSN` (arm64 table + the shared x86_64 fallback under `#ifdef __MACH__`).
- The engine strips the suffix at ONE normalization point — prototype lookup, config matching, real-impl resolution, and logs all see clean `fopen`; user configs unchanged; any future EXTSN variant is covered by the same normalization.

## Test plan
- [x] Minimal repro (cc -O3 -D_DARWIN_C_SOURCE → `_fopen$DARWIN_EXTSN` in nm)
- [x] Live: EXTSN call interposed, logged as plain `fopen` with `*filename` deref, call_real executes
- [x] CI's file test binary: 2 fopen entries now captured
- [x] ctest 79/79; escape-hunting demo unchanged
- [x] Single commit; no AI attribution
- [ ] CI green
- [ ] After merge: tag v2.11.2
