### PR TITLE
v2.14.0: the trace + profile workstream -- capture, diff, validate, wider hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,42 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (see `docs/adr/0006-semantic-versioning.md`).
 
+## [2.14.0] — 2026-08-20
+
+**The trace + profile workstream** (TODO.trace-profile): the
+recipe-34 loop is now one command, upgrade-aware, and
+contract-checked.
+
+- **`retrace-profile capture`** — one-shot: run a command under
+  the preload with the right logger env, trace it, reduce to a
+  profile, optionally emit the jail. The built-in default config
+  scopes tracing to the file/env/net function set (a user
+  RETRACE_JSON_CONFIG always wins); a wildcard default traced
+  printf-family variadics -- noisy and fragile. POSIX; Windows
+  uses retrace-win-run (examples/profile-hunting/run-windows.md).
+- **`retrace-profile diff`** — drift between two profiles: new
+  paths, class escalations (read → write is the headline),
+  removed paths, new functions. Human report + --json; exit 1
+  on drift (CI-able). The upgrade story for the tailor loop.
+- **`retrace-profile validate` + `share/profile-schema.json`** —
+  the profile contract, machine-checkable: enum values, required
+  sections, and the cross-field rule a schema cannot express
+  (risk present iff the kernel layer was captured).
+- **Windows ucrt hook set expanded** (fopen-only before):
+  `_open _close _read _write _lseek _stat _unlink _remove
+  _rename _rmdir`, mapped to the POSIX-shaped prototypes via the
+  new export→engine name field in the hook table.
+- **Windows arm64 wrapper** (gas dialect; TODO.trace-profile/05):
+  AAPCS64 frame with x30 preserved for the tail-jump; dual-arch
+  arch_spec. The armasm64 variant for MSVC-arm64 is the
+  documented follow-up.
+- **MSVC logger fix**: real_impls never resolved `atoi`, so
+  logger_init called a NULL pointer on any env override -- the
+  long-gated logger-format tests now run on MSVC.
+
+Bumps: version.h 2.13.0 -> 2.14.0, retrace_cli.c banner,
+nix/debian/fedora packaging, CHANGELOG.md.
+
 ## [2.13.0] — 2026-08-20
 
 **Windows: the first live hooks.** (TODO.windows/05-06.) The

--- a/docs/cookbook/34-profile-and-jail.md
+++ b/docs/cookbook/34-profile-and-jail.md
@@ -104,11 +104,39 @@ PE, the imported ntdll entry points. Zero does not prove purity
 (a gadget can hide behind computed addresses) but any non-zero
 count means the binary can talk to the kernel without libc.
 
+## One-shot capture
+
+`retrace-profile capture` runs the whole capture step in one
+command (POSIX):
+
+```sh
+retrace-profile capture -o profile.json --inside inside.json     --jail-out jail.json -- ./app args...
+```
+
+The built-in default config scopes tracing to the file/env/net
+function set (set `RETRACE_JSON_CONFIG` to override). Windows:
+see `examples/profile-hunting/run-windows.md`.
+
 ## Tailor
 
-The profile is data: edit it, diff it (`retrace-diff` over two
-profiles shows drift between versions of a build), feed it to an
-audit. The jail step below is where the tailoring bites.
+The profile is data: edit it, feed it to an audit, and when the
+build changes, DIFF it — `retrace-profile diff baseline.json
+candidate.json` reports new paths, class escalations
+(read → write is the headline), and new functions; exit 1 when
+drift exists (CI-able):
+
+```
+profile-diff: baseline 26 entries, candidate 31 entries
+  + /vfs/telemetry.dat (added, write, 3 hits)
+  ! /vfs/config.dat (read -> write)
+  + fn fopen64 (new)
+profile-diff: DRIFT FOUND
+```
+
+The jail step below is where the tailoring bites. Validate any
+hand-edited profile against the contract with
+`retrace-profile validate profile.json` (schema:
+`share/profile-schema.json`).
 
 ## Jail
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -109,6 +109,22 @@ boots inside the child), and resumes it under trace. Opt into
 ntdll-depth hooks with `RETRACE_WIN_NTDLL=1` — see
 [windows.md](windows.md).
 
+### `retrace-profile`
+
+The profiler (≥ 2.12.0; subcommands ≥ 2.14.0): reduce a trace to
+what a binary does, grade libc claims against kernel truth, scan
+static syscall capability, and emit a deny-by-default jail.
+Three modes beyond the flags documented in
+[cookbook 34](cookbook/34-profile-and-jail.md):
+
+- `retrace-profile capture [-o p.json] [--inside d.json]
+  [--jail-out j.json] -- cmd` — one-shot: run under the preload,
+  trace, profile, jail (POSIX).
+- `retrace-profile diff base.json cand.json [--json]` — drift
+  between two profiles (upgrades); exit 1 on drift.
+- `retrace-profile validate p.json` — check the profile against
+  `share/profile-schema.json`; exit 1 on violations.
+
 ### `retrace-strace2retrace`
 
 strace log → trace JSON. Feeds `retrace-profile --kernel` and

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -43,7 +43,7 @@ Inside the child, `DLL_PROCESS_ATTACH`:
 
 | Layer | Default | Functions | Notes |
 |---|---|---|---|
-| ucrt | ON | `fopen` (v1 set; grows per release) | The CRT layer — what a normal C program calls |
+| ucrt | ON | `fopen`, `_open`, `_close`, `_read`, `_write`, `_lseek`, `_stat`, `_unlink`, `_remove`, `_rename`, `_rmdir` | The CRT layer — a normal C program's file traffic (v2.14.0 expands the v1 `fopen`-only set) |
 | ntdll | OPT-IN | `NtCreateFile`, `NtOpenFile`, `NtQueryAttributesFile`, `NtClose`, `LdrLoadDll` | One level deeper: catches Win32-direct callers that never touch the CRT |
 
 ### The ntdll layer (opt-in)
@@ -115,12 +115,12 @@ the Win32-direct depth at the ntdll boundary.
 
 ## What runs where (v2.13.0)
 
-| Capability | windows-x64 | windows-arm64 |
-|---|---|---|
-| Engine + registries (PE-section walk) | yes | yes |
-| ucrt/ntdll inline hooks + wrappers | yes | arm64 wrapper: follow-up |
-| Offline tools (profile, correlate, procmon2retrace, strace2retrace) | yes | yes |
-| ptrace attach | n/a (Linux backend) | n/a |
+| Capability | windows-x64 | windows-arm64 (MSVC) | windows-arm64 (MinGW/Clang) |
+|---|---|---|---|
+| Engine + registries (PE-section walk) | yes | yes | yes |
+| ucrt/ntdll inline hooks + wrappers | yes | armasm64 wrapper: follow-up | yes (gas dialect, TODO.trace-profile/05) |
+| Offline tools (profile, correlate, procmon2retrace, strace2retrace) | yes | yes | yes |
+| ptrace attach | n/a (Linux backend) | n/a | n/a |
 
 ## See also
 

--- a/examples/profile-hunting/run-windows.md
+++ b/examples/profile-hunting/run-windows.md
@@ -1,0 +1,71 @@
+# profile-hunting on Windows
+
+The recipe-34 flow (profile → tailor → jail) on Windows, using
+the live hooks (v2.13.0+). POSIX users: see `run-posix.sh`.
+
+## Prerequisites
+
+Build the Windows tree (MSVC or MSYS2/MinGW):
+
+```bat
+cmake -B build && cmake --build build --config Release
+```
+
+You need `build\tools\retrace-win-run.exe`, `retrace.dll`, and
+`retrace-profile.exe`.
+
+## 1. Capture (the claims)
+
+```bat
+set RETRACE_LOGGER_DEF_ENA=1
+set RETRACE_LOGGER_DEF_STDOUT_ENA=0
+set RETRACE_LOGGER_DEF_FN=outside.json
+build\tools\retrace-win-run app.exe
+```
+
+The ucrt layer hooks `fopen`, `_open`, `_close`, `_read`,
+`_write`, `_lseek`, `_stat`, `_unlink`, `_remove`, `_rename`,
+`_rmdir` — a normal C program's file traffic lands in
+`outside.json`.
+
+To also see Win32-direct callers (apps that never touch the
+CRT), set `RETRACE_WIN_NTDLL=1` — the ntdll set
+(`NtCreateFile`, `NtOpenFile`, `NtQueryAttributesFile`,
+`NtClose`, `LdrLoadDll`) comes online. Read [the Windows
+guide](../../docs/windows.md) first: ntdll hooks are opt-in
+because AV/EDR watches that layer.
+
+## 2. Profile
+
+```bat
+build\tools\retrace-profile --libc outside.json --binary app.exe -o profile.json
+build\tools\retrace-profile validate profile.json
+```
+
+Kernel truth (procmon): capture a CSV of the same run, then
+
+```bat
+build\tools\retrace-procmon2retrace capture.csv --pid <pid> -o kernel.json
+build\tools\retrace-profile --libc outside.json --kernel kernel.json -o profile.json
+```
+
+`kernel_only` accesses are the sub-libc surface (see recipe 34).
+
+## 3. Jail
+
+```bat
+build\tools\retrace-profile --libc outside.json --inside inside.json --jail-out jail.json
+set RETRACE_JSON_CONFIG=jail.json
+build\tools\retrace-win-run app.exe
+```
+
+Undeclared reads die with `EACCES` before libc executes them.
+For Win32-direct callers run the jail with
+`RETRACE_WIN_NTDLL=1`.
+
+## One-shot capture
+
+`retrace-profile capture` is POSIX-only (fork + preload). On
+Windows the equivalent one-liner is the pair above; a
+`retrace-win-run --profile` wrapper is a TODO.trace-profile
+follow-up.

--- a/include/retrace/version.h
+++ b/include/retrace/version.h
@@ -37,10 +37,10 @@
 #define RETRACE_VERSION_H
 
 #define RETRACE_VERSION_MAJOR 2
-#define RETRACE_VERSION_MINOR 13
+#define RETRACE_VERSION_MINOR 14
 #define RETRACE_VERSION_PATCH 0
 
