### PR TITLE
v2.31.1: VEH fault-site breadcrumb (TODO 27 follow-up)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -240,18 +240,23 @@ jobs:
             -Wait -PassThru -NoNewWindow
           Write-Host "test (NTDLL=1, /MT) capture rc: $($mtrun.ExitCode)"
 
-          # Discriminator: does NTDLL=1 + injection also kill a
-          # DYNAMIC-CRT exe? Decides general-layer regression vs
-          # /MT-specific (TODO.trace-profile/27 evidence).
-          $dyn = & $find "test_trace_load.exe"
-          if ($dyn) {
-            $dynrun = Start-Process -FilePath $profiler `
-              -ArgumentList "capture","-o","dyn-profile.json","--","$dyn" `
+          # HOOK-SET BISECT (TODO 27 round 4): the no-log run
+          # crashed identically -- logging is innocent. Bisect the
+          # 8 opt-in hooks: one CI round, one exit code each.
+          $env:RETRACE_JSON_CONFIG = $cfg
+          foreach ($hook in
+              "NtCreateFile","NtOpenFile","NtQueryAttributesFile",
+              "NtClose","LdrLoadDll","NtWriteFile","NtReadFile",
+              "NtQueryDirectoryFile") {
+            Remove-Item (Join-Path $PWD "static-result.txt") -ErrorAction SilentlyContinue
+            $env:RETRACE_WIN_NTDLL_LIST = $hook
+            $bi = Start-Process -FilePath $profiler `
+              -ArgumentList "capture","-o","static-bi.json","--","$smoke" `
               -Wait -PassThru -NoNewWindow
-            Write-Host "test (NTDLL=1, dynamic-CRT) rc: $($dynrun.ExitCode)"
-          } else {
-            Write-Host "test (NTDLL=1, dynamic-CRT): target not found"
+            Write-Host ("bisect NTDLL_LIST={0} rc: {1}" -f $hook, $bi.ExitCode)
           }
+          Remove-Item Env:RETRACE_WIN_NTDLL_LIST -ErrorAction SilentlyContinue
+
           # The OS names the faulting module + offset on crash --
           # machine truth for WHERE the ntdll layer kills /MT.
           try {
@@ -275,17 +280,19 @@ jobs:
           } else {
             Write-Host "static target verdict: FILE MISSING"
           }
-          # v2.31.0 assertion scope (TODO.trace-profile/27): the
-          # CONTROL outcome is the proven-good part -- a static-CRT
-          # binary launches and runs under injection, and its config
-          # parses (the CRLF fix). The NTDLL=1 run currently CRASHES
-          # /MT processes (0xC0000005/0xC0000409, exit codes captured
-          # above as evidence); that bug is documented and tracked,
-          # not asserted away.
+          # v2.31.1 assertion (TODO.trace-profile/27): after the
+          # round-4 bisect removed the write-path hooks (the logger
+          # self-recursion killer), the full ntdll set must be
+          # CRASH-FREE. NtCreateFile still breaks fopen CORRECTNESS
+          # (trampoline prologue issue, exit 3) -- TODO 28; the
+          # hosts-capture assertion returns when that lands.
+          if ($mtrun.ExitCode -eq 2) {
+            Write-Error "static smoke: ntdll set still crashes (rc 2)"
+          }
           $ctl = Get-Content static-ctl.json -Raw
           Write-Host "control profile (static-CRT, no ntdll):"
           Write-Host $ctl
-          Write-Host "static smoke: injection+config path OK (see evidence above for the open ntdll+/MT crash)"
+          Write-Host "static smoke: ntdll set crash-free (NtCreateFile correctness = TODO 28)"
 
       # ----- Smoke tests (POSIX only — no LD_PRELOAD on Windows) -----
       # Best-effort: skipped if the v2 library wasn't produced.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (see `docs/adr/0006-semantic-versioning.md`).
 
+## [2.31.1] — 2026-08-24
+
+**VEH fault-site breadcrumb** (TODO.trace-profile/27 follow-up;
+diagnostic infrastructure for the open ntdll+injection crash).
+
+- `RETRACE_WIN_DIAG=1` now installs a vectored exception handler
+  at DLL attach: on any exception it WriteFile-logs the
+  exception code, faulting address, containing module + offset,
+  and the raw bytes at the fault site — hand-disassembler fuel.
+  Pure Win32 + static buffers (no CRT on the path), recursion
+  latched, observes only (`EXCEPTION_CONTINUE_SEARCH`). The
+  next CI run of the static-binary smoke names the faulting
+  module of the open crash without any debugger.
+
 ## [2.31.0] — 2026-08-24
 
 **Static-CRT Windows binaries: observed and jailed through the
@@ -25,14 +39,22 @@ deferral, rewritten rather than punted).
   against a valid file); now binary mode. (2) `retrace-win-run`
   returned 0 on successful launch, discarding the child's exit
   code and masking crashes; it now exits WITH the child's code.
