### PR TITLE
ci: TODO 28 rounds 2-4 -- NtCreateFile failure evidence chain

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -262,12 +262,23 @@ jobs:
           $cfgnl = Join-Path $env:RUNNER_TEMP "static-cfg-nolog.json"
           '{"intercept_scripts":[{"func_name":"NtCreateFile","actions":[{"action_name":"call_real"}]},{"func_name":"NtOpenFile","actions":[{"action_name":"call_real"}]}]}' |
             Set-Content -Path $cfgnl -Encoding ascii
+          # param-shape control: NtOpenFile (6 params) vs
+          # NtCreateFile (11 params + OUT IO_STATUS_BLOCK)
+          $env:RETRACE_WIN_NTDLL_LIST = "NtOpenFile"
+          $env:RETRACE_JSON_CONFIG = $cfgnl
+          $ofbi = Start-Process -FilePath $profiler `
+            -ArgumentList "capture","-o","static-ofbi.json","--","$smoke" `
+            -Wait -PassThru -NoNewWindow
+          Write-Host ("bisect NTDLL_LIST=NtOpenFile NO-logging rc: {0}" -f $ofbi.ExitCode)
           $env:RETRACE_WIN_NTDLL_LIST = "NtCreateFile"
           $env:RETRACE_JSON_CONFIG = $cfgnl
           $nlbi = Start-Process -FilePath $profiler `
             -ArgumentList "capture","-o","static-nlbi.json","--","$smoke" `
             -Wait -PassThru -NoNewWindow
           Write-Host ("bisect NTDLL_LIST=NtCreateFile NO-logging rc: {0}" -f $nlbi.ExitCode)
+          Write-Host "NtCreateFile no-log verdict:"
+          Get-Content (Join-Path $PWD "static-result.txt") -ErrorAction SilentlyContinue | Write-Host
+          Remove-Item (Join-Path $PWD "static-result.txt") -ErrorAction SilentlyContinue
           $env:RETRACE_JSON_CONFIG = $cfg
           Remove-Item Env:RETRACE_WIN_NTDLL_LIST -ErrorAction SilentlyContinue
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -306,19 +306,21 @@ jobs:
           } else {
             Write-Host "static target verdict: FILE MISSING"
           }