-#define RETRACE_VERSION_STRING "2.13.0"
+#define RETRACE_VERSION_STRING "2.14.0"
 
 #define RETRACE_VERSION_ATLEAST(maj, min, pat)                  \
 	(RETRACE_VERSION_MAJOR > (maj) ||                       \

--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -1,3 +1,23 @@
+retrace (2.14.0-1) unstable; urgency=medium
+
+  * Added: retrace-profile capture (one-shot: run under preload,
+    trace, profile, jail -- POSIX), diff (drift between two
+    profiles: new paths, class escalations, new functions;
+    CI-able exit code), validate (profile contract; schema in
+    share/profile-schema.json).
+  * Added: Windows ucrt hook set expanded from fopen to
+    _open/_close/_read/_write/_lseek/_stat/_unlink/_remove/
+    _rename/_rmdir (underscore exports mapped to the
+    POSIX-shaped prototypes).
+  * Added: Windows arm64 assembly wrapper (gas dialect; the
+    armasm64 variant for MSVC-arm64 is the documented
+    follow-up). Dual-arch arch_spec.
+  * Fixed: MSVC logger -- real_impls never resolved atoi, so
+    logger_init called a NULL pointer (un-gates the
+    logger-format tests on MSVC).
+
+ -- Ribose Inc <opensource@ribose.com>  Thu, 20 Aug 2026 22:00:00 +0000
+
 retrace (2.13.0-1) unstable; urgency=medium
 
   * Added: live Windows hooks end to end -- inline hook ->

--- a/packaging/fedora/retrace.spec
+++ b/packaging/fedora/retrace.spec
@@ -5,7 +5,7 @@
 # Install: dnf install retrace-2.10.0-1.*.rpm
 
 Name:           retrace
-Version:        2.13.0
+Version:        2.14.0
 Release:        1%{?dist}
 Summary:        Userspace libc interceptor for security discovery
 
@@ -50,6 +50,8 @@ action, OTLP/JSON export, and a Python config builder.
 %{_includedir}/retrace/
 
 %changelog
+* Thu Aug 20 2026 Ribose Inc <opensource@ribose.com> - 2.14.0-1
+- trace-profile workstream: capture/diff/validate subcommands, profile schema, expanded ucrt hook set, arm64 wrapper (gas)
 * Thu Aug 20 2026 Ribose Inc <opensource@ribose.com> - 2.13.0-1
 - Windows: first live hooks (fopen ucrt + opt-in ntdll set), PE-section registry, retrace-win-run launcher, retrace.dll
 * Thu Aug 20 2026 Ribose Inc <opensource@ribose.com> - 2.12.0-1

--- a/packaging/nix/default.nix
+++ b/packaging/nix/default.nix
@@ -8,7 +8,7 @@
 
 stdenv.mkDerivation rec {
   pname = "retrace";
-  version = "2.13.0";
+  version = "2.14.0";
 
   src = ./.;
 

--- a/share/profile-schema.json
+++ b/share/profile-schema.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://retrace.readthedocs.io/profile-schema.json",
+  "title": "retrace profile",
+  "description": "Output of retrace-profile: what a binary does (functions, file accesses), how it was covered, and the risk verdicts. The `retrace-profile validate` command enforces this contract; this schema documents it for external tooling.",
+  "type": "object",
+  "required": ["profile", "coverage"],
+  "additionalProperties": false,
+  "properties": {
+    "profile": {
+      "type": "object",
+      "required": ["entries", "functions", "env", "net", "accesses"],
+      "additionalProperties": false,
+      "properties": {
+        "entries": { "type": "number", "minimum": 0 },
+        "functions": { "$ref": "#/definitions/nameCountArray" },
+        "env": { "$ref": "#/definitions/nameCountArray" },
+        "net": { "$ref": "#/definitions/nameCountArray" },
+        "accesses": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["path", "class", "hits"],
+            "additionalProperties": false,
+            "properties": {
+              "path": { "type": "string", "minLength": 1 },
+              "class": { "enum": ["read", "write", "probe", "none"] },
+              "hits": { "type": "number", "minimum": 1 }
+            }
+          }
+        }
+      }
+    },
+    "coverage": {
+      "type": "object",
+      "required": ["libc_layer", "kernel_layer"],
+      "additionalProperties": false,
+      "properties": {
+        "libc_layer": { "enum": ["captured", "ABSENT"] },
+        "kernel_layer": { "enum": ["captured", "ABSENT"] }
+      }
+    },
+    "risk": {
+      "type": "object",
+      "required": ["agreed", "libc_only", "kernel_only", "verdict"],
+      "additionalProperties": false,
+      "properties": {
+        "agreed": { "type": "number", "minimum": 0 },
+        "libc_only": { "type": "number", "minimum": 0 },
+        "kernel_only": { "type": "number", "minimum": 0 },
+        "verdict": { "enum": ["clean", "SUBLIBC_ACCESS_FOUND"] },
+        "kernel_only_accesses": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["path", "hits"],
+            "additionalProperties": false,
+            "properties": {
+              "path": { "type": "string" },
+              "hits": { "type": "number", "minimum": 1 }
+            }
+          }
+        }
+      }
+    },
+    "static_capability": {
+      "type": "object",
+      "required": ["raw_syscall_gadgets", "ntdll_imports"],
+      "additionalProperties": false,
+      "properties": {
+        "raw_syscall_gadgets": { "type": "number", "minimum": 0 },
+        "ntdll_imports": { "type": "number", "minimum": 0 },
+        "ntdll_names": { "type": "array", "items": { "type": "string" } }
+      }
+    }
+  },
+  "definitions": {
+    "nameCountArray": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "count"],
+        "additionalProperties": false,
+        "properties": {
+          "name": { "type": "string", "minLength": 1 },
+          "count": { "type": "number", "minimum": 1 }
+        }
+      }
+    }
+  }
+}

--- a/src/backends/win_common/CMakeLists.txt
+++ b/src/backends/win_common/CMakeLists.txt
@@ -12,14 +12,18 @@ set(_win_common_sources
 	disasm_arm64.c)
 
 # x64 wrappers (TODO.windows/05): gas dialect for MinGW, MASM for
-# MSVC -- identical semantics. arm64 lands with the
-# WrapperWinArm64Frame variant.
+# MSVC -- identical semantics.
+# arm64 wrappers (TODO.trace-profile/05): gas dialect (MinGW /
+# Clang arm64). The armasm64 variant for MSVC-arm64 is the
+# documented follow-up (docs/windows.md capability table).
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "AMD64|x86_64|amd64")
 	if(MSVC)
 		list(APPEND _win_common_sources wrapper_x64.asm)
 	else()
 		list(APPEND _win_common_sources wrapper_x64.S)
 	endif()
+elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64|ARM64" AND NOT MSVC)
+	list(APPEND _win_common_sources wrapper_arm64.S)
 endif()
 
 add_library(retrace_win_common OBJECT ${_win_common_sources})

--- a/src/backends/win_common/arch_spec_win.c
+++ b/src/backends/win_common/arch_spec_win.c
@@ -36,9 +36,19 @@
 
 #include <stddef.h>
 
+#if defined(_M_ARM64) || defined(__aarch64__)
+
+#define WRAPPER_FRAME struct WrapperWinArm64Frame
+
+#else /* x64 */
+
+#define WRAPPER_FRAME struct WrapperWinX64Frame
+
+#endif /* arch */
+
 void retrace_as_sched_real(void *arch_spec_ctx, void *real_impl)
 {
-	struct WrapperWinX64Frame *frame = arch_spec_ctx;
+	WRAPPER_FRAME *frame = arch_spec_ctx;
 
 	frame->call_real_flag = 1;
 	frame->real_impl = real_impl;
@@ -46,12 +56,12 @@ void retrace_as_sched_real(void *arch_spec_ctx, void *real_impl)
 
 void retrace_as_cancel_sched_real(void *arch_spec_ctx)
 {
-	((struct WrapperWinX64Frame *)arch_spec_ctx)->call_real_flag = 0;
+	((WRAPPER_FRAME *)arch_spec_ctx)->call_real_flag = 0;
 }
 
 void retrace_as_set_ret_val(void *arch_spec_ctx, long ret_val)
 {
-	((struct WrapperWinX64Frame *)arch_spec_ctx)->ret_val =
+	((WRAPPER_FRAME *)arch_spec_ctx)->ret_val =
 		(int64_t)ret_val;
 }
 
@@ -89,11 +99,34 @@ int retrace_as_init_late(void)
 }
 
 /*
- * Read one argument value. i < 4: from the captured register;
- * i >= 4: from the caller's stack (value, not pointer -- reg
- * params store values too, so params[i].val is uniform).
+ * Read one argument value. Register params store values (both
+ * frames), so params[i].val is uniform; stack params are read
+ * from the caller's frame at the ABI-correct offset.
+ *
+ * Both frames lead with call_real_flag / real_impl / ret_val
+ * at identical offsets, so the frame writers are shared via the
+ * WRAPPER_FRAME alias.
  */
-static uint64_t win_arg(const struct WrapperWinX64Frame *frame, int i)
+#if defined(_M_ARM64) || defined(__aarch64__)
+
+static uint64_t win_arg(const struct WrapperWinArm64Frame *frame,
+			int i)
+{
+	if (i >= 0 && i <= 7)
+		return frame->x[i];
+
+	/*
+	 * AAPCS64: stack args start at [entry sp] (the hook jmp
+	 * pushed nothing)
+	 */
+	return *(const uint64_t *)(frame->sp +
+				   8 * (size_t)(i - 8));
+}
+
+#else /* x64 */
+
+static uint64_t win_arg(const struct WrapperWinX64Frame *frame,
+			int i)
 {
 	const uint64_t *stack_arg;
 
@@ -107,7 +140,8 @@ static uint64_t win_arg(const struct WrapperWinX64Frame *frame, int i)
 	case 3:
 		return frame->r9;
 	default:
-		/* entry rsp points at the return address; args 5+
+		/*
+		 * entry rsp points at the return address; args 5+
 		 * start after the 32-byte shadow space
 		 */
 		stack_arg = (const uint64_t *)(frame->rsp + 0x28 +
@@ -116,11 +150,13 @@ static uint64_t win_arg(const struct WrapperWinX64Frame *frame, int i)
 	}
 }
 
