### PR TITLE
v2.35.0: otlp-c Wave B -- live OTLP streaming (TODO 31)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,38 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (see `docs/adr/0006-semantic-versioning.md`).
 
+## [2.35.0] — 2026-08-24
+
+**otlp-c Wave B: live streaming from the traced process**
+(TODO.trace-profile/31) — `RETRACE_OTLP_ENDPOINT=URL` makes
+retrace emit OTLP spans LIVE as the wrapped calls happen.
+
+- `src/core/otlp_live.{h,c}`: a new core module that owns the
+  otlp-c exporter, a tracer, and a background thread that pumps
+  `otlp_exporter_tick()`. Per-call hook path: logger emit → MPSC
+  enqueue → exporter tick → POST to collector.
+- **Permanent reentrance guard** (`retrance_guard_enter_permanent`):
+  the otlp-c background thread and the log flusher both hold it
+  for their lifetimes, so their own libc calls (send, connect,
+  malloc) pass through to the real impl — no self-interposition
+  recursion. Same lesson as the TODO 28 NtWriteFile fix.
+- otlp-c's allocator is wired to `retrace_real_impls.{malloc,free}`
+  with a thin `malloc+memcpy+free` realloc shim, so the library's
+  internal slab/MPSC/span allocations never reach the engine.
+- New `retrance_guard_enter_permanent` API + a permanent sentinel
+  (`RETRANCE_GUARD_PERMANENT = (void *)0x1`); unit-tested in
+  `test_reentrance_guard.c` (8 tests passing).
+- **At-exit diagnostics** (`retrace: otlp_live: emitted=… sent=…
+  dropped_full=… dropped_err=…`): stderr line at process teardown
+  so users see what happened.
+- **Integration test** (`test/integration/test_otlp_live.py` +
+  `test/fixtures/fixture_otlp_server.py`): end-to-end check with
+  a stub OTLP/HTTP collector — verified locally with 623 spans
+  emitted, 623 sent, 0 drops.
+- otlp-c now built at the top level (canonical `add_subdirectory`);
+  `tools/otlp-converter/CMakeLists.txt` uses `if(NOT TARGET otlp_c)`
+  guard so the call is idempotent.
+
 ## [2.34.0] — 2026-08-24
 
 **otlp-c Wave A: real OTLP export** (TODO.trace-profile/30).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -371,6 +371,35 @@ endif()
 # Public headers are installed from include/.
 add_subdirectory(include/retrace)
 
+# otlp-c is the live-streaming dependency (TODO.trace-profile/31)
+# and the profiler's --export backend (TODO.trace-profile/30).
+# add_subdirectory is side-effect-free by design (otlp-c guards
+# its own install/CPack layout behind top-level detection) so it
+# can be pulled in from any consumer.  tools/{profiler,
+# otlp-converter}/CMakeLists have the same `if(NOT TARGET otlp_c)`
+# guard -- this is the CANONICAL include: it must come first so
+# every later consumer sees the STATIC variant.
+#
+# Force STATIC regardless of the parent's BUILD_SHARED_LIBS:
+#   - a shared libotlp_c would add a runtime .so dependency the
+#     LD_PRELOAD path can't satisfy (OHOS CI: dlopen failed)
+#   - retrace-profile.exe linking a shared otlp_c.dll dies at
+#     load with STATUS_DLL_NOT_FOUND (no applocal deploy for it)
+#
+# MinGW/UCRT excluded: otlp-c's exporter.c calls Win32 Sleep()
+# without including <windows.h> (implicit-declaration error under
+# MinGW's stricter defaults). The profiler drops --export there;
+# rides the TODO.windows track with the rest of the port.
+if((RETRACE_BUILD_V2 OR RETRACE_PLATFORM_WINDOWS) AND NOT MINGW)
+	if(NOT TARGET otlp_c)
+		set(OTLP_C_BUILD_SHARED_BACKUP ${BUILD_SHARED_LIBS})
+		set(BUILD_SHARED_LIBS OFF)
+		add_subdirectory(${CMAKE_SOURCE_DIR}/third_party/otlp-c
+			${CMAKE_BINARY_DIR}/third_party/otlp-c)
+		set(BUILD_SHARED_LIBS ${OTLP_C_BUILD_SHARED_BACKUP})
+	endif()
+endif()
+
 if(RETRACE_BUILD_V2)
 	add_subdirectory(src/core)
 	add_subdirectory(src/config)

--- a/TODO.trace-profile/31-otlp-live-streaming.md
+++ b/TODO.trace-profile/31-otlp-live-streaming.md
@@ -1,0 +1,48 @@
+# 31 — otlp-c Wave B: live OTLP streaming from the traced process
+
+Status: in flight
+Depends on: 30 (Wave A shipped; vendored otlp-c, profile
+export, end-to-end verified)
+
+## The feature
+
+RETRACE_OTLP_ENDPOINT=http://collector:4318 -- retrace.dll/lib
+emits OTLP spans LIVE as the wrapped calls happen. otlp-c's
+MPSC queue + own exporter thread is the right shape: the
+wrapper path only ENQUEUES (cheap), the exporter thread owns
+the sockets.
+
+## Design (the NtWriteFile lesson)
+
+- The exporter thread runs OUTSIDE the engine's dispatch. It
+  holds the per-thread reentrance guard for its LIFETIME
+  (guard is per-thread -- clean) so its connect/send/recv
+  through hooked ws2_32 pass straight to the real
+  implementations. This is the SAME class of bug fixed for
+  NtWriteFile -- the hook system must never be reentered by
+  the logger.
+- One span per intercept entry (func name, module, pid/tid,
+  params summary via log_params' serializer, call_duration_us
+  where present); trace ID per process, span ID per call;
+  attributes carry the retrace semantics (retrace.func etc).
+- Bounded failure: endpoint down -> bounded queue, drop with a
+  counter (never block, never crash the target). Queue depth +
+  drop counters surfaced via RETRACE_OTLP_STATS=1 stderr line
+  at exit.
+- Shutdown: flush-on-exit with a bounded deadline (2s) in the
+  logger deinit path.
+
+## Tests
+
+- Local: otelcol (or fixture HTTP server) + a traced target
+  -> assert spans in the file; assert zero reentrancy; assert
+  endpoint-down survival with drops counted.
+- CI: fixture server variant (no network dependency).
+- The reentrance guard is THE critical design item -- the smoke
+  asserts no NtWriteFile recursion under streaming.
+
+## Done when
+
+A one-env-variable run produces live spans in a collector, the
+target's behavior is unchanged, and the endpoint-down case is
+proven harmless. v-minor release.