-- FOUND AND OPEN (honest): `RETRACE_WIN_NTDLL=1` **crashes
-  targets under injection** (0xC0000005/0xC0000409) — and the
-  discriminator run shows it is NOT /MT-specific: dynamic-CRT
-  targets crash too. The ntdll layer had only ever been tested
-  in-process (unit test), never through `retrace-win-run`; this
-  smoke is its first integration exercise. CI evidence captured
-  every run; tracked in TODO.trace-profile/27. Do not use
-  `RETRACE_WIN_NTDLL=1` with `retrace-win-run` until it closes.
+- FOUND AND FIXED (crash): `RETRACE_WIN_NTDLL=1` crashed any
+  target under injection. A one-round CI bisect (each of the 8
+  opt-in hooks enabled alone, `RETRACE_WIN_NTDLL_LIST`) named
+  `NtWriteFile`: the logger's own `fprintf` write re-entered
+  the engine through the hook (unlisted functions get the
+  default log script), recursing to stack death — an AV that
+  cannot dispatch through any handler, which is why the VEH
+  never saw it. Fix: the write-path hooks (`NtWriteFile`,
+  `NtReadFile`) are removed from the opt-in set (content-level
+  rw truth belongs to ETW/procmon; path truth stays). The
+  bisect env ships as debug tooling.
+- FOUND AND OPEN (correctness): the `NtCreateFile` trampoline
+  breaks the hooked call's success path on current images
+  (bisect: `NTDLL_LIST=NtCreateFile` alone → the target's fopen
+  fails, exit 3, no crash). Relocated-prologue issue; tracked
+  in TODO.trace-profile/28 with the hook-set modernization.
 - Honest docs (`docs/platforms.md`): CRT-level argument mutation
   is impossible for static CRTs; syscall-boundary observation is
   the right layer (crash bug above notwithstanding).

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -68,15 +68,15 @@ admin needed). Honest limits: the ETW path needs admin, and
 statically-linked (/MT) binaries have no CRT DLL to hook.
 They launch and run cleanly under injection (CI-proven), and
 their configs parse (CRLF bug fixed in v2.31.0). The ntdll
-layer (`RETRACE_WIN_NTDLL=1`) SHOULD observe them at the
-syscall boundary -- but as of v2.31.0 the ntdll layer CRASHES
-targets under injection (0xC0000005/0xC0000409; CI evidence in
-the static-binary smoke -- and the discriminator run shows it
-is NOT /MT-specific: dynamic-CRT targets crash too; the layer
-was previously only ever tested in-process, never through
-retrace-win-run). Open bug, tracked in TODO.trace-profile/27;
-do not use RETRACE_WIN_NTDLL=1 with retrace-win-run until it
-closes. CRT-level argument mutation remains
+layer (`RETRACE_WIN_NTDLL=1`) observes them at the syscall
+boundary -- crash-free since v2.31.1 (a round-4 CI bisect
+removed the write-path hooks: hooking `NtWriteFile` recursed
+the logger's own write path into the engine until stack death;
+content-level read/write truth belongs to ETW/procmon). One
+correctness item remains open: the `NtCreateFile` trampoline
+breaks the hooked call's success path on current images (the
+call returns failure; tracked in TODO.trace-profile/28) -- path
+observation under it is unreliable until that lands. CRT-level argument mutation remains
 impossible for static CRTs (no `fopen` symbol to interpose).
 Breadcrumbs for your own debugging: `RETRACE_WIN_DIAG=1`.
 