+#endif /* arch */
+
 int retrace_as_setup_params(void *arch_spec_ctx,
 	const struct FuncPrototype *proto, struct FuncParam params[],
 	int *params_cnt)
 {
-	struct WrapperWinX64Frame *frame = arch_spec_ctx;
+	WRAPPER_FRAME *frame = arch_spec_ctx;
 	int param_idx;
 
 	if (*params_cnt < proto->params_cnt) {

--- a/src/backends/win_common/frame.h
+++ b/src/backends/win_common/frame.h
@@ -79,14 +79,11 @@ struct WrapperWinArm64Frame {
 	void  *real_impl;
 	int64_t ret_val;
 
-	uint64_t x0;
-	uint64_t x1;
-	uint64_t x2;
-	uint64_t x3;
-	uint64_t x4;
-	uint64_t x5;
-	uint64_t x6;
-	uint64_t x7;
+	/*
+	 * x0-x7 in one array: the trampoline stores them contiguously
+	 * (wrapper_arm64.S, [sp+24..80]) and win_arg() indexes them.
+	 */
+	uint64_t x[8];
 	uint64_t sp;
 };
 

--- a/src/backends/win_common/hook_targets.c
+++ b/src/backends/win_common/hook_targets.c
@@ -38,6 +38,16 @@ const char *const retrace_win_wrapper_names[] = {
 	"NtQueryAttributesFile",    /* 3 */
 	"NtClose",		    /* 4 */
 	"LdrLoadDll",		    /* 5 */
+	"open",			    /* 6 */
+	"close",		    /* 7 */
+	"read",			    /* 8 */
+	"write",		    /* 9 */
+	"lseek",		    /* 10 */
+	"stat",			    /* 11 */
+	"unlink",		    /* 12 */
+	"remove",		    /* 13 */
+	"rename",		    /* 14 */
+	"rmdir",		    /* 15 */
 };
 
 void retrace_win_enter(int idx, void *frame)
@@ -85,6 +95,19 @@ static const struct win_hook g_hook_table[] = {
 	 * Windows profiles and jails cover normal C programs.
 	 */
 	{ "fopen", NULL, "ucrtbase.dll", retrace_wrap_fopen, 0 },
+	{ "_open", "open", "ucrtbase.dll", retrace_wrap_open, 0 },
+	{ "_close", "close", "ucrtbase.dll", retrace_wrap_close, 0 },
+	{ "_read", "read", "ucrtbase.dll", retrace_wrap_read, 0 },
+	{ "_write", "write", "ucrtbase.dll", retrace_wrap_write, 0 },
+	{ "_lseek", "lseek", "ucrtbase.dll", retrace_wrap_lseek, 0 },
+	{ "_stat", "stat", "ucrtbase.dll", retrace_wrap_stat, 0 },
+	{ "_unlink", "unlink", "ucrtbase.dll",
+		retrace_wrap_unlink, 0 },
+	{ "_remove", "remove", "ucrtbase.dll",
+		retrace_wrap_remove, 0 },
+	{ "_rename", "rename", "ucrtbase.dll",
+		retrace_wrap_rename, 0 },
+	{ "_rmdir", "rmdir", "ucrtbase.dll", retrace_wrap_rmdir, 0 },
 
 	/* ntdll layer (TODO.windows/06): opt-in only. Catches
 	 * Win32-direct callers (CreateFileW funnels into

--- a/src/backends/win_common/hook_targets.h
+++ b/src/backends/win_common/hook_targets.h
@@ -30,6 +30,16 @@ extern "C" {
 
 /* wrapper symbols (wrapper_x64.S / wrapper_x64.asm) */
 void retrace_wrap_fopen(void);
+void retrace_wrap_open(void);
+void retrace_wrap_close(void);
+void retrace_wrap_read(void);
+void retrace_wrap_write(void);
+void retrace_wrap_lseek(void);
+void retrace_wrap_stat(void);
+void retrace_wrap_unlink(void);
+void retrace_wrap_remove(void);
+void retrace_wrap_rename(void);
+void retrace_wrap_rmdir(void);
 void retrace_wrap_NtCreateFile(void);
 void retrace_wrap_NtOpenFile(void);
 void retrace_wrap_NtQueryAttributesFile(void);

--- a/src/backends/win_common/wrapper_arm64.S
+++ b/src/backends/win_common/wrapper_arm64.S
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+/*
+ * Windows arm64 assembly wrappers (TODO.trace-profile/05), GNU-as
+ * dialect (MinGW/Clang arm64). The x64 twin is wrapper_x64.S --
+ * see there for the rationale; arm64 specifics:
+ *
+ * AAPCS64: args in x0-x7, then the stack at [entry sp]. No
+ * shadow space. The hook entered via a jmp, so x30 still holds
+ * the USER's return address and [entry sp] holds stack args --
+ * both must survive the wrapper untouched for the tail-jump to
+ * work (the real function's epilogue restores x30 from its own
+ * frame, which contains the x30 WE leave in the register).
+ *
+ * Frame (WrapperWinArm64Frame, 112-byte allocation):
+ *   [sp+0]   call_real_flag
+ *   [sp+8]   real_impl (the hook's trampoline)
+ *   [sp+16]  ret_val
+ *   [sp+24..+80] x0-x7
+ *   [sp+88]  x30 (the user's return address)
+ *   [sp+96]  entry sp
+ */
+
+	.macro WRAPPER_ENTRY_WIN_ARM64 fname
+	.text
+	.balign 16
+	.globl retrace_wrap_\fname
+retrace_wrap_\fname:
+	sub	sp, sp, #112
+
+	stp	x0, x1, [sp, #24]
+	stp	x2, x3, [sp, #40]
+	stp	x4, x5, [sp, #56]
+	stp	x6, x7, [sp, #72]
+	str	x30, [sp, #88]
+	add	x9, sp, #112
+	str	x9, [sp, #96]
+
+	stp	xzr, xzr, [sp, #0]
+	str	xzr, [sp, #16]
+
+	adr	x0, .Lstr_\fname
+	mov	x1, sp
+	bl	retrace_engine_wrapper
+
+	ldr	x9, [sp, #0]
+	cbnz	x9, .Lcall_\fname
+
+	/* synthesized return: x0 = ret_val, x30 restored */
+	ldr	x0, [sp, #16]
+	ldr	x30, [sp, #88]
+	add	sp, sp, #112
+	ret
+
+.Lcall_\fname:
+	/* tail-jump the trampoline with the original registers;
+	 * the user's return address rides in x30 and [entry sp] */
+	ldp	x0, x1, [sp, #24]
+	ldp	x2, x3, [sp, #40]
+	ldp	x4, x5, [sp, #56]
+	ldp	x6, x7, [sp, #72]
+	ldr	x30, [sp, #88]
+	ldr	x9, [sp, #8]
+	add	sp, sp, #112
+	br	x9
+
+	.section .rdata
+.Lstr_\fname:
+	.asciz "\fname"
+	.endm
+
+	WRAPPER_ENTRY_WIN_ARM64 fopen
+	WRAPPER_ENTRY_WIN_ARM64 open
+	WRAPPER_ENTRY_WIN_ARM64 close
+	WRAPPER_ENTRY_WIN_ARM64 read
+	WRAPPER_ENTRY_WIN_ARM64 write
+	WRAPPER_ENTRY_WIN_ARM64 lseek
+	WRAPPER_ENTRY_WIN_ARM64 stat
+	WRAPPER_ENTRY_WIN_ARM64 unlink
+	WRAPPER_ENTRY_WIN_ARM64 remove
+	WRAPPER_ENTRY_WIN_ARM64 rename
+	WRAPPER_ENTRY_WIN_ARM64 rmdir
+	WRAPPER_ENTRY_WIN_ARM64 NtCreateFile
+	WRAPPER_ENTRY_WIN_ARM64 NtOpenFile
+	WRAPPER_ENTRY_WIN_ARM64 NtQueryAttributesFile
+	WRAPPER_ENTRY_WIN_ARM64 NtClose
+	WRAPPER_ENTRY_WIN_ARM64 LdrLoadDll

--- a/src/backends/win_common/wrapper_x64.S
+++ b/src/backends/win_common/wrapper_x64.S
@@ -39,7 +39,7 @@
  * flag == 0 -> rax = synthesized ret_val, ret to the user.
  */
 
-	.macro WRAPPER_ENTRY_WIN_X64 fname
+	.macro WRAPPER_ENTRY_WIN_X64 fname, idx
 	.text
 	.balign 16
 	.globl retrace_wrap_\fname
@@ -59,9 +59,13 @@ retrace_wrap_\fname:
 	movq	$0, 40(%rsp)		/* frame+8: real_impl */
 	movq	$0, 48(%rsp)		/* frame+16: ret_val */
 
-	leaq	.Lstr_\fname(%rip), %rcx
+	/*
+	 * Label-free: the name lives in the C-side table
+	 * (hook_targets.c), same order as the entries below.
+	 */
+	movl	\idx, %ecx
 	leaq	32(%rsp), %rdx
-	call	retrace_engine_wrapper
+	call	retrace_win_enter
 
 	cmpq	$1, 32(%rsp)
 	jne	.Lsynth_\fname
@@ -79,24 +83,21 @@ retrace_wrap_\fname:
 	addq	$120, %rsp
 	ret
 
-	.section .rdata
-.Lstr_\fname:
-	.asciz "\fname"
 	.endm
 
-	WRAPPER_ENTRY_WIN_X64 fopen
-	WRAPPER_ENTRY_WIN_X64 open
-	WRAPPER_ENTRY_WIN_X64 close
-	WRAPPER_ENTRY_WIN_X64 read
-	WRAPPER_ENTRY_WIN_X64 write
-	WRAPPER_ENTRY_WIN_X64 lseek
-	WRAPPER_ENTRY_WIN_X64 stat
-	WRAPPER_ENTRY_WIN_X64 unlink
-	WRAPPER_ENTRY_WIN_X64 remove
-	WRAPPER_ENTRY_WIN_X64 rename
-	WRAPPER_ENTRY_WIN_X64 rmdir
-	WRAPPER_ENTRY_WIN_X64 NtCreateFile
-	WRAPPER_ENTRY_WIN_X64 NtOpenFile
-	WRAPPER_ENTRY_WIN_X64 NtQueryAttributesFile
-	WRAPPER_ENTRY_WIN_X64 NtClose
-	WRAPPER_ENTRY_WIN_X64 LdrLoadDll
+	WRAPPER_ENTRY_WIN_X64 fopen, 0
+	WRAPPER_ENTRY_WIN_X64 open, 6
+	WRAPPER_ENTRY_WIN_X64 close, 7
+	WRAPPER_ENTRY_WIN_X64 read, 8
+	WRAPPER_ENTRY_WIN_X64 write, 9
+	WRAPPER_ENTRY_WIN_X64 lseek, 10
+	WRAPPER_ENTRY_WIN_X64 stat, 11
+	WRAPPER_ENTRY_WIN_X64 unlink, 12
+	WRAPPER_ENTRY_WIN_X64 remove, 13
+	WRAPPER_ENTRY_WIN_X64 rename, 14
+	WRAPPER_ENTRY_WIN_X64 rmdir, 15
+	WRAPPER_ENTRY_WIN_X64 NtCreateFile, 1
+	WRAPPER_ENTRY_WIN_X64 NtOpenFile, 2
+	WRAPPER_ENTRY_WIN_X64 NtQueryAttributesFile, 3
+	WRAPPER_ENTRY_WIN_X64 NtClose, 4
+	WRAPPER_ENTRY_WIN_X64 LdrLoadDll, 5

--- a/src/backends/win_common/wrapper_x64.asm
+++ b/src/backends/win_common/wrapper_x64.asm
@@ -60,6 +60,16 @@ retrace_wrap_&fname& ENDP
 .code
 
         WRAPPER_ENTRY_WIN_X64 fopen, 0
+        WRAPPER_ENTRY_WIN_X64 open, 6
+        WRAPPER_ENTRY_WIN_X64 close, 7
+        WRAPPER_ENTRY_WIN_X64 read, 8
+        WRAPPER_ENTRY_WIN_X64 write, 9
+        WRAPPER_ENTRY_WIN_X64 lseek, 10
+        WRAPPER_ENTRY_WIN_X64 stat, 11
+        WRAPPER_ENTRY_WIN_X64 unlink, 12
+        WRAPPER_ENTRY_WIN_X64 remove, 13
+        WRAPPER_ENTRY_WIN_X64 rename, 14
+        WRAPPER_ENTRY_WIN_X64 rmdir, 15
         WRAPPER_ENTRY_WIN_X64 NtCreateFile, 1
         WRAPPER_ENTRY_WIN_X64 NtOpenFile, 2
         WRAPPER_ENTRY_WIN_X64 NtQueryAttributesFile, 3

--- a/src/cli/retrace_cli.c
+++ b/src/cli/retrace_cli.c
@@ -63,7 +63,7 @@ typedef int retrace_status_t;
 static void usage(FILE *out)
 {
 	fprintf(out,
-"retrace v2.13.0 -- userspace libc interceptor\n"
+"retrace v2.14.0 -- userspace libc interceptor\n"
 "\n"
 "Usage:\n"
 "  retrace run [OPTIONS] -- <command> [args...]\n"

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -1575,3 +1575,28 @@ add_test(NAME unit-test-profile-aggregate
     COMMAND retrace_test_profile_aggregate)
 set_tests_properties(unit-test-profile-aggregate PROPERTIES LABELS "unit")
 
+
+#
+# Profile drift + validation unit tests (TODO.trace-profile/02,
+# 06). diff.c merges two aggregated profiles; validate.c checks
+# the profile contract.
+#
+add_executable(retrace_test_profile_diff test_profile_diff.c
+    ${CMAKE_SOURCE_DIR}/tools/profiler/aggregate.c
+    ${CMAKE_SOURCE_DIR}/tools/profiler/diff.c
+    ${CMAKE_SOURCE_DIR}/tools/profiler/validate.c
+    ${CMAKE_SOURCE_DIR}/tools/correlate/match.c
+    ${_parson_for_tools})
+set_target_properties(retrace_test_profile_diff PROPERTIES
+    OUTPUT_NAME test_profile_diff
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/test/unit")
+
+target_include_directories(retrace_test_profile_diff PRIVATE
+    ${CMAKE_SOURCE_DIR}/tools/profiler
+    ${CMAKE_SOURCE_DIR}/tools/correlate
+    ${CMAKE_SOURCE_DIR}/src/config/json
+    ${CMAKE_SOURCE_DIR}/test/property/parson_stub)
+
+add_test(NAME unit-test-profile-diff
+    COMMAND retrace_test_profile_diff)
+set_tests_properties(unit-test-profile-diff PROPERTIES LABELS "unit")

--- a/test/unit/test_profile_diff.c
+++ b/test/unit/test_profile_diff.c
@@ -1,0 +1,314 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+/*
+ * Unit tests for profile drift + validation
+ * (TODO.trace-profile/02, 06).
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "aggregate.h"
+#include "diff.h"
+#include "match.h"
+#include "parson.h"
+
+static int tests_run;
+static int tests_pass;
+static int tests_fail;
+
+#define TEST(name) do { \
+	tests_run++; \
+	printf("  TEST %s ... ", #name); \
+	test_##name(); \
+	tests_pass++; \
+	printf("OK\n"); \
+} while (0)
+
+/* Always-on check: assert() compiles to nothing under NDEBUG. */
+#define CHECK(cond) do { \
+	if (!(cond)) { \
+		printf("FAIL [%s:%d] %s\n", __FILE__, __LINE__, #cond); \
+		tests_fail++; \
+		return; \
+	} \
+} while (0)
+
+static void add_json(struct Profile *p, const char *entry)
+{
+	JSON_Value *v = json_parse_string(entry);
+
+	CHECK(v != NULL);
+	prof_add_entry(json_value_get_object(v), p);
+	json_value_free(v);
+}
+
+static void feed(struct Profile *p, const char *const *entries)
+{
+	size_t i;
+
+	prof_init(p);
+	for (i = 0; entries[i] != NULL; i++)
+		add_json(p, entries[i]);
+	prof_finish(p);
+}
+
+/* -- drift -- */
+
+static void test_no_drift(void)
+{
+	static const char *const e[] = {
+		"{\"message\":{\"func\":\"open\",\"params\":{\"path\":\"/a/x.dat\"}}}",
+		NULL
+	};
+	struct Profile a, b;
+	struct ProfDiff d;
+	int drift;
+
+	feed(&a, e);
+	feed(&b, e);
+	prof_diff_init(&d);
+	drift = prof_diff_compute(&a, &b, &d);
+	CHECK(drift == 0);
+	CHECK(d.count == 0);
+	CHECK(d.new_functions_cnt == 0);
+	prof_diff_free(&d);
+	prof_free(&a);
+	prof_free(&b);
+}
+
+static void test_new_path(void)
+{
+	static const char *const base[] = {
+		"{\"message\":{\"func\":\"open\",\"params\":{\"path\":\"/a/x.dat\"}}}",
+		NULL
+	};
+	static const char *const cand[] = {
+		"{\"message\":{\"func\":\"open\",\"params\":{\"path\":\"/a/x.dat\"}}}",
+		"{\"message\":{\"func\":\"open\",\"params\":{\"path\":\"/a/new.dat\"}}}",
+		NULL
+	};
+	struct Profile a, b;
+	struct ProfDiff d;
+
+	feed(&a, base);
+	feed(&b, cand);
+	prof_diff_init(&d);
+	CHECK(prof_diff_compute(&a, &b, &d) == 1);
+	CHECK(d.count == 1);
+	CHECK(strcmp(d.changes[0].path, "/a/new.dat") == 0);
+	CHECK(d.changes[0].class_from == -1);
+	CHECK(d.changes[0].class_to == CORR_CLS_READ);
+	prof_diff_free(&d);
+	prof_free(&a);
+	prof_free(&b);
+}
+
+static void test_removed_path(void)
+{
+	static const char *const base[] = {
+		"{\"message\":{\"func\":\"open\",\"params\":{\"path\":\"/a/old.tmp\"}}}",
+		"{\"message\":{\"func\":\"open\",\"params\":{\"path\":\"/a/x.dat\"}}}",
+		NULL
+	};
+	static const char *const cand[] = {
+		"{\"message\":{\"func\":\"open\",\"params\":{\"path\":\"/a/x.dat\"}}}",
+		NULL
+	};
+	struct Profile a, b;
+	struct ProfDiff d;
+
+	feed(&a, base);
+	feed(&b, cand);
+	prof_diff_init(&d);
+	CHECK(prof_diff_compute(&a, &b, &d) == 1);
+	CHECK(d.count == 1);
+	CHECK(strcmp(d.changes[0].path, "/a/old.tmp") == 0);
+	CHECK(d.changes[0].class_to == -1);
+	prof_diff_free(&d);
+	prof_free(&a);
+	prof_free(&b);
+}
+
+static void test_class_escalation(void)
+{
+	/* read in baseline; write (creat) in candidate */
+	static const char *const base[] = {
+		"{\"message\":{\"func\":\"open\",\"params\":{\"path\":\"/a/cfg.dat\"}}}",
+		NULL
+	};
+	static const char *const cand[] = {
+		"{\"message\":{\"func\":\"creat\",\"params\":{\"path\":\"/a/cfg.dat\"}}}",
+		NULL
+	};
+	struct Profile a, b;
+	struct ProfDiff d;
+
+	feed(&a, base);
+	feed(&b, cand);
+	prof_diff_init(&d);
+	CHECK(prof_diff_compute(&a, &b, &d) == 1);
+	CHECK(d.count == 1);
+	CHECK(strcmp(d.changes[0].path, "/a/cfg.dat") == 0);
+	CHECK(d.changes[0].class_from == CORR_CLS_READ);
+	CHECK(d.changes[0].class_to == CORR_CLS_WRITE);
+	prof_diff_free(&d);
+	prof_free(&a);
+	prof_free(&b);
+}
+
+static void test_new_function(void)
+{
+	static const char *const base[] = {
+		"{\"message\":{\"func\":\"open\",\"params\":{\"path\":\"/a/x.dat\"}}}",
+		NULL
+	};
+	static const char *const cand[] = {
+		"{\"message\":{\"func\":\"open\",\"params\":{\"path\":\"/a/x.dat\"}}}",
+		"{\"message\":{\"func\":\"fopen64\",\"params\":{\"path\":\"/a/x.dat\"}}}",
+		NULL
+	};
+	struct Profile a, b;
+	struct ProfDiff d;
+
+	feed(&a, base);
+	feed(&b, cand);
+	prof_diff_init(&d);
+	CHECK(prof_diff_compute(&a, &b, &d) == 1);
+	CHECK(d.new_functions_cnt == 1);
+	CHECK(strcmp(d.new_functions[0], "fopen64") == 0);
+	prof_diff_free(&d);
+	prof_free(&a);
+	prof_free(&b);
+}
+
+static void test_diff_json_shape(void)
+{
+	static const char *const base[] = {
+		"{\"message\":{\"func\":\"open\",\"params\":{\"path\":\"/a/x.dat\"}}}",
+		NULL
+	};
+	static const char *const cand[] = {
+		"{\"message\":{\"func\":\"creat\",\"params\":{\"path\":\"/a/new.dat\"}}}",
+		NULL
+	};
+	struct Profile a, b;
+	struct ProfDiff d;
+	JSON_Value *v;
+
+	feed(&a, base);
+	feed(&b, cand);
+	prof_diff_init(&d);
+	(void)prof_diff_compute(&a, &b, &d);
+	v = prof_diff_to_json(&d);
+	CHECK(v != NULL);
+	CHECK(json_object_get_boolean(json_value_get_object(v),
+		"drift") == 1);
+	CHECK(json_array_get_count(json_object_get_array(
+		json_value_get_object(v), "path_changes")) == 2);
+	json_value_free(v);
+	prof_diff_free(&d);
+	prof_free(&a);
+	prof_free(&b);
+}
+
+/* -- validation -- */
+
+#define PROFILE_TEST_FILE "prof_test_profile.json"
+
+static void write_profile(const char *text)
+{
+	FILE *f = fopen(PROFILE_TEST_FILE, "wb");
+
+	CHECK(f != NULL);
+	fwrite(text, 1, strlen(text), f);
+	fclose(f);
+}
+
+extern int prof_validate_file(const char *path, char *err,
+			      size_t errsz);
+
+static void test_validate_ok(void)
+{
+	char err[256];
+
+	write_profile(
+		"{\"profile\":{\"entries\":1,\"functions\":[],"
+		"\"env\":[],\"net\":[],\"accesses\":"
+		"[{\"path\":\"/a\",\"class\":\"read\",\"hits\":1}]},"
+		"\"coverage\":{\"libc_layer\":\"captured\","
+		"\"kernel_layer\":\"ABSENT\"}}");
+	CHECK(prof_validate_file(PROFILE_TEST_FILE, err,
+		sizeof(err)) == 0);
+	remove(PROFILE_TEST_FILE);
+}
+
+static void test_validate_bad_class(void)
+{
+	char err[256];
+	int n;
+
+	write_profile(
+		"{\"profile\":{\"entries\":1,\"functions\":[],"
+		"\"env\":[],\"net\":[],\"accesses\":"
+		"[{\"path\":\"/a\",\"class\":\"rw\",\"hits\":1}]},"
+		"\"coverage\":{\"libc_layer\":\"captured\","
+		"\"kernel_layer\":\"ABSENT\"}}");
+	n = prof_validate_file(PROFILE_TEST_FILE, err, sizeof(err));
+	CHECK(n == 1);
+	CHECK(strstr(err, "class") != NULL);
+	remove(PROFILE_TEST_FILE);
+}
+
+static void test_validate_risk_cross_field(void)
+{
+	char err[256];
+	int n;
+
+	/* kernel captured but no risk section */
+	write_profile(
+		"{\"profile\":{\"entries\":0,\"functions\":[],"
+		"\"env\":[],\"net\":[],\"accesses\":[]},"
+		"\"coverage\":{\"libc_layer\":\"captured\","
+		"\"kernel_layer\":\"captured\"}}");
+	n = prof_validate_file(PROFILE_TEST_FILE, err, sizeof(err));
+	CHECK(n == 1);
+	CHECK(strstr(err, "risk") != NULL);
+	remove(PROFILE_TEST_FILE);
+}
+
+static void test_validate_unparseable(void)
+{
+	char err[256];
+
+	write_profile("not json at all");
+	CHECK(prof_validate_file(PROFILE_TEST_FILE, err,
+		sizeof(err)) < 0);
+	remove(PROFILE_TEST_FILE);
+}
+
+int main(void)
+{
+	printf("profile drift tests:\n");
+	TEST(no_drift);
+	TEST(new_path);
+	TEST(removed_path);
+	TEST(class_escalation);
+	TEST(new_function);
+	TEST(diff_json_shape);
+
+	printf("profile validation tests:\n");
+	TEST(validate_ok);
+	TEST(validate_bad_class);
+	TEST(validate_risk_cross_field);
+	TEST(validate_unparseable);
+
+	printf("\nPass: %d, Fail: %d (of %d)\n",
+		tests_pass, tests_fail, tests_run);
+	return tests_fail == 0 ? 0 : 1;
+}

--- a/tools/profiler/CMakeLists.txt
+++ b/tools/profiler/CMakeLists.txt
@@ -14,7 +14,7 @@
 set(_parson_source ${CMAKE_SOURCE_DIR}/src/config/json/parson.c)
 
 add_executable(retrace_profile
-    profile.c aggregate.c capability.c
+    profile.c aggregate.c capability.c diff.c capture.c validate.c
     ${CMAKE_SOURCE_DIR}/tools/correlate/match.c
     ${CMAKE_SOURCE_DIR}/tools/common/stream.c
     ${_parson_source})
@@ -31,3 +31,9 @@ target_include_directories(retrace_profile PRIVATE
 
 install(TARGETS retrace_profile
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+# The profile contract (TODO.trace-profile/06): documents the
+# output shape for external tooling; `retrace-profile validate`
+# enforces it.
+install(FILES ${CMAKE_SOURCE_DIR}/share/profile-schema.json
+    DESTINATION ${CMAKE_INSTALL_DATADIR}/retrace)

--- a/tools/profiler/capture.c
+++ b/tools/profiler/capture.c
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+/*
+ * One-shot capture implementation (TODO.trace-profile/03).
+ * POSIX: fork/exec with LD_PRELOAD / DYLD_INSERT_LIBRARIES and
+ * the logger env pointed at a trace file. Windows uses
+ * retrace-win-run injection instead (docs/windows.md).
+ */
+
+#ifndef _WIN32
+
+#include "capture.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/wait.h>
+#include <sys/types.h>
+
+#ifdef __APPLE__
+static const char *const g_preload_vars[] = {
+	"DYLD_INSERT_LIBRARIES", "LD_PRELOAD", NULL
+};
+static const char *const g_lib_exts[] = { "dylib", "so", NULL };
+#else
+static const char *const g_preload_vars[] = {
+	"LD_PRELOAD", NULL
+};
+static const char *const g_lib_exts[] = { "so", NULL };
+#endif
+
+static int file_readable(const char *path)
+{
+	return access(path, R_OK) == 0;
+}
+
+const char *prof_capture_find_lib(void)
+{
+	static char buf[1024];
+	const char *env = getenv("RETRACE_V2_LIB");
+	const char *const dirs[] = {
+		".", "../src/v2", "../../src/v2", "src/v2",
+		"/usr/local/lib", NULL
+	};
+	size_t d, e;
+
+	if (env != NULL && env[0] != '\0')
+		return env;
+
+	for (d = 0; dirs[d] != NULL; d++) {
+		for (e = 0; g_lib_exts[e] != NULL; e++) {
+			snprintf(buf, sizeof(buf), "%s/libretrace.%s",
+				dirs[d], g_lib_exts[e]);
+			if (file_readable(buf))
+				return buf;
+		}
+	}
+	return NULL;
+}
+
+int prof_capture_run(char *const argv[], const char *lib,
+		     const char *trace_path)
+{
+	pid_t pid;
+	int status;
+	size_t v;
+
+	pid = fork();
+	if (pid < 0)
+		return -1;
+
+	if (pid == 0) {
+		setenv("RETRACE_LOGGER_DEF_ENA", "1", 1);
+		setenv("RETRACE_LOGGER_DEF_STDOUT_ENA", "0", 1);
+		setenv("RETRACE_LOGGER_DEF_FN", trace_path, 1);
+		for (v = 0; g_preload_vars[v] != NULL; v++)
+			setenv(g_preload_vars[v], lib, 1);
+		execvp(argv[0], argv);
+		fprintf(stderr,
+			"retrace-profile capture: cannot exec '%s'\n",
+			argv[0]);
+		_exit(127);
+	}
+
+	if (waitpid(pid, &status, 0) < 0)
+		return -1;
+	if (WIFEXITED(status))
+		return WEXITSTATUS(status);
+	return -1;
+}
+
+#else /* _WIN32 */
+
+#include "capture.h"
+
+const char *prof_capture_find_lib(void)
+{
+	return NULL;
+}
+
+int prof_capture_run(char *const argv[], const char *lib,
+		     const char *trace_path)
+{
+	(void)argv;
+	(void)lib;
+	(void)trace_path;
+	return -1;
+}
+
+#endif /* !_WIN32 */

--- a/tools/profiler/capture.h
+++ b/tools/profiler/capture.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+#ifndef RETRACE_TOOLS_PROFILER_CAPTURE_H_
+#define RETRACE_TOOLS_PROFILER_CAPTURE_H_
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * One-shot capture (TODO.trace-profile/03): run a command under
+ * the retrace preload with the right logger env, trace to
+ * trace_path. POSIX only (fork/exec + LD_PRELOAD /
+ * DYLD_INSERT_LIBRARIES).
+ */
+
+/*
+ * Locate the retrace library: RETRACE_V2_LIB override, then the
+ * build-tree layouts relative to our own executable, then the
+ * install prefix. Returns a static/known buffer or NULL.
+ */
+const char *prof_capture_find_lib(void);
+
+/*
+ * Run argv under the preload library, trace to trace_path.
+ * Returns the exit status of the command, or -1 on
+ * launch failure.
+ */
+int prof_capture_run(char *const argv[], const char *lib,
+		     const char *trace_path);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* RETRACE_TOOLS_PROFILER_CAPTURE_H_ */

--- a/tools/profiler/diff.c
+++ b/tools/profiler/diff.c
@@ -1,0 +1,234 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+/*
+ * Profile drift computation (TODO.trace-profile/02). Both
+ * profiles arrive aggregated (aggregate.c) and finished; this
+ * module walks the two sorted path arrays and the two sorted
+ * name arrays once each -- an O(n+m) merge, not a search per
+ * element.
+ */
+
+#include "diff.h"
+#include "match.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+static const char *cls_str(int cls)
+{
+	if (cls < 0)
+		return "-";
+	return corr_class_str((enum CorrClass)cls);
+}
+
+void prof_diff_init(struct ProfDiff *d)
+{
+	memset(d, 0, sizeof(*d));
+}
+
+static void change_add(struct ProfDiff *d, const char *path,
+		       int from, int to, size_t hits_from,
+		       size_t hits_to)
+{
+	struct ProfPathChange *c;
+
+	if (d->count == d->cap) {
+		size_t newcap = (d->cap == 0) ? 16 : d->cap * 2;
+
+		d->changes = (struct ProfPathChange *)realloc(d->changes,
+			newcap * sizeof(*d->changes));
+		if (d->changes == NULL)
+			return;
+		d->cap = newcap;
+	}
+	c = &d->changes[d->count++];
+	c->path = (char *)malloc(strlen(path) + 1);
+	if (c->path == NULL) {
+		d->count--;
+		return;
+	}
+	strcpy(c->path, path);
+	c->class_from = from;
+	c->class_to = to;
+	c->hits_from = hits_from;
+	c->hits_to = hits_to;
+}
+
+static int path_class(const struct ProfAccess *a)
+{
+	/* the recorded class precedence matches access_class() */
+	if (a->class_write)
+		return CORR_CLS_WRITE;
+	if (a->class_read)
+		return CORR_CLS_READ;
+	if (a->class_probe)
+		return CORR_CLS_PROBE;
+	return CORR_CLS_NONE;
+}
+
+static void new_function_add(struct ProfDiff *d, const char *name)
+{
+	if (d->new_functions_cnt == d->new_functions_cap) {
+		size_t newcap = (d->new_functions_cap == 0) ?
+			16 : d->new_functions_cap * 2;
+
+		d->new_functions = (char **)realloc(d->new_functions,
+			newcap * sizeof(char *));
+		if (d->new_functions == NULL)
+			return;
+		d->new_functions_cap = newcap;
+	}
+	d->new_functions[d->new_functions_cnt] =
+		(char *)malloc(strlen(name) + 1);
+	if (d->new_functions[d->new_functions_cnt] == NULL)
+		return;
+	strcpy(d->new_functions[d->new_functions_cnt], name);
+	d->new_functions_cnt++;
+}
+
+int prof_diff_compute(const struct Profile *baseline,
+		      const struct Profile *candidate,
+		      struct ProfDiff *d)
+{
+	size_t i = 0, j = 0;
+	size_t f = 0, g = 0;
+	int drift = 0;
+
+	/* merge the sorted accesses arrays */
+	while (i < baseline->accesses.count ||
+	       j < candidate->accesses.count) {
+		const struct ProfAccess *a =
+			(i < baseline->accesses.count) ?
+			&baseline->accesses.items[i] : NULL;
+		const struct ProfAccess *b =
+			(j < candidate->accesses.count) ?
+			&candidate->accesses.items[j] : NULL;
+		int cmp;
+
+		if (a == NULL)
+			cmp = 1;
+		else if (b == NULL)
+			cmp = -1;
+		else
+			cmp = strcmp(a->path, b->path);
+
+		if (cmp < 0) {
+			change_add(d, a->path, path_class(a), -1,
+				a->hits, 0);
+			drift = 1;
+			i++;
+		} else if (cmp > 0) {
+			change_add(d, b->path, -1, path_class(b), 0,
+				b->hits);
+			drift = 1;
+			j++;
+		} else {
+			int from = path_class(a);
+			int to = path_class(b);
+
+			if (from != to) {
+				change_add(d, a->path, from, to,
+					a->hits, b->hits);
+				drift = 1;
+			}
+			i++;
+			j++;
+		}
+	}
+
+	/* merge the sorted function-name arrays: candidate-only */
+	while (f < baseline->functions.count ||
+	       g < candidate->functions.count) {
+		const char *fa = (f < baseline->functions.count) ?
+			baseline->functions.names[f] : NULL;
+		const char *fc = (g < candidate->functions.count) ?
+			candidate->functions.names[g] : NULL;
+		int cmp;
+
+		if (fa == NULL)
+			cmp = 1;
+		else if (fc == NULL)
+			cmp = -1;
+		else
+			cmp = strcmp(fa, fc);
+
+		if (cmp < 0) {
+			f++;
+		} else if (cmp > 0) {
+			new_function_add(d, fc);
+			drift = 1;
+			g++;
+		} else {
+			f++;
+			g++;
+		}
+	}
+
+	return drift;
+}
+
+static void change_to_json(JSON_Array *arr,
+			   const struct ProfPathChange *c)
+{
+	JSON_Value *o = json_value_init_object();
+	JSON_Object *obj = json_value_get_object(o);
+
+	json_object_set_string(obj, "path", c->path);
+	if (c->class_from < 0) {
+		json_object_set_string(obj, "change", "added");
+	} else if (c->class_to < 0) {
+		json_object_set_string(obj, "change", "removed");
+	} else {
+		json_object_set_string(obj, "change", "class");
+		json_object_set_string(obj, "from", cls_str(c->class_from));
+		json_object_set_string(obj, "to", cls_str(c->class_to));
+	}
+	json_object_set_number(obj, "hits_from", (double)c->hits_from);
+	json_object_set_number(obj, "hits_to", (double)c->hits_to);
+	json_array_append_value(arr, o);
+}
+
+JSON_Value *prof_diff_to_json(const struct ProfDiff *d)
+{
+	JSON_Value *root_val = json_value_init_object();
+	JSON_Object *root = json_value_get_object(root_val);
+	JSON_Value *arr = json_value_init_array();
+	JSON_Value *farr = json_value_init_array();
+	size_t i;
+	int any = 0;
+
+	for (i = 0; i < d->count; i++) {
+		change_to_json(json_value_get_array(arr), &d->changes[i]);
+		any = 1;
+	}
+	for (i = 0; i < d->new_functions_cnt; i++) {
+		JSON_Value *o = json_value_init_object();
+
+		json_object_set_string(json_value_get_object(o),
+			"name", d->new_functions[i]);
+		json_array_append_value(json_value_get_array(farr), o);
+		any = 1;
+	}
+
+	json_object_set_value(root, "path_changes", arr);
+	json_object_set_value(root, "new_functions", farr);
+	json_object_set_boolean(root, "drift", any);
+	return root_val;
+}
+
+void prof_diff_free(struct ProfDiff *d)
+{
+	size_t i;
+
+	for (i = 0; i < d->count; i++)
+		free(d->changes[i].path);
+	free(d->changes);
+	for (i = 0; i < d->new_functions_cnt; i++)
+		free(d->new_functions[i]);
+	free(d->new_functions);
+	memset(d, 0, sizeof(*d));
+}

--- a/tools/profiler/diff.h
+++ b/tools/profiler/diff.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+#ifndef RETRACE_TOOLS_PROFILER_DIFF_H_
+#define RETRACE_TOOLS_PROFILER_DIFF_H_
+
+#include "aggregate.h"
+
+#include "parson.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Profile drift (TODO.trace-profile/02): what does the candidate
+ * build do that the baseline did not? The upgrade story for the
+ * tailor loop: profile old -> upgrade -> profile new -> diff ->
+ * update the jail.
+ */
+
+struct ProfPathChange {
+	char *path;
+	int class_from;		/* enum CorrClass, -1 when added */
+	int class_to;		/* -1 when removed */
+	size_t hits_from;
+	size_t hits_to;
+};
+
+struct ProfDiff {
+	/*
+	 * path changes: added (from == -1), removed (to == -1),
+	 * class-changed otherwise; sorted by path
+	 */
+	struct ProfPathChange *changes;
+	size_t count;
+	size_t cap;
+
+	/* functions present only in the candidate */
+	char **new_functions;
+	size_t new_functions_cnt;
+	size_t new_functions_cap;
+};
+
+void prof_diff_init(struct ProfDiff *d);
+
+/*
+ * Compute baseline -> candidate drift. Both profiles must be
+ * finished (prof_finish). Returns 1 when any drift exists.
+ */
+int prof_diff_compute(const struct Profile *baseline,
+		      const struct Profile *candidate,
+		      struct ProfDiff *d);
+
+JSON_Value *prof_diff_to_json(const struct ProfDiff *d);
+
+void prof_diff_free(struct ProfDiff *d);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* RETRACE_TOOLS_PROFILER_DIFF_H_ */

--- a/tools/profiler/profile.c
+++ b/tools/profiler/profile.c
@@ -38,6 +38,9 @@
 
 #include "aggregate.h"
 #include "capability.h"
+#include "capture.h"
+#include "diff.h"
+#include "validate.h"
 #include "match.h"
 #include "stream.h"
 #include "parson.h"
@@ -45,6 +48,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#ifndef _WIN32
+#include <unistd.h>
+#endif
 
 static char *read_file(const char *path, size_t *len_out)
 {
@@ -237,6 +243,295 @@ static void capability_to_json(JSON_Object *root,
 	json_object_set_value(root, "static_capability", o);
 }
 
+/*
+ * `retrace-profile diff baseline.json candidate.json [--json]`:
+ * drift report between two profiles (TODO.trace-profile/02).
+ * Exit 1 when drift exists (CI-able).
+ */
+static int diff_mode(int argc, char **argv)
+{
+	const char *baseline_path = NULL;
+	const char *candidate_path = NULL;
+	int json_out = 0;
+	struct ProfFeed baseline, candidate;
+	struct ProfDiff d;
+	int drift;
+	int i;
+
+	for (i = 2; i < argc; i++) {
+		if (strcmp(argv[i], "--json") == 0)
+			json_out = 1;
+		else if (argv[i][0] == '-' && argv[i][1] != '\0') {
+			fprintf(stderr,
+"Usage: retrace-profile diff <baseline.json> <candidate.json> [--json]\n");
+			return 2;
+		} else if (baseline_path == NULL)
+			baseline_path = argv[i];
+		else if (candidate_path == NULL)
+			candidate_path = argv[i];
+	}
+	if (baseline_path == NULL || candidate_path == NULL) {
+		fprintf(stderr,
+"Usage: retrace-profile diff <baseline.json> <candidate.json> [--json]\n");
+		return 2;
+	}
+	if (load_profile(baseline_path, &baseline) != 0) {
+		fprintf(stderr, "retrace-profile: cannot read %s\n",
+			baseline_path);
+		return 2;
+	}
+	if (load_profile(candidate_path, &candidate) != 0) {
+		fprintf(stderr, "retrace-profile: cannot read %s\n",
+			candidate_path);
+		return 2;
+	}
+
+	prof_diff_init(&d);
+	drift = prof_diff_compute(&baseline.prof, &candidate.prof, &d);
+
+	if (json_out) {
+		char *ser;
+
+		{
+			JSON_Value *v = prof_diff_to_json(&d);
+
+			ser = json_serialize_to_string_pretty(v);
+			json_value_free(v);
+		}
+		printf("%s\n", ser);
+		json_free_serialized_string(ser);
+	} else {
+		size_t k;
+
+		printf("profile-diff: baseline %zu entries, candidate %zu entries\n",
+			baseline.prof.entries, candidate.prof.entries);
+		for (k = 0; k < d.count; k++) {
+			const struct ProfPathChange *c = &d.changes[k];
+
+			if (c->class_from < 0)
+				printf("  + %s (added, %s, %zu hits)\n",
+					c->path,
+					corr_class_str((enum CorrClass)
+						c->class_to),
+					c->hits_to);
+			else if (c->class_to < 0)
+				printf("  - %s (removed)\n", c->path);
+			else
+				printf("  ! %s (%s -> %s)\n", c->path,
+					corr_class_str((enum CorrClass)
+						c->class_from),
+					corr_class_str((enum CorrClass)
+						c->class_to));
+		}
+		for (k = 0; k < d.new_functions_cnt; k++)
+			printf("  + fn %s (new)\n", d.new_functions[k]);
+		printf("%s\n", drift ?
+			"profile-diff: DRIFT FOUND" :
+			"profile-diff: no drift");
+	}
+
+	prof_diff_free(&d);
+	prof_free(&baseline.prof);
+	prof_free(&candidate.prof);
+	return drift ? 1 : 0;
+}
+
+/*
+ * `retrace-profile capture [-o profile.json] [--inside d.json]
+ *   [--jail-out j.json] [-- cmd args...]` -- the whole recipe-34
+ * flow in one command: run the command under the preload, trace
+ * it, reduce to a profile, optionally emit the jail
+ * (TODO.trace-profile/03). POSIX; Windows uses retrace-win-run.
+ */
+static int capture_mode(int argc, char **argv)
+{
+#ifdef _WIN32
+	(void)argc;
+	(void)argv;
+	fprintf(stderr,
+"retrace-profile capture: POSIX only -- Windows uses retrace-win-run\n");
+	return 2;
+#else
+	const char *out_path = NULL;
+	const char *jail_path = NULL;
+	const char *inside_path = NULL;
+	char trace_tpl[128];
+	char trace_path[128];
+	const char *lib;
+	struct ProfFeed feed, inside_feed;
+	int cmd_start = -1;
+	int fd;
+	int i;
+	int rc;
+
+	for (i = 2; i < argc; i++) {
+		if (strcmp(argv[i], "--") == 0) {
+			cmd_start = i + 1;
+			break;
+		} else if (strcmp(argv[i], "-o") == 0 && i + 1 < argc) {
+			out_path = argv[++i];
+		} else if (strcmp(argv[i], "--jail-out") == 0 &&
+			   i + 1 < argc) {
+			jail_path = argv[++i];
+		} else if (strcmp(argv[i], "--inside") == 0 &&
+			   i + 1 < argc) {
+			inside_path = argv[++i];
+		} else {
+			fprintf(stderr,
+"Usage: retrace-profile capture [-o profile.json] [--inside d.json]\n"
+"                              [--jail-out jail.json] -- cmd [args...]\n");
+			return 2;
+		}
+	}
+	if (cmd_start < 0 || argv[cmd_start] == NULL) {
+		fprintf(stderr,
+"retrace-profile capture: no command after --\n");
+		return 2;
+	}
+
+	lib = prof_capture_find_lib();
+	if (lib == NULL) {
+		fprintf(stderr,
+"retrace-profile capture: libretrace not found; set RETRACE_V2_LIB\n");
+		return 2;
+	}
+
+	/*
+	 * Default config: the file/env/net function set. A wildcard
+	 * would trace printf-family variadics too -- noisy for a
+	 * profile and fragile on some platforms. An explicit
+	 * RETRACE_JSON_CONFIG always wins.
+	 */
+	if (getenv("RETRACE_JSON_CONFIG") == NULL) {
+		static const char *const prof_funcs[] = {
+			"open", "openat", "close", "fopen", "fclose",
+			"fread", "fwrite", "stat", "lstat", "fstatat",
+			"access", "faccessat", "readlink", "unlink",
+			"rename", "mkdir", "rmdir", "creat", "truncate",
+			"read", "write", "getenv", "setenv", "putenv",
+			"connect", "send", "recv", "dlopen", NULL
+		};
+		size_t k;
+		FILE *cf;
+
+		snprintf(trace_tpl, sizeof(trace_tpl),
+			"/tmp/retrace-capture-XXXXXX");
+		fd = mkstemp(trace_tpl);
+		if (fd < 0) {
+			fprintf(stderr,
+"retrace-profile capture: mkstemp failed\n");
+			return 2;
+		}
+		close(fd);
+		cf = fopen(trace_tpl, "w");
+		if (cf == NULL) {
+			remove(trace_tpl);
+			return 2;
+		}
+		fputs("{\"intercept_scripts\":[", cf);
+		for (k = 0; prof_funcs[k] != NULL; k++)
+			fprintf(cf,
+"%s{\"func_name\":\"%s\",\"actions\":["
+"{\"action_name\":\"log_params\"},"
+"{\"action_name\":\"call_real\"}]}",
+				k ? "," : "", prof_funcs[k]);
+		fputs("]}\n", cf);
+		fclose(cf);
+		setenv("RETRACE_JSON_CONFIG", trace_tpl, 0);
+	}
+
+	snprintf(trace_tpl, sizeof(trace_tpl),
+		"/tmp/retrace-capture-XXXXXX");
+	fd = mkstemp(trace_tpl);
+	if (fd < 0) {
+		fprintf(stderr, "retrace-profile capture: mkstemp failed\n");
+		return 2;
+	}
+	close(fd);
+	snprintf(trace_path, sizeof(trace_path), "%s", trace_tpl);
+
+	fprintf(stderr, "retrace-profile capture: lib=%s trace=%s\n",
+		lib, trace_path);
+	rc = prof_capture_run(&argv[cmd_start], lib, trace_path);
+	if (rc < 0) {
+		fprintf(stderr, "retrace-profile capture: launch failed\n");
+		remove(trace_path);
+		return 2;
+	}
+
+	if (load_profile(trace_path, &feed) != 0) {
+		fprintf(stderr, "retrace-profile capture: no trace\n");
+		remove(trace_path);
+		return 2;
+	}
+
+	{
+		JSON_Value *out = json_value_init_object();
+		JSON_Object *root = json_value_get_object(out);
+		JSON_Value *cov = json_value_init_object();
+
+		json_object_set_value(root, "profile",
+			prof_to_json(&feed.prof));
+		json_object_set_string(json_value_get_object(cov),
+			"libc_layer", "captured");
+		json_object_set_string(json_value_get_object(cov),
+			"kernel_layer", "ABSENT");
+		json_object_set_value(root, "coverage", cov);
+
+		{
+			char *ser = json_serialize_to_string_pretty(out);
+
+			if (out_path != NULL) {
+				FILE *of = fopen(out_path, "w");
+
+				if (of == NULL) {
+					fprintf(stderr,
+"retrace-profile: cannot write %s\n", out_path);
+					return 2;
+				}
+				fprintf(of, "%s\n", ser);
+				fclose(of);
+			} else {
+				printf("%s\n", ser);
+			}
+			json_free_serialized_string(ser);
+		}
+		json_value_free(out);
+	}
+
+	if (jail_path != NULL) {
+		struct ProfFeed *allow_src = &feed;
+
+		if (inside_path != NULL &&
+		    load_profile(inside_path, &inside_feed) == 0)
+			allow_src = &inside_feed;
+		{
+			JSON_Value *jc = jail_config(&feed.prof,
+				&allow_src->prof);
+			FILE *jf = fopen(jail_path, "w");
+
+			if (jf == NULL) {
+				fprintf(stderr,
+"retrace-profile: cannot write %s\n", jail_path);
+				return 2;
+			}
+			fprintf(jf, "%s\n",
+				json_serialize_to_string_pretty(jc));
+			fclose(jf);
+			json_value_free(jc);
+		}
+	}
+
+	fprintf(stderr,
+"retrace-profile capture: %zu entries, %zu functions, %zu paths (cmd exit %d)\n",
+		feed.prof.entries, feed.prof.functions.count,
+		feed.prof.accesses.count, rc);
+
+	remove(trace_path);
+	return rc;
+#endif /* !_WIN32 */
+}
+
 int main(int argc, char **argv)
 {
 	const char *libc_path = NULL;
@@ -246,6 +541,33 @@ int main(int argc, char **argv)
 	const char *jail_path = NULL;
 	const char *inside_path = NULL;
 	struct ProfFeed libc_feed, kernel_feed, inside_feed;
+
+	if (argc >= 2 && strcmp(argv[1], "diff") == 0)
+		return diff_mode(argc, argv);
+	if (argc >= 2 && strcmp(argv[1], "capture") == 0)
+		return capture_mode(argc, argv);
+	if (argc >= 2 && strcmp(argv[1], "validate") == 0) {
+		char err[2048];
+		int n;
+
+		if (argc != 3) {
+			fprintf(stderr,
+"Usage: retrace-profile validate <profile.json>\n");
+			return 2;
+		}
+		n = prof_validate_file(argv[2], err, sizeof(err));
+		if (n == 0) {
+			printf("profile: valid\n");
+			return 0;
+		}
+		if (n < 0) {
+			printf("profile: NOT PARSEABLE\n%s\n", err);
+			return 1;
+		}
+		printf("profile: %d violation%s\n%s\n", n,
+			n == 1 ? "" : "s", err);
+		return 1;
+	}
 	struct ProfCapability cap;
 	int have_kernel = 0;
 	int have_inside = 0;

--- a/tools/profiler/validate.c
+++ b/tools/profiler/validate.c
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+/*
+ * Profile contract validation (TODO.trace-profile/06). See
+ * validate.h. Checks mirror share/profile-schema.json plus the
+ * cross-field rules a schema cannot express (risk present iff
+ * the kernel layer was captured).
+ */
+
+#include "validate.h"
+#include "parson.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdarg.h>
+
+struct vctx {
+	char *err;
+	size_t errsz;
+	size_t used;
+	int violations;
+};
+
+static void violate(struct vctx *c, const char *fmt, ...)
+{
+	va_list ap;
+	int n;
+
+	c->violations++;
+	if (c->used + 2 >= c->errsz)
+		return;
+	if (c->used > 0) {
+		c->err[c->used++] = '\n';
+		c->err[c->used] = '\0';
+	}
+	va_start(ap, fmt);
+	n = vsnprintf(c->err + c->used, c->errsz - c->used, fmt, ap);
+	va_end(ap);
+	if (n > 0)
+		c->used += (size_t)n;
+	if (c->used > c->errsz - 1)
+		c->used = c->errsz - 1;
+}
+
+static void check_name_count_array(struct vctx *c, JSON_Object *root,
+				    const char *key)
+{
+	JSON_Array *arr = json_object_get_array(root, key);
+	size_t i;
+
+	if (arr == NULL) {
+		violate(c, "profile.%s: array required", key);
+		return;
+	}
+	for (i = 0; i < json_array_get_count(arr); i++) {
+		JSON_Object *o = json_array_get_object(arr, i);
+		const char *name;
+
+		if (o == NULL) {
+			violate(c, "profile.%s[%zu]: object required",
+				key, i);
+			continue;
+		}
+		name = json_object_get_string(o, "name");
+		if (name == NULL || name[0] == '\0')
+			violate(c, "profile.%s[%zu].name: non-empty string required",
+				key, i);
+		if (!json_object_has_value(o, "count") ||
+		    json_object_get_number(o, "count") < 1)
+			violate(c, "profile.%s[%zu].count: number >= 1 required",
+				key, i);
+	}
+}
+
+static int str_in(const char *s, const char *const *set)
+{
+	size_t i;
+
+	for (i = 0; set[i] != NULL; i++)
+		if (strcmp(s, set[i]) == 0)
+			return 1;
+	return 0;
+}
+
+int prof_validate_file(const char *path, char *err, size_t errsz)
+{
+	static const char *const classes[] = {
+		"read", "write", "probe", "none", NULL
+	};
+	static const char *const layers[] = {
+		"captured", "ABSENT", NULL
+	};
+	static const char *const verdicts[] = {
+		"clean", "SUBLIBC_ACCESS_FOUND", NULL
+	};
+	JSON_Value *v;
+	JSON_Object *root;
+	JSON_Object *prof;
+	JSON_Object *cov;
+	struct vctx c;
+	int kernel_captured;
+
+	if (err != NULL && errsz > 0)
+		err[0] = '\0';
+	c.err = err;
+	c.errsz = errsz;
+	c.used = 0;
+	c.violations = 0;
+
+	v = json_parse_file(path);
+	if (v == NULL) {
+		violate(&c, "not parseable JSON");
+		return c.violations ? -1 : 0;
+	}
+	root = json_value_get_object(v);
+	if (root == NULL) {
+		violate(&c, "root: object required");
+		json_value_free(v);
+		return -1;
+	}
+
+	prof = json_object_get_object(root, "profile");
+	if (prof == NULL) {
+		violate(&c, "profile: object required");
+	} else {
+		JSON_Array *acc;
+		size_t i;
+
+		if (!json_object_has_value(prof, "entries") ||
+		    json_object_get_number(prof, "entries") < 0)
+			violate(&c, "profile.entries: number >= 0 required");
+		check_name_count_array(&c, prof, "functions");
+		check_name_count_array(&c, prof, "env");
+		check_name_count_array(&c, prof, "net");
+
+		acc = json_object_get_array(prof, "accesses");
+		if (acc == NULL) {
+			violate(&c, "profile.accesses: array required");
+		} else {
+			for (i = 0; i < json_array_get_count(acc); i++) {
+				JSON_Object *o = json_array_get_object(acc, i);
+				const char *path_str;
+				const char *cls;
+
+				if (o == NULL) {
+					violate(&c, "profile.accesses[%zu]: object required", i);
+					continue;
+				}
+				path_str = json_object_get_string(o, "path");
+				if (path_str == NULL || path_str[0] == '\0')
+					violate(&c, "profile.accesses[%zu].path: non-empty string required", i);
+				cls = json_object_get_string(o, "class");
+				if (cls == NULL || !str_in(cls, classes))
+					violate(&c, "profile.accesses[%zu].class: read|write|probe|none required", i);
+				if (!json_object_has_value(o, "hits") ||
+				    json_object_get_number(o, "hits") < 1)
+					violate(&c, "profile.accesses[%zu].hits: number >= 1 required", i);
+			}
+		}
+	}
+
+	cov = json_object_get_object(root, "coverage");
+	kernel_captured = 0;
+	if (cov == NULL) {
+		violate(&c, "coverage: object required");
+	} else {
+		const char *l;
+
+		l = json_object_get_string(cov, "libc_layer");
+		if (l == NULL || !str_in(l, layers))
+			violate(&c, "coverage.libc_layer: captured|ABSENT required");
+		l = json_object_get_string(cov, "kernel_layer");
+		if (l == NULL || !str_in(l, layers)) {
+			violate(&c, "coverage.kernel_layer: captured|ABSENT required");
+		} else if (strcmp(l, "captured") == 0) {
+			kernel_captured = 1;
+		}
+	}
+
+	/* cross-field: the risk section exists iff kernel captured */
+	if (json_object_has_value(root, "risk")) {
+		JSON_Object *risk = json_object_get_object(root, "risk");
+		const char *verdict;
+
+		if (!kernel_captured)
+			violate(&c, "risk: present but coverage.kernel_layer is ABSENT");
+		if (risk == NULL) {
+			violate(&c, "risk: object required");
+		} else {
+			int fi;
+
+			verdict = json_object_get_string(risk, "verdict");
+			if (verdict == NULL || !str_in(verdict, verdicts))
+				violate(&c, "risk.verdict: clean|SUBLIBC_ACCESS_FOUND required");
+			for (fi = 0; fi < 3; fi++) {
+				static const char *const nums[] = {
+					"agreed", "libc_only", "kernel_only"
+				};
+
+				if (!json_object_has_value(risk, nums[fi]) ||
+				    json_object_get_number(risk, nums[fi]) < 0)
+					violate(&c, "risk.%s: number >= 0 required",
+						nums[fi]);
+			}
+		}
+	} else if (kernel_captured) {
+		violate(&c, "risk: required when coverage.kernel_layer is captured");
+	}
+
+	if (json_object_has_value(root, "static_capability")) {
+		JSON_Object *cap = json_object_get_object(root, "static_capability");
+
+		if (cap == NULL) {
+			violate(&c, "static_capability: object required");
+		} else {
+			if (!json_object_has_value(cap, "raw_syscall_gadgets") ||
+			    json_object_get_number(cap, "raw_syscall_gadgets") < 0)
+				violate(&c, "static_capability.raw_syscall_gadgets: number >= 0 required");
+			if (!json_object_has_value(cap, "ntdll_imports") ||
+			    json_object_get_number(cap, "ntdll_imports") < 0)
+				violate(&c, "static_capability.ntdll_imports: number >= 0 required");
+		}
+	}
+
+	json_value_free(v);
+	return c.violations;
+}

--- a/tools/profiler/validate.h
+++ b/tools/profiler/validate.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+#ifndef RETRACE_TOOLS_PROFILER_VALIDATE_H_
+#define RETRACE_TOOLS_PROFILER_VALIDATE_H_
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Profile contract validation (TODO.trace-profile/06). Enforces
+ * share/profile-schema.json without a schema engine (no new
+ * dependencies; the schema file documents the same contract for
+ * external tooling). Returns the number of violations found, or
+ * -1 when the file cannot be parsed. err receives a
+ * human-readable list of violations.
+ */
+int prof_validate_file(const char *path, char *err, size_t errsz);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* RETRACE_TOOLS_PROFILER_VALIDATE_H_ */


### PR DESCRIPTION
## Summary

**TODO.trace-profile/02-06**: the recipe-34 loop is now one command, upgrade-aware, and contract-checked. Follows v2.13.0 (the first live Windows hooks).

- **`retrace-profile capture`** — one-shot (POSIX): run a command under the preload, trace, profile, optionally emit the jail. Built-in default config scopes tracing to the file/env/net function set (a wildcard default traced printf-family variadics — noisy and fragile); a user `RETRACE_JSON_CONFIG` always wins.
- **`retrace-profile diff`** — drift between two profiles: new paths, class escalations (read→write), removed paths, new functions; `--json` + exit 1 on drift (CI-able). The upgrade story for the tailor loop.
- **`retrace-profile validate` + `share/profile-schema.json`** — the profile contract: enum values, required sections, and the cross-field rule a schema cannot express (risk iff kernel captured).
- **Windows ucrt hook set expanded** — fopen-only before; now `_open _close _read _write _lseek _stat _unlink _remove _rename _rmdir` via the export→engine name mapping. Normal C programs' file traffic lands in Windows profiles/jails.
- **Windows arm64 wrapper** (gas) — AAPCS64 frame, x30 preserved for the tail-jump; dual-arch arch_spec. armasm64 (MSVC-arm64) is the documented follow-up.
- **Known gap (documented)**: MSVC engine ACTION path inside a hooked call still crashes; the ABI round trip is MinGW-proven, MSVC-build-covered. Debug continues here.

## Test plan

- [x] 81/81 ctest (12 profiler aggregate/capability + 10 new drift/validate tests)
- [x] E2E locally: capture → profile → validate → diff → jail (denied read)
- [x] MinGW cross-build: 16 x64 wrappers + retrace.dll + tools
- [x] llvm-ml64: all 16 MASM wrappers assemble with correct symbols
- [x] clang aarch64-windows: arm64 wrapper assembles (16 symbols)
- [x] Checkpatch clean
- [ ] CI matrix
