### PR TITLE
website: bump transitive nanoid to 3.3.18 (dependabot #2)

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -4503,9 +4503,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
Bumps the transitive `nanoid` in `website/package-lock.json` from 3.3.16 to 3.3.18, closing dependabot alert #2 (high: custom generators can loop indefinitely when sized zero).

Lockfile-only change within the existing semver range; the Astro site build verified after the bump.
