### PR TITLE
v2.31.2: diag evidence round -- hook-install success dump (TODO 28)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (see `docs/adr/0006-semantic-versioning.md`).
 
+## [2.31.2] — 2026-08-24
+
+**Diag: hook-install success dump** (TODO.trace-profile/28
+evidence round).
+
+- `RETRACE_WIN_DIAG=1` now also prints every *successfully*
+  installed hook's accepted prologue length and the raw target
+  bytes (via ODS, captured by the VEH payload machinery). The
+  `NtCreateFile` correctness defect (hooked call fails, no
+  crash) becomes visible as data: what the disassembler
+  accepted vs. the stub's real shape.
+
 ## [2.31.1] — 2026-08-24
 
 **VEH fault-site breadcrumb** (TODO.trace-profile/27 follow-up;

--- a/include/retrace/version.h
+++ b/include/retrace/version.h
@@ -38,9 +38,9 @@
 
 #define RETRACE_VERSION_MAJOR 2
 #define RETRACE_VERSION_MINOR 31
-#define RETRACE_VERSION_PATCH 1
+#define RETRACE_VERSION_PATCH 2
 
-#define RETRACE_VERSION_STRING "2.31.1"
+#define RETRACE_VERSION_STRING "2.31.2"
 
 #define RETRACE_VERSION_ATLEAST(maj, min, pat)                  \
 	(RETRACE_VERSION_MAJOR > (maj) ||                       \

--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -1,3 +1,14 @@
+retrace (2.31.2-1) unstable; urgency=medium
+
+  * Added: diag-gated hook-install SUCCESS dump (RETRACE_WIN_
+  DIAG=1): name, accepted prologue_len, raw target bytes per
+  installed hook -- the evidence round for the NtCreateFile
+  trampoline correctness defect (TODO.trace-profile/28). The
+  static-binary smoke already runs diag-gated, so CI captures
+  it with zero workflow changes.
+
+ -- Ribose Inc <opensource@ribose.com>  Mon, 24 Aug 2026 13:00:00 +0000
+
 retrace (2.31.1-1) unstable; urgency=medium
 
   * Added: diag-gated vectored-exception breadcrumb

--- a/packaging/fedora/retrace.spec
+++ b/packaging/fedora/retrace.spec
@@ -5,7 +5,7 @@
 # Install: dnf install retrace-2.10.0-1.*.rpm
 
 Name:           retrace
-Version:        2.31.1
+Version:        2.31.2
 Release:        1%{?dist}
 Summary:        Userspace libc interceptor for security discovery
 
@@ -50,6 +50,8 @@ action, OTLP/JSON export, and a Python config builder.
 %{_includedir}/retrace/
 
 %changelog
+* Mon Aug 24 2026 Ribose Inc <opensource@ribose.com> - 2.31.2-1
+- diag: hook install success dump (prologue_len + bytes) for the NtCreateFile correctness hunt
 * Mon Aug 24 2026 Ribose Inc <opensource@ribose.com> - 2.31.1-1
 - diag-gated VEH fault-site breadcrumb: the ntdll+injection crash names its own faulting module
 * Mon Aug 24 2026 Ribose Inc <opensource@ribose.com> - 2.31.0-1

--- a/packaging/nix/default.nix
+++ b/packaging/nix/default.nix
@@ -8,7 +8,7 @@
 
 stdenv.mkDerivation rec {
   pname = "retrace";
-  version = "2.31.1";
+  version = "2.31.2";
 
   src = ./.;
 

--- a/src/backends/win_common/hook.c
+++ b/src/backends/win_common/hook.c
@@ -48,6 +48,8 @@
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
+static size_t g_last_prologue_len;
+
 #if defined(_M_ARM64) || defined(__aarch64__)
 #  define RETRACE_HOOK_ARCH_ARM64 1
 #else
@@ -307,6 +309,10 @@ retrace_hook_install_ex(void *target_addr,
 	retrace_hook_t *hook;
 	size_t patch_size = required_patch();
 	size_t prologue_len;
+	/* diag evidence (TODO.trace-profile/28): what install ACTUALLY
+	 * accepted, per hook -- prologue length + raw target bytes.
+	 */
+	g_last_prologue_len = 0;
 	retrace_hook_status_t st;
 
 	if (target_addr == NULL || wrapper_addr == NULL ||
@@ -336,6 +342,8 @@ retrace_hook_install_ex(void *target_addr,
 			return RETRACE_HOOK_UNSAFE;
 	}
 #endif
+
+	g_last_prologue_len = prologue_len;
 
 	hook = (retrace_hook_t *)HeapAlloc(GetProcessHeap(), 0, sizeof(*hook));
 	if (hook == NULL)
@@ -431,4 +439,12 @@ retrace_hook_uninstall(retrace_hook_t *hook)
 	retrace_trampoline_free(hook->trampoline);
 	HeapFree(GetProcessHeap(), 0, hook);
 	return RETRACE_HOOK_OK;
+}
+
+/* diag evidence (TODO.trace-profile/28): the prologue length the
+ * most recent install_ex ACCEPTED (0 = none/refused).
+ */
+size_t retrace_hook_last_prologue_len(void)
+{
+	return g_last_prologue_len;
 }

--- a/src/backends/win_common/hook.h
+++ b/src/backends/win_common/hook.h
@@ -115,6 +115,11 @@ retrace_hook_bookmark(void *target, size_t patch_size, void *trampoline,
 /* Minimum number of prologue bytes that must be safe-to-relocate. */
 size_t retrace_hook_required_patch_size(void);
 
+/* Diag evidence (TODO.trace-profile/28): the prologue length the
+ * most recent install ACCEPTED (0 = none/refused).
+ */
+size_t retrace_hook_last_prologue_len(void);
+
 /* Per-process hook-target table descriptor. Each entry maps a libc symbol
  * to the wrapper trampoline that should replace it. The backend (MSVC or
  * MinGW) owns the table; dllmain iterates it to install hooks at startup.

--- a/src/backends/win_common/hook_targets.c
+++ b/src/backends/win_common/hook_targets.c
@@ -383,6 +383,18 @@ static void *follow_thunk_arm64(void *addr, size_t *prefix_len)
 }
 #endif
 
+/* Win32 env read (TODO.trace-profile/28): install-time diag
+ * gate -- CRT getenv may already flow through hooks installed
+ * earlier in THIS loop.
+ */
+static int diag_enabled(void)
+{
+	char buf[8];
+
+	return GetEnvironmentVariableA("RETRACE_WIN_DIAG", buf,
+		sizeof(buf)) > 0 && buf[0] == '1';
+}
+
 static int ntdll_opt_in(void)
 {
 	const char *env = getenv("RETRACE_WIN_NTDLL");
@@ -643,6 +655,25 @@ int retrace_win_install_hooks(void)
 
 
 installed:
+		if (diag_enabled()) {
+			const unsigned char *bytes = target;
+			int bi;
+
+			snprintf(msg, sizeof(msg),
+				"retrace: hooked '%s' prologue_len=%lu bytes:",
+				h->name,
+				(unsigned long)
+					retrace_hook_last_prologue_len());
+			for (bi = 0; bi < 16; bi++) {
+				char hex[8];
+
+				snprintf(hex, sizeof(hex), " %02x",
+					bytes[bi]);
+				strncat(msg, hex, sizeof(msg) -
+					strlen(msg) - 1);
+			}
+			OutputDebugStringA(msg);
+		}
 		g_installed[g_installed_count].handle = handle;
 		g_installed[g_installed_count].trampoline = trampoline;
 		g_installed[g_installed_count].name =

--- a/src/cli/retrace_cli.c
+++ b/src/cli/retrace_cli.c
@@ -63,7 +63,7 @@ typedef int retrace_status_t;
 static void usage(FILE *out)
 {
 	fprintf(out,
-"retrace v2.31.1 -- userspace libc interceptor\n"
+"retrace v2.31.2 -- userspace libc interceptor\n"
 "\n"
 "Usage:\n"
 "  retrace run [OPTIONS] -- <command> [args...]\n"


### PR DESCRIPTION
Evidence round for the `NtCreateFile` trampoline defect (TODO.trace-profile/28): with `RETRACE_WIN_DIAG=1`, every *successfully* installed hook now ODS-prints its accepted prologue length plus the raw target bytes — captured by the existing VEH payload machinery, so the already-diag-gated static-binary smoke surfaces it in CI with zero workflow changes. Data first, fix second.

Bumps to v2.31.2 (version.h, CLI banner, packaging, CHANGELOG).
