### PR TITLE
v2.30.0: converter-main DRY -- one shared driver, five tiny wrappers (TODO 26)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (see `docs/adr/0006-semantic-versioning.md`).
 
+## [2.30.0] — 2026-08-23
+
+**Converter-main DRY** (TODO.trace-profile/26).
+
+- The five `*2retrace` converter CLIs (strace, dtrace, truss,
+  ktrace, etw) were structural ~90-line clones. They now share
+  one driver — `tools/common/converter.c` (`converter_main`) —
+  and each CLI wrapper is a ~25-line table: name, usage text,
+  `convert()` hook, row noun. A sixth converter is a convert
+  function plus a table entry, no new CLI code (OCP).
+- Behavior-preserving: all five tool outputs byte-identical on
+  their inputs (compared pre/post refactor); CLI, exit codes,
+  and the stderr count line unchanged; golden tests untouched
+  and green (89/89).
+
 ## [2.29.2] — 2026-08-23
 
 **Fixed: `etw2retrace` numeric Id table corrected from the OS's

--- a/include/retrace/version.h
+++ b/include/retrace/version.h
@@ -37,10 +37,10 @@
 #define RETRACE_VERSION_H
 
 #define RETRACE_VERSION_MAJOR 2
-#define RETRACE_VERSION_MINOR 29
-#define RETRACE_VERSION_PATCH 2
+#define RETRACE_VERSION_MINOR 30
+#define RETRACE_VERSION_PATCH 0
 
