### PR TITLE
v2.28.0: fuzz_str -- dictionary-driven string fuzzing (TODO 25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (see `docs/adr/0006-semantic-versioning.md`).
 
+## [2.28.0] — 2026-08-23
+
+**Dictionary-driven string fuzzing — `fuzz_str`**
+(TODO.trace-profile/25; the content-fuzzing deferral closes).
+
+- New action: replaces an incoming `sz` param with a token drawn
+  from an AFL-style dictionary file (one token per line, `#`
+  comments and blanks skipped; 256 tokens x 4096 bytes bounded).
+  Deterministic under the shared seed machinery — reproducer =
+  config + seed + dict. Optional `match_str` gates the
+  replacement to calls carrying a given value.
+- Seed policy extracted (`fuzz_seed_init`): a script using only
+  `fuzz_str` still seeds (param > `RETRACE_FUZZ_SEED` > time).
+- Loader split into `fuzz_dict.{c,h}` — unit-testable without
+  action machinery; 12 new tests (load semantics, pick
+  determinism, action param validation, replacement, match
+  gating, no-leak repeated calls). 89/89 total.
+- `examples/fuzz-workbench`: `paths.c` demo target + dictionary
+  section in the runner — three runs, token sequence extracted
+  from the trace logs, byte-compared (the reproducibility
+  promise, shown not claimed).
+- `docs/configuration.md`: full `fuzz_str` reference.
+
 ## [2.27.0] — 2026-08-23
 
 **Scripted Windows ETW kernel truth — the last kernel-truth gap

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -262,6 +262,37 @@ script and synthesizes a `NULL` (or `0`) return value. `call_real`
 must precede `memory_fuzz` for the real allocator to run on
 successful calls.
 
+#### `fuzz_str`
+
+Replaces an incoming string parameter with a token drawn from an
+AFL-style dictionary file -- content fuzzing for parsers, env
+handling, and decoders without writing a harness. Deterministic
+under the shared seed machinery (reproducer = config + seed +
+dict file).
+
+```json
+{
+  "action_name": "fuzz_str",
+  "action_params": {
+    "param_name": "filename",
+    "dict": "/path/to/dict.txt",
+    "match_str": "/etc/hosts",
+    "fuzz_seed": 42
+  }
+}
+```
+
+| Param       | Type   | Required | Notes                                        |
+|-------------|--------|----------|----------------------------------------------|
+| `param_name`| string | yes      | Must be an IN `sz` pointer param.            |
+| `dict`      | string | yes      | Dictionary path: one token per line; `#` lines and blanks skipped. 256 tokens max, 4096 bytes each. |
+| `match_str` | string | no       | Only replace when the current value matches. |
+| `fuzz_seed` | number | no       | Seeds the shared RNG (once per process; also honors `RETRACE_FUZZ_SEED`). |
+
+Place `fuzz_str` BEFORE `log_params` so the trace records the
+token the callee actually received. See
+`examples/fuzz-workbench` for the full flow.
+
 #### `incomplete_io`
 
 Truncates the return value of a read/write-like call at a

--- a/examples/fuzz-workbench/README.md
+++ b/examples/fuzz-workbench/README.md
@@ -27,3 +27,14 @@ The pieces:
 
 Assertion mode: pass `--marker <substring>` to classify
 non-signal failures by a marker string in the trace.
+
+## Dictionary fuzzing (fuzz_str)
+
+The same runner also demos CONTENT fuzzing: `fuzz_str` replaces
+`fopen`'s `filename` with tokens from `dict.txt` (AFL-style:
+one per line, `#` comments skipped), deterministically per
+`fuzz_seed`. The demo runs the target three times and
+byte-compares the token sequence from the trace logs -- the
+reproducibility promise (reproducer = config + seed + dict).
+See `paths.c` and the dictionary section in `run-posix.sh`;
+action reference in `docs/configuration.md`.

--- a/examples/fuzz-workbench/paths.c
+++ b/examples/fuzz-workbench/paths.c
@@ -1,0 +1,22 @@
+/*
+ * paths.c: the fuzz_str demo target (TODO.trace-profile/25).
+ * Opens argv[1] and reports OPEN/FAIL -- the dictionary fuzzer
+ * replaces the path before libc executes, so the printed path
+ * shows which dict token was spliced in. Deterministic per
+ * fuzz_seed: the same seed prints the same token sequence.
+ */
+
+#include <stdio.h>
+
+int main(int argc, char **argv)
+{
+	FILE *f;
+
+	if (argc < 2)
+		return 2;
+	f = fopen(argv[1], "rb");
+	printf("%s: %s\n", argv[1], f != NULL ? "OPEN" : "FAIL");
+	if (f != NULL)
+		fclose(f);
+	return 0;
+}

