### PR TITLE
v2.24.0: libFuzzer harness template example

### DIFF
--- a/examples/fuzz-target/README.md
+++ b/examples/fuzz-target/README.md
@@ -1,0 +1,22 @@
+# fuzz-target: libFuzzer harness template
+
+The persistent in-process harness (TODO.trace-profile/20's
+deferred item, now shipped): replace `target_parse` with your
+parser; the harness shapes hostile inputs (embedded NUL,
+truncation, oversize via the buf cap) and retrace's JSON config
+adds libc-level fault injection on top (malloc failure via
+memory_fuzz, redirects, mocks) when the harness runs under the
+preload.
+
+```sh
+clang -g -O1 -fsanitize=fuzzer -o fuzz harness.c
+./fuzz corpus/
+```
+
+Pair with the workbench: `retrace-fuzz-report --emit-corpus`
+produces the minimized reproducing corpus; deterministic
+replays need only `RETRACE_FUZZ_SEED`.
+
+Dictionary note: token-dictionary string injection is the
+stringinjector tool's job (tools/stringinjector) -- feed its
+wordlists there; this harness owns byte-level shaping.

--- a/examples/fuzz-target/harness.c
+++ b/examples/fuzz-target/harness.c
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+/*
+ * libFuzzer harness template (TODO.trace-profile/20): the
+ * retrace JSON config drives what happens to each fuzzer input
+ * BEFORE the target parses it -- mutate, inject, or fail the
+ * underlying libc calls -- while libFuzzer's coverage feedback
+ * (plus retrace's call_hash) explores. The TARGET FUNCTION is
+ * the only part you replace.
+ *
+ * build:  clang -g -O1 -fsanitize=fuzzer -o fuzz harness.c
+ * run:    ./fuzz corpus/        (seed corpus from the workbench)
+ *
+ * Pair with the workbench: corpus minimized by
+ * retrace-fuzz-report feeds this harness's corpus dir; a config
+ * with RETRACE_FUZZ_SEED determinism reproduces any finding.
+ */
+
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
+
+/*
+ * TARGET: replace this with the parser under test. It must be
+ * deterministic and memory-safe BY CONTRACT -- the harness
+ * supplies hostile inputs (truncated, embedded-NUL, oversized)
+ * via the mutations below.
+ */
+static int target_parse(const uint8_t *data, size_t size)
+{
+	/* example: a header parser that crashes on a bad length */
+	uint16_t len;
+
+	if (size < 2)
+		return -1;
+	memcpy(&len, data, 2);
+	if (len > size - 2)
+		return -1; /* correct rejection */
+	return data[2 + len - 1]; /* demo sink */
+}
+
+/*
+ * HARNESS MUTATIONS (v1): deterministic input shaping before
+ * the target. Extend with your grammar; the retrace layer adds
+ * libc-level fault injection via the JSON config.
+ */
+static size_t mutate(uint8_t *buf, size_t size)
+{
+	/* embedded NUL: parsers that stop at NUL miss the tail */
+	if (size > 4)
+		buf[size / 2] = 0;
+	return size;
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+	uint8_t buf[4096];
+	size_t n = size < sizeof(buf) ? size : sizeof(buf);
+
+	memcpy(buf, data, n);
+	(void)target_parse(buf, mutate(buf, n));
+	return 0;
+}

--- a/include/retrace/version.h
+++ b/include/retrace/version.h
@@ -37,10 +37,10 @@
 #define RETRACE_VERSION_H
 
 #define RETRACE_VERSION_MAJOR 2
-#define RETRACE_VERSION_MINOR 23
+#define RETRACE_VERSION_MINOR 24
 #define RETRACE_VERSION_PATCH 0
 
-#define RETRACE_VERSION_STRING "2.23.0"
+#define RETRACE_VERSION_STRING "2.24.0"
 
 #define RETRACE_VERSION_ATLEAST(maj, min, pat)                  \
 	(RETRACE_VERSION_MAJOR > (maj) ||                       \

--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -1,3 +1,10 @@
+retrace (2.24.0-1) unstable; urgency=medium
+
+  * Added: examples/fuzz-target -- the libFuzzer harness
+    template paired with the fuzz workbench.
+
+ -- Ribose Inc <opensource@ribose.com>  Sun, 23 Aug 2026 02:00:00 +0000
+
 retrace (2.22.0-1) unstable; urgency=medium
 
   * Added: fuzz-report drift oracle (--baseline: behavior the

--- a/packaging/fedora/retrace.spec
+++ b/packaging/fedora/retrace.spec
@@ -5,7 +5,7 @@
 # Install: dnf install retrace-2.10.0-1.*.rpm
 
 Name:           retrace
-Version:        2.23.0
+Version:        2.24.0
 Release:        1%{?dist}
 Summary:        Userspace libc interceptor for security discovery
 
@@ -50,6 +50,8 @@ action, OTLP/JSON export, and a Python config builder.
 %{_includedir}/retrace/
 
 %changelog
+* Sun Aug 23 2026 Ribose Inc <opensource@ribose.com> - 2.24.0-1
+- libFuzzer harness template example
 * Sat Aug 22 2026 Ribose Inc <opensource@ribose.com> - 2.21.0-1
 - fuzzing workbench: retrace-fuzz-report (clustering + reproducers), RETRACE_FUZZ_SEED determinism
 * Sat Aug 22 2026 Ribose Inc <opensource@ribose.com> - 2.20.0-1

--- a/packaging/nix/default.nix
+++ b/packaging/nix/default.nix
@@ -8,7 +8,7 @@
 
 stdenv.mkDerivation rec {
   pname = "retrace";
-  version = "2.23.0";
+  version = "2.24.0";
 
   src = ./.;
 

--- a/src/cli/retrace_cli.c
+++ b/src/cli/retrace_cli.c
@@ -63,7 +63,7 @@ typedef int retrace_status_t;
 static void usage(FILE *out)
 {
 	fprintf(out,
-"retrace v2.23.0 -- userspace libc interceptor\n"
+"retrace v2.24.0 -- userspace libc interceptor\n"
 "\n"
 "Usage:\n"
 "  retrace run [OPTIONS] -- <command> [args...]\n"


### PR DESCRIPTION
TODO.trace-profile/20's last item: the persistent in-process libFuzzer harness (examples/fuzz-target) — replace target_parse with your parser; pairs with the workbench's minimized corpora and RETRACE_FUZZ_SEED determinism. Dictionary note: stringinjector owns token wordlists.