### PR TITLE
v2.29.1: polish -- wrong error name, PS count bug, ETW manifest table in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -172,6 +172,15 @@ jobs:
           & $conv -o "$out\trace.json" "$out\etw-events.jsonl"
           Write-Host "ETW smoke rows:"
           Get-Content "$out\etw-events.jsonl" | Write-Host
+          # Machine truth for the Id<->task mapping (TODO 24):
+          # the OS's own manifest table, printed every run.
+          try {
+            $prov = Get-WinEvent -ListProvider Microsoft-Windows-Kernel-File
+            $prov.Tasks | Sort-Object Value |
+              ForEach-Object { Write-Host ("ETW manifest: id={0} task={1}" -f $_.Value, $_.Name) }
+          } catch {
+            Write-Host "ETW manifest: provider table unavailable"
+          }
           $trace = Get-Content "$out\trace.json" -Raw
           if (-not $trace.Contains("hosts")) {
             Write-Error "ETW smoke: no hosts read captured"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (see `docs/adr/0006-semantic-versioning.md`).
 
+## [2.29.1] — 2026-08-23
+
+**Polish.**
+
+- `memory_fuzz`: missing-params error message named the wrong
+  action (copy-paste from `modify_return_value_int`).
+- `etw-capture.ps1`: the event-count line printed 1 regardless
+  of the real row count (PowerShell unroll bug).
+- ETW CI smoke now prints the OS's own Kernel-File Id↔task
+  manifest table each run — machine truth for completing the
+  converter's numeric Id mapping (the Id10 follow-up).
+
 ## [2.29.0] — 2026-08-23
 
 **Packaging audit completes: `personal-files`/`system-files`

--- a/include/retrace/version.h
+++ b/include/retrace/version.h
@@ -38,9 +38,9 @@
 
 #define RETRACE_VERSION_MAJOR 2
 #define RETRACE_VERSION_MINOR 29
-#define RETRACE_VERSION_PATCH 0
+#define RETRACE_VERSION_PATCH 1
 
-#define RETRACE_VERSION_STRING "2.29.0"
+#define RETRACE_VERSION_STRING "2.29.1"
 
 #define RETRACE_VERSION_ATLEAST(maj, min, pat)                  \
 	(RETRACE_VERSION_MAJOR > (maj) ||                       \

--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -1,3 +1,15 @@
+retrace (2.29.1-1) unstable; urgency=medium
+
+  * Fixed: memory_fuzz's missing-params error named the wrong
+    action (copy-paste from modify_return_value_int);
+    etw-capture.ps1 event count printed 1 regardless of the
+    real row count (PS unroll bug). The ETW CI smoke now also
+    prints the OS's own Kernel-File Id<->task manifest table
+    every run -- machine truth for completing the converter's
+    numeric mapping (TODO.trace-profile/24 Id10 follow-up).
+
+ -- Ribose Inc <opensource@ribose.com>  Sun, 23 Aug 2026 20:10:00 +0000
+
 retrace (2.29.0-1) unstable; urgency=medium
 
   * Improved: snap2inside maps personal-files and system-files

--- a/packaging/fedora/retrace.spec
+++ b/packaging/fedora/retrace.spec
@@ -5,7 +5,7 @@
 # Install: dnf install retrace-2.10.0-1.*.rpm
 
 Name:           retrace
-Version:        2.29.0
+Version:        2.29.1
 Release:        1%{?dist}
 Summary:        Userspace libc interceptor for security discovery
 
@@ -50,6 +50,8 @@ action, OTLP/JSON export, and a Python config builder.
 %{_includedir}/retrace/
 
 %changelog
+* Sun Aug 23 2026 Ribose Inc <opensource@ribose.com> - 2.29.1-1
+- polish: memory_fuzz error message copy-paste fix, etw-capture count fix, ETW manifest table in CI
 * Sun Aug 23 2026 Ribose Inc <opensource@ribose.com> - 2.29.0-1
 - snap2inside: personal-files/system-files plug read/write lists mapped (TODO 19 follow-up)
 * Sun Aug 23 2026 Ribose Inc <opensource@ribose.com> - 2.28.0-1

--- a/packaging/nix/default.nix
+++ b/packaging/nix/default.nix
@@ -8,7 +8,7 @@
 
 stdenv.mkDerivation rec {
   pname = "retrace";
-  version = "2.29.0";
+  version = "2.29.1";
 
   src = ./.;
 

--- a/scripts/win/etw-capture.ps1
+++ b/scripts/win/etw-capture.ps1
@@ -114,7 +114,7 @@ if ($rows) {
         $_ | ConvertTo-Json -Compress -Depth 2
     } | Set-Content -Path $jsonl -Encoding ascii
     Write-Host ("etw-capture: {0} file events (pid {1}) -> {2}" -f `
-        @($rows | Measure-Object).Count, $targetPid, $jsonl)
+        @($rows).Count, $targetPid, $jsonl)
 } else {
     Set-Content -Path $jsonl -Value "" -Encoding ascii
     Write-Warning "etw-capture: no named file events captured for pid $targetPid."

--- a/src/cli/retrace_cli.c
+++ b/src/cli/retrace_cli.c
@@ -63,7 +63,7 @@ typedef int retrace_status_t;
 static void usage(FILE *out)
 {
 	fprintf(out,
-"retrace v2.29.0 -- userspace libc interceptor\n"
+"retrace v2.29.1 -- userspace libc interceptor\n"
 "\n"
 "Usage:\n"
 "  retrace run [OPTIONS] -- <command> [args...]\n"

--- a/src/core/actions/memfuzz.c
+++ b/src/core/actions/memfuzz.c
@@ -79,7 +79,7 @@ static int ia_memory_fuzz
 	long random_value;
 
 	if (action_params == NULL) {
-		log_err("action_params must exists for modify_return_value_int");
+		log_err("action_params must exists for memory_fuzz");
 		return -1;
 	}
 


### PR DESCRIPTION
Patch-level polish:

- `memory_fuzz` missing-params error named the wrong action (copy-paste); fixed.
- `etw-capture.ps1` event-count line always printed 1 (PowerShell unroll bug); fixed.
- ETW CI smoke now prints the OS's own Kernel-File Id↔task manifest table every run — machine truth to complete the converter's numeric Id mapping (Id10 follow-up).

Bumps to v2.29.1 (version.h, CLI banner, packaging, CHANGELOG).