--- a/examples/fuzz-workbench/run-posix.sh
+++ b/examples/fuzz-workbench/run-posix.sh
@@ -79,4 +79,48 @@ rm -rf mincorpus
 	-- ./crashy >/dev/null 2>&1 || true
 ls mincorpus 2>/dev/null || echo "(no failures -> empty corpus)"
 
+echo "=== dictionary fuzzing: fuzz_str on fopen's filename"
+
+# AFL-style dictionary: '#' lines and blanks are skipped
+cat > dict.txt <<'DICT'
+# paths a parser should survive
+/etc/passwd
+../../../etc/shadow
+%s%s%s%n
+https://example.invalid/callback
+DICT
+
+# fuzz_str BEFORE log_params: the trace records the token the
+# callee actually received (mutation happens in the wrapper)
+cat > dictfuzz.json <<'CONF'
+{"intercept_scripts":[{"func_name":"fopen","actions":[
+ {"action_name":"fuzz_str","action_params":{
+   "param_name":"filename","dict":"dict.txt","fuzz_seed":42}},
+ {"action_name":"log_params"},
+ {"action_name":"call_real"}]}]}
+CONF
+
+cc -O0 -g -o paths "$HERE/paths.c"
+
+# same seed -> same token sequence (the reproducibility promise):
+# three runs, tokens extracted from each trace log, byte-compared
+i=1
+while [ $i -le 3 ]; do
+	rm -f trace.log
+	RETRACE_JSON_CONFIG=dictfuzz.json \
+	RETRACE_LOGGER_DEF_ENA=1 RETRACE_LOGGER_DEF_STDOUT_ENA=0 \
+	RETRACE_LOGGER_DEF_FN=trace.log \
+	LD_PRELOAD="$LIB" DYLD_INSERT_LIBRARIES="$LIB" \
+	./paths /etc/hosts >/dev/null 2>&1 || true
+	grep -aoE '/etc/passwd|[.][.]/[.][.]/[.][.]/etc/shadow|%s%s%s%n|https://example[.]invalid/callback' \
+		trace.log > tokens$i.txt || : > tokens$i.txt
+	i=$((i + 1))
+done
+if cmp -s tokens1.txt tokens2.txt && cmp -s tokens2.txt tokens3.txt; then
+	echo "deterministic: same seed -> same token sequence"
+	echo "tokens: $(tr '\n' ' ' < tokens1.txt)"
+else
+	echo "UNDETERMINISTIC token sequence"
+fi
+
 echo "=== done: $WORK"

--- a/include/retrace/version.h
+++ b/include/retrace/version.h
@@ -37,10 +37,10 @@
 #define RETRACE_VERSION_H
 
 #define RETRACE_VERSION_MAJOR 2
-#define RETRACE_VERSION_MINOR 27
+#define RETRACE_VERSION_MINOR 28
 #define RETRACE_VERSION_PATCH 0
 