-          # v2.31.1 assertion (TODO.trace-profile/27): after the
-          # round-4 bisect removed the write-path hooks (the logger
-          # self-recursion killer), the full ntdll set must be
-          # CRASH-FREE. NtCreateFile still breaks fopen CORRECTNESS
-          # (trampoline prologue issue, exit 3) -- TODO 28; the
-          # hosts-capture assertion returns when that lands.
-          if ($mtrun.ExitCode -eq 2) {
-            Write-Error "static smoke: ntdll set still crashes (rc 2)"
+          # v2.32.0 assertion (TODO.trace-profile/28): the
+          # dispatch fix (0..6 -> 0..12 args) makes the scripted
+          # call_real path WORK for the ntdll file API -- the
+          # FULL original assertion returns: a static-CRT
+          # binary's file activity, captured with decoded paths.
+          $prof = ""
+          if (Test-Path static-profile.json) {
+            $prof = Get-Content static-profile.json -Raw
           }
-          $ctl = Get-Content static-ctl.json -Raw
-          Write-Host "control profile (static-CRT, no ntdll):"
-          Write-Host $ctl
-          Write-Host "static smoke: ntdll set crash-free (NtCreateFile correctness = TODO 28)"
+          Write-Host "static-profile (NTDLL=1, /MT):"
+          Write-Host $prof
+          if (-not $prof.Contains("hosts")) {
+            Write-Error "static smoke: no hosts capture through the ntdll layer"
+          }
+          Write-Host "static smoke: ntdll-layer capture OK (static-CRT)"
 
       # ----- Smoke tests (POSIX only — no LD_PRELOAD on Windows) -----
       # Best-effort: skipped if the v2 library wasn't produced.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -233,12 +233,27 @@ jobs:
           Get-Content (Join-Path $PWD "static-result.txt") -ErrorAction SilentlyContinue | Write-Host
           Remove-Item (Join-Path $PWD "static-result.txt") -ErrorAction SilentlyContinue
 
-          # TEST run: the ntdll layer on.
+          # TEST run: direct win-run with OUR trace path -- the
+          # raw JSON stays on disk for evidence (capture consumes
+          # its temp), then aggregate explicitly. Same product
+          # surface: injection -> hooks -> engine -> logger ->
+          # profile.
           $env:RETRACE_WIN_NTDLL = "1"
-          $mtrun = Start-Process -FilePath $profiler `
-            -ArgumentList "capture","-o","static-profile.json","--","$smoke" `
-            -Wait -PassThru -NoNewWindow
-          Write-Host "test (NTDLL=1, /MT) capture rc: $($mtrun.ExitCode)"
+          $env:RETRACE_LOGGER_DEF_ENA = "1"
+          $env:RETRACE_LOGGER_DEF_STDOUT_ENA = "0"
+          $env:RETRACE_LOGGER_DEF_FN = "$PWD\static-trace.json"
+          Remove-Item "$PWD\static-trace.json" -ErrorAction SilentlyContinue
+          $wr = Get-ChildItem -Path build -Recurse -Filter "retrace-win-run.exe" |
+            Select-Object -First 1 -ExpandProperty FullName
+          & $wr --lib "$lib" $smoke
+          Write-Host "win-run rc: $LASTEXITCODE"
+          Write-Host "RAW TRACE:"
+          Get-Content "$PWD\static-trace.json" -Raw | Write-Host
+          Remove-Item Env:RETRACE_LOGGER_DEF_ENA -ErrorAction SilentlyContinue
+          Remove-Item Env:RETRACE_LOGGER_DEF_STDOUT_ENA -ErrorAction SilentlyContinue
+          Remove-Item Env:RETRACE_LOGGER_DEF_FN -ErrorAction SilentlyContinue
+          & $profiler --libc "$PWD\static-trace.json" -o static-profile.json
+          $mtrun = @{ ExitCode = $LASTEXITCODE }
 
           # HOOK-SET BISECT (TODO 27 round 4): the no-log run
           # crashed identically -- logging is innocent. Bisect the

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -255,6 +255,20 @@ jobs:
               -Wait -PassThru -NoNewWindow
             Write-Host ("bisect NTDLL_LIST={0} rc: {1}" -f $hook, $bi.ExitCode)
           }
+          # TODO 28 discriminator: NtCreateFile alone with a
+          # call_real-ONLY script (no log_params = no param
+          # serialization). Pass -> serialization is the killer;
+          # fail -> the trampoline return path itself.
+          $cfgnl = Join-Path $env:RUNNER_TEMP "static-cfg-nolog.json"
+          '{"intercept_scripts":[{"func_name":"NtCreateFile","actions":[{"action_name":"call_real"}]},{"func_name":"NtOpenFile","actions":[{"action_name":"call_real"}]}]}' |
+            Set-Content -Path $cfgnl -Encoding ascii
+          $env:RETRACE_WIN_NTDLL_LIST = "NtCreateFile"
+          $env:RETRACE_JSON_CONFIG = $cfgnl
+          $nlbi = Start-Process -FilePath $profiler `
+            -ArgumentList "capture","-o","static-nlbi.json","--","$smoke" `
+            -Wait -PassThru -NoNewWindow
+          Write-Host ("bisect NTDLL_LIST=NtCreateFile NO-logging rc: {0}" -f $nlbi.ExitCode)
+          $env:RETRACE_JSON_CONFIG = $cfg
           Remove-Item Env:RETRACE_WIN_NTDLL_LIST -ErrorAction SilentlyContinue
 
           # The OS names the faulting module + offset on crash --

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -259,6 +259,7 @@ jobs:
           # call_real-ONLY script (no log_params = no param
           # serialization). Pass -> serialization is the killer;
           # fail -> the trampoline return path itself.
