### PR TITLE
v2.29.0: snap2inside maps personal-files/system-files plugs (TODO 19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (see `docs/adr/0006-semantic-versioning.md`).
 
+## [2.29.0] — 2026-08-23
+
+**Packaging audit completes: `personal-files`/`system-files`
+plugs mapped** (TODO.trace-profile/19 follow-up).
+
+- `retrace-snap2inside` now reads the top-level `plugs:` section
+  of snapcraft.yaml: plugs with `interface: personal-files` or
+  `system-files` map their author-declared `read:`/`write:`
+  path lists into accesses (`$HOME` expands to the concrete
+  home, `SNAP2INSIDE_HOME` override as before). Previously
+  these plugs were reported unmapped.
+- Honest scope, stated in the output docs: this maps the snap's
+  REQUEST; what snapd actually connects is admin policy outside
+  snapcraft.yaml. `raw-usb` & co. stay unmapped notes.
+- Golden fixture extended (personal + system plug, $HOME
+  expansion, write class); 89/89 tests.
+
 ## [2.28.0] — 2026-08-23
 
 **Dictionary-driven string fuzzing — `fuzz_str`**

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -87,6 +87,8 @@ violations.
 
 ```sh
 retrace-snap2inside -o inside.json snapcraft.yaml
+# personal-files/system-files plugs: the author-declared
+# read:/write: path lists become accesses ($HOME expanded)
 retrace-flatpak2inside -o inside.json manifest.json   # JSON form
 retrace-profile capture -o profile.json -- ./app
 retrace-profile --libc profile.json --inside inside.json

--- a/include/retrace/version.h
+++ b/include/retrace/version.h
@@ -37,10 +37,10 @@
 #define RETRACE_VERSION_H
 
 #define RETRACE_VERSION_MAJOR 2
-#define RETRACE_VERSION_MINOR 28
+#define RETRACE_VERSION_MINOR 29
 #define RETRACE_VERSION_PATCH 0
 
-#define RETRACE_VERSION_STRING "2.28.0"
+#define RETRACE_VERSION_STRING "2.29.0"
 
 #define RETRACE_VERSION_ATLEAST(maj, min, pat)                  \
 	(RETRACE_VERSION_MAJOR > (maj) ||                       \

--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -1,3 +1,14 @@
+retrace (2.29.0-1) unstable; urgency=medium
+
+  * Improved: snap2inside maps personal-files and system-files
+    plugs -- the author-declared read:/write: path lists (top-
+    level plugs section) become read/write accesses with $HOME
+    expanded; previously reported unmapped. Honest scope: this
+    maps the snap's REQUEST; snapd connection policy is
+    admin-side and stays out of snapcraft.yaml truth.
+
+ -- Ribose Inc <opensource@ribose.com>  Sun, 23 Aug 2026 19:30:00 +0000
+
 retrace (2.28.0-1) unstable; urgency=medium
 
   * Added: fuzz_str action -- dictionary-driven string param

--- a/packaging/fedora/retrace.spec
+++ b/packaging/fedora/retrace.spec
@@ -5,7 +5,7 @@
 # Install: dnf install retrace-2.10.0-1.*.rpm
 
 Name:           retrace
-Version:        2.28.0
+Version:        2.29.0
 Release:        1%{?dist}
 Summary:        Userspace libc interceptor for security discovery
 
@@ -50,6 +50,8 @@ action, OTLP/JSON export, and a Python config builder.
 %{_includedir}/retrace/
 
 %changelog
+* Sun Aug 23 2026 Ribose Inc <opensource@ribose.com> - 2.29.0-1
+- snap2inside: personal-files/system-files plug read/write lists mapped (TODO 19 follow-up)
 * Sun Aug 23 2026 Ribose Inc <opensource@ribose.com> - 2.28.0-1
 - fuzz_str action: dictionary-driven string fuzzing (TODO 25)
 * Sun Aug 23 2026 Ribose Inc <opensource@ribose.com> - 2.27.0-1

--- a/packaging/nix/default.nix
+++ b/packaging/nix/default.nix
@@ -8,7 +8,7 @@
 
 stdenv.mkDerivation rec {
   pname = "retrace";
-  version = "2.28.0";
+  version = "2.29.0";
 
   src = ./.;
 

--- a/src/cli/retrace_cli.c
+++ b/src/cli/retrace_cli.c
@@ -63,7 +63,7 @@ typedef int retrace_status_t;
 static void usage(FILE *out)
 {
 	fprintf(out,
-"retrace v2.28.0 -- userspace libc interceptor\n"
+"retrace v2.29.0 -- userspace libc interceptor\n"
 "\n"
 "Usage:\n"
 "  retrace run [OPTIONS] -- <command> [args...]\n"

--- a/test/fixtures/snap2inside.expected.json
+++ b/test/fixtures/snap2inside.expected.json
@@ -5,6 +5,21 @@
                 "path": "\/home\/testuser",
                 "class": "read",
                 "hits": 1
+            },
+            {
+                "path": "\/home\/testuser\/.config\/demo",
+                "class": "read",
+                "hits": 1
+            },
+            {
+                "path": "\/home\/testuser\/.local\/share\/demo",
+                "class": "write",
+                "hits": 1
+            },
+            {
+                "path": "\/etc\/demo.conf",
+                "class": "read",
+                "hits": 1
             }
         ],
         "net": [

--- a/test/fixtures/snapcraft.yaml
+++ b/test/fixtures/snapcraft.yaml
@@ -7,3 +7,17 @@ apps:
       - home
       - network
       - raw-usb
+      - dot-config-demo
+      - etc-demo
+
+plugs:
+  dot-config-demo:
+    interface: personal-files
+    read:
+      - $HOME/.config/demo
+    write:
+      - $HOME/.local/share/demo
+  etc-demo:
+    interface: system-files
+    read:
+      - /etc/demo.conf

--- a/tools/snap2inside/snap2inside.c
+++ b/tools/snap2inside/snap2inside.c
@@ -19,10 +19,14 @@
  *   removable-media  -> /media/, /run/media/ (read prefixes)
  *   network          -> net (connect/send/recv)
  *   network-bind     -> net (listening)
- *   personal-files / system-files / raw-usb / others: NOT
- *     mapped (their per-snap read/write lists are declared in
- *     the snap's snapd slot config, not in snapcraft.yaml) --
- *     reported as unmapped in the output notes.
+ *   personal-files / system-files: the AUTHOR-declared read/
+ *     write path lists (top-level plugs:<name>:interface with
+ *     read:/write: attributes) become read/write accesses;
+ *     $HOME expands to the concrete home (SNAP2INSIDE_HOME).
+ *     What snapd actually CONNECTS is admin policy -- this maps
+ *     the snap's request, the honest ceiling of the audit.
+ *   raw-usb / others: no path surface here -- reported as
+ *     unmapped in the output notes.
  */
 
 #include <stdio.h>
@@ -144,6 +148,148 @@ static int collect_plugs(FILE *in, char (*plugs)[32], size_t max,
 	return n > 0 ? 0 : -1;
 }
 
+/*
+ * Attribute plugs (personal-files / system-files): the named
+ * top-level plugs:<name> entries whose read:/write: lists we
+ * turn into accesses. Bounded; enough for real manifests.
+ */
+#define PF_MAX 8
+#define PF_PATHS_MAX 8
+#define PF_PATH_MAX 128
+
+struct attr_plug {
+	char name[32];
+	int is_system;                  /* system-files */
+	char read[PF_PATHS_MAX][PF_PATH_MAX];
+	size_t read_n;
+	char write[PF_PATHS_MAX][PF_PATH_MAX];
+	size_t write_n;
+};
+
+enum pf_state { PF_NONE, PF_READ, PF_WRITE };
+
+static struct attr_plug g_attr_plugs[PF_MAX];
+static size_t g_attr_plug_n;
+
+/*
+ * Scan the TOP-LEVEL plugs: section (outside apps:). Same
+ * minimal-YAML grammar as collect_plugs: named plug blocks with
+ * interface:/read:/write: attributes; list items are "- path".
+ */
+static void collect_attr_plugs(FILE *in)
+{
+	char line[512];
+	int in_plugs = 0;
+	long plugs_indent = -1;
+	int cur = -1;
+	enum pf_state st = PF_NONE;
+
+	g_attr_plug_n = 0;
+	while (fgets(line, sizeof(line), in) != NULL) {
+		char *s = line;
+		size_t len = strlen(line);
+		long indent = 0;
+
+		while (len > 0 && (line[len - 1] == '\n' ||
+				   line[len - 1] == '\r'))
+			line[--len] = '\0';
+		if (len == 0 || line[0] == '#')
+			continue;
+
+		if (s[0] != ' ' && s[0] != '\t') {
+			in_plugs = strncmp(s, "plugs:", 6) == 0;
+			plugs_indent = -1;
+			cur = -1;
+			st = PF_NONE;
+			continue;
+		}
+		if (!in_plugs)
+			continue;
+
+		while (s[indent] == ' ')
+			indent++;
+		s += indent;
+
+		if (plugs_indent < 0)
+			plugs_indent = indent;
+
+		if (indent == plugs_indent && s[0] != '-') {
+			/* a named plug block opens */
+			char *colon = strchr(s, ':');
+
+			if (colon != NULL &&
+			    g_attr_plug_n < PF_MAX) {
+				size_t l = (size_t)(colon - s);
+
+				if (l > 0 && l < 32) {
+					cur = (int)g_attr_plug_n;
+					memset(&g_attr_plugs[cur], 0,
+						sizeof(g_attr_plugs[cur]));
+					memcpy(g_attr_plugs[cur].name,
+						s, l);
+					g_attr_plugs[cur].name[l] = '\0';
+					g_attr_plug_n++;
+				} else {
+					cur = -1;
+				}
+			} else {
+				cur = -1;
+			}
+			st = PF_NONE;
+			continue;
+		}
+
+		if (cur < 0)
+			continue;
+
+		if (strncmp(s, "interface:", 10) == 0) {
+			char *v = s + 10;
+
+			while (*v == ' ')
+				v++;
+			g_attr_plugs[cur].is_system =
+				strncmp(v, "system-files", 12) == 0;
+			st = PF_NONE;
+			continue;
+		}
+		if (strncmp(s, "read:", 5) == 0) {
+			st = PF_READ;
+			continue;
+		}
+		if (strncmp(s, "write:", 6) == 0) {
+			st = PF_WRITE;
+			continue;
+		}
+		if (s[0] == '-' &&
+		    (st == PF_READ || st == PF_WRITE)) {
+			char *v = s + 1;
+			char (*dst)[PF_PATH_MAX];
+			size_t *n;
+
+			while (*v == ' ')
+				v++;
+			if (st == PF_READ) {
+				dst = g_attr_plugs[cur].read;
+				n = &g_attr_plugs[cur].read_n;
+			} else {
+				dst = g_attr_plugs[cur].write;
+				n = &g_attr_plugs[cur].write_n;
+			}
+			if (*n < PF_PATHS_MAX && *v != '\0') {
+				size_t l = strlen(v);
+
+				if (l >= PF_PATH_MAX)
+					l = PF_PATH_MAX - 1;
+				memcpy(dst[*n], v, l);
+				dst[*n][l] = '\0';
+				(*n)++;
+			}
+			continue;
+		}
+		st = PF_NONE;
+	}
+}
+
 struct iface_map {
 	const char *plug;
 	const char *path;   /* NULL = no path surface */
@@ -165,6 +311,32 @@ static const struct iface_map g_map[] = {
 	{ "network-control", NULL, 1, NULL },
 	{ NULL, NULL, 0, NULL }
 };
+
+/*
+ * One personal-files path -> one access entry. "$HOME" expands
+ * to the concrete home (same rationale as the home interface: a
+ * literal "$HOME" would never match an observed absolute path).
+ */
+static void add_attr_access(JSON_Value *accesses, const char *path,
+	const char *cls, const char *home)
+{
+	char expanded[PF_PATH_MAX + 256];
+	JSON_Value *a = json_value_init_object();
+
+	if (strncmp(path, "$HOME", 5) == 0)
+		snprintf(expanded, sizeof(expanded), "%s%s",
+			home, path + 5);
+	else
+		snprintf(expanded, sizeof(expanded), "%s", path);
+
+	json_object_set_string(json_value_get_object(a),
+		"path", expanded);
+	json_object_set_string(json_value_get_object(a),
+		"class", cls);
+	json_object_set_number(json_value_get_object(a),
+		"hits", 1);
+	json_array_append_value(json_value_get_array(accesses), a);
+}
 
 int main(int argc, char **argv)
 {
@@ -208,6 +380,8 @@ int main(int argc, char **argv)
 		perror(in_path);
 		return 2;
 	}
+	collect_attr_plugs(in);
+	rewind(in);
 	if (collect_plugs(in, plugs, 32, &count) != 0) {
 		fprintf(stderr,
 "retrace-snap2inside: no plugs found (need apps:<app>:plugs)\n");
@@ -227,6 +401,40 @@ int main(int argc, char **argv)
 	for (i = 0; i < count; i++) {
 		const struct iface_map *m = g_map;
 		int hit = 0;
+		size_t ap;
+
+		/* attribute plugs (personal-files / system-files)
+		 * map by NAME against the top-level plugs section
+		 */
+		for (ap = 0; ap < g_attr_plug_n; ap++) {
+			if (strcmp(plugs[i],
+			    g_attr_plugs[ap].name) == 0) {
+				const char *home = getenv(
+					"SNAP2INSIDE_HOME");
+				size_t k;
+
+				if (home == NULL)
+					home = getenv("HOME");
+				if (home == NULL)
+					home = "/home/";
+				hit = 1;
+				for (k = 0;
+				     k < g_attr_plugs[ap].read_n; k++) {
+					add_attr_access(accesses,
+						g_attr_plugs[ap].read[k],
+						"read", home);
+				}
+				for (k = 0;
+				     k < g_attr_plugs[ap].write_n; k++) {
+					add_attr_access(accesses,
+						g_attr_plugs[ap].write[k],
+						"write", home);
+				}
+				break;
+			}
+		}
+		if (hit)
+			continue;
 
 		for (; m->plug != NULL; m++) {
 			if (strcmp(plugs[i], m->plug) == 0) {


### PR DESCRIPTION
Closes the packaging-audit deferral from TODO.trace-profile/19: `personal-files`/`system-files` plugs now map into the declared set instead of being reported unmapped.

- New second scan of snapcraft.yaml's top-level `plugs:` section (same minimal-YAML grammar family) picks up named plug blocks with `interface:`/`read:`/`write:` attributes.
- App plugs matching by name expand their read/write lists into accesses — `$HOME` → concrete home (`SNAP2INSIDE_HOME` override), read → class read, write → class write.
- Honest scope documented: this maps the snap's *request*; snapd's connection policy is admin-side and outside snapcraft.yaml truth. `raw-usb` & co. remain unmapped notes.
- Golden fixture extended; 89/89 tests.

Bumps to v2.29.0 (version.h, CLI banner, packaging, CHANGELOG).