-#define RETRACE_VERSION_STRING "2.27.0"
+#define RETRACE_VERSION_STRING "2.28.0"
 
 #define RETRACE_VERSION_ATLEAST(maj, min, pat)                  \
 	(RETRACE_VERSION_MAJOR > (maj) ||                       \

--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -1,3 +1,13 @@
+retrace (2.28.0-1) unstable; urgency=medium
+
+  * Added: fuzz_str action -- dictionary-driven string param
+    fuzzing (AFL-style dict, deterministic under the shared seed;
+    reproducer = config + seed + dict). Loader split into
+    fuzz_dict.{c,h}; fuzz-workbench example demonstrates the
+    content-fuzzing flow E2E (TODO.trace-profile/25).
+
+ -- Ribose Inc <opensource@ribose.com>  Sun, 23 Aug 2026 18:40:00 +0000
+
 retrace (2.27.0-1) unstable; urgency=medium
 
   * Added: scripted Windows kernel-truth capture --

--- a/packaging/fedora/retrace.spec
+++ b/packaging/fedora/retrace.spec
@@ -5,7 +5,7 @@
 # Install: dnf install retrace-2.10.0-1.*.rpm
 
 Name:           retrace
-Version:        2.27.0
+Version:        2.28.0
 Release:        1%{?dist}
 Summary:        Userspace libc interceptor for security discovery
 
@@ -50,6 +50,8 @@ action, OTLP/JSON export, and a Python config builder.
 %{_includedir}/retrace/
 
 %changelog
+* Sun Aug 23 2026 Ribose Inc <opensource@ribose.com> - 2.28.0-1
+- fuzz_str action: dictionary-driven string fuzzing (TODO 25)
 * Sun Aug 23 2026 Ribose Inc <opensource@ribose.com> - 2.27.0-1
 - scripted Windows ETW kernel truth: etw-capture.ps1 + retrace-etw2retrace (TODO 24)
 * Sun Aug 23 2026 Ribose Inc <opensource@ribose.com> - 2.26.0-1

--- a/packaging/nix/default.nix
+++ b/packaging/nix/default.nix
@@ -8,7 +8,7 @@
 
 stdenv.mkDerivation rec {
   pname = "retrace";
-  version = "2.27.0";
+  version = "2.28.0";
 
   src = ./.;
 

--- a/src/cli/retrace_cli.c
+++ b/src/cli/retrace_cli.c
@@ -63,7 +63,7 @@ typedef int retrace_status_t;
 static void usage(FILE *out)
 {
 	fprintf(out,
-"retrace v2.27.0 -- userspace libc interceptor\n"
+"retrace v2.28.0 -- userspace libc interceptor\n"
 "\n"
 "Usage:\n"
 "  retrace run [OPTIONS] -- <command> [args...]\n"

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -44,7 +44,7 @@ set(_core_action_sources
 	actions/delay.c actions/call_count_limit.c
 	actions/sandbox.c actions/addr_deny.c
 	actions/filter.c actions/decode_http.c actions/decode_dns.c
-	actions/capture_buffer.c)
+	actions/capture_buffer.c actions/fuzz_dict.c)
 
 set(_core_datatype_sources
 	datatypes/basic.c datatypes/uio.c datatypes/unistd.c)

--- a/src/core/actions/fuzz_dict.c
+++ b/src/core/actions/fuzz_dict.c
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "real_impls.h"
+
+#include "fuzz_dict.h"
+
+int fuzz_dict_load(fuzz_dict_t *d, const char *path)
+{
+	char *raw;
+	long sz;
+	size_t got;
+	FILE *f;
+	size_t i;
+
+	d->count = 0;
+	f = retrace_real_impls.fopen(path, "rb");
+	if (f == NULL)
+		return -1;
+	if (retrace_real_impls.fseek(f, 0, SEEK_END) != 0) {
+		retrace_real_impls.fclose(f);
+		return -1;
+	}
+	sz = retrace_real_impls.ftell(f);
+	if (sz < 0) {
+		retrace_real_impls.fclose(f);
+		return -1;
+	}
+	retrace_real_impls.fseek(f, 0, SEEK_SET);
+	if (sz > FUZZ_DICT_MAX * FUZZ_DICT_TOKEN_MAX)
+		sz = FUZZ_DICT_MAX * FUZZ_DICT_TOKEN_MAX;
+
+	raw = retrace_real_impls.malloc((size_t)sz + 1);
+	if (raw == NULL) {
+		retrace_real_impls.fclose(f);
+		return -1;
+	}
+	got = retrace_real_impls.fread(raw, 1, (size_t)sz, f);
+	retrace_real_impls.fclose(f);
+	raw[got] = '\0';
+
+	/* line split; '#'-comment, blank, and edge-whitespace skip */
+	for (i = 0; i < got && d->count < FUZZ_DICT_MAX; ) {
+		const char *line = raw + i;
+		const char *nl = line;
+		size_t len;
+		size_t lead = 0;
+
+		while (*nl != '\0' && *nl != '\n')
+			nl++;
+		len = (size_t)(nl - line);
+		i += len + 1;
+
+		while (lead < len && (line[lead] == ' ' ||
+				      line[lead] == '\t' ||
+				      line[lead] == '\r'))
+			lead++;
+		if (lead == len || line[lead] == '#')
+			continue;
+		len -= lead;
+		while (len > 0 && (line[lead + len - 1] == '\r' ||
+				   line[lead + len - 1] == ' ' ||
+				   line[lead + len - 1] == '\t'))
+			len--;
+		if (len == 0)
+			continue;
+		if (len >= FUZZ_DICT_TOKEN_MAX)
+			len = FUZZ_DICT_TOKEN_MAX - 1;
+		memcpy(d->tokens[d->count], line + lead, len);
+		d->tokens[d->count][len] = '\0';
+		d->count++;
+	}
+	retrace_real_impls.free(raw);
+	return 0;
+}
+
+const char *fuzz_dict_pick(const fuzz_dict_t *d)
+{
+	if (d->count <= 0)
+		return NULL;
+	return d->tokens[rand() % d->count];
+}

--- a/src/core/actions/fuzz_dict.h
+++ b/src/core/actions/fuzz_dict.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+/*
+ * fuzz_dict: the dictionary behind the fuzz_str action
+ * (TODO.trace-profile/25). AFL-style: one token per line; '#'
+ * lines and blanks are skipped. Loading and picking are kept
+ * free of action machinery so they are unit-testable directly.
+ */
+
+#ifndef RETRACE_CORE_ACTIONS_FUZZ_DICT_H_
+#define RETRACE_CORE_ACTIONS_FUZZ_DICT_H_
+
+#define FUZZ_DICT_MAX 256
+#define FUZZ_DICT_TOKEN_MAX 4096
+
+typedef struct fuzz_dict {
+	char tokens[FUZZ_DICT_MAX][FUZZ_DICT_TOKEN_MAX];
+	int count;
+} fuzz_dict_t;
+
+/*
+ * Load tokens from path. Returns 0 on success (even when the
+ * file holds fewer tokens than the cap), -1 when the file
+ * cannot be opened or read. Truncates tokens longer than
+ * FUZZ_DICT_TOKEN_MAX - 1 bytes; stops at FUZZ_DICT_MAX tokens.
+ */
+int fuzz_dict_load(fuzz_dict_t *d, const char *path);
+
+/*
+ * Pick a token with the global RNG (the seed machinery memory_fuzz
+ * uses -- retrace_actions_fuzzing_seed_maybe_apply drives the
+ * sequence). Returns NULL when the dictionary is empty.
+ */
+const char *fuzz_dict_pick(const fuzz_dict_t *d);
+
+#endif /* RETRACE_CORE_ACTIONS_FUZZ_DICT_H_ */

--- a/src/core/actions/memfuzz.c
+++ b/src/core/actions/memfuzz.c
@@ -26,11 +26,50 @@
 #include <errno.h>
 
 #include "actions.h"
+#include "action_utils.h"
 #include "logger.h"
 #include "real_impls.h"
 #include "data_types.h"
 
+#include "fuzz_dict.h"
+
 static int initialized;
+
+/*
+ * Seed policy shared by every fuzz action (TODO.trace-profile/25
+ * extracted it so a script using ONLY fuzz_str still seeds):
+ * explicit fuzz_seed param > RETRACE_FUZZ_SEED env > time.
+ */
+static void fuzz_seed_init(const JSON_Object *action_params)
+{
+	if (initialized)
+		return;
+	initialized = 1;
+
+	if (action_params != NULL &&
+	    json_object_has_value(action_params, "fuzz_seed")) {
+		double fuzz_seed;
+
+		fuzz_seed = json_object_get_number(action_params,
+			"fuzz_seed");
+
+		srand(fuzz_seed);
+	} else if (retrace_real_impls.getenv(
+		"RETRACE_FUZZ_SEED") != NULL) {
+		/*
+		 * External seed (TODO.trace-profile/20): makes
+		 * ANY fuzz config deterministically re-drivable
+		 * without editing it -- the fuzz workbench's
+		 * reproducibility path (a reproducer is config +
+		 * this env var).
+		 */
+		srand((unsigned int)retrace_real_impls.atoi(
+			retrace_real_impls.getenv(
+				"RETRACE_FUZZ_SEED")));
+	} else {
+		srand(retrace_real_impls.time(NULL));
+	}
+}
 
 static int ia_memory_fuzz
 	(struct ThreadContext *t_ctx,
@@ -44,31 +83,7 @@ static int ia_memory_fuzz
 		return -1;
 	}
 
-	if (!initialized) {
-		initialized = 1;
-
-		if (json_object_has_value(action_params, "fuzz_seed")) {
-			double fuzz_seed;
-
-			fuzz_seed = json_object_get_number(action_params, "fuzz_seed");
-
-			srand(fuzz_seed);
-		} else if (retrace_real_impls.getenv(
-			"RETRACE_FUZZ_SEED") != NULL) {
-			/*
-			 * External seed (TODO.trace-profile/20): makes
-			 * ANY memory_fuzz config deterministically
-			 * re-drivable without editing it -- the fuzz
-			 * workbench's reproducibility path (a reproducer
-			 * is config + this env var).
-			 */
-			srand((unsigned int)retrace_real_impls.atoi(
-				retrace_real_impls.getenv(
-					"RETRACE_FUZZ_SEED")));
-		} else {
-			srand(retrace_real_impls.time(NULL));
-		}
-	}
+	fuzz_seed_init(action_params);
 
 	/*
 	 * If the user has invoked the fuzzing_seed action at any point
@@ -101,6 +116,139 @@ static int ia_memory_fuzz
 }
 
 /*
+ * fuzz_str (TODO.trace-profile/25): dictionary-driven string
+ * fuzzing. Replaces an incoming sz param with a token drawn
+ * from an AFL-style dictionary file -- deterministic under the
+ * shared seed (reproducer = config + seed + dict). match_str
+ * optionally gates the replacement to calls carrying a given
+ * value, mirroring modify_in_param_str.
+ */
+static fuzz_dict_t *g_fuzz_str_dict;
+static char g_fuzz_str_path[512];
+
+static int ia_fuzz_str
+	(struct ThreadContext *t_ctx,
+		const JSON_Object *action_params)
+{
+	const char *param_name;
+	const char *dict_path;
+	const char *match_str;
+	const char *token;
+	const struct FuncParam *param;
+	int param_idx;
+
+	if (action_params == NULL) {
+		log_err("action_params must exists for fuzz_str");
+		return -1;
+	}
+
+	fuzz_seed_init(action_params);
+	retrace_actions_fuzzing_seed_maybe_apply();
+
+	param_name = json_object_get_string(action_params,
+			"param_name");
+
+	if (param_name == NULL) {
+		log_err("param_name must exist in action_params "
+				"for fuzz_str");
+		return -1;
+	}
+
+	dict_path = json_object_get_string(action_params, "dict");
+
+	if (dict_path == NULL) {
+		log_err("dict must exist in action_params "
+				"for fuzz_str");
+		return -1;
+	}
+
+	/* lazy load; a path change reloads (tests swap dicts) */
+	if (g_fuzz_str_dict == NULL ||
+	    retrace_real_impls.strcmp(g_fuzz_str_path, dict_path) != 0) {
+		if (g_fuzz_str_dict == NULL) {
+			g_fuzz_str_dict = retrace_real_impls.malloc(
+				sizeof(*g_fuzz_str_dict));
+			if (g_fuzz_str_dict == NULL) {
+				log_err("fuzz_str: out of memory");
+				return -1;
+			}
+		}
+		if (fuzz_dict_load(g_fuzz_str_dict, dict_path) != 0) {
+			log_err("fuzz_str: cannot load dict '%s'",
+				dict_path);
+			return -1;
+		}
+		retrace_real_impls.strcpy(g_fuzz_str_path, dict_path);
+	}
+
+	param_idx = retrace_action_find_param(t_ctx, param_name);
+
+	if (param_idx < 0) {
+		log_err("param '%s', is not defined for func '%s'",
+			param_name, t_ctx->prototype->name);
+
+		return -1;
+	}
+
+	param = &t_ctx->params[param_idx];
+
+	if (param->param_meta.direction != PDIR_IN) {
+		log_err("param '%s' is not an input param", param_name);
+
+		return -1;
+	}
+
+	if (!(param->param_meta.modifiers & CDM_POINTER) ||
+		(retrace_real_impls.strcmp(
+			param->param_meta.ref_type_name, "sz"))) {
+		log_err("param '%s' is not a pointer to string", param_name);
+
+		return -1;
+	}
+
+	match_str = json_object_get_string(action_params,
+		"match_str");
+
+	if (match_str != NULL) {
+		if (retrace_real_impls.strcmp(match_str,
+			(char *) param->val)) {
+			log_info("no match for param '%s'", param_name);
+
+			/* no match, do nothing */
+			return 0;
+		}
+
+		log_info("match for param '%s'", param_name);
+	}
+
+	token = fuzz_dict_pick(g_fuzz_str_dict);
+	if (token == NULL) {
+		log_err("fuzz_str: dict '%s' is empty", dict_path);
+		return -1;
+	}
+
+	if (t_ctx->params[param_idx].free_val) {
+		retrace_real_impls.free(
+			(void *) t_ctx->params[param_idx].val);
+		t_ctx->params[param_idx].free_val = 0;
+	}
+
+	t_ctx->params[param_idx].val =
+		(intptr_t) retrace_real_impls.malloc(
+			retrace_real_impls.strlen(token) + 1);
+	t_ctx->params[param_idx].free_val = 1;
+
+	retrace_real_impls.strcpy(
+		(char *) t_ctx->params[param_idx].val,
+		token);
+
+	log_info("param '%s' fuzzed to '%s'", param_name, token);
+
+	/* 0 indicates successful processing */
+	return 0;
+}
+
+/*
  * Package name must be unique (it names the external symbol on
  * PE): memfuzz extends the basic set but lives in its own TU.
  */
@@ -108,5 +256,9 @@ retrace_actions_define_package(memfuzz) = {
 	{
 		.name = "memory_fuzz",
 		.action = ia_memory_fuzz
+	},
+	{
+		.name = "fuzz_str",
+		.action = ia_fuzz_str
 	}
 };

--- a/test/fixtures/fuzz-dict.txt
+++ b/test/fixtures/fuzz-dict.txt
@@ -1,0 +1,8 @@
+# fuzz_str dictionary fixture (TODO.trace-profile/25):
+# '#' lines and blanks are skipped; everything else is a token.
+
+/etc/passwd
+../../../etc/shadow
+%s%s%s%n
+https://example.invalid/callback
+\x00\xff\xfe

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -670,6 +670,42 @@ add_test(NAME unit-test-memory-fuzz
 set_tests_properties(unit-test-memory-fuzz PROPERTIES LABELS "unit")
 
 #
+# fuzz_str action unit tests (TODO.trace-profile/25).
+#
+add_executable(retrace_test_fuzz_str test_fuzz_str.c)
+set_target_properties(retrace_test_fuzz_str PROPERTIES
+    OUTPUT_NAME test_fuzz_str
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/test/unit")
+
+target_link_libraries(retrace_test_fuzz_str PRIVATE
+    retrace_core
+    retrace_config_json
+    retrace_backends
+    ${_unit_backend_lib}
+    retrace_preload_common
+    retrace_headers
+    ${CMAKE_DL_LIBS}
+    Threads::Threads)
+
+target_include_directories(retrace_test_fuzz_str PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/core
+    ${CMAKE_SOURCE_DIR}/src/core/actions
+    ${CMAKE_SOURCE_DIR}/src/backends
+    ${CMAKE_SOURCE_DIR}/src/config/json
+    ${_unit_arch_include})
+
+if(RETRACE_PLATFORM_LINUX OR RETRACE_PLATFORM_FREEBSD)
+    target_compile_definitions(retrace_test_fuzz_str PRIVATE _GNU_SOURCE _DEFAULT_SOURCE)
+elseif(RETRACE_PLATFORM_DARWIN)
+    target_compile_definitions(retrace_test_fuzz_str PRIVATE _DARWIN_C_SOURCE)
+endif()
+
+add_test(NAME unit-test-fuzz-str
+    COMMAND retrace_test_fuzz_str)
+set_tests_properties(unit-test-fuzz-str PROPERTIES LABELS "unit"
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/test/fixtures)
+
+#
 # modify_in_param_str action unit tests (TODO.complete/14).
 #
 add_executable(retrace_test_modify_in_param_str test_modify_in_param_str.c)

--- a/test/unit/test_fuzz_str.c
+++ b/test/unit/test_fuzz_str.c
@@ -1,0 +1,317 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+/*
+ * Unit tests for fuzz_str (TODO.trace-profile/25) -- the
+ * dictionary-driven string fuzzing action -- and its fuzz_dict
+ * loader.
+ *
+ * Function level (real instances, no doubles):
+ *   - dict load: comments/blanks skipped, token count, exact
+ *     contents
+ *   - dict load: missing file -> -1
+ *   - pick determinism: same srand seed -> same token sequence
+ *
+ * Action level (lookup by name, real ThreadContext):
+ *   - Action lookup succeeds
+ *   - NULL params -> -1
+ *   - Missing param_name -> -1
+ *   - Missing dict -> -1
+ *   - Bad dict path -> -1
+ *   - Unknown param name -> -1
+ *   - Happy path: value replaced with SOME dict token, free_val
+ *     set
+ *   - match_str no-match -> value untouched
+ *   - Repeated call frees the prior buffer (no leak growth):
+ *     free_val toggles and value still a dict token
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "engine.h"
+#include "actions.h"
+#include "fuzz_dict.h"
+#include "data_types.h"
+#include "real_impls.h"
+#include "parson.h"
+
+typedef int (*action_fn_t)(struct ThreadContext *t_ctx,
+			    const JSON_Object *action_params);
+
+#define DICT_PATH "fuzz-dict.txt"
+#define DICT_TOKENS 5
+
+static int tests_run;
+static int tests_pass;
+static int tests_fail;
+
+#define TEST(name) do { \
+	tests_run++; \
+	printf("  TEST %s ... ", #name); \
+	test_##name(); \
+	tests_pass++; \
+	printf("OK\n"); \
+} while (0)
+
+/* Always-on check: assert() compiles to nothing under NDEBUG. */
+#define CHECK(cond) do { \
+	if (!(cond)) { \
+		printf("FAIL [%s:%d] %s\n", __FILE__, __LINE__, #cond); \
+		tests_fail++; \
+		return; \
+	} \
+} while (0)
+
+static int token_in_dict(const fuzz_dict_t *d, const char *s)
+{
+	int i;
+
+	for (i = 0; i < d->count; i++)
+		if (strcmp(d->tokens[i], s) == 0)
+			return 1;
+	return 0;
+}
+
+static void test_dict_load(void)
+{
+	static fuzz_dict_t d;
+
+	CHECK(fuzz_dict_load(&d, DICT_PATH) == 0);
+	CHECK(d.count == DICT_TOKENS);
+	CHECK(strcmp(d.tokens[0], "/etc/passwd") == 0);
+	CHECK(strcmp(d.tokens[1], "../../../etc/shadow") == 0);
+	CHECK(strcmp(d.tokens[2], "%s%s%s%n") == 0);
+	CHECK(strcmp(d.tokens[3],
+		"https://example.invalid/callback") == 0);
+}
+
+static void test_dict_load_missing(void)
+{
+	static fuzz_dict_t d;
+
+	CHECK(fuzz_dict_load(&d, "no/such/dict.txt") == -1);
+	CHECK(d.count == 0);
+}
+
+static void test_dict_pick_deterministic(void)
+{
+	static fuzz_dict_t d;
+	char seq_a[8][128];
+	char seq_b[8][128];
+	int i;
+
+	CHECK(fuzz_dict_load(&d, DICT_PATH) == 0);
+
+	srand(1498729252);
+	for (i = 0; i < 8; i++)
+		strcpy(seq_a[i], fuzz_dict_pick(&d));
+	srand(1498729252);
+	for (i = 0; i < 8; i++)
+		strcpy(seq_b[i], fuzz_dict_pick(&d));
+
+	for (i = 0; i < 8; i++)
+		CHECK(strcmp(seq_a[i], seq_b[i]) == 0);
+}
+
+static JSON_Object *build_params(const char *param_name,
+				  const char *dict, int with_match,
+				  const char *match_str)
+{
+	JSON_Value *root_val = json_value_init_object();
+	JSON_Object *root = json_value_get_object(root_val);
+
+	json_object_set_string(root, "param_name", param_name);
+	json_object_set_string(root, "dict", dict);
+	if (with_match)
+		json_object_set_string(root, "match_str", match_str);
+	return root;
+}
+
+static struct ThreadContext *build_ctx_with_str_param(const char *name,
+						       const char *val)
+{
+	static struct ThreadContext ctx;
+	static struct FuncPrototype proto;
+	static char buf[256];
+	struct FuncParam params[8];
+
+	memset(&ctx, 0, sizeof(ctx));
+	memset(params, 0, sizeof(params));
+	memset(&proto, 0, sizeof(proto));
+
+	strncpy(proto.name, "test_func", sizeof(proto.name) - 1);
+	ctx.prototype = &proto;
+
+	strncpy(buf, val, sizeof(buf) - 1);
+	buf[sizeof(buf) - 1] = '\0';
+
+	strncpy(params[0].param_meta.name, name,
+		sizeof(params[0].param_meta.name) - 1);
+	params[0].param_meta.modifiers = CDM_POINTER;
+	params[0].param_meta.direction = PDIR_IN;
+	strcpy(params[0].param_meta.ref_type_name, "sz");
+	params[0].val = (intptr_t)buf;
+	params[0].free_val = 0;
+
+	ctx.params_cnt = 1;
+	memcpy(ctx.params, params, sizeof(params));
+	ctx.ret_val = 0;
+	return &ctx;
+}
+
+static struct ThreadContext *build_empty_ctx(void)
+{
+	static struct ThreadContext ctx;
+	static struct FuncPrototype proto;
+
+	memset(&ctx, 0, sizeof(ctx));
+	memset(&proto, 0, sizeof(proto));
+	strncpy(proto.name, "test_func", sizeof(proto.name) - 1);
+	ctx.prototype = &proto;
+	return &ctx;
+}
+
+static void test_action_lookup(void)
+{
+	CHECK(retrace_actions_get("fuzz_str") != NULL);
+}
+
+static void test_params_null(void)
+{
+	action_fn_t action = retrace_actions_get("fuzz_str");
+	int rc;
+
+	rc = action(build_empty_ctx(), NULL);
+	CHECK(rc == -1);
+}
+
+static void test_missing_param_name(void)
+{
+	action_fn_t action = retrace_actions_get("fuzz_str");
+	JSON_Value *root_val = json_value_init_object();
+	JSON_Object *root = json_value_get_object(root_val);
+	int rc;
+
+	json_object_set_string(root, "dict", DICT_PATH);
+	rc = action(build_empty_ctx(), root);
+	CHECK(rc == -1);
+	json_value_free(root_val);
+}
+
+static void test_missing_dict(void)
+{
+	action_fn_t action = retrace_actions_get("fuzz_str");
+	JSON_Object *params = build_params("path", NULL, 0, NULL);
+	int rc;
+
+	/* parson keeps the key absent when value is NULL */
+	rc = action(build_empty_ctx(), params);
+	CHECK(rc == -1);
+}
+
+static void test_bad_dict_path(void)
+{
+	action_fn_t action = retrace_actions_get("fuzz_str");
+	JSON_Object *params =
+		build_params("path", "no/such/dict.txt", 0, NULL);
+	int rc;
+
+	rc = action(build_ctx_with_str_param("path", "/etc/hosts"),
+		params);
+	CHECK(rc == -1);
+}
+
+static void test_unknown_param(void)
+{
+	action_fn_t action = retrace_actions_get("fuzz_str");
+	JSON_Object *params = build_params("nope", DICT_PATH, 0, NULL);
+	int rc;
+
+	rc = action(build_ctx_with_str_param("path", "/etc/hosts"),
+		params);
+	CHECK(rc == -1);
+}
+
+static void test_replaces_with_dict_token(void)
+{
+	action_fn_t action = retrace_actions_get("fuzz_str");
+	JSON_Object *params = build_params("path", DICT_PATH, 0, NULL);
+	struct ThreadContext *ctx =
+		build_ctx_with_str_param("path", "/etc/hosts");
+	int rc;
+
+	static fuzz_dict_t d;
+
+	rc = action(ctx, params);
+	CHECK(rc == 0);
+	CHECK(ctx->params[0].free_val == 1);
+	CHECK(fuzz_dict_load(&d, DICT_PATH) == 0);
+	CHECK(token_in_dict(&d, (char *)ctx->params[0].val) == 1);
+	CHECK(strcmp((char *)ctx->params[0].val, "/etc/hosts") != 0);
+
+	free((void *)(intptr_t)ctx->params[0].val);
+	ctx->params[0].free_val = 0;
+}
+
+static void test_match_str_no_match(void)
+{
+	action_fn_t action = retrace_actions_get("fuzz_str");
+	JSON_Object *params =
+		build_params("path", DICT_PATH, 1, "/etc/passwd");
+	struct ThreadContext *ctx =
+		build_ctx_with_str_param("path", "/etc/hosts");
+	int rc;
+
+	rc = action(ctx, params);
+	CHECK(rc == 0);
+	CHECK(strcmp((char *)ctx->params[0].val, "/etc/hosts") == 0);
+	CHECK(ctx->params[0].free_val == 0);
+}
+
+static void test_repeated_call_no_leak_growth(void)
+{
+	action_fn_t action = retrace_actions_get("fuzz_str");
+	JSON_Object *params = build_params("path", DICT_PATH, 0, NULL);
+	struct ThreadContext *ctx =
+		build_ctx_with_str_param("path", "/etc/hosts");
+	int i;
+
+	for (i = 0; i < 16; i++) {
+		CHECK(action(ctx, params) == 0);
+		CHECK(ctx->params[0].free_val == 1);
+		CHECK(strlen((char *)ctx->params[0].val) > 0);
+	}
+
+	free((void *)(intptr_t)ctx->params[0].val);
+	ctx->params[0].free_val = 0;
+}
+
+int main(void)
+{
+	retrace_actions_init();
+
+	printf("fuzz_str action tests:\n");
+
+	TEST(dict_load);
+	TEST(dict_load_missing);
+	TEST(dict_pick_deterministic);
+	TEST(action_lookup);
+	TEST(params_null);
+	TEST(missing_param_name);
+	TEST(missing_dict);
+	TEST(bad_dict_path);
+	TEST(unknown_param);
+	TEST(replaces_with_dict_token);
+	TEST(match_str_no_match);
+	TEST(repeated_call_no_leak_growth);
+
+	printf("Pass: %d, Fail: %d (of %d)\n", tests_pass, tests_fail,
+		tests_run);
+	return tests_fail == 0 ? 0 : 1;
+}


### PR DESCRIPTION
Closes the content-fuzzing deferral (TODO.trace-profile/25): the new `fuzz_str` action turns any intercepted `sz` param into a dictionary-driven fuzz point.

- AFL-style dict file (one token per line, `#`/blanks skipped, bounded 256x4096); token picked via the shared seed machinery — reproducer = config + seed + dict. Optional `match_str` gating.
- Seed init extracted so a script using only `fuzz_str` still seeds; loader split into `fuzz_dict.{c,h}` for direct unit testing.
- 12 new tests (load semantics, determinism, validation, replacement, match no-op, no-leak repeated calls) — 89/89 local.
- `examples/fuzz-workbench` gains `paths.c` + a demo that byte-compares token sequences across three runs — reproducibility shown, not claimed.
- `docs/configuration.md` reference included.

Bumps to v2.28.0 (version.h, CLI banner, packaging, CHANGELOG).