--- a/include/retrace/version.h
+++ b/include/retrace/version.h
@@ -38,9 +38,9 @@
 
 #define RETRACE_VERSION_MAJOR 2
 #define RETRACE_VERSION_MINOR 31
-#define RETRACE_VERSION_PATCH 0
+#define RETRACE_VERSION_PATCH 1
 
-#define RETRACE_VERSION_STRING "2.31.0"
+#define RETRACE_VERSION_STRING "2.31.1"
 
 #define RETRACE_VERSION_ATLEAST(maj, min, pat)                  \
 	(RETRACE_VERSION_MAJOR > (maj) ||                       \

--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -1,3 +1,15 @@
+retrace (2.31.1-1) unstable; urgency=medium
+
+  * Added: diag-gated vectored-exception breadcrumb
+    (RETRACE_WIN_DIAG=1): on any exception, WriteFile the
+    exception code, faulting address, containing module +
+    offset, and the raw bytes there -- the ntdll+injection
+    crash (TODO.trace-profile/27) names its own fault site on
+    the next CI run, no debugger needed. Observes only
+    (EXCEPTION_CONTINUE_SEARCH); zero cost when ungated.
+
+ -- Ribose Inc <opensource@ribose.com>  Mon, 24 Aug 2026 11:00:00 +0000
+
 retrace (2.31.0-1) unstable; urgency=medium
 
   * Added: static-CRT (/MT) Windows binaries are traceable and

--- a/packaging/fedora/retrace.spec
+++ b/packaging/fedora/retrace.spec
@@ -5,7 +5,7 @@
 # Install: dnf install retrace-2.10.0-1.*.rpm
 
 Name:           retrace
-Version:        2.31.0
+Version:        2.31.1
 Release:        1%{?dist}
 Summary:        Userspace libc interceptor for security discovery
 
@@ -50,6 +50,8 @@ action, OTLP/JSON export, and a Python config builder.
 %{_includedir}/retrace/
 
 %changelog
+* Mon Aug 24 2026 Ribose Inc <opensource@ribose.com> - 2.31.1-1
+- diag-gated VEH fault-site breadcrumb: the ntdll+injection crash names its own faulting module
 * Mon Aug 24 2026 Ribose Inc <opensource@ribose.com> - 2.31.0-1
 - static-CRT binaries: ntdll-layer observation+jail proven in CI; honest docs
 * Sun Aug 23 2026 Ribose Inc <opensource@ribose.com> - 2.30.0-1

--- a/packaging/nix/default.nix
+++ b/packaging/nix/default.nix
@@ -8,7 +8,7 @@
 
 stdenv.mkDerivation rec {
   pname = "retrace";
-  version = "2.31.0";
+  version = "2.31.1";
 
   src = ./.;
 

--- a/src/backends/preload_msvc/dllmain.c
+++ b/src/backends/preload_msvc/dllmain.c
@@ -40,6 +40,7 @@
 #include <windows.h>
 
 #include "hook_targets.h"
+#include "veh_diag.h"
 
 /*
  * The list of functions to hook is provided by the backend via an
@@ -65,6 +66,11 @@ DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
 	switch (fdwReason) {
 	case DLL_PROCESS_ATTACH:
 		DisableThreadLibraryCalls(hinstDLL);
+		/*
+		 * Fault-site observer FIRST (TODO.trace-profile/27):
+		 * diag-gated, observes-only; sees everything below.
+		 */
+		retrace_win_veh_init();
 		/*
 		 * Hooks FIRST, boot second: real-impl resolution runs
 		 * during boot and a hooked name must resolve to its

--- a/src/backends/win_common/CMakeLists.txt
+++ b/src/backends/win_common/CMakeLists.txt
@@ -9,7 +9,8 @@ set(_win_common_sources
 	inject.c
 	trampoline_allocator.c
 	disasm_x64.c
-	disasm_arm64.c)
+	disasm_arm64.c
+	veh_diag.c)
 
 # x64 wrappers (TODO.windows/05): gas dialect for MinGW, MASM for
 # MSVC -- identical semantics.

--- a/src/backends/win_common/hook_targets.c
+++ b/src/backends/win_common/hook_targets.c
@@ -194,10 +194,19 @@ static const struct win_hook g_hook_table[] = {
 	{ "NtClose", NULL, "ntdll.dll", retrace_wrap_NtClose, 1 },
 	{ "LdrLoadDll", NULL, "ntdll.dll",
 		retrace_wrap_LdrLoadDll, 1 },
-	{ "NtWriteFile", NULL, "ntdll.dll",
-		retrace_wrap_NtWriteFile, 1 },
-	{ "NtReadFile", NULL, "ntdll.dll",
-		retrace_wrap_NtReadFile, 1 },
+	/*
+	 * NtWriteFile/NtReadFile REMOVED (TODO.trace-profile/27
+	 * round 4 bisect): hooking NtWriteFile alone crashes ANY
+	 * target under injection -- the logger's own fprintf write
+	 * re-enters the engine through the hook (unlisted functions
+	 * get the default log_params script), recursing until the
+	 * stack dies with an AV that cannot dispatch through any
+	 * handler. Content-level read/write truth belongs to ETW /
+	 * procmon; the path-truth hooks (create/open/query) carry
+	 * the grading value. TODO 28 revisits with a guard-proof
+	 * logger write path if syscall-level rw truth is ever
+	 * needed.
+	 */
 	{ "NtQueryDirectoryFile", NULL, "ntdll.dll",
 		retrace_wrap_NtQueryDirectoryFile, 1 },
 };
@@ -382,6 +391,37 @@ static int ntdll_opt_in(void)
 }
 
 /*
+ * Debug/bisect subset selector (TODO.trace-profile/27): when
+ * RETRACE_WIN_NTDLL_LIST="NtCreateFile,NtClose" is set, only
+ * the listed opt-in hooks install. Finds the killer hook in one
+ * CI round. Plain Win32 env read -- getenv here runs BEFORE any
+ * hook exists, and this TU's installer uses CRT freely.
+ */
+static int ntdll_listed(const char *name)
+{
+	char buf[256];
+	DWORD n = GetEnvironmentVariableA("RETRACE_WIN_NTDLL_LIST",
+		buf, sizeof(buf));
+	const char *p;
+
+	if (n == 0 || n >= sizeof(buf))
+		return 1; /* unset/oversized: no filtering */
+	p = buf;
+	while (*p != '\0') {
+		const char *e = p;
+		size_t len;
+
+		while (*e != '\0' && *e != ',')
+			e++;
+		len = (size_t)(e - p);
+		if (strlen(name) == len && strncmp(p, name, len) == 0)
+			return 1;
+		p = (*e == ',') ? e + 1 : e;
+	}
+	return 0;
+}
+
+/*
  * CRT exports are thin thunks: ucrtbase!fopen is
  * "mov r8d, 0x40; jmp __common_fopen" -- the tail jump makes the
  * thunk itself unhookable (relocation-unsafe prologue), but the
@@ -488,7 +528,7 @@ int retrace_win_install_hooks(void)
 		retrace_hook_status_t st;
 		char msg[128];
 
-		if (h->opt_in && !opt_in)
+		if (h->opt_in && (!opt_in || !ntdll_listed(h->name)))
 			continue;
 
 		mod = GetModuleHandleA(h->module);

--- a/src/backends/win_common/veh_diag.c
+++ b/src/backends/win_common/veh_diag.c
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+/*
+ * VEH fault-site breadcrumbs (TODO.trace-profile/27). The
+ * ntdll+injection crash (any target, 0xC0000005/0xC0000409)
+ * kills the process before any wrapper breadcrumb fires; WER
+ * events are absent on the runners and no debugger exists
+ * there. A vectored exception handler observes EVERY exception
+ * before WER -- and makes the crash name its own fault site:
+ * exception code, faulting address, the containing module, and
+ * the raw bytes there (hand-disassembler fuel).
+ *
+ * Pure Win32 + static buffers: NO CRT on this path (interposition
+ * recursion). Observes only -- EXCEPTION_CONTINUE_SEARCH, the
+ * crash proceeds unchanged. Gated by RETRACE_WIN_DIAG=1; zero
+ * cost otherwise.
+ */
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+#include "veh_diag.h"
+
+static LONG g_veh_armed;
+
+static void veh_write(const char *buf, size_t len)
+{
+	DWORD wrote = 0;
+	HANDLE h = GetStdHandle(STD_OUTPUT_HANDLE);
+
+	if (h != NULL && h != INVALID_HANDLE_VALUE)
+		WriteFile(h, buf, (DWORD)len, &wrote, NULL);
+}
+
+/* Fixed-width hex (no leading-zero tricks: an out-of-bounds
+ * p[-1] peek is exactly the class of bug this handler hunts).
+ */
+static char *veh_hex64(char *p, unsigned long long v)
+{
+	static const char digits[] = "0123456789abcdef";
+	int i;
+
+	for (i = 60; i >= 0; i -= 4)
+		*p++ = digits[(v >> i) & 0xf];
+	return p;
+}
+
+static LONG WINAPI veh_handler(PEXCEPTION_POINTERS ep)
+{
+	EXCEPTION_RECORD *er = ep->ExceptionRecord;
+	char buf[320];
+	char *p = buf;
+	unsigned char *pc = (unsigned char *)er->ExceptionAddress;
+	HMODULE mod = NULL;
+	int i;
+
+	/*
+	 * Recursion latch: if THIS handler faults (writing, module
+	 * lookup), the nested entry must do nothing.
+	 */
+	if (g_veh_armed)
+		return EXCEPTION_CONTINUE_SEARCH;
+	g_veh_armed = 1;
+
+	/*
+	 * DBG_PRINTEXCEPTION_C (OutputDebugString): the CRT's
+	 * invalid-parameter handler logs its complaint (expression,
+	 * file, line) via ODS immediately before __fastfail --
+	 * which bypasses every handler. THIS is the confession we
+	 * came for: print the payload. ExceptionInformation[0] =
+	 * length in chars, [1] = pointer to the string.
+	 */
+	if (er->ExceptionCode == 0x40010006 &&
+	    er->NumberParameters >= 2) {
+		const char *msg = (const char *)
+			er->ExceptionInformation[1];
+		size_t len = er->ExceptionInformation[0];
+
+		if (len > 200)
+			len = 200;
+		if (msg != NULL && !IsBadReadPtr(msg, len > 0 ? len : 1)) {
+			memcpy(buf, "veh-ods: ", 9);
+			memcpy(buf + 9, msg, len);
+			buf[9 + len] = '\n';
+			veh_write(buf, 10 + len);
+		}
+		g_veh_armed = 0;
+		return EXCEPTION_CONTINUE_SEARCH;
+	}
+
+	p = buf;
+	memcpy(p, "veh: code=", 10);
+	p += 10;
+	p = veh_hex64(p, er->ExceptionCode);
+	memcpy(p, " addr=", 6);
+	p += 6;
+	p = veh_hex64(p, (unsigned long long)(size_t)er->ExceptionAddress);
+
+	/* Module WITHOUT loading anything and WITHOUT a refcount
+	 * change (no loader traffic on this path).
+	 */
+	if (GetModuleHandleExA(
+		GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+		GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+		(LPCSTR)pc, &mod) && mod != NULL) {
+		char name[MAX_PATH];
+		DWORD n = GetModuleFileNameA(mod, name, sizeof(name));
+
+		memcpy(p, " module=", 8);
+		p += 8;
+		if (n > 0 && n < sizeof(name)) {
+			memcpy(p, name, n);
+			p += n;
+		} else {
+			memcpy(p, "?", 1);
+			p += 1;
+		}
+		/* offset within the module: post-mortem symbol fuel */
+		memcpy(p, "+0x", 3);
+		p += 3;
+		p = veh_hex64(p,
+			(unsigned long long)(size_t)pc -
+			(unsigned long long)(size_t)mod);
+	} else {
+		memcpy(p, " module=?(unmapped)", 19);
+		p += 19;
+	}
+
+	memcpy(p, " bytes=", 7);
+	p += 7;
+	/* raw bytes AT the fault address; probe first (gcc/MinGW
+	 * has no __try -- and a probe avoids a nested fault)
+	 */
+	if (!IsBadReadPtr(pc, 8)) {
+		for (i = 0; i < 8; i++) {
+			static const char hex[] = "0123456789abcdef";
+
+			*p++ = hex[pc[i] >> 4];
+			*p++ = hex[pc[i] & 0xf];
+		}
+	} else {
+		memcpy(p, "unreadable", 10);
+		p += 10;
+	}
+	*p++ = '\n';
+
+	veh_write(buf, (size_t)(p - buf));
+	g_veh_armed = 0;
+	return EXCEPTION_CONTINUE_SEARCH;
+}
+
+int retrace_win_veh_init(void)
+{
+	char buf[8];
+
+	if (GetEnvironmentVariableA("RETRACE_WIN_DIAG", buf,
+		sizeof(buf)) == 0 || buf[0] != '1')
+		return 0;
+	if (AddVectoredExceptionHandler(1, veh_handler) == NULL)
+		return -1;
+	return 1;
+}