-#define RETRACE_VERSION_STRING "2.29.2"
+#define RETRACE_VERSION_STRING "2.30.0"
 
 #define RETRACE_VERSION_ATLEAST(maj, min, pat)                  \
 	(RETRACE_VERSION_MAJOR > (maj) ||                       \

--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -1,3 +1,16 @@
+retrace (2.30.0-1) unstable; urgency=medium
+
+  * Changed: the five *2retrace converter CLIs (strace, dtrace,
+    truss, ktrace, etw) now share ONE driver --
+    tools/common/converter.c (arg parse, IO, serialize, count
+    line). Each CLI wrapper is a ~25-line table (name, usage,
+    convert hook, row noun). Behavior-preserving: all five
+    outputs byte-identical on their fixtures; golden tests
+    unchanged. The next converter is a convert() plus a table
+    entry -- no new CLI code (TODO.trace-profile/26).
+
+ -- Ribose Inc <opensource@ribose.com>  Sun, 23 Aug 2026 21:30:00 +0000
+
 retrace (2.29.2-1) unstable; urgency=medium
 
   * Fixed: etw2retrace's provisional numeric Id mapping was

--- a/packaging/fedora/retrace.spec
+++ b/packaging/fedora/retrace.spec
@@ -5,7 +5,7 @@
 # Install: dnf install retrace-2.10.0-1.*.rpm
 
 Name:           retrace
-Version:        2.29.2
+Version:        2.30.0
 Release:        1%{?dist}
 Summary:        Userspace libc interceptor for security discovery
 
@@ -50,6 +50,8 @@ action, OTLP/JSON export, and a Python config builder.
 %{_includedir}/retrace/
 
 %changelog
+* Sun Aug 23 2026 Ribose Inc <opensource@ribose.com> - 2.30.0-1
+- converter-main DRY: shared tools/common/converter driver; five CLI wrappers collapse to tables
 * Sun Aug 23 2026 Ribose Inc <opensource@ribose.com> - 2.29.2-1
 - etw2retrace: Id->task table corrected from the OS manifest (Id14 was mislabeled Read; full table mapped)
 * Sun Aug 23 2026 Ribose Inc <opensource@ribose.com> - 2.29.1-1

--- a/packaging/nix/default.nix
+++ b/packaging/nix/default.nix
@@ -8,7 +8,7 @@
 
 stdenv.mkDerivation rec {
   pname = "retrace";
-  version = "2.29.2";
+  version = "2.30.0";
 
   src = ./.;
 

--- a/src/cli/retrace_cli.c
+++ b/src/cli/retrace_cli.c
@@ -63,7 +63,7 @@ typedef int retrace_status_t;
 static void usage(FILE *out)
 {
 	fprintf(out,
-"retrace v2.29.2 -- userspace libc interceptor\n"
+"retrace v2.30.0 -- userspace libc interceptor\n"
 "\n"
 "Usage:\n"
 "  retrace run [OPTIONS] -- <command> [args...]\n"

--- a/tools/common/converter.c
+++ b/tools/common/converter.c
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "converter.h"
+#include "parson.h"
+
+static void usage(FILE *out, const struct converter_app *app)
+{
+	fprintf(out, "Usage: %s [-o out.json] <input>\n\n%s\n"
+		"Output goes to stdout unless -o is given.\n",
+		app->name, app->usage);
+}
+
+int converter_main(int argc, char **argv,
+	const struct converter_app *app)
+{
+	const char *in_path = NULL;
+	const char *out_path = NULL;
+	FILE *in;
+	FILE *out = stdout;
+	JSON_Value *root;
+	JSON_Array *arr;
+	char *serialized;
+	int converted;
+	int i;
+
+	for (i = 1; i < argc; i++) {
+		if (strcmp(argv[i], "-o") == 0 && i + 1 < argc)
+			out_path = argv[++i];
+		else if (strcmp(argv[i], "-h") == 0 ||
+			 strcmp(argv[i], "--help") == 0) {
+			usage(stdout, app);
+			return 0;
+		} else if (argv[i][0] != '-' || argv[i][1] == '\0')
+			in_path = argv[i];
+		else {
+			usage(stderr, app);
+			return 2;
+		}
+	}
+	if (in_path == NULL) {
+		usage(stderr, app);
+		return 2;
+	}
+
+	in = fopen(in_path, "r");
+	if (in == NULL) {
+		perror(in_path);
+		return 2;
+	}
+
+	root = json_value_init_array();
+	arr = json_value_get_array(root);
+	converted = app->convert(in, arr);
+	fclose(in);
+
+	serialized = json_serialize_to_string(root);
+	if (out_path != NULL) {
+		out = fopen(out_path, "w");
+		if (out == NULL) {
+			perror(out_path);
+			return 2;
+		}
+	}
+	fprintf(out, "%s\n", serialized);
+	if (out != stdout)
+		fclose(out);
+
+	json_free_serialized_string(serialized);
+	json_value_free(root);
+
+	fprintf(stderr, "%s: %d %s converted\n",
+		app->name, converted, app->row_noun);
+	return 0;
+}

--- a/tools/common/converter.h
+++ b/tools/common/converter.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+/*
+ * converter_main (TODO.trace-profile/26): the shared CLI for
+ * the *2retrace converter family. Every kernel-truth converter
+ * has the same shape -- [-o out] in, convert, serialize, write,
+ * and a converted-rows count on stderr -- so the family shares
+ * ONE implementation; a converter is now its convert() plus
+ * this table entry (OCP: new converter = no new CLI code).
+ */
+
+#ifndef RETRACE_TOOLS_COMMON_CONVERTER_H_
+#define RETRACE_TOOLS_COMMON_CONVERTER_H_
+
+#include <stdio.h>
+
+#include "parson.h"
+
+struct converter_app {
+	const char *name;      /* e.g. "retrace-ktrace2retrace" */
+	const char *usage;     /* capture hint; printed under Usage */
+	int (*convert)(FILE *in, JSON_Array *out);
+	const char *row_noun;  /* "syscall lines", "ETW rows", ... */
+};
+
+int converter_main(int argc, char **argv,
+	const struct converter_app *app);
+
+#endif /* RETRACE_TOOLS_COMMON_CONVERTER_H_ */

--- a/tools/dtrace2retrace/CMakeLists.txt
+++ b/tools/dtrace2retrace/CMakeLists.txt
@@ -7,6 +7,7 @@
 set(_parson_source ${CMAKE_SOURCE_DIR}/src/config/json/parson.c)
 
 add_executable(retrace_dtrace2retrace dtrace2retrace.c convert.c
+	${CMAKE_SOURCE_DIR}/tools/common/converter.c
 	${_parson_source})
 set_target_properties(retrace_dtrace2retrace PROPERTIES
     OUTPUT_NAME retrace-dtrace2retrace
@@ -14,6 +15,7 @@ set_target_properties(retrace_dtrace2retrace PROPERTIES
 
 target_include_directories(retrace_dtrace2retrace PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_SOURCE_DIR}/tools/common
     ${CMAKE_SOURCE_DIR}/src/config/json
     ${CMAKE_SOURCE_DIR}/test/property/parson_stub)
 

--- a/tools/dtrace2retrace/dtrace2retrace.c
+++ b/tools/dtrace2retrace/dtrace2retrace.c
@@ -5,99 +5,24 @@
  */
 
 /*
- * retrace-dtrace2retrace -- the macOS kernel-truth converter
- * (TODO.trace-profile/14). Feeds retrace-profile --kernel (and
- * retrace-correlate --outside) from a dtrace/dtruss file
- * capture; dtrace/dtruss need SIP off (csrutil disable) for
- * system binaries.
- *
- * usage: retrace-dtrace2retrace [-o out.json] dtruss.log
- *
- * Recognized line shape (anything else is skipped):
- *   PID/TSYS  syscall("path\0", 0x0, 0x0)         = 0 0
- * e.g.
- *   84546/0x30d7:  open_nocancel("/etc/hosts\0", 0x0, 0x0) = 0 0
- *
- * dtruss shows C strings with a literal "\0" suffix -- stripped.
- * Name variants normalize to the POSIX names the correlate
- * classifier knows (open_nocancel -> open, stat64 -> stat).
+ * CLI wrapper only -- the conversion logic lives in convert.c;
+ * the shared driver is tools/common/converter.c
+ * (TODO.trace-profile/26).
  */
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-
+#include "converter.h"
 #include "convert.h"
-#include "parson.h"
-
-static void usage(FILE *out)
-{
-	fprintf(out,
-		"Usage: retrace-dtrace2retrace [-o out.json] dtruss.log\n"
-		"\n"
-		"Convert `sudo dtruss -f ./app` output to a retrace trace\n"
-		"document (kernel-layer truth; dtrace needs SIP off).\n"
-		"Output goes to stdout unless -o is given.\n");
-}
 
 int main(int argc, char **argv)
 {
-	const char *in_path = NULL;
-	const char *out_path = NULL;
-	FILE *in;
-	FILE *out = stdout;
-	JSON_Value *root;
-	JSON_Array *arr;
-	char *serialized;
-	int converted;
-	int i;
+	static const struct converter_app app = {
+		.name = "retrace-dtrace2retrace",
+		.usage =
+		"Convert `sudo dtruss -f ./app` output to a retrace trace\n"
+		"document (kernel-layer truth; dtrace needs SIP off).\n",
+		.convert = dtrace_convert,
+		.row_noun = "syscall lines",
+	};
 
-	for (i = 1; i < argc; i++) {
-		if (strcmp(argv[i], "-o") == 0 && i + 1 < argc)
-			out_path = argv[++i];
-		else if (strcmp(argv[i], "-h") == 0 ||
-			 strcmp(argv[i], "--help") == 0) {
-			usage(stdout);
-			return 0;
-		} else if (argv[i][0] != '-' || argv[i][1] == '\0') {
-			in_path = argv[i];
-		} else {
-			usage(stderr);
-			return 2;
-		}
-	}
-	if (in_path == NULL) {
-		usage(stderr);
-		return 2;
-	}
-
-	in = fopen(in_path, "r");
-	if (in == NULL) {
-		perror(in_path);
-		return 2;
-	}
-
-	root = json_value_init_array();
-	arr = json_value_get_array(root);
-	converted = dtrace_convert(in, arr);
-	fclose(in);
-
-	serialized = json_serialize_to_string(root);
-	if (out_path != NULL) {
-		out = fopen(out_path, "w");
-		if (out == NULL) {
-			perror(out_path);
-			return 2;
-		}
-	}
-	fprintf(out, "%s\n", serialized);
-	if (out != stdout)
-		fclose(out);
-
-	json_free_serialized_string(serialized);
-	json_value_free(root);
-
-	fprintf(stderr, "retrace-dtrace2retrace: %d syscall lines converted\n",
-		converted);
-	return 0;
+	return converter_main(argc, argv, &app);
 }

--- a/tools/etw2retrace/CMakeLists.txt
+++ b/tools/etw2retrace/CMakeLists.txt
@@ -8,6 +8,7 @@
 set(_parson_source ${CMAKE_SOURCE_DIR}/src/config/json/parson.c)
 
 add_executable(retrace_etw2retrace etw2retrace.c convert.c
+	${CMAKE_SOURCE_DIR}/tools/common/converter.c
 	${_parson_source})
 set_target_properties(retrace_etw2retrace PROPERTIES
     OUTPUT_NAME retrace-etw2retrace
@@ -15,6 +16,7 @@ set_target_properties(retrace_etw2retrace PROPERTIES
 
 target_include_directories(retrace_etw2retrace PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_SOURCE_DIR}/tools/common
     ${CMAKE_SOURCE_DIR}/src/config/json
     ${CMAKE_SOURCE_DIR}/test/property/parson_stub)
 

--- a/tools/etw2retrace/etw2retrace.c
+++ b/tools/etw2retrace/etw2retrace.c
@@ -5,89 +5,24 @@
  */
 
 /*
- * retrace-etw2retrace -- the scripted Windows kernel-truth
- * converter (TODO.trace-profile/24). Feeds retrace-profile
- * --kernel (and retrace-correlate --outside) from an ETW
- * capture taken with scripts/win/etw-capture.ps1 (admin).
- * procmon2retrace stays the zero-install path.
- *
- * usage: retrace-etw2retrace [-o out.json] etw-events.jsonl
+ * CLI wrapper only -- the conversion logic lives in convert.c;
+ * the shared driver is tools/common/converter.c
+ * (TODO.trace-profile/26).
  */
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-
+#include "converter.h"
 #include "convert.h"
-
-static void usage(FILE *out)
-{
-	fprintf(out,
-		"Usage: retrace-etw2retrace [-o out.json] etw-events.jsonl\n"
-		"\n"
-		"Convert scripts/win/etw-capture.ps1 raw rows to a retrace\n"
-		"trace document (kernel-layer truth). Output goes to stdout\n"
-		"unless -o is given.\n");
-}
 
 int main(int argc, char **argv)
 {
-	const char *in_path = NULL;
-	const char *out_path = NULL;
-	FILE *in;
-	FILE *out = stdout;
-	JSON_Value *root;
-	JSON_Array *arr;
-	char *serialized;
-	int converted;
-	int i;
+	static const struct converter_app app = {
+		.name = "retrace-etw2retrace",
+		.usage =
+		"Convert scripts/win/etw-capture.ps1 raw rows to a retrace\n"
+		"trace document (kernel-layer truth).\n",
+		.convert = etw_convert,
+		.row_noun = "ETW rows",
+	};
 
-	for (i = 1; i < argc; i++) {
-		if (strcmp(argv[i], "-o") == 0 && i + 1 < argc)
-			out_path = argv[++i];
-		else if (strcmp(argv[i], "-h") == 0 ||
-			 strcmp(argv[i], "--help") == 0) {
-			usage(stdout);
-			return 0;
-		} else if (argv[i][0] != '-' || argv[i][1] == '\0') {
-			in_path = argv[i];
-		} else {
-			usage(stderr);
-			return 2;
-		}
-	}
-	if (in_path == NULL) {
-		usage(stderr);
-		return 2;
-	}
-
-	in = fopen(in_path, "r");
-	if (in == NULL) {
-		perror(in_path);
-		return 2;
-	}
-
-	root = json_value_init_array();
-	arr = json_value_get_array(root);
-	converted = etw_convert(in, arr);
-	fclose(in);
-
-	serialized = json_serialize_to_string(root);
-	if (out_path != NULL) {
-		out = fopen(out_path, "w");
-		if (out == NULL) {
-			perror(out_path);
-			return 2;
-		}
-	}
-	fprintf(out, "%s\n", serialized);
-	if (out != stdout)
-		fclose(out);
-
-	json_free_serialized_string(serialized);
-	json_value_free(root);
-
-	fprintf(stderr, "retrace-etw2retrace: %d ETW rows converted\n",
-		converted);
-	return 0;
+	return converter_main(argc, argv, &app);
 }

--- a/tools/ktrace2retrace/CMakeLists.txt
+++ b/tools/ktrace2retrace/CMakeLists.txt
@@ -7,6 +7,7 @@
 set(_parson_source ${CMAKE_SOURCE_DIR}/src/config/json/parson.c)
 
 add_executable(retrace_ktrace2retrace ktrace2retrace.c convert.c
+	${CMAKE_SOURCE_DIR}/tools/common/converter.c
 	${_parson_source})
 set_target_properties(retrace_ktrace2retrace PROPERTIES
     OUTPUT_NAME retrace-ktrace2retrace
@@ -14,6 +15,7 @@ set_target_properties(retrace_ktrace2retrace PROPERTIES
 
 target_include_directories(retrace_ktrace2retrace PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_SOURCE_DIR}/tools/common
     ${CMAKE_SOURCE_DIR}/src/config/json
     ${CMAKE_SOURCE_DIR}/test/property/parson_stub)
 

--- a/tools/ktrace2retrace/ktrace2retrace.c
+++ b/tools/ktrace2retrace/ktrace2retrace.c
@@ -5,88 +5,24 @@
  */
 
 /*
- * retrace-ktrace2retrace -- the OpenBSD/NetBSD kernel-truth
- * converter (TODO.trace-profile/21). Feeds retrace-profile
- * --kernel (and retrace-correlate --outside) from a kdump
- * file capture.
- *
- * usage: retrace-ktrace2retrace [-o out.json] kdump.log
+ * CLI wrapper only -- the conversion logic lives in convert.c;
+ * the shared driver is tools/common/converter.c
+ * (TODO.trace-profile/26).
  */
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-
+#include "converter.h"
 #include "convert.h"
-
-static void usage(FILE *out)
-{
-	fprintf(out,
-		"Usage: retrace-ktrace2retrace [-o out.json] kdump.log\n"
-		"\n"
-		"Convert `ktrace -i -f kd.out ./app && kdump -f kd.out` output\n"
-		"output to a retrace trace document (kernel-layer truth).\n"
-		"Output goes to stdout unless -o is given.\n");
-}
 
 int main(int argc, char **argv)
 {
-	const char *in_path = NULL;
-	const char *out_path = NULL;
-	FILE *in = stdin;
-	FILE *out = stdout;
-	JSON_Value *root;
-	JSON_Array *arr;
-	char *serialized;
-	int converted;
-	int i;
+	static const struct converter_app app = {
+		.name = "retrace-ktrace2retrace",
+		.usage =
+		"Convert `ktrace -i -f kd.out ./app && kdump -f kd.out` output\n"
+		"output to a retrace trace document (kernel-layer truth).\n",
+		.convert = ktrace_convert,
+		.row_noun = "syscall lines",
+	};
 
-	for (i = 1; i < argc; i++) {
-		if (strcmp(argv[i], "-o") == 0 && i + 1 < argc)
-			out_path = argv[++i];
-		else if (strcmp(argv[i], "-h") == 0 ||
-			 strcmp(argv[i], "--help") == 0) {
-			usage(stdout);
-			return 0;
-		} else if (argv[i][0] != '-' || argv[i][1] == '\0') {
-			in_path = argv[i];
-		} else {
-			usage(stderr);
-			return 2;
-		}
-	}
-	if (in_path == NULL) {
-		usage(stderr);
-		return 2;
-	}
-
-	in = fopen(in_path, "r");
-	if (in == NULL) {
-		perror(in_path);
-		return 2;
-	}
-
-	root = json_value_init_array();
-	arr = json_value_get_array(root);
-	converted = ktrace_convert(in, arr);
-	fclose(in);
-
-	serialized = json_serialize_to_string(root);
-	if (out_path != NULL) {
-		out = fopen(out_path, "w");
-		if (out == NULL) {
-			perror(out_path);
-			return 2;
-		}
-	}
-	fprintf(out, "%s\n", serialized);
-	if (out != stdout)
-		fclose(out);
-
-	json_free_serialized_string(serialized);
-	json_value_free(root);
-
-	fprintf(stderr, "retrace-ktrace2retrace: %d syscall lines converted\n",
-		converted);
-	return 0;
+	return converter_main(argc, argv, &app);
 }

--- a/tools/strace2retrace/CMakeLists.txt
+++ b/tools/strace2retrace/CMakeLists.txt
@@ -9,6 +9,7 @@
 set(_parson_source ${CMAKE_SOURCE_DIR}/src/config/json/parson.c)
 
 add_executable(retrace_strace2retrace strace2retrace.c convert.c
+	${CMAKE_SOURCE_DIR}/tools/common/converter.c
 	${_parson_source})
 set_target_properties(retrace_strace2retrace PROPERTIES
     OUTPUT_NAME retrace-strace2retrace
@@ -16,6 +17,7 @@ set_target_properties(retrace_strace2retrace PROPERTIES
 
 target_include_directories(retrace_strace2retrace PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_SOURCE_DIR}/tools/common
     ${CMAKE_SOURCE_DIR}/src/config/json
     ${CMAKE_SOURCE_DIR}/test/property/parson_stub)
 

--- a/tools/strace2retrace/strace2retrace.c
+++ b/tools/strace2retrace/strace2retrace.c
@@ -5,87 +5,24 @@
  */
 
 /*
- * retrace-strace2retrace -- the Linux kernel-truth converter
- * (TODO.windows/08). Feeds retrace-profile --kernel (and
- * retrace-correlate --outside) from an strace file capture.
- *
- * usage: retrace-strace2retrace [-o out.json] strace.log
+ * CLI wrapper only -- the conversion logic lives in convert.c;
+ * the shared driver is tools/common/converter.c
+ * (TODO.trace-profile/26).
  */
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-
+#include "converter.h"
 #include "convert.h"
-
-static void usage(FILE *out)
-{
-	fprintf(out,
-		"Usage: retrace-strace2retrace [-o out.json] strace.log\n"
-		"\n"
-		"Convert `strace -f -e trace=%%file -o strace.log ./app`\n"
-		"output to a retrace trace document (kernel-layer truth).\n"
-		"Output goes to stdout unless -o is given.\n");
-}
 
 int main(int argc, char **argv)
 {
-	const char *in_path = NULL;
-	const char *out_path = NULL;
-	FILE *in = stdin;
-	FILE *out = stdout;
-	JSON_Value *root;
-	JSON_Array *arr;
-	char *serialized;
-	int converted;
-	int i;
+	static const struct converter_app app = {
+		.name = "retrace-strace2retrace",
+		.usage =
+		"Convert `strace -f -e trace=%file -o strace.log ./app`\n"
+		"output to a retrace trace document (kernel-layer truth).\n",
+		.convert = strace_convert,
+		.row_noun = "syscall lines",
+	};
 
-	for (i = 1; i < argc; i++) {
-		if (strcmp(argv[i], "-o") == 0 && i + 1 < argc)
-			out_path = argv[++i];
-		else if (strcmp(argv[i], "-h") == 0 ||
-			 strcmp(argv[i], "--help") == 0) {
-			usage(stdout);
-			return 0;
-		} else if (argv[i][0] != '-' || argv[i][1] == '\0') {
-			in_path = argv[i];
-		} else {
-			usage(stderr);
-			return 2;
-		}
-	}
-	if (in_path == NULL) {
-		usage(stderr);
-		return 2;
-	}
-
-	in = fopen(in_path, "r");
-	if (in == NULL) {
-		perror(in_path);
-		return 2;
-	}
-
-	root = json_value_init_array();
-	arr = json_value_get_array(root);
-	converted = strace_convert(in, arr);
-	fclose(in);
-
-	serialized = json_serialize_to_string(root);
-	if (out_path != NULL) {
-		out = fopen(out_path, "w");
-		if (out == NULL) {
-			perror(out_path);
-			return 2;
-		}
-	}
-	fprintf(out, "%s\n", serialized);
-	if (out != stdout)
-		fclose(out);
-
-	json_free_serialized_string(serialized);
-	json_value_free(root);
-
-	fprintf(stderr, "retrace-strace2retrace: %d syscall lines converted\n",
-		converted);
-	return 0;
+	return converter_main(argc, argv, &app);
 }

--- a/tools/truss2retrace/CMakeLists.txt
+++ b/tools/truss2retrace/CMakeLists.txt
@@ -7,6 +7,7 @@
 set(_parson_source ${CMAKE_SOURCE_DIR}/src/config/json/parson.c)
 
 add_executable(retrace_truss2retrace truss2retrace.c convert.c
+	${CMAKE_SOURCE_DIR}/tools/common/converter.c
 	${_parson_source})
 set_target_properties(retrace_truss2retrace PROPERTIES
     OUTPUT_NAME retrace-truss2retrace
@@ -14,6 +15,7 @@ set_target_properties(retrace_truss2retrace PROPERTIES
 
 target_include_directories(retrace_truss2retrace PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_SOURCE_DIR}/tools/common
     ${CMAKE_SOURCE_DIR}/src/config/json
     ${CMAKE_SOURCE_DIR}/test/property/parson_stub)
 

--- a/tools/truss2retrace/truss2retrace.c
+++ b/tools/truss2retrace/truss2retrace.c
@@ -5,87 +5,24 @@
  */
 
 /*
- * retrace-truss2retrace -- the FreeBSD kernel-truth converter
- * (TODO.trace-profile/14). Feeds retrace-profile --kernel (and
- * retrace-correlate --outside) from a truss file capture.
- *
- * usage: retrace-truss2retrace [-o out.json] truss.log
+ * CLI wrapper only -- the conversion logic lives in convert.c;
+ * the shared driver is tools/common/converter.c
+ * (TODO.trace-profile/26).
  */
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-
+#include "converter.h"
 #include "convert.h"
-
-static void usage(FILE *out)
-{
-	fprintf(out,
-		"Usage: retrace-truss2retrace [-o out.json] truss.log\n"
-		"\n"
-		"Convert `truss -f -o truss.log ./app`\n"
-		"output to a retrace trace document (kernel-layer truth).\n"
-		"Output goes to stdout unless -o is given.\n");
-}
 
 int main(int argc, char **argv)
 {
-	const char *in_path = NULL;
-	const char *out_path = NULL;
-	FILE *in = stdin;
-	FILE *out = stdout;
-	JSON_Value *root;
-	JSON_Array *arr;
-	char *serialized;
-	int converted;
-	int i;
+	static const struct converter_app app = {
+		.name = "retrace-truss2retrace",
+		.usage =
+		"Convert `truss -f -o truss.log ./app`\n"
+		"output to a retrace trace document (kernel-layer truth).\n",
+		.convert = truss_convert,
+		.row_noun = "syscall lines",
+	};
 
-	for (i = 1; i < argc; i++) {
-		if (strcmp(argv[i], "-o") == 0 && i + 1 < argc)
-			out_path = argv[++i];
-		else if (strcmp(argv[i], "-h") == 0 ||
-			 strcmp(argv[i], "--help") == 0) {
-			usage(stdout);
-			return 0;
-		} else if (argv[i][0] != '-' || argv[i][1] == '\0') {
-			in_path = argv[i];
-		} else {
-			usage(stderr);
-			return 2;
-		}
-	}
-	if (in_path == NULL) {
-		usage(stderr);
-		return 2;
-	}
-
-	in = fopen(in_path, "r");
-	if (in == NULL) {
-		perror(in_path);
-		return 2;
-	}
-
-	root = json_value_init_array();
-	arr = json_value_get_array(root);
-	converted = truss_convert(in, arr);
-	fclose(in);
-
-	serialized = json_serialize_to_string(root);
-	if (out_path != NULL) {
-		out = fopen(out_path, "w");
-		if (out == NULL) {
-			perror(out_path);
-			return 2;
-		}
-	}
-	fprintf(out, "%s\n", serialized);
-	if (out != stdout)
-		fclose(out);
-
-	json_free_serialized_string(serialized);
-	json_value_free(root);
-
-	fprintf(stderr, "retrace-truss2retrace: %d syscall lines converted\n",
-		converted);
-	return 0;
+	return converter_main(argc, argv, &app);
 }


### PR DESCRIPTION
DRY for the converter family (TODO.trace-profile/26): the five `*2retrace` CLIs (strace, dtrace, truss, ktrace, etw) were ~90-line structural clones. One shared driver now lives in `tools/common/converter.c` (`converter_main` + a `converter_app` table); each CLI is a ~25-line table entry — the next converter is a convert function plus a table, no new CLI code.

Behavior-preserving by evidence: all five outputs byte-compared identical pre/post on their inputs; golden tests untouched and green (89/89); CLI, exit codes, and the stderr count line unchanged.

Bumps to v2.30.0 (version.h, CLI banner, packaging, CHANGELOG).