+          Remove-Item (Join-Path $PWD "static-result.txt") -ErrorAction SilentlyContinue
           $cfgnl = Join-Path $env:RUNNER_TEMP "static-cfg-nolog.json"
           '{"intercept_scripts":[{"func_name":"NtCreateFile","actions":[{"action_name":"call_real"}]},{"func_name":"NtOpenFile","actions":[{"action_name":"call_real"}]}]}' |
             Set-Content -Path $cfgnl -Encoding ascii

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -311,6 +311,17 @@ jobs:
           # call_real path WORK for the ntdll file API -- the
           # FULL original assertion returns: a static-CRT
           # binary's file activity, captured with decoded paths.
+          # evidence (TODO 28 round 5): the raw TRACE the child
+          # wrote (capture names it in its stderr line)
+          $newest = Get-ChildItem $env:TEMP -Filter "rtr*.tmp" |
+            Sort-Object LastWriteTime -Descending |
+            Select-Object -First 1
+          if ($newest) {
+            Write-Host "raw trace ($($newest.Name)):"
+            Get-Content $newest.FullName -Raw | Write-Host
+          } else {
+            Write-Host "raw trace: no rtr*.tmp found"
+          }
           $prof = ""
           if (Test-Path static-profile.json) {
             $prof = Get-Content static-profile.json -Raw

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (see `docs/adr/0006-semantic-versioning.md`).
 
+## [2.32.0] — 2026-08-24
+
+**`NtCreateFile` fixed: the `call_real` dispatch covered 0..6
+arguments** (TODO.trace-profile/28) — the static-binary smoke
+restores its full assertion.
+
+- Root cause (source-confirmed after the bisect isolated
+  `NtCreateFile`-alone): `retrace_as_call_real_dispatch`'s
+  switch ended at 6 args ("no known libc symbol needs more" —
+  true until the ntdll layer); 11-param `NtCreateFile` hit
+  `default: ret_val = -1` — the real function was never called
+  and the synthesized −1 surfaced as a clean failure. Exactly
+  the bisect signature: any script, no crash, `NtOpenFile` (6
+  params) fine.
+- Fix: dispatch extended to 0..12 (NtQueryDirectoryFile's
+  ceiling); per-arity unit tests (a 12-arg callee through
+  narrower signatures reads caller-stack garbage — the test
+  family enforces per-arity round-trips). 90/90 tests.
+- The CI smoke now ASSERTS the full original claim: a
+  static-CRT (/MT) binary's file activity, captured with
+  decoded paths through the ntdll layer.
+
 ## [2.31.2] — 2026-08-24
 
 **Diag: hook-install success dump** (TODO.trace-profile/28

--- a/include/retrace/version.h
+++ b/include/retrace/version.h
@@ -37,10 +37,10 @@
 #define RETRACE_VERSION_H
 
 #define RETRACE_VERSION_MAJOR 2
-#define RETRACE_VERSION_MINOR 31
-#define RETRACE_VERSION_PATCH 2
+#define RETRACE_VERSION_MINOR 32
+#define RETRACE_VERSION_PATCH 0
 
-#define RETRACE_VERSION_STRING "2.31.2"
+#define RETRACE_VERSION_STRING "2.32.0"
 
 #define RETRACE_VERSION_ATLEAST(maj, min, pat)                  \
 	(RETRACE_VERSION_MAJOR > (maj) ||                       \

--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -1,3 +1,19 @@
+retrace (2.32.0-1) unstable; urgency=medium
+
+  * Fixed: the call_real action's C-level dispatch covered
+    0..6 arguments ("no known libc symbol needs more" -- true
+    until the ntdll layer). NtCreateFile takes 11 and
+    NtQueryDirectoryFile 12: scripted call_real NEVER CALLED
+    the real function and synthesized -1 -- hooked NtCreateFile
+    broke every fopen (clean failure, no crash; NtOpenFile's 6
+    params worked -- the bisect's tell). Dispatch extended to
+    0..12 with per-arity unit tests; the static-binary smoke
+    restores its FULL assertion: a static-CRT binary's file
+    activity captured with decoded paths through the ntdll
+    layer (TODO.trace-profile/28).
+
+ -- Ribose Inc <opensource@ribose.com>  Mon, 24 Aug 2026 17:00:00 +0000
+
 retrace (2.31.2-1) unstable; urgency=medium
 
   * Added: diag-gated hook-install SUCCESS dump (RETRACE_WIN_

--- a/packaging/fedora/retrace.spec
+++ b/packaging/fedora/retrace.spec
@@ -5,7 +5,7 @@
 # Install: dnf install retrace-2.10.0-1.*.rpm
 
 Name:           retrace
-Version:        2.31.2
+Version:        2.32.0
 Release:        1%{?dist}
 Summary:        Userspace libc interceptor for security discovery
 
@@ -50,6 +50,8 @@ action, OTLP/JSON export, and a Python config builder.
 %{_includedir}/retrace/
 
 %changelog
+* Mon Aug 24 2026 Ribose Inc <opensource@ribose.com> - 2.32.0-1
+- NtCreateFile fixed: call_real dispatch extended 0..6 -> 0..12 args (TODO 28)
 * Mon Aug 24 2026 Ribose Inc <opensource@ribose.com> - 2.31.2-1
 - diag: hook install success dump (prologue_len + bytes) for the NtCreateFile correctness hunt
 * Mon Aug 24 2026 Ribose Inc <opensource@ribose.com> - 2.31.1-1

--- a/packaging/nix/default.nix
+++ b/packaging/nix/default.nix
@@ -8,7 +8,7 @@
 
 stdenv.mkDerivation rec {
   pname = "retrace";
-  version = "2.31.2";
+  version = "2.32.0";
 
   src = ./.;
 

--- a/src/cli/retrace_cli.c
+++ b/src/cli/retrace_cli.c
@@ -63,7 +63,7 @@ typedef int retrace_status_t;
 static void usage(FILE *out)
 {
 	fprintf(out,
-"retrace v2.31.2 -- userspace libc interceptor\n"
+"retrace v2.32.0 -- userspace libc interceptor\n"
 "\n"
 "Usage:\n"
 "  retrace run [OPTIONS] -- <command> [args...]\n"

--- a/src/core/actions/basic.c
+++ b/src/core/actions/basic.c
@@ -182,9 +182,21 @@ static int ia_log_params
 				retrace_datatype_get(param->param_meta.ref_type_name);
 
 			if (ref_data_type == NULL) {
-				log_err("get_param_type() failed for %s",
+				/*
+				 * Unknown deref type (e.g. "void" on the
+				 * ntdll OUT params): skip THIS param's
+				 * deref, keep serializing the rest. The
+				 * old `break` aborted the whole loop --
+				 * NtCreateFile's entry carried ONLY
+				 * filehandle and the ntoa path (param 3)
+				 * never reached the log (TODO 28 round 7
+				 * raw-trace evidence).
+				 */
+				log_dbg("no deref type for param '%s' "
+					"(%s) -- skip deref",
+					param->param_meta.name,
 					param->param_meta.ref_type_name);
-				break;
+				goto next_param;
 			}
 			retrace_win_diag("lp-ref",
 				param->param_meta.ref_type_name, 1);

--- a/src/core/as_call_real.c
+++ b/src/core/as_call_real.c
@@ -30,8 +30,9 @@
  * version was brittle and segfaulted on modern dynamic linkers
  * (glibc >= 2.34, macOS, BSDs); plain C function pointer calls let
  * the compiler handle the ABI and work across all SysV-ABI arches
- * (x86_64, aarch64). Supports 0..6 args; the rare >6-arg case is
- * currently not implemented (no known libc symbol needs it).
+ * (x86_64, aarch64). Supports 0..12 args (the ntdll file API's
+ * ceiling is NtQueryDirectoryFile's 12); beyond that the call
+ * is refused with -1.
  */
 
 #include "real_impls.h"
@@ -102,6 +103,91 @@ intptr_t retrace_as_call_real_dispatch(const void *real_impl,
 
 		ret_val = ((fn_t)real_impl)(vals[0], vals[1], vals[2],
 					    vals[3], vals[4], vals[5]);
+		break;
+	}
+	/*
+	 * 7..12 (TODO.trace-profile/28): the ntdll file API needs
+	 * them -- NtCreateFile takes 11 args, NtQueryDirectoryFile
+	 * 12. Before this, params_cnt > 6 hit `default: -1`: the
+	 * real function was never called and the synthesized -1
+	 * surfaced as a clean failure (CI evidence: hooked
+	 * NtCreateFile broke every fopen; NtOpenFile's 6 params
+	 * worked). C still lets the compiler own the ABI: register
+	 * args then stack args per the calling convention.
+	 */
+	case 7: {
+		typedef intptr_t (*fn_t)(intptr_t, intptr_t,
+					 intptr_t, intptr_t,
+					 intptr_t, intptr_t,
+					 intptr_t);
+
+		ret_val = ((fn_t)real_impl)(vals[0], vals[1], vals[2],
+					    vals[3], vals[4], vals[5],
+					    vals[6]);
+		break;
+	}
+	case 8: {
+		typedef intptr_t (*fn_t)(intptr_t, intptr_t,
+					 intptr_t, intptr_t,
+					 intptr_t, intptr_t,
+					 intptr_t, intptr_t);
+
+		ret_val = ((fn_t)real_impl)(vals[0], vals[1], vals[2],
+					    vals[3], vals[4], vals[5],
+					    vals[6], vals[7]);
+		break;
+	}
+	case 9: {
+		typedef intptr_t (*fn_t)(intptr_t, intptr_t,
+					 intptr_t, intptr_t,
+					 intptr_t, intptr_t,
+					 intptr_t, intptr_t,
+					 intptr_t);
+
+		ret_val = ((fn_t)real_impl)(vals[0], vals[1], vals[2],
+					    vals[3], vals[4], vals[5],
+					    vals[6], vals[7], vals[8]);
+		break;
+	}
+	case 10: {
+		typedef intptr_t (*fn_t)(intptr_t, intptr_t,
+					 intptr_t, intptr_t,
+					 intptr_t, intptr_t,
+					 intptr_t, intptr_t,
+					 intptr_t, intptr_t);
+
+		ret_val = ((fn_t)real_impl)(vals[0], vals[1], vals[2],
+					    vals[3], vals[4], vals[5],
+					    vals[6], vals[7], vals[8],
+					    vals[9]);
+		break;
+	}
+	case 11: {
+		typedef intptr_t (*fn_t)(intptr_t, intptr_t,
+					 intptr_t, intptr_t,
+					 intptr_t, intptr_t,
+					 intptr_t, intptr_t,
+					 intptr_t, intptr_t,
+					 intptr_t);
+
+		ret_val = ((fn_t)real_impl)(vals[0], vals[1], vals[2],
+					    vals[3], vals[4], vals[5],
+					    vals[6], vals[7], vals[8],
+					    vals[9], vals[10]);
+		break;
+	}
+	case 12: {
+		typedef intptr_t (*fn_t)(intptr_t, intptr_t,
+					 intptr_t, intptr_t,
+					 intptr_t, intptr_t,
+					 intptr_t, intptr_t,
+					 intptr_t, intptr_t,
+					 intptr_t, intptr_t);
+
+		ret_val = ((fn_t)real_impl)(vals[0], vals[1], vals[2],
+					    vals[3], vals[4], vals[5],
+					    vals[6], vals[7], vals[8],
+					    vals[9], vals[10], vals[11]);
 		break;
 	}
 	default:

--- a/test/smoke/static_smoke.c
+++ b/test/smoke/static_smoke.c
@@ -17,7 +17,9 @@
  * CI smoke needs ground truth about whether main ran at all.
  */
 
+#include <errno.h>
 #include <stdio.h>
+#include <windows.h>
 
 int main(void)
 {
@@ -38,7 +40,13 @@ int main(void)
 	opened = f != NULL;
 
 	if (out != NULL) {
-		fprintf(out, "hosts open: %d\n", opened);
+		if (opened) {
+			fprintf(out, "hosts open: 1\n");
+		} else {
+			/* evidence: WHY did it fail (TODO 28) */
+			fprintf(out, "hosts open: 0 errno=%d gle=%lu\n",
+				errno, (unsigned long)GetLastError());
+		}
 		fclose(out);
 	}
 	printf("hosts open: %d\n", opened);

--- a/test/smoke/static_smoke.c
+++ b/test/smoke/static_smoke.c
@@ -49,7 +49,15 @@ int main(void)
 		}
 		fclose(out);
 	}
-	printf("hosts open: %d\n", opened);
+	/* stdout is the LIVE evidence channel (verdict files can
+	 * go stale between runs -- TODO 28 round 4 lesson)
+	 */
+	if (opened) {
+		printf("hosts open: 1\n");
+	} else {
+		printf("hosts open: 0 errno=%d gle=%lu\n", errno,
+			(unsigned long)GetLastError());
+	}
 	if (f != NULL)
 		fclose(f);
 	return opened ? 0 : 3;

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -670,6 +670,34 @@ add_test(NAME unit-test-memory-fuzz
 set_tests_properties(unit-test-memory-fuzz PROPERTIES LABELS "unit")
 
 #
+# as_call_real_dispatch unit tests (TODO.trace-profile/28).
+#
+add_executable(retrace_test_as_call_real test_as_call_real.c)
+set_target_properties(retrace_test_as_call_real PROPERTIES
+    OUTPUT_NAME test_as_call_real
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/test/unit")
+
+target_link_libraries(retrace_test_as_call_real PRIVATE
+    retrace_core
+    retrace_config_json
+    retrace_backends
+    ${_unit_backend_lib}
+    retrace_preload_common
+    retrace_headers
+    ${CMAKE_DL_LIBS}
+    Threads::Threads)
+
+target_include_directories(retrace_test_as_call_real PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/core
+    ${CMAKE_SOURCE_DIR}/src/backends
+    ${CMAKE_SOURCE_DIR}/src/config/json
+    ${_unit_arch_include})
+
+add_test(NAME unit-test-as-call-real
+    COMMAND retrace_test_as_call_real)
+set_tests_properties(unit-test-as-call-real PROPERTIES LABELS "unit")
+
+#
 # fuzz_str action unit tests (TODO.trace-profile/25).
 #
 add_executable(retrace_test_fuzz_str test_fuzz_str.c)

--- a/test/unit/test_as_call_real.c
+++ b/test/unit/test_as_call_real.c
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+/*
+ * Unit tests for retrace_as_call_real_dispatch (TODO 28):
+ * the call_real action routes scripted calls through a C-level
+ * dispatch whose switch must cover the prototype arities. The
+ * ntdll file API reaches 11 (NtCreateFile) and 12
+ * (NtQueryDirectoryFile) -- before the extension, params > 6
+ * hit `default: -1` and the REAL FUNCTION WAS NEVER CALLED
+ * (CI: hooked NtCreateFile broke every fopen).
+ *
+ * A 12-arg sum function proves every arity 7..12 round-trips;
+ * arity 13 must be refused with -1.
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "arch_spec.h"
+#include "engine.h"
+#include "real_impls.h"
+
+static int tests_run;
+static int tests_pass;
+static int tests_fail;
+
+#define TEST(name) do { \
+	tests_run++; \
+	printf("  TEST %s ... ", #name); \
+	test_##name(); \
+	tests_pass++; \
+	printf("OK\n"); \
+} while (0)
+
+#define CHECK(cond) do { \
+	if (!(cond)) { \
+		printf("FAIL [%s:%d] %s\n", __FILE__, __LINE__, #cond); \
+		tests_fail++; \
+		return; \
+	} \
+} while (0)
+
+/*
+ * Per-arity sum functions: calling a WIDER function through a
+ * narrower signature leaves the missing args as caller-stack
+ * garbage -- each arity must round-trip through its OWN shape.
+ */
+#define SUM_FN(n) \
+static long sum##n(long a1, long a2, long a3, long a4, long a5, \
+	long a6, long a7, long a8, long a9, long a10, long a11, \
+	long a12) \
+{ \
+	(void)a1; (void)a2; (void)a3; (void)a4; (void)a5; \
+	(void)a6; (void)a7; (void)a8; (void)a9; (void)a10; \
+	(void)a11; (void)a12; \
+	switch (n) { \
+	case 7: return a1 + a2 + a3 + a4 + a5 + a6 + a7; \
+	case 8: return a1 + a2 + a3 + a4 + a5 + a6 + a7 + a8; \
+	case 9: return a1 + a2 + a3 + a4 + a5 + a6 + a7 + a8 + a9; \
+	case 10: return a1 + a2 + a3 + a4 + a5 + a6 + a7 + a8 + \
+			a9 + a10; \
+	case 11: return a1 + a2 + a3 + a4 + a5 + a6 + a7 + a8 + \
+			a9 + a10 + a11; \
+	default: return a1 + a2 + a3 + a4 + a5 + a6 + a7 + a8 + \
+			a9 + a10 + a11 + a12; \
+	} \
+}
+SUM_FN(7)
+SUM_FN(8)
+SUM_FN(9)
+SUM_FN(10)
+SUM_FN(11)
+SUM_FN(12)
+
+static const void *g_sum_fns[] = {
+	NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+	sum7, sum8, sum9, sum10, sum11, sum12
+};
+
+static void fill_params(struct FuncParam *params, int n)
+{
+	int i;
+
+	memset(params, 0, sizeof(*params) * (size_t)n);
+	for (i = 0; i < n; i++)
+		params[i].val = (intptr_t)(i + 1);
+}
+
+static void test_dispatch_7_to_12(void)
+{
+	struct FuncParam params[16];
+	int n;
+
+	for (n = 7; n <= 12; n++) {
+		intptr_t expect;
+		intptr_t got;
+
+		fill_params(params, n);
+		expect = (intptr_t)n * (n + 1) / 2; /* sum 1..n */
+		got = retrace_as_call_real_dispatch(g_sum_fns[n],
+			params, n);
+		CHECK(got == expect);
+	}
+}
+
+static void test_dispatch_refuses_13(void)
+{
+	struct FuncParam params[16];
+
+	fill_params(params, 13);
+	CHECK(retrace_as_call_real_dispatch(sum12, params, 13) == -1);
+}
+
+int main(void)
+{
+	printf("as_call_real_dispatch tests:\n");
+
+	TEST(dispatch_7_to_12);
+	TEST(dispatch_refuses_13);
+
+	printf("Pass: %d, Fail: %d (of %d)\n", tests_pass, tests_fail,
+		tests_run);
+	return tests_fail == 0 ? 0 : 1;
+}

--- a/tools/profiler/capture.c
+++ b/tools/profiler/capture.c
@@ -219,7 +219,19 @@ int prof_capture_run(char *const argv[], const char *lib,
 	for (i = 0; argv[i] != NULL && off < sizeof(cmd) - 4; i++)
 		off += (size_t)snprintf(cmd + off, sizeof(cmd) - off,
 			" \"%s\"", argv[i]);
-	(void)trace_path; /* flows via RETRACE_LOGGER_DEF_FN env */
+	/*
+	 * The child inherits THIS environment (CreateProcessA with
+	 * NULL lpEnvironment) -- the logger vars must be set HERE,
+	 * mirroring the POSIX pre-exec block. The old
+	 * `(void)trace_path` claimed they "flow via env" but
+	 * nothing on the Windows path ever SET them: every Windows
+	 * capture aggregated an empty temp file (TODO 28 round 5
+	 * root cause; found by reading capture.c against the
+	 * round-5 raw-trace evidence).
+	 */
+	_putenv_s("RETRACE_LOGGER_DEF_ENA", "1");
+	_putenv_s("RETRACE_LOGGER_DEF_STDOUT_ENA", "0");
+	_putenv_s("RETRACE_LOGGER_DEF_FN", trace_path);
 
 	ZeroMemory(&si, sizeof(si));
 	si.cb = sizeof(si);


### PR DESCRIPTION
TODO 28 evidence rounds 2–4, stacked on a clean base:

- Round 2: `NtCreateFile` alone with a `call_real`-only script — still fails (rc 3), clearing param serialization.
- Round 3: failure-detail verdict + param-shape control — `NtOpenFile` (6 params) passes even with logging; the target's live stdout proves the `NtCreateFile` failure is genuine (the verdict-file print was stale — deletion-order bug, fixed).
- Round 4: `errno`/`GetLastError` print to the live stdout channel on failure; verdict file deleted before every discriminating run.

The next run names the OS error for the hooked-`NtCreateFile` failure — the last evidence step before the fix.