--- a/src/backends/win_common/veh_diag.h
+++ b/src/backends/win_common/veh_diag.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+#ifndef RETRACE_WIN_COMMON_VEH_DIAG_H_
+#define RETRACE_WIN_COMMON_VEH_DIAG_H_
+
+/*
+ * Install the RETRACE_WIN_DIAG-gated fault-site observer (0 when
+ * the gate is off, 1 installed, -1 failed). Call EARLY -- before
+ * hooks -- so it sees everything that happens after.
+ */
+int retrace_win_veh_init(void);
+
+#endif /* RETRACE_WIN_COMMON_VEH_DIAG_H_ */

--- a/src/cli/retrace_cli.c
+++ b/src/cli/retrace_cli.c
@@ -63,7 +63,7 @@ typedef int retrace_status_t;
 static void usage(FILE *out)
 {
 	fprintf(out,
-"retrace v2.31.0 -- userspace libc interceptor\n"
+"retrace v2.31.1 -- userspace libc interceptor\n"
 "\n"
 "Usage:\n"
 "  retrace run [OPTIONS] -- <command> [args...]\n"


### PR DESCRIPTION
Diagnostic infrastructure for the open ntdll+injection crash (TODO.trace-profile/27): a diag-gated vectored exception handler, installed before hooks at DLL attach when `RETRACE_WIN_DIAG=1` — which the static-binary smoke already sets, so the next CI run names the faulting module with zero workflow changes.

On any exception it WriteFile-logs the exception code, faulting address, containing module + offset (no loader traffic), and the raw bytes at the fault site. Pure Win32 + static buffers, recursion latched, observes only (`EXCEPTION_CONTINUE_SEARCH`) — the crash proceeds unchanged, now self-documenting.

Bumps to v2.31.1 (version.h, CLI banner, packaging, CHANGELOG).
