### PR TITLE
ci: TODO 28 round 3 -- failure-detail verdict + param-shape control

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -262,12 +262,23 @@ jobs:
           $cfgnl = Join-Path $env:RUNNER_TEMP "static-cfg-nolog.json"
           '{"intercept_scripts":[{"func_name":"NtCreateFile","actions":[{"action_name":"call_real"}]},{"func_name":"NtOpenFile","actions":[{"action_name":"call_real"}]}]}' |
             Set-Content -Path $cfgnl -Encoding ascii
+          # param-shape control: NtOpenFile (6 params) vs
+          # NtCreateFile (11 params + OUT IO_STATUS_BLOCK)
+          $env:RETRACE_WIN_NTDLL_LIST = "NtOpenFile"
+          $env:RETRACE_JSON_CONFIG = $cfgnl
+          $ofbi = Start-Process -FilePath $profiler `
+            -ArgumentList "capture","-o","static-ofbi.json","--","$smoke" `
+            -Wait -PassThru -NoNewWindow
+          Write-Host ("bisect NTDLL_LIST=NtOpenFile NO-logging rc: {0}" -f $ofbi.ExitCode)
           $env:RETRACE_WIN_NTDLL_LIST = "NtCreateFile"
           $env:RETRACE_JSON_CONFIG = $cfgnl
           $nlbi = Start-Process -FilePath $profiler `
             -ArgumentList "capture","-o","static-nlbi.json","--","$smoke" `
             -Wait -PassThru -NoNewWindow
           Write-Host ("bisect NTDLL_LIST=NtCreateFile NO-logging rc: {0}" -f $nlbi.ExitCode)
+          Write-Host "NtCreateFile no-log verdict:"
+          Get-Content (Join-Path $PWD "static-result.txt") -ErrorAction SilentlyContinue | Write-Host
+          Remove-Item (Join-Path $PWD "static-result.txt") -ErrorAction SilentlyContinue
           $env:RETRACE_JSON_CONFIG = $cfg
           Remove-Item Env:RETRACE_WIN_NTDLL_LIST -ErrorAction SilentlyContinue
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -255,6 +255,20 @@ jobs:
               -Wait -PassThru -NoNewWindow
             Write-Host ("bisect NTDLL_LIST={0} rc: {1}" -f $hook, $bi.ExitCode)
           }
+          # TODO 28 discriminator: NtCreateFile alone with a
+          # call_real-ONLY script (no log_params = no param
+          # serialization). Pass -> serialization is the killer;
+          # fail -> the trampoline return path itself.
+          $cfgnl = Join-Path $env:RUNNER_TEMP "static-cfg-nolog.json"
+          '{"intercept_scripts":[{"func_name":"NtCreateFile","actions":[{"action_name":"call_real"}]},{"func_name":"NtOpenFile","actions":[{"action_name":"call_real"}]}]}' |
+            Set-Content -Path $cfgnl -Encoding ascii
+          $env:RETRACE_WIN_NTDLL_LIST = "NtCreateFile"
+          $env:RETRACE_JSON_CONFIG = $cfgnl
+          $nlbi = Start-Process -FilePath $profiler `
+            -ArgumentList "capture","-o","static-nlbi.json","--","$smoke" `
+            -Wait -PassThru -NoNewWindow
+          Write-Host ("bisect NTDLL_LIST=NtCreateFile NO-logging rc: {0}" -f $nlbi.ExitCode)
+          $env:RETRACE_JSON_CONFIG = $cfg
           Remove-Item Env:RETRACE_WIN_NTDLL_LIST -ErrorAction SilentlyContinue
 
           # The OS names the faulting module + offset on crash --

--- a/test/smoke/static_smoke.c
+++ b/test/smoke/static_smoke.c
@@ -17,7 +17,9 @@
  * CI smoke needs ground truth about whether main ran at all.
  */
 
+#include <errno.h>
 #include <stdio.h>
+#include <windows.h>
 
 int main(void)
 {
@@ -38,7 +40,13 @@ int main(void)
 	opened = f != NULL;
 
 	if (out != NULL) {
-		fprintf(out, "hosts open: %d\n", opened);
+		if (opened) {
+			fprintf(out, "hosts open: 1\n");
+		} else {
+			/* evidence: WHY did it fail (TODO 28) */
+			fprintf(out, "hosts open: 0 errno=%d gle=%lu\n",
+				errno, (unsigned long)GetLastError());
+		}
 		fclose(out);
 	}
 	printf("hosts open: %d\n", opened);


### PR DESCRIPTION
TODO 28 evidence round 3: the no-logging run also fails (rc 3), clearing param serialization — the minimal call_real path itself is broken for `NtCreateFile`. This round adds two evidence axes: the smoke target's verdict now prints `errno`/`GetLastError` on the failed `fopen`, and a param-shape control runs `NtOpenFile` alone no-log (6 params — it passed even *with* logging in the bisect) against `NtCreateFile` (11 params including the OUT `IO_STATUS_BLOCK`). No product behavior change beyond the target's evidence print.