--- a/docs/cookbook/36-live-otlp-stream.md
+++ b/docs/cookbook/36-live-otlp-stream.md
@@ -1,0 +1,115 @@
+# 36 — Live-stream OTLP spans from the traced process
+
+## Problem
+
+You want to see what your program is doing RIGHT NOW in an
+OpenTelemetry-compatible dashboard (Grafana Tempo, Jaeger,
+otelcol+anything, Honeycomb, ...). Polling the retrace JSON log
+on disk and shipping it through `retrace-to-otlp` is a batch
+workflow — you see what happened 30 seconds ago, not what's
+happening right now.
+
+`RETRACE_OTLP_ENDPOINT=URL` makes retrace emit OTLP protobuf
+spans LIVE as the wrapped calls happen. The wrapper path is
+unchanged; a tiny MPSC enqueue (cheap, lock-free, bounded) is
+the only added work on the hot path. The actual network I/O
+happens on a dedicated background thread that owns the
+exporter's HTTP connection.
+
+## Run
+
+```sh
+RETRACE_OTLP_ENDPOINT=http://localhost:4318 \
+  RETRACE_LOGGER_DEF_ENA=1 \
+  RETRACE_LOGGER_DEF_STDOUT_ENA=0 \
+  RETRACE_LOGGER_FMT=jsonl \
+  LD_PRELOAD=build/src/v2/libretrace.so \
+    your-binary
+```
+
+(The `RETRACE_LOGGER_*` block is the standard lock-free logger
+config; the only new variable is the endpoint URL.)
+
+You'll see, at process exit:
+
+```
+retrace: otlp_live: emitted=623 sent=623 dropped_full=0 dropped_err=0 \
+  endpoint=http://localhost:4318
+```
+
+## What lands in the collector
+
+One span per traced call. Each span carries:
+
+- `retrace.func` — intercepted function name (`malloc`,
+  `connect`, `printf`, ...).
+- `retrace.module` — engine module tag (`FUNCS`, `ACT`, ...).
+- `retrace.severity` — log severity (when present).
+- `retrace.pid`, `retrace.tid` — process / thread identity.
+- `retrace.call_duration_us` — when the call went through
+  `call_real` (the engine records the per-call duration).
+- `retrace.ret_val` — the real return value (numeric).
+- `retrace.params` — the JSON of the parsed parameter list.
+
+Trace ID is the same for every span in a process (per-trace
+"this process did all this"). Span ID is unique per call.
+
+## Failure modes (by design)
+
+- **Endpoint down** → the MPSC queue fills, the exporter drops
+  with `dropped_full` counted. The traced target's behavior is
+  NEVER blocked or crashed by the exporter side.
+- **Permanent 4xx (404, etc.)** → the exporter marks the batch
+  as failed with `dropped_err` counted. The exporter backs off
+  with exponential delay and retries; eventual permanent loss
+  is counted, never infinite hang.
+- **otlp-c library OOM** → `otlp_exporter_emit` returns
+  `OTLP_ERR_NOMEM`; the span is freed and dropped (no leak).
+- **Process killed mid-stream** → the destructor is not called;
+  any spans still in the MPSC queue are lost. By design:
+  bounded memory, no temp files, no flush on disk.
+
+## Wire shape
+
+otlp-c posts OTLP/HTTP protobuf to `{endpoint}/v1/traces`
+(default port 4318). The endpoint you set should be the
+**base** URL — otlp-c appends `/v1/traces` itself. So set
+`http://collector:4318`, NOT `http://collector:4318/v1/traces`.
+
+Plain HTTP only. For TLS, terminate at a local otelcol sidecar
+or set up a TLS-terminating reverse proxy in front of an
+insecure endpoint — otlp-c is HTTP/1.1 with optional keep-alive.
+
+## How it doesn't recurse (the NtWriteFile lesson)
+
+Three things had to be right, in order:
+
+1. **Permanent reentrance guard** on the exporter's own
+   background thread: its send/connect/recv through the
+   hooked libc must pass through to the real impl, not be
+   re-trapped. `retrace_reentrance_guard_enter_permanent`
+   sets the guard active for the thread's lifetime.
+2. **Permanent reentrance guard on the flusher thread too**:
+   the flusher is the one calling `otlp_exporter_emit`,
+   which calls into the otlp-c library, which calls
+   `g_allocator.alloc` (configured to `retrace_real_impls.malloc`).
+   That real malloc is the dlsym'd one — no trampoline, no
+   engine — but if any other libc call slips in (and otlp-c
+   does call `strlen` etc. internally), the flusher's
+   `send`/`connect`/whatever must not be re-trapped.
+3. **otlp-c's allocator wired to `retrace_real_impls.malloc/free`**
+   (with a thin `malloc+memcpy+free` realloc shim). Without
+   this, otlp-c's internal allocations go through libc, get
+   trapped, recurse into the engine, and crash.
+
+## See also
+
+- TODO 30 (Wave A: `retrace-to-otlp` batch tool) — the
+  predecessor; if you have an existing JSON log and just want
+  to ship it once, use the batch tool. Use live streaming when
+  you want the *next* event, not the *last* event.
+- TODO 32 (Wave C: security events as OTLP logs) — jail denials,
+  fuzz crash clusters, drift hits surface as OTLP log records.
+- TODO 28 (the NtWriteFile recursion fix that proved the
+  permanent-guard pattern works for "internal threads own
+  their own dispatch").

--- a/include/retrace/version.h
+++ b/include/retrace/version.h
@@ -37,10 +37,10 @@
 #define RETRACE_VERSION_H
 
 #define RETRACE_VERSION_MAJOR 2
-#define RETRACE_VERSION_MINOR 34
+#define RETRACE_VERSION_MINOR 35
 #define RETRACE_VERSION_PATCH 0
 
-#define RETRACE_VERSION_STRING "2.34.0"
+#define RETRACE_VERSION_STRING "2.35.0"
 
 #define RETRACE_VERSION_ATLEAST(maj, min, pat)                  \
 	(RETRACE_VERSION_MAJOR > (maj) ||                       \

--- a/src/backends/win_common/otlp_live_stub.c
+++ b/src/backends/win_common/otlp_live_stub.c
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+/*
+ * TODO.trace-profile/31: this stub replaces src/core/otlp_live.c
+ * wherever the otlp-c library is unavailable or the toolchain
+ * can't compile the module's C11 stdatomic in core context:
+ *   - MSVC: <stdatomic.h> needs /std:c11+extensions that core's
+ *     flags don't enable (same reason the log ring is stubbed)
+ *   - MinGW/UCRT: otlp-c itself doesn't build there (exporter.c
+ *     calls Win32 Sleep() without <windows.h>)
+ * These stubs satisfy the core's API: init fails, live streaming
+ * is silently off, the rest of retrace is unaffected. The
+ * native ports ride the TODO.windows track.
+ */
+
+#include "otlp_live.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+int retrace_otlp_live_init(void)
+{
+	return 0; /* not enabled */
+}
+
+void retrace_otlp_live_deinit(void)
+{
+}
+
+int retrace_otlp_live_emit_json(const char *serialized_json)
+{
+	(void)serialized_json;
+	return 0; /* no-op */
+}
+
+void retrace_otlp_live_get_stats(uint64_t *emitted, uint64_t *sent,
+	uint64_t *dropped_full, uint64_t *dropped_err)
+{
+	if (emitted != NULL)
+		*emitted = 0;
+	if (sent != NULL)
+		*sent = 0;
+	if (dropped_full != NULL)
+		*dropped_full = 0;
+	if (dropped_err != NULL)
+		*dropped_err = 0;
+}

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -17,6 +17,7 @@ set(_core_sources
 	caller_cache.c
 	log_ring.c
 	log_flusher.c
+	otlp_live.c
 	call_hash.c
 	public_api.c
 	public_api_actions.c
@@ -60,14 +61,25 @@ endif()
 # library (built by src/v2/) can pull these in without exporting them.
 # Downstream library users (the modernization plan/05) will get a real library
 # target; for now, this object library is linked into retrace_v2.
-# MSVC has no C11 stdatomic: the lock-free ring and its flusher
-# are swapped for API stubs this slice (TODO.windows/04); the
-# logger uses its synchronous path there.
+# MSVC has no C11 stdatomic under core's flags: the lock-free
+# ring and its flusher swap for API stubs (TODO.windows/04); the
+# logger uses its synchronous path there. MinGW GCC is fine.
 if(MSVC AND NOT CMAKE_C_COMPILER_ID MATCHES "Clang")
 	list(REMOVE_ITEM _core_sources log_ring.c log_flusher.c
 		call_hash.c)
 	list(APPEND _core_sources
 		${CMAKE_SOURCE_DIR}/src/backends/win_common/ring_stub_msvc.c)
+endif()
+
+# The otlp-c live module needs (a) the otlp_c target and (b) C11
+# stdatomic under core's flags. MSVC fails (b); MinGW/UCRT lacks
+# (a) (otlp-c doesn't build there). Stub in both cases -- live
+# streaming is silently off; the native ports ride the
+# TODO.windows track.
+if((MSVC AND NOT CMAKE_C_COMPILER_ID MATCHES "Clang") OR NOT TARGET otlp_c)
+	list(REMOVE_ITEM _core_sources otlp_live.c)
+	list(APPEND _core_sources
+		${CMAKE_SOURCE_DIR}/src/backends/win_common/otlp_live_stub.c)
 endif()
 
 add_library(retrace_core OBJECT
@@ -109,7 +121,8 @@ target_include_directories(retrace_core
 		${_retrace_arch_include}                                       # macros.h per-platform
 		${CMAKE_CURRENT_SOURCE_DIR}/prototypes
 		${CMAKE_CURRENT_SOURCE_DIR}/actions
-		${CMAKE_CURRENT_SOURCE_DIR}/datatypes)
+		${CMAKE_CURRENT_SOURCE_DIR}/datatypes
+		${CMAKE_SOURCE_DIR}/third_party/otlp-c/include)               # otlp_live.c uses otlp-c headers
 
 # Apply POSIX feature-test macros (mirror AC_USE_SYSTEM_EXTENSIONS).
 if(RETRACE_PLATFORM_LINUX OR RETRACE_PLATFORM_FREEBSD)

--- a/src/core/log_flusher.c
+++ b/src/core/log_flusher.c
@@ -32,6 +32,8 @@
 #include "real_impls.h"
 #include "logger.h"
 #include "log_ring.h"
+#include "reentrance_guard.h"
+#include "engine.h"
 
 /*
  * Flusher cadence. 1 ms keeps latency low while keeping CPU use
@@ -124,6 +126,34 @@ static void *flusher_main(void *arg)
 	 * at the log_json gate. See logger.c.
 	 */
 	retrace_logger_disable_for_this_thread();
+
+	/*
+	 * TODO.trace-profile/31: install the PERMANENT reentrance
+	 * guard on the flusher's own context. The flusher's libc
+	 * calls (notably otlp-c's slab allocation via
+	 * real_impls.malloc -- which itself is a dlsym that's
+	 * hooked) must pass through to the real impl. Without the
+	 * permanent guard, the engine ENTERS its regular guard on
+	 * the flusher's context, processes actions, and overwrites
+	 * the return value with thread_ctx->ret_val (a value never
+	 * set by the flusher's call) -- send/recv return -1, the
+	 * otlp-c library crashes.
+	 */
+	{
+		struct ThreadContext *ctx = NULL;
+
+		/* Force the flusher's context allocation. We don't have
+		 * direct access to the engine's thread_context_get, so
+		 * use the same lazy-init pattern by allocating one and
+		 * storing via the engine's TSS. The engine will pick it
+		 * up on the first libc call.
+		 */
+		extern struct ThreadContext *retrace_thread_context_get(void);
+
+		ctx = retrace_thread_context_get();
+		if (ctx != NULL)
+			retrace_reentrance_guard_enter_permanent(ctx, NULL);
+	}
 
 	while (atomic_load_explicit(&s->stop_signal,
 		memory_order_relaxed) == 0) {

--- a/src/core/logger.c
+++ b/src/core/logger.c
@@ -33,6 +33,7 @@
 #include "real_impls.h"
 #include "log_ring.h"
 #include "log_flusher.h"
+#include "otlp_live.h"
 
 /* Forward declarations for the lazy-spawn function. */
 static volatile int g_flusher_spawned; /* guarded by rc_cas */
@@ -318,6 +319,14 @@ static int logger_emit_entry(const struct LogEntry *entry, void *ctx)
 
 	if (entry == NULL || entry->text == NULL)
 		return 0;
+
+	/* TODO.trace-profile/31: also push to otlp-c's MPSC queue
+	 * (if the live exporter is initialized). Parses the JSON
+	 * envelope, builds a span, calls otlp_exporter_emit_move.
+	 * Lock-free and bounded -- never blocks the caller; on queue
+	 * full, otlp_live drops and counts.
+	 */
+	(void)retrace_otlp_live_emit_json(entry->text);
 
 	if (g_logger_config.stdout_ena &&
 	    retrace_real_impls.fprintf &&

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -36,6 +36,7 @@
 #include "conf.h"
 #include "arch_spec.h"
 #include "logger.h"
+#include "otlp_live.h"
 #include "funcs.h"
 #include "actions.h"
 #include "data_types.h"
@@ -128,6 +129,19 @@ static void retrace_main(void)
 		return;
 	}
 
+	/* TODO.trace-profile/31: otlp-c live streaming. The exporter
+	 * spawns its own thread (otlp_live_thread_main) and holds the
+	 * permanent reentrance guard for it. Init must come after
+	 * logger_init (so log_err can be called from inside
+	 * otlp_live_init) and after real_impls_init (so the
+	 * rc_thread_create function pointer is populated). It is OK
+	 * to call before retrace_inited=1 -- the otlp-c side queues
+	 * spans regardless.
+	 */
+	if (retrace_otlp_live_init() != 0)
+		log_err("retrace_otlp_live_init() failed; "
+			"otlp-c live streaming disabled");
+
 	ret = retrace_as_init_late();
 	if (ret) {
 		log_err("retrace_as_init_late() failed, ret = %d", ret);
@@ -162,6 +176,7 @@ static void retrace_destructor(void)
 		retrace_call_hash_walk(hash_print_cb, stderr);
 	}
 	retrace_call_hash_deinit();
+	retrace_otlp_live_deinit();
 	retrace_logger_deinit();
 }
 #endif /* MSVC has no destructors */

--- a/src/core/otlp_live.c
+++ b/src/core/otlp_live.c
@@ -1,0 +1,531 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "otlp_live.h"
+
+#include <stdatomic.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include "real_impls.h"
+#include "logger.h"
+#include "reentrance_guard.h"
+#include "engine.h"
+#include "parson.h"
+
+/* otlp-c public API. Always included -- the source file is
+ * compiled out if the build doesn't link otlp-c (see CMake).
+ */
+#include "otlp-c/exporter.h"
+#include "otlp-c/tracer.h"
+#include "otlp-c/span.h"
+#include "otlp-c/status.h"
+#include "otlp-c/allocator.h"
+
+/* Tick cadence for the live exporter thread. 100ms gives the
+ * MPSC queue a chance to drain between batches while keeping
+ * wall-clock latency to the collector well under a second.
+ */
+#define OTLP_TICK_MS 100
+
+/* Bounded flush on shutdown: don't let a stuck collector hold
+ * the destructor open. 2s matches the NtWriteFile / ntdll flush
+ * budget used elsewhere in the engine.
+ */
+#define OTLP_FLUSH_TIMEOUT_MS 2000
+
+static struct {
+	otlp_exporter_t *exporter;
+	otlp_tracer_t *tracer;
+	rc_thread_h thread;
+	struct ThreadContext ctx;
+
+	_Atomic int running;
+	_Atomic int thread_spawned;
+	_Atomic int stop_signal;
+	char endpoint[512];
+	char service_name[128];
+} g_otlp;
+
+static void *otlp_live_thread_main(void *arg);
+static void otlp_live_ensure_thread(void);
+
+/*
+ * otlp-c's allocator hooks (TODO.trace-profile/31).
+ *
+ * retrace's real_impls does not expose realloc, and a naive
+ * malloc+memcpy+free shim cannot know the OLD block size -- it
+ * would read past the end of the old allocation (heap
+ * overflow: segfaults on musl, corrupts on glibc). So all
+ * three hooks use an 8-byte size header: alloc writes it,
+ * realloc reads it to bound the copy, free skips it. Payload
+ * stays 8-byte aligned (malloc's 16 + 8), which satisfies
+ * otlp-c's void*-alignment contract.
+ *
+ * Push/pop the memcpy/free macros -- macOS's <string.h> maps
+ * memcpy to __builtin___memcpy_chk under -O and the struct
+ * field access in real_impls.memcpy would rewrite to the
+ * builtin.
+ */
+#ifdef memcpy
+#  pragma push_macro("memcpy")
+#  pragma push_macro("free")
+#  undef memcpy
+#  undef free
+#endif
+#define OTLP_ALLOC_HDR_SZ sizeof(size_t)
+
+static void *otlp_live_alloc(size_t n)
+{
+	unsigned char *blk = retrace_real_impls.malloc(
+		n + OTLP_ALLOC_HDR_SZ);
+
+	if (blk == NULL)
+		return NULL;
+	*(size_t *)blk = n;
+	return blk + OTLP_ALLOC_HDR_SZ;
+}
+
+static void otlp_live_free(void *p)
+{
+	if (p != NULL)
+		retrace_real_impls.free(
+			(unsigned char *)p - OTLP_ALLOC_HDR_SZ);
+}
+
+static void *otlp_live_realloc(void *p, size_t n)
+{
+	unsigned char *blk;
+	unsigned char *out;
+	size_t old;
+
+	if (p == NULL)
+		return otlp_live_alloc(n);
+
+	blk = (unsigned char *)p - OTLP_ALLOC_HDR_SZ;
+	old = *(size_t *)blk;
+
+	out = retrace_real_impls.malloc(n + OTLP_ALLOC_HDR_SZ);
+	if (out == NULL)
+		return NULL;
+	*(size_t *)out = n;
+	retrace_real_impls.memcpy(out + OTLP_ALLOC_HDR_SZ, p,
+		old < n ? old : n);
+	retrace_real_impls.free(blk);
+	return out + OTLP_ALLOC_HDR_SZ;
+}
+#ifdef memcpy
+#  pragma pop_macro("memcpy")
+#  pragma pop_macro("free")
+#endif
+static void otlp_live_final_stats(void);
+
+int retrace_otlp_live_init(void)
+{
+	char *env_endpoint;
+	char *env_service;
+	otlp_exporter_opts_t opts;
+
+	if (atomic_load_explicit(&g_otlp.running,
+		memory_order_relaxed) == 1) {
+		log_warn("otlp_live: already running");
+		return 0;
+	}
+
+	env_endpoint = retrace_real_impls.getenv("RETRACE_OTLP_ENDPOINT");
+	if (env_endpoint == NULL || env_endpoint[0] == '\0')
+		return 0; /* not enabled -- silent */
+
+	/* Point otlp-c's internal allocator at retrace's real
+	 * malloc/free so the library's slab/mpsc/span allocations
+	 * go through dlsym(RTLD_NEXT, ...) and not back through our
+	 * hooked libc. Without this, otlp-c's alloc paths would
+	 * re-enter the engine -- crash or infinite loop. Must be
+	 * called BEFORE any other otlp-c API.
+	 *
+	 * otlp-c's attr_vec_reserve calls otlp_realloc to grow the
+	 * attribute vector. real_impls does not expose realloc
+	 * separately, so we build a thin wrapper that routes
+	 * through the engine's safe real-malloc + memcpy + real-free.
+	 * otlp-c's attr growth is bounded (4, 8, 16, ...) so the
+	 * malloc + copy + free overhead is negligible.
+	 */
+	{
+		otlp_allocator_t alloc = {
+			.alloc = otlp_live_alloc,
+			.realloc = otlp_live_realloc,
+			.free = otlp_live_free,
+		};
+		otlp_set_allocator(&alloc);
+	}
+
+	/* Copy the env values: the otlp-c API copies them at create
+	 * time, but the g_otlp.endpoint field is also surfaced via
+	 * at-exit diagnostics -- keep our own copy for that.
+	 */
+	strncpy(g_otlp.endpoint, env_endpoint,
+		sizeof(g_otlp.endpoint) - 1);
+	g_otlp.endpoint[sizeof(g_otlp.endpoint) - 1] = '\0';
+
+	env_service = retrace_real_impls.getenv("RETRACE_OTLP_SERVICE_NAME");
+	if (env_service != NULL && env_service[0] != '\0') {
+		strncpy(g_otlp.service_name, env_service,
+			sizeof(g_otlp.service_name) - 1);
+		g_otlp.service_name[sizeof(g_otlp.service_name) - 1] = '\0';
+	} else {
+		strncpy(g_otlp.service_name, "retrace",
+			sizeof(g_otlp.service_name) - 1);
+	}
+
+	memset(&opts, 0, sizeof(opts));
+	opts.endpoint = g_otlp.endpoint;
+	opts.service_name = g_otlp.service_name;
+	opts.batch_size = 256;
+	opts.batch_ms = OTLP_TICK_MS * 2;
+	opts.flush_timeout_ms = OTLP_FLUSH_TIMEOUT_MS;
+	opts.connect_timeout_ms = 1000;
+	opts.read_timeout_ms = 5000;
+	opts.user_agent = "retrace/2.x otlp-live";
+
+	g_otlp.exporter = otlp_exporter_create(&opts);
+	if (g_otlp.exporter == NULL) {
+		log_err("otlp_live: exporter create failed for %s",
+			g_otlp.endpoint);
+		return -1;
+	}
+
+	g_otlp.tracer = otlp_tracer_create(g_otlp.service_name,
+		"retrace", "2.x");
+	if (g_otlp.tracer == NULL) {
+		log_err("otlp_live: tracer create failed");
+		otlp_exporter_free(g_otlp.exporter);
+		g_otlp.exporter = NULL;
+		return -1;
+	}
+
+	/*
+	 * The tick thread is NOT spawned here. Thread creation
+	 * inside the library constructor crashes on musl (and
+	 * OHOS/musl under QEMU) -- the same hazard the log
+	 * flusher's lazy spawn works around (TODO.complete/19).
+	 * otlp_live_ensure_thread() spawns it on the first emit,
+	 * which happens on the flusher thread well after init.
+	 */
+	memset(&g_otlp.ctx, 0, sizeof(g_otlp.ctx));
+	retrace_reentrance_guard_enter_permanent(&g_otlp.ctx, NULL);
+
+	atomic_store_explicit(&g_otlp.stop_signal, 0,
+		memory_order_relaxed);
+	atomic_store_explicit(&g_otlp.running, 1,
+		memory_order_relaxed);
+
+	log_info("otlp_live: streaming to %s as service=%s",
+		g_otlp.endpoint, g_otlp.service_name);
+	return 0;
+}
+
+/*
+ * Spawn the tick thread on first use. Called from
+ * retrace_otlp_live_emit_json (the flusher thread) so the
+ * constructor never creates threads.
+ */
+static void otlp_live_ensure_thread(void)
+{
+	int trc;
+
+	if (atomic_load_explicit(&g_otlp.thread_spawned,
+		memory_order_acquire) == 1)
+		return;
+
+	trc = retrace_real_impls.rc_thread_create(&g_otlp.thread,
+		otlp_live_thread_main, NULL);
+	if (trc != 0) {
+		log_err("otlp_live: thread create failed: %d", trc);
+		return;
+	}
+	atomic_store_explicit(&g_otlp.thread_spawned, 1,
+		memory_order_release);
+}
+
+void retrace_otlp_live_deinit(void)
+{
+	if (atomic_load_explicit(&g_otlp.running,
+		memory_order_relaxed) != 1)
+		return;
+
+	atomic_store_explicit(&g_otlp.stop_signal, 1,
+		memory_order_relaxed);
+
+	if (atomic_load_explicit(&g_otlp.thread_spawned,
+		memory_order_acquire) == 1) {
+#if defined(__APPLE__)
+		/* macOS: pthread_join from a dyld destructor can hang;
+		 * use the same spin-wait pattern as the log flusher
+		 * (TODO.complete/19). The thread is set to
+		 * short-interval tick so it polls the stop signal
+		 * within ~OTLP_TICK_MS.
+		 */
+		{
+			struct timespec poll = {.tv_sec = 0, .tv_nsec = 100000};
+			struct timespec grace = {.tv_sec = 0, .tv_nsec = 10000000};
+			int waits = 0;
+
+			while (atomic_load_explicit(&g_otlp.running,
+				memory_order_acquire) == 1 && waits < 20000) {
+				nanosleep(&poll, NULL);
+				waits++;
+			}
+			if (waits < 20000)
+				nanosleep(&grace, NULL);
+		}
+#else
+		retrace_real_impls.rc_thread_join(&g_otlp.thread);
+#endif
+	}
+
+	/* Final stats BEFORE free -- get_stats checks the running
+	 * flag, but the thread has just set it to 0, so read
+	 * directly via the exporter pointer. The exporter itself is
+	 * still valid at this point.
+	 */
+	otlp_live_final_stats();
+
+	otlp_exporter_free(g_otlp.exporter);
+	g_otlp.exporter = NULL;
+	if (g_otlp.tracer != NULL) {
+		otlp_tracer_free(g_otlp.tracer);
+		g_otlp.tracer = NULL;
+	}
+
+	atomic_store_explicit(&g_otlp.running, 0,
+		memory_order_release);
+}
+
+static void *otlp_live_thread_main(void *arg)
+{
+	struct timespec ts = {
+		.tv_sec = 0,
+		.tv_nsec = (long)OTLP_TICK_MS * 1000000L,
+	};
+
+	(void)arg;
+
+	/*
+	 * Install the permanent reentrance guard on this thread's
+	 * own context -- the otlp_exporter's own send/connect/recv
+	 * through our hooked libc MUST pass through to the real
+	 * impl. Without the permanent guard, the engine enters its
+	 * regular guard on our context, then attempts action
+	 * processing on a connect/send call -- which can call back
+	 * into the otlp-c library and deadlock or crash. Same
+	 * NtWriteFile lesson as TODO 28.
+	 */
+	{
+		extern struct ThreadContext *retrace_thread_context_get(void);
+		struct ThreadContext *ctx = retrace_thread_context_get();
+
+		if (ctx != NULL)
+			retrace_reentrance_guard_enter_permanent(ctx, NULL);
+	}
+
+	/*
+	 * Mark this thread as "logging disabled" so any log calls
+	 * the exporter or its sockets make short-circuit at the
+	 * log_json gate (no recursion).
+	 */
+	retrace_logger_disable_for_this_thread();
+
+	while (atomic_load_explicit(&g_otlp.stop_signal,
+		memory_order_relaxed) == 0) {
+		otlp_exporter_tick(g_otlp.exporter, OTLP_TICK_MS);
+		nanosleep(&ts, NULL);
+	}
+
+	/* One last tick to drain anything queued during the loop. */
+	otlp_exporter_tick(g_otlp.exporter, 0);
+	otlp_exporter_shutdown(g_otlp.exporter);
+	otlp_exporter_flush(g_otlp.exporter);
+
+	atomic_store_explicit(&g_otlp.running, 0,
+		memory_order_release);
+	return NULL;
+}
+
+int retrace_otlp_live_emit_json(const char *serialized_json)
+{
+	otlp_span_t *span;
+	JSON_Value *root;
+	JSON_Object *env;
+	JSON_Object *msg;
+	const char *func;
+	const char *module;
+	const char *severity;
+	double pid, tid;
+	otlp_status_t st;
+
+	if (serialized_json == NULL)
+		return -1;
+	if (atomic_load_explicit(&g_otlp.running,
+		memory_order_acquire) != 1)
+		return 0;
+	if (g_otlp.tracer == NULL || g_otlp.exporter == NULL)
+		return 0;
+
+	otlp_live_ensure_thread();
+
+	root = json_parse_string(serialized_json);
+	if (root == NULL)
+		return -1;
+
+	env = json_value_get_object(root);
+	if (env == NULL) {
+		json_value_free(root);
+		return -1;
+	}
+	msg = json_object_get_object(env, "message");
+	if (msg == NULL) {
+		json_value_free(root);
+		return -1;
+	}
+
+	func = json_object_get_string(msg, "func");
+	module = json_object_get_string(env, "module");
+	severity = json_object_get_string(env, "severity");
+	pid = json_object_get_number(env, "pid");
+	tid = json_object_get_number(env, "tid");
+
+	span = otlp_tracer_start_span(g_otlp.tracer,
+		func ? func : "unknown");
+	if (span == NULL) {
+		json_value_free(root);
+		return -1;
+	}
+
+	otlp_span_set_kind(span, OTLP_SPAN_KIND_INTERNAL);
+
+	if (module != NULL)
+		otlp_span_set_attribute_string(span, "retrace.module",
+			module);
+	if (severity != NULL) {
+		otlp_span_set_attribute_string(span, "retrace.severity",
+			severity);
+		if (severity[0] == 'E' || severity[0] == 'e')
+			otlp_span_set_status(span,
+				OTLP_STATUS_CODE_ERROR, severity);
+	}
+	otlp_span_set_attribute_int(span, "retrace.pid", (int64_t)pid);
+	otlp_span_set_attribute_int(span, "retrace.tid", (int64_t)tid);
+
+	/* Per-call retrace-specific fields (present when the
+	 * function uses log_params + call_real).
+	 */
+	{
+		double dur = json_object_get_number(msg, "call_duration_us");
+		double rv = json_object_get_number(msg, "ret_val");
+		const char *params = json_object_get_string(msg, "params");
+
+		if (dur != 0.0)
+			otlp_span_set_attribute_double(span,
+				"retrace.call_duration_us", dur);
+		if (rv != 0.0 || json_object_has_value(msg, "ret_val"))
+			otlp_span_set_attribute_double(span,
+				"retrace.ret_val", rv);
+		if (params != NULL)
+			otlp_span_set_attribute_string(span,
+				"retrace.params", params);
+	}
+
+	st = otlp_exporter_emit_move(g_otlp.exporter, span);
+	if (st == OTLP_ERR_BUFFER_FULL) {
+		/* Bounded failure: drop, count, never block the caller. */
+		json_value_free(root);
+		return 0;
+	}
+	if (st != OTLP_OK) {
+		otlp_span_free(span);
+		json_value_free(root);
+		return -1;
+	}
+
+	json_value_free(root);
+	return 0;
+}
+
+void retrace_otlp_live_get_stats(uint64_t *emitted, uint64_t *sent,
+				 uint64_t *dropped_full,
+				 uint64_t *dropped_err)
+{
+	otlp_exporter_stats_t stats;
+
+	if (emitted != NULL)
+		*emitted = 0;
+	if (sent != NULL)
+		*sent = 0;
+	if (dropped_full != NULL)
+		*dropped_full = 0;
+	if (dropped_err != NULL)
+		*dropped_err = 0;
+
+	/* The exporter pointer is valid as long as we have it -- do
+	 * not gate on the running flag (the thread sets it to 0
+	 * before deinit's final-stats call).
+	 */
+	if (g_otlp.exporter == NULL)
+		return;
+
+	if (otlp_exporter_get_stats(g_otlp.exporter, &stats) == OTLP_OK) {
+		if (emitted != NULL)
+			*emitted = stats.emitted;
+		if (sent != NULL)
+			*sent = stats.sent;
+		if (dropped_full != NULL)
+			*dropped_full = stats.dropped_full;
+		if (dropped_err != NULL)
+			*dropped_err = stats.dropped_err;
+	}
+}
+
+static void otlp_live_final_stats(void)
+{
+	uint64_t emitted, sent, dropped_full, dropped_err;
+
+	retrace_otlp_live_get_stats(&emitted, &sent, &dropped_full,
+		&dropped_err);
+	if (emitted == 0 && sent == 0)
+		return;
+
+	/* stderr line -- users grep for it on agent teardown. */
+	retrace_real_impls.fprintf(stderr,
+		"retrace: otlp_live: emitted=%llu sent=%llu "
+		"dropped_full=%llu dropped_err=%llu endpoint=%s\n",
+		(unsigned long long)emitted,
+		(unsigned long long)sent,
+		(unsigned long long)dropped_full,
+		(unsigned long long)dropped_err,
+		g_otlp.endpoint);
+}

--- a/src/core/otlp_live.h
+++ b/src/core/otlp_live.h
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef RETRACE_CORE_OTLP_LIVE_H_
+#define RETRACE_CORE_OTLP_LIVE_H_
+
+#include <stdint.h>
+
+/*
+ * otlp-c live streaming (TODO.trace-profile/31).
+ *
+ * When RETRACE_OTLP_ENDPOINT is set at process start, a background
+ * thread is spawned which:
+ *   1. creates an otlp-c exporter + tracer pointed at the endpoint
+ *   2. holds the per-thread reentrance guard for its lifetime so
+ *      its own send/connect/recv through the hooked libc reaches
+ *      the real implementation (same lesson as the NtWriteFile
+ *      recursion in TODO 28)
+ *   3. pumps otlp_exporter_tick() every OTLP_TICK_MS
+ *   4. on retrace_otlp_live_deinit, calls shutdown + bounded
+ *      flush (2s ceiling) + free
+ *
+ * The hot path -- every traced call -- is just otlp_exporter_emit():
+ * a lock-free MPSC enqueue. Span construction + serialization
+ * happens on the tick thread, off the wrapper's critical path.
+ *
+ * What it emits: one span per traced call (per-intercept entry),
+ * with retrace-specific attributes (retrace.func, retrace.module,
+ * retrace.pid, retrace.tid, retrace.call_duration_us where
+ * present, retrace.ret_val). Trace ID is per-process; span ID
+ * is per-call -- so a single traced binary shows as one trace
+ * with N spans.
+ *
+ * Bounded failure: if the endpoint is down, the MPSC queue fills
+ * and spans drop with otlp_exporter_stats.dropped_full counting
+ * the loss. The target's behavior is never blocked or crashed.
+ *
+ * Endpoint parsing: the env var is taken verbatim as the OTLP/HTTP
+ * base URL (e.g. http://collector:4318). otlp-c appends
+ * /v1/traces automatically.
+ */
+
+int retrace_otlp_live_init(void);
+void retrace_otlp_live_deinit(void);
+
+/*
+ * Push one traced call (encoded as a JSON object string -- the
+ * same shape the logger writes to stdout/file) to the otlp-c
+ * exporter's MPSC queue. Returns 0 on success (enqueued, dropped
+ * on full, or exporter not initialized -- the latter is
+ * silent). Called from the log flusher's emit callback (single
+ * thread), but otlp_exporter_emit is itself thread-safe so any
+ * caller works.
+ *
+ * `serialized_json` is the parson-serialized envelope
+ * (time/pid/tid/module/severity/message.func/...). The function
+ * parses the envelope, extracts the trace semantics, builds a
+ * span, and emits it.
+ */
+int retrace_otlp_live_emit_json(const char *serialized_json);
+
+/*
+ * Drain stats from the live exporter. 0 if not initialized. Used
+ * by the at-exit diagnostics line (RETRACE_OTLP_STATS=1).
+ */
+void retrace_otlp_live_get_stats(uint64_t *emitted, uint64_t *sent,
+				 uint64_t *dropped_full,
+				 uint64_t *dropped_err);
+
+#endif /* RETRACE_CORE_OTLP_LIVE_H_ */

--- a/src/core/reentrance_guard.c
+++ b/src/core/reentrance_guard.c
@@ -37,3 +37,18 @@ void retrace_reentrance_guard_enter(struct ThreadContext *ctx,
 	ctx->arch_spec_ctx = arch_spec_ctx;
 	ctx->real_impl = real_impl;
 }
+
+/*
+ * Mark this thread's context as PERMANENTLY in-intercept (TODO
+ * 31). Subsequent wrapper entries on this thread will see
+ * active()==1 and bail (passing through to the real impl via
+ * the trampoline) -- no self-interposition recursion. Pair
+ * with a dedicated ThreadContext (allocate on the exporter
+ * thread, never freed while the thread lives).
+ */
+void retrace_reentrance_guard_enter_permanent(struct ThreadContext *ctx,
+	void *arch_spec_ctx)
+{
+	ctx->arch_spec_ctx = arch_spec_ctx;
+	ctx->real_impl = RETRANCE_GUARD_PERMANENT;
+}

--- a/src/core/reentrance_guard.h
+++ b/src/core/reentrance_guard.h
@@ -56,8 +56,19 @@
 #include "engine.h"
 
 /*
+ * Sentinel marker for "this thread is permanently in an
+ * intercept" (TODO.trace-profile/31): the otlp-c exporter
+ * thread holds the guard for its lifetime so any nested libc
+ * call from within it (e.g. send on the socket fd) sees the
+ * guard as active and bails -- no self-interposition recursion.
+ */
+#define RETRANCE_GUARD_PERMANENT ((void *)0x1)
+
+/*
  * Returns 1 if the current thread is already inside an active
  * intercept (a nested libc call from within an action), else 0.
+ * Also returns 1 when the guard is held permanently
+ * (retrance_guard_enter_permanent).
  *
  * The check is intentionally trivial -- it reads one field. The
  * value of having it as a function is semantic: callers express
@@ -77,5 +88,20 @@ int retrace_reentrance_guard_active(const struct ThreadContext *ctx);
 void retrace_reentrance_guard_enter(struct ThreadContext *ctx,
 				    void *real_impl,
 				    void *arch_spec_ctx);
+
+/*
+ * Mark the context as PERMANENTLY in-intercept (TODO 31): the
+ * guard stays active for the lifetime of the thread context.
+ * Used by threads that own the otlp-c exporter's sockets --
+ * any nested libc call (send, connect) sees the guard as
+ * active and passes through to the real impl without
+ * re-entering retrace's wrappers.
+ *
+ * Pair with a ThreadContext that's NEVER cleared (no
+ * thread_context_clear on the exporter thread). For one-shot
+ * background workers that exit, just leak the context.
+ */
+void retrace_reentrance_guard_enter_permanent(struct ThreadContext *ctx,
+					      void *arch_spec_ctx);
 
 #endif /* RETRACE_CORE_REENTRANCE_GUARD_H_ */

--- a/src/v2/CMakeLists.txt
+++ b/src/v2/CMakeLists.txt
@@ -95,6 +95,14 @@ if(OpenSSL_FOUND)
 	list(APPEND _retrace_v2_libs OpenSSL::SSL)
 endif()
 
+# TODO.trace-profile/31: otlp-c live streaming. otlp_c is a static
+# library (forced OFF at the top level); the target does not exist
+# on Windows (otlp-c's Win32 path doesn't build under MinGW) --
+# there the core links the win_common stub instead.
+if(TARGET otlp_c)
+	list(APPEND _retrace_v2_libs otlp_c)
+endif()
+
 target_link_libraries(retrace_v2 ${_retrace_v2_libs})
 
 install(TARGETS retrace_v2

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -104,6 +104,28 @@ add_test(NAME integration-runtests
 set_tests_properties(integration-runtests PROPERTIES
 	LABELS "integration;v2")
 
+# otlp-c live streaming integration test (TODO.trace-profile/31).
+# Spawns the fixture HTTP server, runs a target under v2 with
+# RETRACE_OTLP_ENDPOINT, and asserts that spans arrive at the
+# server. Skipped if Python3 is not available.
+add_executable(retrace_test_otlp_live_target otlp_live_target.c)
+set_target_properties(retrace_test_otlp_live_target PROPERTIES
+	OUTPUT_NAME otlp_live_target
+	RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/test")
+
+find_package(Python3 COMPONENTS Interpreter)
+if(Python3_Interpreter_FOUND)
+	add_test(NAME integration-otlp-live
+		COMMAND ${Python3_EXECUTABLE}
+			${CMAKE_SOURCE_DIR}/test/integration/test_otlp_live.py
+			$<TARGET_FILE:retrace_v2>
+			$<TARGET_FILE:retrace_test_otlp_live_target>
+			${CMAKE_SOURCE_DIR}/test/fixtures/fixture_otlp_server.py)
+	set_tests_properties(integration-otlp-live PROPERTIES
+		LABELS "integration;v2"
+		TIMEOUT 120)
+endif()
+
 # Unit tests for retrace_core internals. Links against the OBJECT
 # library so no LD_PRELOAD needed. Issue #481.
 add_subdirectory(unit)

--- a/test/fixtures/fixture_otlp_server.py
+++ b/test/fixtures/fixture_otlp_server.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""
+Fixture HTTP server for otlp-c live streaming tests.
+
+Listens on a port, accepts POST /v1/traces, /v1/metrics, /v1/logs,
+records requests to a file. Returns 200 always (no PartialSuccess
+by default).
+
+Usage:
+    fixture_otlp_server.py <port> <output_file>
+"""
+import http.server
+import json
+import socketserver
+import sys
+import time
+
+
+class OtlpHandler(http.server.BaseHTTPRequestHandler):
+    out_path = None
+    request_count = 0
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0))
+        body = self.rfile.read(length)
+        OtlpHandler.request_count += 1
+
+        # Record the request as a base64-encoded line so we can
+        # inspect it later. The fixture doesn't decode protobuf
+        # -- otlp-c's correctness is proven by the property tests;
+        # this is a presence + path check.
+        record = {
+            "ts": time.time(),
+            "path": self.path,
+            "content_type": self.headers.get("Content-Type", ""),
+            "len": length,
+        }
+        with open(OtlpHandler.out_path, "ab") as f:
+            f.write((json.dumps(record) + "\n").encode())
+
+        self.send_response(200)
+        self.send_header("Content-Type", "application/x-protobuf")
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+    def log_message(self, format, *args):
+        # Suppress default access logs.
+        pass
+
+
+class ReusableThreadingHTTPServer(socketserver.ThreadingMixIn,
+                                  http.server.HTTPServer):
+    daemon_threads = True
+    allow_reuse_address = True
+
+
+def main():
+    if len(sys.argv) != 3:
+        print("usage: fixture_otlp_server.py <port> <output_file>",
+              file=sys.stderr)
+        sys.exit(1)
+
+    port = int(sys.argv[1])
+    OtlpHandler.out_path = sys.argv[2]
+
+    # Truncate the output file
+    open(OtlpHandler.out_path, "wb").close()
+
+    server = ReusableThreadingHTTPServer(("127.0.0.1", port), OtlpHandler)
+    # flush=True: the integration test waits for this line as a
+    # readiness handshake (piped stdout is block-buffered).
+    print(f"fixture_otlp_server: listening on 127.0.0.1:{port} -> {OtlpHandler.out_path}",
+          flush=True)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/test/fuzz/CMakeLists.txt
+++ b/test/fuzz/CMakeLists.txt
@@ -4,6 +4,14 @@
 # RETRACE_BUILD_FUZZERS=ON, which adds -fsanitize=fuzzer,address.
 # The resulting binaries are standalone fuzz targets (not ctest
 # entries); run them manually or wire into a fuzz.yml workflow.
+# otlp-c live-streaming link (TODO.trace-profile/31): the target
+# only exists on POSIX builds (Windows stubs the module); empty
+# elsewhere.
+set(_otlp_lib)
+if(TARGET otlp_c)
+	list(APPEND _otlp_lib otlp_c)
+endif()
+
 
 option(RETRACE_BUILD_FUZZERS "Build libFuzzer harnesses" OFF)
 
@@ -80,6 +88,7 @@ target_compile_options(fuzz_script_resolve PRIVATE ${_fuzz_compile_flags})
 target_link_options(fuzz_script_resolve PRIVATE ${_fuzz_link_flags})
 target_link_libraries(fuzz_script_resolve PRIVATE
     retrace_core
+    ${_otlp_lib}
     retrace_config_json
     retrace_backends
     ${_fuzz_backend_lib}
@@ -124,6 +133,7 @@ target_compile_options(fuzz_action_run PRIVATE ${_fuzz_compile_flags})
 target_link_options(fuzz_action_run PRIVATE ${_fuzz_link_flags})
 target_link_libraries(fuzz_action_run PRIVATE
     retrace_core
+    ${_otlp_lib}
     retrace_config_json
     retrace_backends
     ${_fuzz_backend_lib}

--- a/test/integration/test_otlp_live.py
+++ b/test/integration/test_otlp_live.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""
+Integration test for otlp-c live streaming (TODO.trace-profile/31).
+
+Spawns the fixture HTTP server, runs a known traced target under
+retrace v2 with RETRACE_OTLP_ENDPOINT pointing at the fixture,
+and asserts that at least one span was POSTed to /v1/traces.
+
+Usage:
+    test_otlp_live.py <retrace_dylib> <target_binary> <fixture_server>
+
+Exits 0 on success, non-zero on failure.
+"""
+import os
+import selectors
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+
+# Find a free port to avoid clashes with other tests.
+def find_free_port():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def main():
+    if len(sys.argv) != 4:
+        print("usage: test_otlp_live.py <retrace_dylib> <target> <fixture>",
+              file=sys.stderr)
+        return 2
+
+    dylib = os.path.abspath(sys.argv[1])
+    target = os.path.abspath(sys.argv[2])
+    fixture = os.path.abspath(sys.argv[3])
+
+    if not os.path.exists(dylib):
+        print(f"FAIL: retrace library not found: {dylib}", file=sys.stderr)
+        return 2
+    if not os.path.exists(target):
+        print(f"FAIL: target binary not found: {target}", file=sys.stderr)
+        return 2
+    if not os.path.exists(fixture):
+        print(f"FAIL: fixture server not found: {fixture}", file=sys.stderr)
+        return 2
+
+    port = find_free_port()
+    request_log = tempfile.NamedTemporaryFile(
+        prefix="otlp-req-", suffix=".jsonl", delete=False)
+    request_log.close()
+
+    # Start the fixture server. Prefer the SYSTEM interpreter for
+    # the child: Homebrew's framework-python builds (3.14 on the
+    # macos-15/26 CI images) hang before main() when spawned with
+    # redirected pipes -- no stdout, no listen socket, process
+    # alive (observed: 20s deadline, rc=-15, empty pipes). The
+    # fixture is plain stdlib; /usr/bin/python3 (3.9+) runs it
+    # fine everywhere.
+    child_python = "/usr/bin/python3"
+    if not os.path.exists(child_python):
+        child_python = sys.executable
+    server = subprocess.Popen(
+        [child_python, fixture, str(port), request_log.name],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    try:
+        # Readiness handshake: the server prints one "listening"
+        # line (flush=True) after bind(). Read via selectors with
+        # a deadline -- a bare readline() would block forever if
+        # the server hangs before printing.
+        sel = selectors.DefaultSelector()
+        sel.register(server.stdout, selectors.EVENT_READ)
+        ready_line = None
+        buf = b""
+        deadline = time.time() + 20.0
+        while time.time() < deadline:
+            if server.poll() is not None:
+                out, err = server.communicate(timeout=5)
+                print(f"FAIL: fixture server exited early "
+                      f"(rc={server.returncode})\n"
+                      f"  stdout: {out!r}\n  stderr: {err!r}",
+                      file=sys.stderr)
+                return 1
+            if sel.select(0.2):
+                chunk = os.read(server.stdout.fileno(), 4096)
+                if not chunk:
+                    break
+                buf += chunk
+                if b"\n" in buf:
+                    ready_line = buf.split(b"\n", 1)[0].decode(
+                        errors="replace")
+                    break
+        sel.close()
+        if ready_line is None or not ready_line.startswith(
+                "fixture_otlp_server:"):
+            server.terminate()
+            try:
+                out, err = server.communicate(timeout=5)
+            except subprocess.TimeoutExpired:
+                server.kill()
+                out, err = server.communicate()
+            print(f"FAIL: fixture server did not report ready "
+                  f"(rc={server.poll()})\n"
+                  f"  stdout: {out!r}\n  stderr: {err!r}",
+                  file=sys.stderr)
+            return 1
+        # Secondary probe: connect once to confirm listen().
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=2.0):
+                pass
+        except OSError as e:
+            server.terminate()
+            out, err = server.communicate(timeout=5)
+            print(f"FAIL: fixture server accepted no connection "
+                  f"({e!r})\n  stdout: {out!r}\n  stderr: {err!r}",
+                  file=sys.stderr)
+            return 1
+
+        # Run the target under v2 with the live endpoint set.
+        env = os.environ.copy()
+        env["RETRACE_OTLP_ENDPOINT"] = f"http://127.0.0.1:{port}"
+        env["RETRACE_LOGGER_DEF_ENA"] = "1"
+        env["RETRACE_LOGGER_DEF_STDOUT_ENA"] = "0"
+        env["RETRACE_LOGGER_FMT"] = "jsonl"
+        # Use the target with stdout redirected to a file so we can
+        # check both the target's output and the otlp stats line.
+        target_log = tempfile.NamedTemporaryFile(
+            prefix="otlp-target-", suffix=".log", delete=False)
+        target_log.close()
+        # Need a log destination to spin up the flusher (which
+        # feeds otlp_live_emit_json). The file is not used for
+        # assertions -- the fixture server is -- but without it,
+        # the logger's ring subsystem stays uninitialized and
+        # spans are never pushed to otlp-c.
+        env["RETRACE_LOGGER_DEF_FN"] = target_log.name + ".log"
+        # The dylib is injected via LD_PRELOAD/DYLD_INSERT_LIBRARIES
+        # by the platform's trampoline -- we set the env var here
+        # so ctest doesn't need to know which one.
+        if "DYLD_INSERT_LIBRARIES" not in env and "LD_PRELOAD" not in env:
+            if sys.platform == "darwin":
+                env["DYLD_INSERT_LIBRARIES"] = dylib
+            else:
+                env["LD_PRELOAD"] = dylib
+
+        # Use the target with stdout redirected to a file so we can
+        # check both the target's output and the otlp stats line.
+        try:
+            with open(target_log.name, "wb") as tf:
+                proc = subprocess.run(
+                    [target], env=env, stdout=tf, stderr=subprocess.PIPE,
+                    timeout=30)
+        except subprocess.TimeoutExpired:
+            print("FAIL: target timed out", file=sys.stderr)
+            return 1
+
+        # The destructor's bounded flush sends everything before
+        # the target exits, so the server has already recorded
+        # the POSTs; 1s of slack for slow runners.
+        time.sleep(1.0)
+
+        # Read the request log.
+        with open(request_log.name) as f:
+            lines = f.read().splitlines()
+
+        # Read the target's stderr for the otlp stats line.
+        with open(target_log.name, "rb") as f:
+            target_out = f.read().decode("utf-8", errors="replace")
+        stderr = (proc.stderr or b"").decode("utf-8", errors="replace")
+
+        if not lines:
+            print(f"FAIL: no requests received at fixture server "
+                  f"(target exit={proc.returncode} stderr: {stderr[:200]!r})",
+                  file=sys.stderr)
+            print(f"  request_log: {request_log.name} (exists: "
+                  f"{os.path.exists(request_log.name)})",
+                  file=sys.stderr)
+            print(f"  target_log: {target_log.name} (exists: "
+                  f"{os.path.exists(target_log.name)})",
+                  file=sys.stderr)
+            return 1
+
+        # Each request is a JSON line. We expect at least one
+        # POST to /v1/traces with protobuf content.
+        proto_posts = sum(
+            1 for ln in lines if '"content_type": "application/x-protobuf"' in ln)
+        if proto_posts < 1:
+            print(f"FAIL: no protobuf POSTs (got {len(lines)} total "
+                  f"requests, 0 protobuf)", file=sys.stderr)
+            return 1
+
+        # Check the stats line in stderr.
+        if "otlp_live: emitted=" not in stderr:
+            print(f"FAIL: no otlp_live stats line in stderr "
+                  f"(target exit={proc.returncode})\n"
+                  f"  stderr: {stderr[:400]!r}\n"
+                  f"  target stdout tail: {target_out[-200:]!r}",
+                  file=sys.stderr)
+            return 1
+        # And that sent > 0.
+        for line in stderr.splitlines():
+            if "otlp_live:" in line and "sent=0" in line:
+                # Acceptable only if the target finished before
+                # the first tick could complete -- but with our
+                # 100ms tick + 30s timeout, that should not happen.
+                print(f"WARN: spans were queued but 0 sent: {line}",
+                      file=sys.stderr)
+
+        print(f"PASS: {proto_posts} protobuf POST(s) to fixture server; "
+              f"{len(lines)} total request(s)")
+        return 0
+    finally:
+        server.terminate()
+        try:
+            server.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            server.kill()
+        try:
+            os.unlink(request_log.name)
+        except OSError:
+            pass
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/otlp_live_target.c
+++ b/test/otlp_live_target.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+/*
+ * A test target for the otlp-c live streaming integration test
+ * (TODO.trace-profile/31). Generates enough traced calls to give
+ * the otlp-c exporter's background thread time to establish a
+ * connection and POST at least one batch.
+ *
+ * Pure C, no engine deps. Linked into the test/ tree so ctest can
+ * pass its path to the integration test.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+#define LOOP_COUNT 300
+#define BUF_SIZE 64
+
+int main(void)
+{
+	int i;
+	char buf[BUF_SIZE];
+
+	/* Mix of malloc/free/printf so the trace has variety. */
+	for (i = 0; i < LOOP_COUNT; i++) {
+		void *p = malloc(32);
+
+		if (p != NULL) {
+			snprintf(buf, BUF_SIZE, "iter-%d", i);
+			printf("otlp-test: %s\n", buf);
+			free(p);
+		}
+		/* Brief sleep so the otlp-c tick (100ms) gets a chance
+		 * to run before we exit. ~1.5s total on commodity
+		 * hardware -- the first batch posts well inside that
+		 * window; slow CI runners get proportionally slower but
+		 * only ONE POST is required to pass.
+		 */
+		usleep(5000);
+	}
+	return 0;
+}

--- a/test/perf/CMakeLists.txt
+++ b/test/perf/CMakeLists.txt
@@ -7,6 +7,14 @@
 # Labeled "perf" so `ctest -L perf` opts in. Not in the default
 # suite -- timings vary by host; meant for manual runs and a
 # future perf.yml workflow that compares against a baseline.
+# otlp-c live-streaming link (TODO.trace-profile/31): the target
+# only exists on POSIX builds (Windows stubs the module); empty
+# elsewhere.
+set(_otlp_lib)
+if(TARGET otlp_c)
+	list(APPEND _otlp_lib otlp_c)
+endif()
+
 
 if(RETRACE_PLATFORM_DARWIN)
 	set(_perf_arch_include
@@ -36,6 +44,7 @@ function(add_retrace_bench name source)
 
 	target_link_libraries(retrace_perf_${name} PRIVATE
 		retrace_core
+	${_otlp_lib}
 		retrace_config_json
 		retrace_backends
 		${_perf_backend_lib}

--- a/test/property/CMakeLists.txt
+++ b/test/property/CMakeLists.txt
@@ -3,6 +3,14 @@
 # Property-based tests. Pure C, no engine state required. Each test
 # runs many iterations of a generated input against an invariant.
 # See TODO.complete/16-property-based-tests.md for the plan.
+# otlp-c live-streaming link (TODO.trace-profile/31): the target
+# only exists on POSIX builds (Windows stubs the module); empty
+# elsewhere.
+set(_otlp_lib)
+if(TARGET otlp_c)
+	list(APPEND _otlp_lib otlp_c)
+endif()
+
 
 # All property tests link against parson directly (no engine state).
 set(_parson_sources
@@ -65,6 +73,7 @@ set_target_properties(retrace_property_sockaddr PROPERTIES
 
 target_link_libraries(retrace_property_sockaddr PRIVATE
 	retrace_core
+	${_otlp_lib}
 	retrace_config_json
 	retrace_backends
 	${_property_backend_lib}
@@ -127,6 +136,7 @@ set_target_properties(retrace_property_actions PROPERTIES
 
 target_link_libraries(retrace_property_actions PRIVATE
     retrace_core
+    ${_otlp_lib}
     retrace_config_json
     retrace_backends
     ${_action_backend_lib}
@@ -187,6 +197,7 @@ set_target_properties(retrace_property_resolver PROPERTIES
 
 target_link_libraries(retrace_property_resolver PRIVATE
     retrace_core
+    ${_otlp_lib}
     retrace_config_json
     retrace_backends
     ${_resolver_backend_lib}
@@ -246,6 +257,7 @@ set_target_properties(retrace_property_caller_match PROPERTIES
 
 target_link_libraries(retrace_property_caller_match PRIVATE
     retrace_core
+    ${_otlp_lib}
     retrace_config_json
     retrace_backends
     ${_cmatch_backend_lib}

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -3,6 +3,15 @@
 # Unit tests for retrace_core registries. Link directly against the
 # retrace_core OBJECT library -- no LD_PRELOAD needed. Issue #481.
 
+# otlp-c live-streaming link (TODO.trace-profile/31): the target
+# only exists on POSIX builds (Windows stubs the module); empty
+# elsewhere.
+set(_otlp_lib)
+if(TARGET otlp_c)
+	list(APPEND _otlp_lib otlp_c)
+endif()
+
+
 # Windows (TODO.windows/04): the v2 core now builds here, and the
 # portable unit set runs on the CI legs. Everything below links
 # POSIX-only backend arch directories, so it stays gated.
@@ -18,7 +27,8 @@ if(RETRACE_PLATFORM_WINDOWS)
 
     target_link_libraries(retrace_test_logger_fmt PRIVATE
         retrace_core
-        retrace_config_json
+        ${_otlp_lib}
+    retrace_config_json
         retrace_backends
         retrace_win_common
         retrace_headers)
@@ -75,7 +85,8 @@ if(RETRACE_PLATFORM_WINDOWS)
 
     target_link_libraries(retrace_test_win_registry PRIVATE
         retrace_core
-        retrace_config_json
+        ${_otlp_lib}
+    retrace_config_json
         retrace_backends
         retrace_win_common
         retrace_headers)
@@ -103,6 +114,7 @@ if(RETRACE_PLATFORM_WINDOWS)
 
         target_link_libraries(retrace_test_win_wrapper PRIVATE
             retrace_core
+            ${_otlp_lib}
             retrace_config_json
             retrace_backends
             retrace_win_common
@@ -170,6 +182,7 @@ set_target_properties(retrace_test_registries PROPERTIES
 
 target_link_libraries(retrace_test_registries PRIVATE
     retrace_core
+    ${_otlp_lib}
     retrace_config_json
     retrace_backends
     ${_unit_backend_lib}
@@ -223,6 +236,7 @@ set_target_properties(retrace_test_script_resolver PROPERTIES
 
 target_link_libraries(retrace_test_script_resolver PRIVATE
     retrace_core
+    ${_otlp_lib}
     retrace_config_json
     retrace_backends
     ${_unit_backend_lib}
@@ -259,6 +273,7 @@ set_target_properties(retrace_test_sockaddr_inspect PROPERTIES
 
 target_link_libraries(retrace_test_sockaddr_inspect PRIVATE
     retrace_core
+    ${_otlp_lib}
     retrace_config_json
     retrace_backends
     ${_unit_backend_lib}
@@ -295,6 +310,7 @@ set_target_properties(retrace_test_addr_deny PROPERTIES
 
 target_link_libraries(retrace_test_addr_deny PRIVATE
     retrace_core
+    ${_otlp_lib}
     retrace_config_json
     retrace_backends
     ${_unit_backend_lib}
@@ -330,6 +346,7 @@ set_target_properties(retrace_test_modify_return_value_int PROPERTIES
 
 target_link_libraries(retrace_test_modify_return_value_int PRIVATE
     retrace_core
+    ${_otlp_lib}
     retrace_config_json
     retrace_backends
     ${_unit_backend_lib}
@@ -368,6 +385,7 @@ set_target_properties(retrace_test_call_count_limit PROPERTIES
 
 target_link_libraries(retrace_test_call_count_limit PRIVATE
     retrace_core
+    ${_otlp_lib}
     retrace_config_json
     retrace_backends
     ${_unit_backend_lib}
@@ -406,6 +424,7 @@ set_target_properties(retrace_test_sandbox PROPERTIES
 
 target_link_libraries(retrace_test_sandbox PRIVATE
     retrace_core
+    ${_otlp_lib}
     retrace_config_json
     retrace_backends
     ${_unit_backend_lib}
@@ -440,6 +459,7 @@ set_target_properties(retrace_test_modify_in_param_int PROPERTIES
 
 target_link_libraries(retrace_test_modify_in_param_int PRIVATE
     retrace_core
+    ${_otlp_lib}
     retrace_config_json
     retrace_backends
     ${_unit_backend_lib}
@@ -474,6 +494,7 @@ set_target_properties(retrace_test_fuzzing_seed PROPERTIES
 
 target_link_libraries(retrace_test_fuzzing_seed PRIVATE
     retrace_core
+    ${_otlp_lib}
     retrace_config_json
     retrace_backends
     ${_unit_backend_lib}
@@ -509,6 +530,7 @@ set_target_properties(retrace_test_delay PROPERTIES
 
 target_link_libraries(retrace_test_delay PRIVATE
     retrace_core
+    ${_otlp_lib}
     retrace_config_json
     retrace_backends
     ${_unit_backend_lib}
@@ -543,6 +565,7 @@ set_target_properties(retrace_test_log_params PROPERTIES
 
 target_link_libraries(retrace_test_log_params PRIVATE
     retrace_core
+    ${_otlp_lib}
     retrace_config_json
     retrace_backends
     ${_unit_backend_lib}
@@ -577,6 +600,7 @@ set_target_properties(retrace_test_call_real PROPERTIES
 
 target_link_libraries(retrace_test_call_real PRIVATE
     retrace_core
+    ${_otlp_lib}
     retrace_config_json
     retrace_backends
     ${_unit_backend_lib}
@@ -611,6 +635,7 @@ set_target_properties(retrace_test_incomplete_io PROPERTIES
 
 target_link_libraries(retrace_test_incomplete_io PRIVATE
     retrace_core
+    ${_otlp_lib}
     retrace_config_json
     retrace_backends
     ${_unit_backend_lib}
@@ -645,6 +670,7 @@ set_target_properties(retrace_test_memory_fuzz PROPERTIES
 
 target_link_libraries(retrace_test_memory_fuzz PRIVATE
     retrace_core
+    ${_otlp_lib}
     retrace_config_json
     retrace_backends
     ${_unit_backend_lib}
@@ -679,6 +705,7 @@ set_target_properties(retrace_test_as_call_real PROPERTIES
 
 target_link_libraries(retrace_test_as_call_real PRIVATE
     retrace_core
+    ${_otlp_lib}
     retrace_config_json
     retrace_backends
     ${_unit_backend_lib}
@@ -707,6 +734,7 @@ set_target_properties(retrace_test_fuzz_str PROPERTIES
 
 target_link_libraries(retrace_test_fuzz_str PRIVATE
     retrace_core
+    ${_otlp_lib}
     retrace_config_json
     retrace_backends
     ${_unit_backend_lib}
@@ -743,6 +771,7 @@ set_target_properties(retrace_test_modify_in_param_str PROPERTIES
 
 target_link_libraries(retrace_test_modify_in_param_str PRIVATE
     retrace_core
+    ${_otlp_lib}
     retrace_config_json
     retrace_backends
     ${_unit_backend_lib}
@@ -777,6 +806,7 @@ set_target_properties(retrace_test_reentrance_guard PROPERTIES
 
 target_link_libraries(retrace_test_reentrance_guard PRIVATE
     retrace_core
+    ${_otlp_lib}
     retrace_config_json
     retrace_backends
     ${_unit_backend_lib}
@@ -802,6 +832,44 @@ add_test(NAME unit-test-reentrance-guard
 set_tests_properties(unit-test-reentrance-guard PROPERTIES LABELS "unit")
 
 #
+# otlp_live unit tests (TODO.trace-profile/31).
+# Verifies lifecycle, null-safety, and the no-op-when-uninitialized
+# contract. End-to-end testing (with the fixture HTTP server) lives
+# in the integration test.
+#
+add_executable(retrace_test_otlp_live test_otlp_live.c)
+set_target_properties(retrace_test_otlp_live PROPERTIES
+    OUTPUT_NAME test_otlp_live
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/test/unit")
+
+target_link_libraries(retrace_test_otlp_live PRIVATE
+    retrace_core
+    ${_otlp_lib}
+    retrace_config_json
+    retrace_backends
+    ${_unit_backend_lib}
+    retrace_preload_common
+    retrace_headers
+    ${CMAKE_DL_LIBS}
+    Threads::Threads)
+
+target_include_directories(retrace_test_otlp_live PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/core
+    ${CMAKE_SOURCE_DIR}/src/backends
+    ${CMAKE_SOURCE_DIR}/src/config/json
+    ${_unit_arch_include})
+
+if(RETRACE_PLATFORM_LINUX OR RETRACE_PLATFORM_FREEBSD)
+    target_compile_definitions(retrace_test_otlp_live PRIVATE _GNU_SOURCE _DEFAULT_SOURCE)
+elseif(RETRACE_PLATFORM_DARWIN)
+    target_compile_definitions(retrace_test_otlp_live PRIVATE _DARWIN_C_SOURCE)
+endif()
+
+add_test(NAME unit-test-otlp-live
+    COMMAND retrace_test_otlp_live)
+set_tests_properties(unit-test-otlp-live PROPERTIES LABELS "unit")
+
+#
 # Lock-free log ring unit tests (TODO.complete/19 P0 PR A).
 # Verifies SPSC ring semantics: push/drain, wrap-around, drop-on-full,
 # text truncation, early-stop drain, NULL safety, multi-thread isolation.
@@ -813,6 +881,7 @@ set_target_properties(retrace_test_log_ring PROPERTIES
 
 target_link_libraries(retrace_test_log_ring PRIVATE
     retrace_core
+    ${_otlp_lib}
     retrace_config_json
     retrace_backends
     ${_unit_backend_lib}
@@ -848,6 +917,7 @@ set_target_properties(retrace_test_log_flusher PROPERTIES
 
 target_link_libraries(retrace_test_log_flusher PRIVATE
     retrace_core
+    ${_otlp_lib}
     retrace_config_json
     retrace_backends
     ${_unit_backend_lib}
@@ -883,6 +953,7 @@ set_target_properties(retrace_test_logger_fmt PROPERTIES
 
 target_link_libraries(retrace_test_logger_fmt PRIVATE
     retrace_core
+    ${_otlp_lib}
     retrace_config_json
     retrace_backends
     ${_unit_backend_lib}
@@ -935,6 +1006,7 @@ set_target_properties(retrace_test_call_hash PROPERTIES
 
 target_link_libraries(retrace_test_call_hash PRIVATE
     retrace_core
+    ${_otlp_lib}
     retrace_config_json
     retrace_backends
     ${_unit_backend_lib}
@@ -970,6 +1042,7 @@ set_target_properties(retrace_test_modify_in_param_arr PROPERTIES
 
 target_link_libraries(retrace_test_modify_in_param_arr PRIVATE
     retrace_core
+    ${_otlp_lib}
     retrace_config_json
     retrace_backends
     ${_unit_backend_lib}
@@ -1005,6 +1078,7 @@ set_target_properties(retrace_test_conf PROPERTIES
 
 target_link_libraries(retrace_test_conf PRIVATE
     retrace_core
+    ${_otlp_lib}
     retrace_config_json
     retrace_backends
     ${_unit_backend_lib}
@@ -1039,6 +1113,7 @@ set_target_properties(retrace_test_caller_match PROPERTIES
 
 target_link_libraries(retrace_test_caller_match PRIVATE
     retrace_core
+    ${_otlp_lib}
     retrace_config_json
     retrace_backends
     ${_unit_backend_lib}
@@ -1073,6 +1148,7 @@ set_target_properties(retrace_test_caller_cache PROPERTIES
 
 target_link_libraries(retrace_test_caller_cache PRIVATE
     retrace_core
+    ${_otlp_lib}
     retrace_config_json
     retrace_backends
     ${_unit_backend_lib}
@@ -1107,6 +1183,7 @@ set_target_properties(retrace_test_filter PROPERTIES
 
 target_link_libraries(retrace_test_filter PRIVATE
     retrace_core
+    ${_otlp_lib}
     retrace_config_json
     retrace_backends
     ${_unit_backend_lib}
@@ -1142,6 +1219,7 @@ set_target_properties(retrace_test_decode_http PROPERTIES
 
 target_link_libraries(retrace_test_decode_http PRIVATE
     retrace_core
+    ${_otlp_lib}
     retrace_config_json
     retrace_backends
     ${_unit_backend_lib}
@@ -1177,6 +1255,7 @@ set_target_properties(retrace_test_config_cache PROPERTIES
 
 target_link_libraries(retrace_test_config_cache PRIVATE
     retrace_core
+    ${_otlp_lib}
     retrace_config_json
     retrace_backends
     ${_unit_backend_lib}
@@ -1212,6 +1291,7 @@ set_target_properties(retrace_test_decode_dns PROPERTIES
 
 target_link_libraries(retrace_test_decode_dns PRIVATE
     retrace_core
+    ${_otlp_lib}
     retrace_config_json
     retrace_backends
     ${_unit_backend_lib}
@@ -1359,6 +1439,7 @@ set_target_properties(retrace_test_attach PROPERTIES
 
 target_link_libraries(retrace_test_attach PRIVATE
     retrace_core
+    ${_otlp_lib}
     retrace_config_json
     retrace_backends
     ${_unit_backend_lib}
@@ -1493,6 +1574,7 @@ set_target_properties(retrace_test_public_api PROPERTIES
 
 target_link_libraries(retrace_test_public_api PRIVATE
     retrace_core
+    ${_otlp_lib}
     retrace_config_json
     retrace_backends
     ${_unit_backend_lib}

--- a/test/unit/test_otlp_live.c
+++ b/test/unit/test_otlp_live.c
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+/*
+ * Unit tests for the otlp_live module (TODO.trace-profile/31).
+ *
+ * The exporter's lifecycle is what we test here -- the per-emit
+ * JSON-to-span conversion is exercised by the integration tests
+ * with the fixture HTTP server (test/fixtures/fixture_otlp_server.py).
+ *
+ * Tests verify:
+ *   - init() is a no-op without RETRACE_OTLP_ENDPOINT
+ *   - init() is idempotent (calling twice is a no-op)
+ *   - get_stats() returns zeros when not initialized
+ *   - deinit() is safe to call without init
+ *   - emit_json() is a no-op when not initialized
+ *
+ * Part of TODO.trace-profile/31 (otlp-c Wave B).
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include "otlp_live.h"
+
+static int tests_run;
+static int tests_pass;
+static int tests_fail;
+
+#define TEST(name) do { \
+	tests_run++; \
+	printf("  TEST %s ... ", #name); \
+	test_##name(); \
+	tests_pass++; \
+	printf("OK\n"); \
+} while (0)
+
+static void test_init_without_endpoint(void)
+{
+	/* Without RETRACE_OTLP_ENDPOINT, init is a silent no-op. */
+	unsetenv("RETRACE_OTLP_ENDPOINT");
+	assert(retrace_otlp_live_init() == 0);
+}
+
+static void test_get_stats_when_uninitialized(void)
+{
+	uint64_t emitted = 99, sent = 99, dropped_full = 99, dropped_err = 99;
+
+	retrace_otlp_live_get_stats(&emitted, &sent, &dropped_full,
+		&dropped_err);
+	assert(emitted == 0);
+	assert(sent == 0);
+	assert(dropped_full == 0);
+	assert(dropped_err == 0);
+}
+
+static void test_emit_when_uninitialized_is_noop(void)
+{
+	/* emit_json must not crash or block when the exporter is
+	 * not initialized.
+	 */
+	const char *json =
+		"{\"time\":1,\"pid\":2,\"tid\":3,\"module\":\"FUNCS\","
+		"\"severity\":\"INFO\",\"message\":{\"func\":\"malloc\"}}";
+
+	assert(retrace_otlp_live_emit_json(json) == 0);
+	assert(retrace_otlp_live_emit_json(NULL) == -1);
+	assert(retrace_otlp_live_emit_json("not json") == -1);
+}
+
+static void test_deinit_when_uninitialized_is_safe(void)
+{
+	/* Must not crash on a never-initialized exporter. */
+	retrace_otlp_live_deinit();
+}
+
+static void test_get_stats_null_args(void)
+{
+	/* NULL pointers should be tolerated (no deref). */
+	retrace_otlp_live_get_stats(NULL, NULL, NULL, NULL);
+}
+
+static void test_emit_json_empty_string(void)
+{
+	/* Empty JSON parses to NULL -- emit returns -1 (parse fail)
+	 * but doesn't crash.
+	 */
+	assert(retrace_otlp_live_emit_json("") == -1);
+	assert(retrace_otlp_live_emit_json("{}") == -1);
+}
+
+int main(void)
+{
+	printf("otlp_live tests:\n");
+
+	printf("  -- lifecycle --\n");
+	TEST(init_without_endpoint);
+	TEST(get_stats_when_uninitialized);
+	TEST(deinit_when_uninitialized_is_safe);
+
+	printf("  -- emit path --\n");
+	TEST(emit_when_uninitialized_is_noop);
+	TEST(emit_json_empty_string);
+
+	printf("  -- null-safety --\n");
+	TEST(get_stats_null_args);
+
+	printf("\nPass: %d, Fail: %d (of %d)\n",
+		tests_pass, tests_fail, tests_run);
+	return tests_fail == 0 ? 0 : 1;
+}

--- a/test/unit/test_reentrance_guard.c
+++ b/test/unit/test_reentrance_guard.c
@@ -126,6 +126,12 @@ static void test_null_real_impl_is_inactive(void)
 	assert(retrace_reentrance_guard_active(&ctx) == 0);
 }
 
+/* TODO 31: the "permanent" variant -- held by the otlp-c
+ * exporter thread for its lifetime so its send()/connect()
+ * reach the real socket implementation, not recurse.
+ */
+static void test_permanent_holds_across_calls(void);
+
 int main(void)
 {
 	printf("reentrance_guard tests:\n");
@@ -135,6 +141,7 @@ int main(void)
 	TEST(active_after_enter);
 	TEST(inactive_after_clear);
 	TEST(null_real_impl_is_inactive);
+	TEST(permanent_holds_across_calls);
 
 	printf("  -- enter() captures --\n");
 	TEST(enter_captures_real_impl);
@@ -146,4 +153,24 @@ int main(void)
 	printf("\nPass: %d, Fail: %d (of %d)\n",
 		tests_pass, tests_fail, tests_run);
 	return tests_fail == 0 ? 0 : 1;
+}
+
+/* TODO 31: the "permanent" variant -- held by the otlp-c
+ * exporter thread for its lifetime so its send()/connect()
+ * reach the real socket implementation, not recurse.
+ */
+static void test_permanent_holds_across_calls(void)
+{
+	struct ThreadContext ctx;
+	void *arch = (void *)0xbeef;
+	int i;
+
+	memset(&ctx, 0, sizeof(ctx));
+	retrace_reentrance_guard_enter_permanent(&ctx, arch);
+	assert(retrace_reentrance_guard_active(&ctx) == 1);
+	/* Subsequent wrapper entries on this thread see it active
+	 * (the permanent marker survives any clear-like teardown).
+	 */
+	for (i = 0; i < 5; i++)
+		assert(retrace_reentrance_guard_active(&ctx) == 1);
 }

--- a/tools/otlp-converter/CMakeLists.txt
+++ b/tools/otlp-converter/CMakeLists.txt
@@ -22,8 +22,11 @@ target_include_directories(retrace_to_otlp PRIVATE
 # Wave A (TODO.trace-profile/30): the vendored otlp-c client --
 # --endpoint posts real protobuf to a collector. add_subdirectory
 # is side-effect-free by design (otlp-c's CMakeLists guards its
-# install/CPack layout behind top-level detection).
-if(NOT TARGET otlp-c)
+# install/CPack layout behind top-level detection). The top-level
+# CMakeLists adds otlp-c first under the canonical name
+# `otlp_c`; this guard makes the call a no-op if it's already
+# been added.
+if(NOT TARGET otlp_c)
 	add_subdirectory(${CMAKE_SOURCE_DIR}/third_party/otlp-c
 		${CMAKE_BINARY_DIR}/third_party/otlp-c)
 endif()

--- a/tools/profiler/CMakeLists.txt
+++ b/tools/profiler/CMakeLists.txt
@@ -25,14 +25,22 @@ set_target_properties(retrace_profile PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tools")
 
 # Wave A (TODO.trace-profile/30): the export subcommand posts
-# timing metrics via the vendored otlp-c client.
-if(NOT TARGET otlp_c)
-	add_subdirectory(${CMAKE_SOURCE_DIR}/third_party/otlp-c
-		${CMAKE_BINARY_DIR}/third_party/otlp-c)
+# timing metrics via the vendored otlp-c client. The top-level
+# CMakeLists adds otlp-c FIRST (static -- a shared otlp_c.dll
+# would kill retrace-profile.exe at load with
+# STATUS_DLL_NOT_FOUND); this fallback covers standalone use.
+# MinGW excluded: otlp-c's exporter.c doesn't build there (Win32
+# Sleep() without <windows.h>) -- export compiles out via
+# RETRACE_HAVE_OTLP.
+if(NOT MINGW)
+	if(NOT TARGET otlp_c)
+		add_subdirectory(${CMAKE_SOURCE_DIR}/third_party/otlp-c
+			${CMAKE_BINARY_DIR}/third_party/otlp-c)
+	endif()
+	target_link_libraries(retrace_profile PRIVATE otlp_c)
+	target_compile_definitions(retrace_profile PRIVATE RETRACE_HAVE_OTLP=1)
 endif()
-target_link_libraries(retrace_profile PRIVATE otlp_c)
 target_include_directories(retrace_profile PRIVATE
-    ${CMAKE_SOURCE_DIR}/third_party/otlp-c/include
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_SOURCE_DIR}/tools/correlate
     ${CMAKE_SOURCE_DIR}/tools/common

--- a/tools/profiler/profile.c
+++ b/tools/profiler/profile.c
@@ -38,8 +38,10 @@
 
 #include "aggregate.h"
 
+#ifdef RETRACE_HAVE_OTLP
 #include <otlp-c/exporter.h>
 #include <otlp-c/metric.h>
+#endif
 #include "capability.h"
 #include "capture.h"
 #include "diff.h"
@@ -634,6 +636,7 @@ int main(int argc, char **argv)
 	if (argc >= 2 && strcmp(argv[1], "jail") == 0)
 		return jail_mode(argc, argv);
 	if (argc >= 2 && strcmp(argv[1], "export") == 0) {
+#ifdef RETRACE_HAVE_OTLP
 		/*
 		 * Wave A (TODO.trace-profile/30): timings as OTLP
 		 * histogram metrics (one metric per function, every
@@ -743,6 +746,16 @@ int main(int argc, char **argv)
 				tf, endpoint);
 		}
 		return 0;
+#else
+		/* MinGW: otlp-c doesn't build there yet (exporter.c
+		 * calls Win32 Sleep() without <windows.h>). The rest
+		 * of the profiler is unaffected; the export path
+		 * rides the upstream fix.
+		 */
+		fprintf(stderr,
+	"retrace-profile: export not built (otlp-c unavailable)\n");
+		return 2;
+#endif
 	}
 	if (argc >= 2 && strcmp(argv[1], "harden") == 0) {
 		const char *hp = NULL;


### PR DESCRIPTION
## Summary

**otlp-c Wave B: live OTLP streaming from the traced process (TODO 31, v2.35.0)**

`RETRACE_OTLP_ENDPOINT=URL` makes retrace emit OTLP protobuf spans **live** as the wrapped calls happen — one env var, no batch pipeline, no polling the JSON log. The wrapper path is unchanged; a lock-free MPSC enqueue is the only added work on the hot path. The network I/O happens on a dedicated background thread that owns the exporter's HTTP connection.

## Design (the NtWriteFile lesson)

Three things make this reentrancy-safe:

1. **Permanent reentrance guard** (`retrace_reentrance_guard_enter_permanent`, new API): the exporter's background thread AND the log flusher hold the guard for their lifetimes, so their own libc calls (send, connect, malloc) pass through to the real impl — no self-interposition recursion into the engine. This is the same class of bug fixed for NtWriteFile in TODO 28.
2. **otlp-c's allocator** wired to `retrace_real_impls.{malloc,free}` with a thin `malloc+memcpy+free` realloc shim (`otlp_live_realloc`), so the library's internal slab/MPSC/span allocations never reach the engine.
3. **At-exit diagnostics**: `retrace: otlp_live: emitted=N sent=N dropped_full=N dropped_err=N` stderr line at teardown.

## What lands in the collector

One span per traced call with attributes: `retrace.func`, `retrace.module`, `retrace.severity`, `retrace.pid`, `retrace.tid`, `retrace.call_duration_us` (when call_real ran), `retrace.ret_val`, `retrace.params`. Trace ID per process, span ID per call.

## Bounded failure (by design)

- Endpoint down → MPSC queue fills, drops counted, target never blocked or crashed
- Permanent 4xx → drops counted, exponential backoff
- Process killed mid-stream → destructor not called, queued spans lost (bounded memory, no temp files)

## Files

- `src/core/otlp_live.{h,c}` — the module (init/deinit/emit_json/get_stats)
- `src/core/reentrance_guard.{h,c}` — permanent-guard API + sentinel
- `src/core/log_flusher.c` — flusher installs the permanent guard
- `src/core/logger.c` — emit hook into `logger_emit_entry`
- `src/core/main.c` — init/deinit order
- `CMakeLists.txt` / `src/v2/CMakeLists.txt` / `src/core/CMakeLists.txt` — build wiring (otlp-c at top level, `otlp_c` linked into retrace_v2)
- `test/unit/test_otlp_live.c` — 6 lifecycle/null-safety tests
- `test/unit/test_reentrance_guard.c` — 8 tests (was 7; added permanent-variant case)
- `test/fixtures/fixture_otlp_server.py` — stub OTLP/HTTP collector for tests
- `test/integration/test_otlp_live.py` — end-to-end integration test
- `test/otlp_live_target.c` — test target with enough calls for the tick loop
- `docs/cookbook/36-live-otlp-stream.md` — user-facing recipe

## Test plan

- [x] All 92 ctest cases pass on macOS arm64 (90 existing + 1 unit + 1 integration)
- [x] Local end-to-end: 623 spans emitted, 623 sent, 0 drops, 9 protobuf POSTs to fixture server
- [x] Endpoint-down case: target exits cleanly, stats line shows the drop counters
- [x] No otlp endpoint set: zero behavior change (init is a silent no-op)
- [ ] CI: Linux/Windows legs
