### PR TITLE
site: information architecture — five focused pages

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -10,35 +10,35 @@
       "dependencies": {
         "@astrojs/vue": "^7.0.1",
         "@tailwindcss/vite": "^4.3.3",
-        "astro": "^7.1.6",
+        "astro": "^7.2.6",
         "tailwindcss": "^4.3.3",
         "vue": "^3.5.40"
       }
     },
     "node_modules/@astrojs/compiler-binding": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding/-/compiler-binding-0.3.2.tgz",
-      "integrity": "sha512-8w/9CWmYrAJJ8N0SY3O43ws2BgxoW6u3QsD8u2mE140lMYAlwh+tlNoUeSBq22wVheFuiBbR212l6ixZ2IIgCQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding/-/compiler-binding-0.4.0.tgz",
+      "integrity": "sha512-x2RjDUuWfwLNtc3mjAdSRInwqh/rqbLar9cm/5FOMbHvmYZB7yfKewzSclAxWjIZsypJDXv1lhaP2WG+P8TK3g==",
       "license": "MIT",
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@astrojs/compiler-binding-darwin-arm64": "0.3.2",
-        "@astrojs/compiler-binding-darwin-x64": "0.3.2",
-        "@astrojs/compiler-binding-linux-arm64-gnu": "0.3.2",
-        "@astrojs/compiler-binding-linux-arm64-musl": "0.3.2",
-        "@astrojs/compiler-binding-linux-x64-gnu": "0.3.2",
-        "@astrojs/compiler-binding-linux-x64-musl": "0.3.2",
-        "@astrojs/compiler-binding-wasm32-wasi": "0.3.2",
-        "@astrojs/compiler-binding-win32-arm64-msvc": "0.3.2",
-        "@astrojs/compiler-binding-win32-x64-msvc": "0.3.2"
+        "@astrojs/compiler-binding-darwin-arm64": "0.4.0",
+        "@astrojs/compiler-binding-darwin-x64": "0.4.0",
+        "@astrojs/compiler-binding-linux-arm64-gnu": "0.4.0",
+        "@astrojs/compiler-binding-linux-arm64-musl": "0.4.0",
+        "@astrojs/compiler-binding-linux-x64-gnu": "0.4.0",
+        "@astrojs/compiler-binding-linux-x64-musl": "0.4.0",
+        "@astrojs/compiler-binding-wasm32-wasi": "0.4.0",
+        "@astrojs/compiler-binding-win32-arm64-msvc": "0.4.0",
+        "@astrojs/compiler-binding-win32-x64-msvc": "0.4.0"
       }
     },
     "node_modules/@astrojs/compiler-binding-darwin-arm64": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-darwin-arm64/-/compiler-binding-darwin-arm64-0.3.2.tgz",
-      "integrity": "sha512-MM8tn8CSimcfytaOla4b6acN8mKWiL/rlAA1fpT3/Wl7dNGSE4y8FjTN/zJVNnb63CsLWG5zZwCt01TXtDKh9g==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-darwin-arm64/-/compiler-binding-darwin-arm64-0.4.0.tgz",
+      "integrity": "sha512-ZVUwHundaQyFNjE6uoa0usaC0WOCitDCLS/4mdb4rOiJXwVUuKJBMxI5WMzXLWmamsXtK/Z//ifLXvV5Yeh4Hw==",
       "cpu": [
         "arm64"
       ],
@@ -52,9 +52,9 @@
       }
     },
     "node_modules/@astrojs/compiler-binding-darwin-x64": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-darwin-x64/-/compiler-binding-darwin-x64-0.3.2.tgz",
-      "integrity": "sha512-2lXOlzf8xb7jLomRsf/aswh61/NnGusynB2OwFkK6k4pmOtpfXMYnG0PLfXrEvxXYj69NdCnmUYXtHDd+JOOag==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-darwin-x64/-/compiler-binding-darwin-x64-0.4.0.tgz",
+      "integrity": "sha512-FI6G8AY8u6fR1SI/QRR5yGMwtvZwP34CDmZpZ5HwJGa50UM1VISTLhqkhV4a476pmgd25X1Aur2dqw6hUnrlKA==",
       "cpu": [
         "x64"
       ],
@@ -68,9 +68,9 @@
       }
     },
     "node_modules/@astrojs/compiler-binding-linux-arm64-gnu": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-arm64-gnu/-/compiler-binding-linux-arm64-gnu-0.3.2.tgz",
-      "integrity": "sha512-BmU3kWj7qnLrd4vzm49zFEPJ5oFnn1tCT4Vt9hZbqdU5Cmb8GZl7fn6VFsnNfe7B18a2gIFtVzbLINtYl5kBjQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-arm64-gnu/-/compiler-binding-linux-arm64-gnu-0.4.0.tgz",
+      "integrity": "sha512-lB9gLFJK7m82EnjaU8nlRBEfcwGNeHidW3sSjODTUjMNaoewVuUz9fwwdY5M4jiSXIqWLH3yl6TX8FTDKA74Sw==",
       "cpu": [
         "arm64"
       ],
@@ -84,9 +84,9 @@
       }
     },
     "node_modules/@astrojs/compiler-binding-linux-arm64-musl": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-arm64-musl/-/compiler-binding-linux-arm64-musl-0.3.2.tgz",
-      "integrity": "sha512-f0heT9ZZEseSu5bHCeb80eL2DH07ArE6U9xi1WT/PEusNjzPmEr3GJsjG1tRLo5VYUUYX7h3ScaqGmGrMOVGmw==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-arm64-musl/-/compiler-binding-linux-arm64-musl-0.4.0.tgz",
+      "integrity": "sha512-HPbvWqbxFxyaoQJhLxCaSjtYBx9KBo7JGVzEFZCmMl968a2PsSH0UfiODYgYPXofTOIsIH2aoCcrHXML0IA3ig==",
       "cpu": [
         "arm64"
       ],
@@ -100,9 +100,9 @@
       }
     },
     "node_modules/@astrojs/compiler-binding-linux-x64-gnu": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-x64-gnu/-/compiler-binding-linux-x64-gnu-0.3.2.tgz",
-      "integrity": "sha512-M8fOUt0itRpqiGyoEA/ij184s8O+hqbCz3+YozRusOOM3osgGljpDThhbKAJjqh82wOo6FioQ4w8PBvU1XMD5Q==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-x64-gnu/-/compiler-binding-linux-x64-gnu-0.4.0.tgz",
+      "integrity": "sha512-tQKolMxoJ/+0AmLWm1PmJ/i+z3i10ZU1bNuVjEDulCf48azEMtUNjTZgHJ5MPtpYRNc7dlETr8QujUfduzoC7Q==",
       "cpu": [
         "x64"
       ],
@@ -116,9 +116,9 @@
       }
     },
     "node_modules/@astrojs/compiler-binding-linux-x64-musl": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-x64-musl/-/compiler-binding-linux-x64-musl-0.3.2.tgz",
-      "integrity": "sha512-/Kebk8sO6HnLeSd691JkaAPfN7CqR9/KEXmWvyNPkaKNGmj8rTZ/lf2uXtnPu92Lan84UrKdIKVPy1fSo2encQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-x64-musl/-/compiler-binding-linux-x64-musl-0.4.0.tgz",
+      "integrity": "sha512-5v5YymudsxMHp3NBLCS8BUlu5CRqeLtWD9cKS/4nIhIEHCbpz9okmVV6I0HWqmBAPhWYcDa3vw/vltYPrOQCTA==",
       "cpu": [
         "x64"
       ],
@@ -132,25 +132,25 @@
       }
     },
     "node_modules/@astrojs/compiler-binding-wasm32-wasi": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-wasm32-wasi/-/compiler-binding-wasm32-wasi-0.3.2.tgz",
-      "integrity": "sha512-pUA6xbcOSB7DhfzIArB8BCAkFfAIqriiR7zl5zOStd6oU2G0kIKj+GUdGnyXyhfiv881Hffyk5tC0mR18sDjDw==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-wasm32-wasi/-/compiler-binding-wasm32-wasi-0.4.0.tgz",
+      "integrity": "sha512-m/phuH3x3PREvv1OnkM44NoPh4MatUadix1fB1u5SvMLCyDTUZykDJbKnWf1cjnYmHdlB8HcjTjl6JrCqAIXcw==",
       "cpu": [
         "wasm32"
       ],
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@napi-rs/wasm-runtime": "^1.2.0"
+        "@napi-rs/wasm-runtime": "^1.2.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@astrojs/compiler-binding-win32-arm64-msvc": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-win32-arm64-msvc/-/compiler-binding-win32-arm64-msvc-0.3.2.tgz",
-      "integrity": "sha512-ESruf+6Qkl1trHUFxI6GSf6t52j8yN2kCNSzMWdzt7V/T09tFHrYzrVaJQohb2C9bJUH76pNvX6Zb51+xCQc9Q==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-win32-arm64-msvc/-/compiler-binding-win32-arm64-msvc-0.4.0.tgz",
+      "integrity": "sha512-B9zYf3okEY83kM8gydlpH2BHP00w4ifxPqlYlWrgTwuD6wnkrJDCwBlgy1q31cERjCJRXN1lrE2VmkLvFjv/6g==",
       "cpu": [
         "arm64"
       ],
@@ -164,9 +164,9 @@
       }
     },
     "node_modules/@astrojs/compiler-binding-win32-x64-msvc": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-win32-x64-msvc/-/compiler-binding-win32-x64-msvc-0.3.2.tgz",
-      "integrity": "sha512-wzzVrEbOwbsLWOdEbocskjMRx2aZPxJ7ZbmL+jnpBamFwmigm+2M/wzuM6JWncocgYwLic1csSpalBh96kQKXA==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-win32-x64-msvc/-/compiler-binding-win32-x64-msvc-0.4.0.tgz",
+      "integrity": "sha512-zB0Nrv0dGc0zZWPGDRmmETTPhDRqyZjAjk+gWMlVrJX5U89obpB3VUUE1ZiHxOCN5LQojeLK6O8L/dnoHolvNQ==",
       "cpu": [
         "x64"
       ],
@@ -180,21 +180,21 @@
       }
     },
     "node_modules/@astrojs/compiler-rs": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@astrojs/compiler-rs/-/compiler-rs-0.3.2.tgz",
-      "integrity": "sha512-xlx/T7JovIKduu4ucbTQUxQ5+Q8wxkHxhLjnZk3VlJbhbQ9RLvvuDk1p2YYFYFQ5y14dVm3FGGO4isQXa4F+Tg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-rs/-/compiler-rs-0.4.0.tgz",
+      "integrity": "sha512-koVikeon1kreEy+/JzLQRy3vzHHQVOjycs4degg4vFufKApZOwMZvSSAEztYNhmcQVfNVsVZZI4cEge3cexAbQ==",
       "license": "MIT",
       "dependencies": {
-        "@astrojs/compiler-binding": "0.3.2"
+        "@astrojs/compiler-binding": "0.4.0"
       },
       "engines": {
         "node": ">=22.12.0"
       }
     },
     "node_modules/@astrojs/internal-helpers": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.10.2.tgz",
-      "integrity": "sha512-yt7fMgPYqSM4Tmr+taTW6Per+hjJ8Pk6lA1PAcDyqzOt8HzJ6Kje5WzCxA2Sd+9wsUW7uhkLeoTMK0cXPwH9rQ==",
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.10.4.tgz",
+      "integrity": "sha512-nozZSy/mKYLqe4YrqbKtdOszedAfXYCtw3wZ0d+CAjz4GqQ4L9rl1ltIL5BlgwmYVinJg/RZ0MgGuWOdlyRZlA==",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.4",
@@ -208,16 +208,15 @@
       }
     },
     "node_modules/@astrojs/markdown-satteri": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@astrojs/markdown-satteri/-/markdown-satteri-0.3.5.tgz",
-      "integrity": "sha512-CvWVEFAbay7YO+i9SaqDJubipA5ckiVB89QWoMJ5XC0m5CtFg8JwZ7Kau6X9sYY7FZURH0w2l03ISH2jOS/RDQ==",
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-satteri/-/markdown-satteri-0.3.8.tgz",
+      "integrity": "sha512-n8ItpFTCmlDsVR5+rwDmehSf+jFCYLWmZiisZNGuF7xILqYhsVeBfcha4qgS2Seq3fAc9Tm58ZVrvqFQ6RQgRQ==",
       "license": "MIT",
       "dependencies": {
-        "@astrojs/internal-helpers": "0.10.2",
+        "@astrojs/internal-helpers": "0.10.4",
         "@astrojs/prism": "4.0.2",
         "github-slugger": "^2.0.0",
-        "hast-util-from-html": "^2.0.3",
-        "satteri": "^0.9.1"
+        "satteri": "^0.10.3"
       }
     },
     "node_modules/@astrojs/prism": {
@@ -697,9 +696,9 @@
       }
     },
     "node_modules/@bruits/satteri-darwin-arm64": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/@bruits/satteri-darwin-arm64/-/satteri-darwin-arm64-0.9.5.tgz",
-      "integrity": "sha512-iw4nZgx9v30lWo/MTngQqi1pI78KI0DnkSm+lVJGYdmPLgAyDNJigVhpG42/Iq55A6c1Ll8q66ljyyRiQUxwow==",
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-darwin-arm64/-/satteri-darwin-arm64-0.10.5.tgz",
+      "integrity": "sha512-27KTVl4TJkVahMy/ohyA7qd4938G5UNneFUz/PsScYfpIhj0IVAS23mpcJXdPF44sa6nva198lmV/cKIb2YPyA==",
       "cpu": [
         "arm64"
       ],
@@ -710,9 +709,9 @@
       ]
     },
     "node_modules/@bruits/satteri-darwin-x64": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/@bruits/satteri-darwin-x64/-/satteri-darwin-x64-0.9.5.tgz",
-      "integrity": "sha512-6T26Z5Kf3cFW2PSlk9p7zT7yVxvuBSiJvYyz9u8KjYwMTqZyIDOj2wDyNpxKV4+6yUVG7rddq2QwvG/8LJA2+Q==",
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-darwin-x64/-/satteri-darwin-x64-0.10.5.tgz",
+      "integrity": "sha512-IjnLe3nKspq6qaeqGgjT7MT8VrTV74yWRlaag7ZdNsI8TDAYZ0iPxMCo+9KQZHUk5EyVB+reBI/PFWL5KuFw9Q==",
       "cpu": [
         "x64"
       ],
@@ -723,9 +722,9 @@
       ]
     },
     "node_modules/@bruits/satteri-linux-arm64-gnu": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-arm64-gnu/-/satteri-linux-arm64-gnu-0.9.5.tgz",
-      "integrity": "sha512-u51id17uJwNEMK9nBlICsq6U31c+XVqQueVBkwRIzZG+gMpS8TOJctt5h5Wz33Z8xnMdTd+adtACVz0yHgGuOA==",
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-arm64-gnu/-/satteri-linux-arm64-gnu-0.10.5.tgz",
+      "integrity": "sha512-glkYXZCJywjP13v67eAyAMSJdF+ncvEbYvgi/wOtffL9tQ27lr/zsyzUfgs+ovjJ9d8JNQKiXeiArJcX8PJL9w==",
       "cpu": [
         "arm64"
       ],
@@ -736,9 +735,9 @@
       ]
     },
     "node_modules/@bruits/satteri-linux-arm64-musl": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-arm64-musl/-/satteri-linux-arm64-musl-0.9.5.tgz",
-      "integrity": "sha512-v39HxiwGC5Rqm01HksP6+5Y+xKLPlsuVFgIgpEAo+SiQ22c+mJVhS3u7Z6ePAKdhL5NJoK1xq70kLz3L13AhpQ==",
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-arm64-musl/-/satteri-linux-arm64-musl-0.10.5.tgz",
+      "integrity": "sha512-yWdgG1g17Nh2QyGVlFUxGRa3FEFwiMcpZEyMNWkbM3deC94cmVc+/i9OuyFpdKuWo3GkgoCtYVOoxk1uCnCZIA==",
       "cpu": [
         "arm64"
       ],
@@ -749,9 +748,9 @@
       ]
     },
     "node_modules/@bruits/satteri-linux-x64-gnu": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-x64-gnu/-/satteri-linux-x64-gnu-0.9.5.tgz",
-      "integrity": "sha512-F3uO8uFp3pAP5ZGXttwvh57GS7s0lL953tnNdyI2gRyP4kOOkp6pyGojNJzCjkDvWI2Cvb9iNrKok3aqQPauAw==",
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-x64-gnu/-/satteri-linux-x64-gnu-0.10.5.tgz",
+      "integrity": "sha512-FVaLoPT1fBgGl0J+AYebyyXJYBachGl8Oyyrf1lye4RTqCB4S0Gwkj1uM9RJyThUOvx5VUmAT1CnNh1SFHA+kw==",
       "cpu": [
         "x64"
       ],
@@ -762,9 +761,9 @@
       ]
     },
     "node_modules/@bruits/satteri-linux-x64-musl": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-x64-musl/-/satteri-linux-x64-musl-0.9.5.tgz",
-      "integrity": "sha512-bicEqglLlz++mWyADaZoP0JY20s4vDfLjaPYgQqC+NI4zZLTOOg1T4GB8aqtc822Pqji8SQBmSrTb7CrP8i08Q==",
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-x64-musl/-/satteri-linux-x64-musl-0.10.5.tgz",
+      "integrity": "sha512-EHpVAx2bqW3GINHTKkljtxVfQmVDGWIuwOYOP5YghTj+0PkBa2o8oKPRtQ9Kbsr1Fye8jtUcDjhwj2jMNugZKg==",
       "cpu": [
         "x64"
       ],
@@ -775,9 +774,9 @@
       ]
     },
     "node_modules/@bruits/satteri-wasm32-wasi": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/@bruits/satteri-wasm32-wasi/-/satteri-wasm32-wasi-0.9.5.tgz",
-      "integrity": "sha512-zauAuMwfPnKPUkd4AFixRFpXdgKwP2mKgxrIIo2gJzW0/ZneF9dbHnLkojSpaBnCCp7VUL1hIi5WWZvB1CqmAQ==",
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-wasm32-wasi/-/satteri-wasm32-wasi-0.10.5.tgz",
+      "integrity": "sha512-ypz8c/Zmipxp4IoeDa228Gstv6TLzVmNs3yC6wKCoNSOjx1iwpgzu87Y3hTkXFdwChVGU85qeUDuOIarGUZQLw==",
       "cpu": [
         "wasm32"
       ],
@@ -786,7 +785,7 @@
       "dependencies": {
         "@emnapi/core": "1.11.1",
         "@emnapi/runtime": "1.11.1",
-        "@napi-rs/wasm-runtime": "^1.1.6"
+        "@napi-rs/wasm-runtime": "^1.2.3"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -824,9 +823,9 @@
       }
     },
     "node_modules/@bruits/satteri-win32-arm64-msvc": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/@bruits/satteri-win32-arm64-msvc/-/satteri-win32-arm64-msvc-0.9.5.tgz",
-      "integrity": "sha512-SrfE7NEsgZjBvU3c+RR6oQRu0ToXY5uVJEbieXEF0YTctIV2zAVlbaMjWLts074QCgh3a+XHWkR/lWh2VH2LUg==",
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-win32-arm64-msvc/-/satteri-win32-arm64-msvc-0.10.5.tgz",
+      "integrity": "sha512-siTV88nb0LRqNpkL2gXboqCwVdq95sLtzMHS1/3eONV2gLbB3NAK46wmSMvCO/yquBvI2lvaFIfd8P12ecsxBw==",
       "cpu": [
         "arm64"
       ],
@@ -837,9 +836,9 @@
       ]
     },
     "node_modules/@bruits/satteri-win32-x64-msvc": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/@bruits/satteri-win32-x64-msvc/-/satteri-win32-x64-msvc-0.9.5.tgz",
-      "integrity": "sha512-5Kw9ZAtTGS8WHizyn+CJhjjfIQrw+7jcZodpmpXJjefnO15M8UexIi6JR2E5thyvsmHyhL6ZDDMUNR4bKJPd4g==",
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-win32-x64-msvc/-/satteri-win32-x64-msvc-0.10.5.tgz",
+      "integrity": "sha512-C3IfPvfvMXmlzBxaMPKFS1XiuV9pu2mC7YqkPk7PSvTgPZ8gbdASIpHpztDLvTTQjqZ0z1Ol8tK5X+V6XXC0wQ==",
       "cpu": [
         "x64"
       ],
@@ -1883,9 +1882,9 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.2.tgz",
-      "integrity": "sha512-JfB4kuJQjaoHuCTseIINHtHWeJnvgEcxjwA5t/Y00ZgaOO1Crz3fjT/p8kT28zA/Caz7oiUMn3d6H2yOVCVwuw==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.3.tgz",
+      "integrity": "sha512-UMduMbqO5s5zF2NkNacMT/yK5Y5QiKvWr2+50bzIIxFDwVJ2h49b+oyjaCGPhJxd2/gC2x39EHv/gHVuu36x2Q==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1899,8 +1898,8 @@
         "url": "https://github.com/sponsors/Brooooooklyn"
       },
       "peerDependencies": {
-        "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.3",
-        "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.3"
+        "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.4",
+        "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.4"
       }
     },
     "node_modules/@oslojs/encoding": {
@@ -2200,36 +2199,14 @@
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "license": "MIT"
     },
-    "node_modules/@rollup/pluginutils": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.4.0.tgz",
-      "integrity": "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0",
-        "estree-walker": "^2.0.2",
-        "picomatch": "^4.0.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "rollup": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@shikijs/core": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.4.1.tgz",
-      "integrity": "sha512-VeR2CY6Nn9/WbisoYLOQZ7HZOnwTrpBuOw4wExjqLnBCi62BNWynBUO6K2uPIASPFJwAv7cX1fUu+LrPlSstcw==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.4.3.tgz",
+      "integrity": "sha512-QCR4q2ZO/ILJEuwiBMel4wdcTDb1JGwfjKTxPDF6x8ixOaluPrVqIn06C99AcRPhmYlBR56d/Fb+GN58GzExpg==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/primitive": "4.4.1",
-        "@shikijs/types": "4.4.1",
+        "@shikijs/primitive": "4.4.3",
+        "@shikijs/types": "4.4.3",
         "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.5",
         "hast-util-to-html": "^9.0.5"
@@ -2239,12 +2216,12 @@
       }
     },
     "node_modules/@shikijs/engine-javascript": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.4.1.tgz",
-      "integrity": "sha512-6U4lJBh8LTvIkEVqRHv/rr3ruwtO6IweFQt1ME1ntHJMGHS+6N86vfYGO1o8c/DtOCTia2lfhdQBtBrps1sDfQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.4.3.tgz",
+      "integrity": "sha512-FbOjFJp9VLdo1Wevs10BBtVxiTWwNLqZh5Gkhjgda/ioL15YOgeSl9n+6XMa3qRlPQzfhFNe641SrynFHYG0nQ==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "4.4.1",
+        "@shikijs/types": "4.4.3",
         "@shikijs/vscode-textmate": "^10.0.2",
         "oniguruma-to-es": "^4.3.6"
       },
@@ -2253,12 +2230,12 @@
       }
     },
     "node_modules/@shikijs/engine-oniguruma": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.4.1.tgz",
-      "integrity": "sha512-p23RugMKss0r5DAtRJW1yAXUDl60JvhQYV20yuxei//26JyDSJefV3umyWzzwep2weblMnJGDYahuti6XkcMgA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.4.3.tgz",
+      "integrity": "sha512-EcOQkxdxGQrc1Row/cC2c96/v1dbZqGnEVu1qTuT/MJmp6+cXCvQussowVmCv5Tqr3KuY3c7IbM6HTW3LJ1k9w==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "4.4.1",
+        "@shikijs/types": "4.4.3",
         "@shikijs/vscode-textmate": "^10.0.2"
       },
       "engines": {
@@ -2266,24 +2243,24 @@
       }
     },
     "node_modules/@shikijs/langs": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.4.1.tgz",
-      "integrity": "sha512-xb2kCMloBCIraIy2fS5MW0t/BxVY3q2nDyQKBoeSeq6KNrQbShHetCFlw2n35fGIJ6t3+hXDLQogP5ir9O9bvA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.4.3.tgz",
+      "integrity": "sha512-ePic0yfAJGOF83D5wBHK/00EjK65oahBYxFk5epgq33WRv7X9UuxLEV8PtR0szC0z8dl7INIpIodB99JRFlR+A==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "4.4.1"
+        "@shikijs/types": "4.4.3"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@shikijs/primitive": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.4.1.tgz",
-      "integrity": "sha512-ko2OfDoG89YuQ7xL5LtcQiWKb7NIv1Ephb7g48TVU198OzAMLC8lXVEwaJGHK4sUMYrfAGJDqYmNLOLiW/Kz8w==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.4.3.tgz",
+      "integrity": "sha512-m0wBeLDQDeIxRdUmrCPdQqfuUamDwRL5isCfYbguKD6NiaKpVbsv+3J81DyIKgNW5h4WAIIr8T4EkgQrBBxvaQ==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "4.4.1",
+        "@shikijs/types": "4.4.3",
         "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.5"
       },
@@ -2292,21 +2269,21 @@
       }
     },
     "node_modules/@shikijs/themes": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.4.1.tgz",
-      "integrity": "sha512-wudOaoFro+/Zl9gQv2W1Ur5XlVduqvTuYLI483Xi0wgc1A+cy1hfB2r6ac6ufBgF+ID7KJEW7L41MHrzQ4wH+w==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.4.3.tgz",
+      "integrity": "sha512-w8UHjeUnIR965KMWJHUPXOc2mNJUnK3vpVLYLvw5IYU2mnTTJ89E24OrJDBNiJDQ0qzb0tc4l7mrIXx5cFeIyw==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "4.4.1"
+        "@shikijs/types": "4.4.3"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/@shikijs/types": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.4.1.tgz",
-      "integrity": "sha512-GOwCLQDHM5EjGUWNPrhzJbr6JP8V/Dx/CDVkWvbZ1Avw5JFnNUckrgbLmE07qtg4WlW7Q7QFndhjIkeU9XMPvw==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.4.3.tgz",
+      "integrity": "sha512-UEJxmRR++MAGR6hugn0vgVS2W/6lWAts84FFSrnlH9sP0LNol7E5+NQ792pH8liWUhyMyjhTgSUH3k7iD7tc5g==",
       "license": "MIT",
       "dependencies": {
         "@shikijs/vscode-textmate": "^10.0.2",
@@ -2870,6 +2847,21 @@
         "am-i-vibing": "dist/cli.mjs"
       }
     },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/ansis": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/ansis/-/ansis-4.3.1.tgz",
@@ -2920,19 +2912,18 @@
       }
     },
     "node_modules/astro": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-7.1.6.tgz",
-      "integrity": "sha512-83x9rYbHazMaZkYrAFRVZXSQx2moFkz0F7cjTDUF3GWfS0a3p2vZXG1ZdhV86rStHApQCodBJW+XTD37xISIrQ==",
+      "version": "7.2.6",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-7.2.6.tgz",
+      "integrity": "sha512-qzT4tAhgHYX/6/MUGslAkF0PVkM4WNsMw2A1GrbfA9cXp68hmdqF3f7MuF5rRFvwQbjowqjOf90ao9whfgV5mw==",
       "license": "MIT",
       "dependencies": {
-        "@astrojs/compiler-rs": "^0.3.2",
-        "@astrojs/internal-helpers": "0.10.2",
-        "@astrojs/markdown-satteri": "0.3.5",
+        "@astrojs/compiler-rs": "^0.4.0",
+        "@astrojs/internal-helpers": "0.10.4",
+        "@astrojs/markdown-satteri": "0.3.8",
         "@astrojs/telemetry": "3.3.3",
         "@capsizecss/unpack": "^4.0.0",
         "@clack/prompts": "^1.1.0",
         "@oslojs/encoding": "^1.1.0",
-        "@rollup/pluginutils": "^5.3.0",
         "am-i-vibing": "^0.4.0",
         "aria-query": "^5.3.2",
         "axobject-query": "^4.1.0",
@@ -2941,10 +2932,11 @@
         "common-ancestor-path": "^2.0.0",
         "cookie": "^2.0.1",
         "devalue": "^5.8.1",
-        "diff": "^8.0.3",
+        "diff": "^9.0.0",
         "dset": "^3.1.4",
         "es-module-lexer": "^2.0.0",
         "esbuild": "^0.28.0",
+        "find-process": "^2.1.1",
         "flattie": "^1.1.1",
         "fontace": "~0.4.1",
         "get-tsconfig": "5.0.0-beta.4",
@@ -2971,7 +2963,7 @@
         "tinyexec": "^1.0.4",
         "tinyglobby": "^0.2.15",
         "ultrahtml": "^1.6.0",
-        "unifont": "~0.7.4",
+        "unifont": "~0.7.5",
         "unstorage": "^1.17.5",
         "vite": "^8.0.13",
         "vitefu": "^1.1.2",
@@ -2995,7 +2987,7 @@
         "sharp": "^0.34.0 || ^0.35.0"
       },
       "peerDependencies": {
-        "@astrojs/markdown-remark": "7.2.2"
+        "@astrojs/markdown-remark": "7.2.4"
       },
       "peerDependenciesMeta": {
         "@astrojs/markdown-remark": {
@@ -3148,6 +3140,22 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/character-entities-html4": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
@@ -3206,6 +3214,24 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
     },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
@@ -3456,9 +3482,9 @@
       }
     },
     "node_modules/diff": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
-      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -3695,6 +3721,29 @@
         }
       }
     },
+    "node_modules/find-process": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/find-process/-/find-process-2.1.1.tgz",
+      "integrity": "sha512-SrQDx3QhlmHM90iqn9rdjCQcw/T+WlpOkHFsjoRgB+zTpDfltNA1VSNYeYELwhUTJy12UFxqjWhmhOrJc+o4sA==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "~4.1.2",
+        "commander": "^14.0.3",
+        "loglevel": "^1.9.2"
+      },
+      "bin": {
+        "find-process": "dist/cjs/bin/find-process.js"
+      }
+    },
+    "node_modules/find-process/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/flattie": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/flattie/-/flattie-1.1.1.tgz",
@@ -3792,55 +3841,13 @@
         "uncrypto": "^0.1.3"
       }
     },
-    "node_modules/hast-util-from-html": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
-      "integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "devlop": "^1.1.0",
-        "hast-util-from-parse5": "^8.0.0",
-        "parse5": "^7.0.0",
-        "vfile": "^6.0.0",
-        "vfile-message": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-from-parse5": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
-      "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "@types/unist": "^3.0.0",
-        "devlop": "^1.0.0",
-        "hastscript": "^9.0.0",
-        "property-information": "^7.0.0",
-        "vfile": "^6.0.0",
-        "vfile-location": "^5.0.0",
-        "web-namespaces": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-parse-selector": {
+    "node_modules/has-flag": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
-      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/hast-util-to-html": {
@@ -3873,23 +3880,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hastscript": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
-      "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "comma-separated-tokens": "^2.0.0",
-        "hast-util-parse-selector": "^4.0.0",
-        "property-information": "^7.0.0",
-        "space-separated-tokens": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -4342,6 +4332,19 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/loglevel": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
+      "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -4700,30 +4703,6 @@
       "integrity": "sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==",
       "license": "MIT"
     },
-    "node_modules/parse5": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
-      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
-      "license": "MIT",
-      "dependencies": {
-        "entities": "^6.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
-    "node_modules/parse5/node_modules/entities": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -4941,26 +4920,26 @@
       }
     },
     "node_modules/satteri": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/satteri/-/satteri-0.9.5.tgz",
-      "integrity": "sha512-ZuWVl+vnM64y+/TtX8Kosv2c00W+hLQiiwnEL6H0UKVVrxFqMw4D2CJHHQaouVd89OAhtBBfjWLqhKi3TVUV4w==",
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/satteri/-/satteri-0.10.5.tgz",
+      "integrity": "sha512-Ao1LKpAEa9Wdg0otgbVKViZHEq9ebdXe4DMrp3s9vQAU0HNIuHnFEuMuOcm0ZIXyV0Yzxj91NvhLpvXZJO/5ZQ==",
       "license": "MIT",
       "dependencies": {
         "@types/estree-jsx": "^1.0.5",
-        "@types/hast": "^3.0.4",
+        "@types/hast": "^3.0.5",
         "@types/mdast": "^4.0.4",
         "@types/unist": "^3.0.3"
       },
       "optionalDependencies": {
-        "@bruits/satteri-darwin-arm64": "0.9.5",
-        "@bruits/satteri-darwin-x64": "0.9.5",
-        "@bruits/satteri-linux-arm64-gnu": "0.9.5",
-        "@bruits/satteri-linux-arm64-musl": "0.9.5",
-        "@bruits/satteri-linux-x64-gnu": "0.9.5",
-        "@bruits/satteri-linux-x64-musl": "0.9.5",
-        "@bruits/satteri-wasm32-wasi": "0.9.5",
-        "@bruits/satteri-win32-arm64-msvc": "0.9.5",
-        "@bruits/satteri-win32-x64-msvc": "0.9.5"
+        "@bruits/satteri-darwin-arm64": "0.10.5",
+        "@bruits/satteri-darwin-x64": "0.10.5",
+        "@bruits/satteri-linux-arm64-gnu": "0.10.5",
+        "@bruits/satteri-linux-arm64-musl": "0.10.5",
+        "@bruits/satteri-linux-x64-gnu": "0.10.5",
+        "@bruits/satteri-linux-x64-musl": "0.10.5",
+        "@bruits/satteri-wasm32-wasi": "0.10.5",
+        "@bruits/satteri-win32-arm64-msvc": "0.10.5",
+        "@bruits/satteri-win32-x64-msvc": "0.10.5"
       }
     },
     "node_modules/sax": {
@@ -5045,17 +5024,17 @@
       }
     },
     "node_modules/shiki": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.4.1.tgz",
-      "integrity": "sha512-rFP+iYKzjLEIqiMiKANhARqiAbk4deDhWnBtnUO/K0D0dPxMGDH4N0FVfBY/VeI+lPrV4wNGCHQZp7EOr7NNBw==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.4.3.tgz",
+      "integrity": "sha512-Mb/GvXPHBAXdgGIcnfU5L3ldpn1XcxrGkPHwqgRx17/I2XRfqlFKk2vGkHWINn1kdXvzJZeuO3is6I9KLPFm0g==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/core": "4.4.1",
-        "@shikijs/engine-javascript": "4.4.1",
-        "@shikijs/engine-oniguruma": "4.4.1",
-        "@shikijs/langs": "4.4.1",
-        "@shikijs/themes": "4.4.1",
-        "@shikijs/types": "4.4.1",
+        "@shikijs/core": "4.4.3",
+        "@shikijs/engine-javascript": "4.4.3",
+        "@shikijs/engine-oniguruma": "4.4.3",
+        "@shikijs/langs": "4.4.3",
+        "@shikijs/themes": "4.4.3",
+        "@shikijs/types": "4.4.3",
         "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.5"
       },
@@ -5084,9 +5063,9 @@
       "license": "MIT"
     },
     "node_modules/smol-toml": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.7.1.tgz",
-      "integrity": "sha512-PPlsspAZ4jbMBu5DMFhfUGDQLu/vrL4SyBROVS37x8ynnVmFIs1VPBz1Co8Xks3TvpIaZXmU85y4DrQ+UyVFoQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.8.0.tgz",
+      "integrity": "sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 18"
@@ -5126,6 +5105,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/svgo": {
@@ -5266,6 +5257,15 @@
       "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
       "license": "MIT"
     },
+    "node_modules/undici": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
     "node_modules/unified": {
       "version": "11.0.5",
       "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
@@ -5286,14 +5286,14 @@
       }
     },
     "node_modules/unifont": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/unifont/-/unifont-0.7.4.tgz",
-      "integrity": "sha512-oHeis4/xl42HUIeHuNZRGEvxj5AaIKR+bHPNegRq5LV1gdc3jundpONbjglKpihmJf+dswygdMJn3eftGIMemg==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/unifont/-/unifont-0.7.5.tgz",
+      "integrity": "sha512-ULe/Cs+ZIsq+dcFofNkhqielCrUJnb5mr+Yc4EBM2VlL+6OZR6+cjtI2mT1bJvRBrVncqHAbLURxmPLcCXzWMg==",
       "license": "MIT",
       "dependencies": {
         "css-tree": "^3.1.0",
-        "ofetch": "^1.5.1",
-        "ohash": "^2.0.11"
+        "ohash": "^2.0.11",
+        "undici": "^8.0.0"
       }
     },
     "node_modules/unist-util-is": {
@@ -5523,20 +5523,6 @@
       "dependencies": {
         "@types/unist": "^3.0.0",
         "vfile-message": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/vfile-location": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
-      "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "vfile": "^6.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -6079,16 +6065,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/web-namespaces": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
-      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/wsl-utils": {

--- a/website/package.json
+++ b/website/package.json
@@ -10,9 +10,9 @@
     "astro": "astro"
   },
   "dependencies": {
-    "astro": "^7.1.6",
     "@astrojs/vue": "^7.0.1",
     "@tailwindcss/vite": "^4.3.3",
+    "astro": "^7.2.6",
     "tailwindcss": "^4.3.3",
     "vue": "^3.5.40"
   }

--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -1,6 +1,16 @@
 ---
 const cols = [
   {
+    title: "Explore",
+    links: [
+      { label: "Audiences", href: "/retrace/audiences/" },
+      { label: "Use cases", href: "/retrace/use-cases/" },
+      { label: "Examples", href: "/retrace/examples/" },
+      { label: "Docs & quickstart", href: "/retrace/docs/" },
+      { label: "About & roadmap", href: "/retrace/about/" },
+    ],
+  },
+  {
     title: "Docs",
     links: [
       { label: "README", href: "https://github.com/riboseinc/retrace/blob/main/README.adoc" },
@@ -58,7 +68,7 @@ const cols = [
     </div>
     <div class="footer-bottom">
       <span>BSD-2-Clause · built by Ribose</span>
-      <span>v2.2.2</span>
+      <span>v2.37.0</span>
     </div>
   </div>
 </footer>

--- a/website/src/components/Nav.astro
+++ b/website/src/components/Nav.astro
@@ -9,6 +9,10 @@ import SiteSearch from "./SiteSearch.vue";
       <span class="dot"></span>retrace
     </a>
     <div class="nav-links">
+      <a href="/retrace/audiences/">Audiences</a>
+      <a href="/retrace/use-cases/">Use cases</a>
+      <a href="/retrace/examples/">Examples</a>
+      <a href="/retrace/docs/">Docs</a>
       <a href="#playground">Try it</a>
       <a href="#anatomy">How it works</a>
       <a href="#actions">Actions</a>
@@ -16,6 +20,7 @@ import SiteSearch from "./SiteSearch.vue";
       <a href="#use-cases">Use cases</a>
       <a href="#tutorials">Tutorials</a>
       <a href="#faq">FAQ</a>
+      <a href="/retrace/about/">About</a>
       <a href="#platforms">Platforms</a>
       <a href="https://github.com/riboseinc/retrace/blob/main/docs/cookbook/README.md">Cookbook</a>
       <a href="https://github.com/riboseinc/retrace">GitHub</a>

--- a/website/src/pages/about.astro
+++ b/website/src/pages/about.astro
@@ -1,0 +1,126 @@
+---
+// About — what retrace is, the license story, the roadmap.
+import Layout from "../layouts/Layout.astro";
+import Nav from "../components/Nav.astro";
+import Footer from "../components/Footer.astro";
+---
+
+<Layout title="About retrace" description="What retrace is, who builds it, how it's licensed, and where it's going.">
+  <Nav />
+  <main id="top">
+    <section class="hero">
+      <div class="wrap">
+        <p class="eyebrow">ABOUT</p>
+        <h1>A userspace libc interceptor<br />that answers questions.</h1>
+        <p class="lede">
+          retrace began as a debugging tool and became an instrument: observe
+          every libc call, rewrite it, break it, jail it — without source,
+          without recompiling, on thirteen platforms. One shared library, one
+          JSON config language, BSD-2-Clause.
+        </p>
+      </div>
+    </section>
+
+    <section class="sec">
+      <div class="wrap">
+        <h2>What it is</h2>
+        <div class="cols">
+          <div>
+            <h3>The engine</h3>
+            <p>A per-arch assembly trampoline funnels every intercepted call
+            into one engine, which runs a JSON script of composable actions —
+            log, mutate, inject failure, deny, decode, capture. Prototypes
+            (parameter metadata) live in tables; new functions are an
+            inventory line plus a prototype entry, conformance-tested.</p>
+          </div>
+          <div>
+            <h3>The backends</h3>
+            <p>Preload backends for ELF, Mach-O, and the BSDs; inline-hooking
+            backends for Windows (MSVC + MinGW, x64 + arm64, including
+            static-CRT binaries through the ntdll layer); ptrace for Linux
+            static binaries. All one engine behind them.</p>
+          </div>
+          <div>
+            <h3>The truth layer</h3>
+            <p>libc-level claims are graded against kernel truth: strace,
+            dtrace, truss, ktrace, procmon, and raw ETW all convert into the
+            retrace shape, so "what it touched" has evidence behind it.</p>
+          </div>
+          <div>
+            <h3>The observability bridge</h3>
+            <p>Live OTLP streaming (spans, security events, metrics) and a
+            documented attribute schema — retrace feeds the pipeline you
+            already run instead of inventing another one.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="sec">
+      <div class="wrap">
+        <h2>License & provenance</h2>
+        <ul class="plain">
+          <li><strong>retrace</strong> — BSD-2-Clause, by <a href="https://www.ribose.com">Ribose</a>. Source of truth: the LICENSE file; no CLA required, contributions are inbound BSD-2.</li>
+          <li><strong>otlp-c</strong> (vendored, <code>third_party/otlp-c</code>) — BSD-3-Clause. The pure-C OTLP client behind the streaming waves; see THIRD_PARTY_NOTICES.</li>
+          <li><strong>parson</strong> (vendored) — MIT. The tolerant JSON parser behind configs and traces.</li>
+        </ul>
+        <p>Every release ships a THIRD_PARTY_NOTICES with the license text
+        of each vendored dependency and its pin.</p>
+      </div>
+    </section>
+
+    <section class="sec" id="roadmap">
+      <div class="wrap">
+        <h2>Roadmap: the supervisor arc</h2>
+        <p>The next chapter is <code>retraced</code>: a per-host supervisor
+        daemon behind a formally-versioned control protocol. Fleets of
+        traced processes under central, signed policy; incident response
+        that attaches, freezes, and pulls the flight recorder from a live
+        hostile process; audit-grade, hash-chained event journals — with
+        telemetry still flowing through OTLP, untouched.</p>
+        <div class="pill-row">
+          <span class="pill">detonation farms</span>
+          <span class="pill">specimen freeze + black-box pull</span>
+          <span class="pill">signed, versioned policy</span>
+          <span class="pill">session trees → one trace</span>
+          <span class="pill">fleet CLI over TLS</span>
+        </div>
+      </div>
+    </section>
+
+    <section class="sec last">
+      <div class="wrap">
+        <h2>Contributing</h2>
+        <p>Pull requests, issues, and cookbook recipes are all contributions.
+        The <a href="https://github.com/riboseinc/retrace/blob/main/docs/development.md">development
+        guide</a> covers the build, the test pyramid, and the one-line test
+        registration; CI runs the full 13-platform matrix on every PR, and
+        checkpatch holds the kernel style.</p>
+      </div>
+    </section>
+  </main>
+  <Footer />
+</Layout>
+
+<style>
+  .hero { padding: 96px 0 44px; }
+  .wrap { max-width: 980px; margin: 0 auto; padding: 0 24px; }
+  .eyebrow { font-family: var(--font-mono); font-size: 11px; letter-spacing: .22em; color: var(--color-dim); margin-bottom: 14px; }
+  h1 { font-size: clamp(28px, 4.6vw, 44px); letter-spacing: -0.02em; margin: 0 0 14px; line-height: 1.15; }
+  .lede { color: var(--color-dim); max-width: 660px; font-size: 16px; line-height: 1.65; }
+  .sec { padding: 44px 0; border-top: 1px solid rgba(255,255,255,.05); scroll-margin-top: 80px; }
+  .sec.last { padding-bottom: 90px; }
+  h2 { font-size: 22px; margin: 0 0 18px; letter-spacing: -0.01em; }
+  h3 { font-size: 14.5px; margin: 0 0 8px; }
+  p { color: var(--color-dim); font-size: 13.5px; line-height: 1.65; }
+  p code { font-family: var(--font-mono); font-size: 12px; color: var(--color-text); background: rgba(255,255,255,.05); padding: 1px 5px; border-radius: 3px; }
+  a { color: var(--color-see); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  .cols { display: grid; grid-template-columns: 1fr 1fr; gap: 26px; }
+  @media (max-width: 720px) { .cols { grid-template-columns: 1fr; } }
+  .plain { list-style: none; padding: 0; margin: 0 0 12px; display: grid; gap: 10px; }
+  .plain li { color: var(--color-dim); font-size: 13.5px; line-height: 1.6; }
+  .plain strong { color: var(--color-text); }
+  .pill-row { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 16px; }
+  .pill { font-family: var(--font-mono); font-size: 11px; color: var(--color-see); background: var(--color-see-soft); padding: 4px 11px; border-radius: 999px; }
+</style>

--- a/website/src/pages/audiences.astro
+++ b/website/src/pages/audiences.astro
@@ -1,0 +1,150 @@
+---
+// Audiences — who retrace is for, with the trail each one walks.
+import Layout from "../layouts/Layout.astro";
+import Nav from "../components/Nav.astro";
+import Footer from "../components/Footer.astro";
+
+const audiences = [
+  {
+    id: "researcher",
+    accent: "see",
+    verb: "See",
+    who: "Security researchers & malware analysts",
+    why: "You reverse binaries without source. retrace maps every file, network, and process call in seconds — then lets you rewrite them mid-flight, jail them, and stream violations live to your collector.",
+    steps: [
+      { t: "Map the surface", c: "retrace trace open,connect,system,getenv -- ./sample", d: "One command, every libc touchpoint, JSON out." },
+      { t: "Detonate under a jail", c: "retrace-profile capture -o p.json -- ./sample", d: "Profile the run, emit a jail config, re-run confined." },
+      { t: "Watch violations live", c: "RETRACE_OTLP_ENDPOINT=http://collector:4318 retrace ...", d: "Denials stream as OTLP log records while it runs." },
+    ],
+    trail: [
+      { label: "Live detonation workflow", href: "/retrace/use-cases/#detonation" },
+      { label: "id-redirection example", href: "/retrace/examples/#id-redirection" },
+      { label: "Cookbook: jail + harden", href: "https://github.com/riboseinc/retrace/blob/main/docs/cookbook/34-profile-and-jail.md" },
+    ],
+  },
+  {
+    id: "fuzzer",
+    accent: "break",
+    verb: "Break",
+    who: "Fuzzing engineers & QA",
+    why: "Error paths hide bugs but need fixtures nobody writes. Inject OOM, short I/O, latency, and mutated strings straight into the target — deterministic seeds, reproducible runs, clustered crash reports.",
+    steps: [
+      { t: "Fail allocations deterministically", c: "retrace fuzz malloc --rate 0.1 -- ./parser file", d: "Same seed, same failures — every crash reproducible." },
+      { t: "Run a corpus campaign", c: "retrace-fuzz-report --config fuzz.json --seeds corpus/ -- ./target", d: "Clusters, reproducers, minimized corpus, drift oracle." },
+      { t: "Mutate strings by grammar", c: "fuzz_str with @-template dictionaries", d: "Template lines expand at load; %1..%9 reference tokens." },
+    ],
+    trail: [
+      { label: "Fuzz campaign workflow", href: "/retrace/use-cases/#fuzzing" },
+      { label: "fuzz-workbench example", href: "/retrace/examples/#fuzz-workbench" },
+      { label: "Cookbook: dictionary fuzzing", href: "https://github.com/riboseinc/retrace/blob/main/docs/cookbook/35-dictionary-fuzz.md" },
+    ],
+  },
+  {
+    id: "auditor",
+    accent: "control",
+    verb: "Attest",
+    who: "Auditors & compliance teams",
+    why: "Claims need ground truth. retrace grades what a binary SAYS it touches against kernel-layer evidence (strace/dtrace/ktrace/procmon/ETW) and against the declared set of its packaging manifest.",
+    steps: [
+      { t: "Capture + grade", c: "retrace-profile --libc t.json --kernel truth.json", d: "libc_only/kernel_only counts: sub-libc access made visible." },
+      { t: "Audit a package's declared set", c: "retrace-profile --libc t.json --inside declared.json", d: "Observed-but-not-granted paths are headline violations." },
+      { t: "Diff behavior across versions", c: "retrace-profile diff baseline.json candidate.json", d: "Drift the baseline never saw — the supply-chain signal." },
+    ],
+    trail: [
+      { label: "Continuous audit workflow", href: "/retrace/use-cases/#audit" },
+      { label: "packaging-audit example", href: "/retrace/examples/#packaging-audit" },
+      { label: "Output shapes reference", href: "https://github.com/riboseinc/retrace/blob/main/docs/reports.md" },
+    ],
+  },
+  {
+    id: "sre",
+    accent: "see",
+    verb: "Diagnose",
+    who: "SREs & backend developers",
+    why: "The 3am failure is environmental. Trace the exact libc calls of a misbehaving service — timings, env reads, DNS, connects — without redeploying instrumented builds.",
+    steps: [
+      { t: "Time every call", c: "retrace trace 'sqlite3_*' --time -- ./migration", d: "p99/max per function, honest aggregates." },
+      { t: "Watch env + DNS behavior", c: "retrace trace getenv,getaddrinfo,connect -- ./svc", d: "Config drift and resolver paths, visible." },
+      { t: "Replay deterministically", c: "retrace replay session.json", d: "Same calls, same mutations — bugs replay on your laptop." },
+    ],
+    trail: [
+      { label: "OTLP observability", href: "/retrace/use-cases/#otlp" },
+      { label: "All examples", href: "/retrace/examples/" },
+      { label: "Docs: quickstart", href: "/retrace/docs/#quickstart" },
+    ],
+  },
+];
+---
+
+<Layout title="Audiences — who retrace is for" description="Four audiences, four trails: security research, fuzzing, audit, and operations.">
+  <Nav />
+  <main id="top">
+    <section class="hero">
+      <div class="wrap">
+        <p class="eyebrow">AUDIENCES</p>
+        <h1>One instrument, four professions.</h1>
+        <p class="lede">
+          retrace's actions compose differently for each audience. Pick your
+          trail — every step is a command you can run today.
+        </p>
+      </div>
+    </section>
+
+    {audiences.map((a) => (
+      <section class="section" id={a.id}>
+        <div class="wrap">
+          <div class={`head accent-${a.accent}`}>
+            <span class={`verb v-${a.accent}`}>{a.verb}</span>
+            <div>
+              <h2>{a.who}</h2>
+              <p>{a.why}</p>
+            </div>
+          </div>
+          <div class="steps">
+            {a.steps.map((s) => (
+              <article class="step glass">
+                <h3>{s.t}</h3>
+                <pre class="cmd"><span class="prompt">$</span> {s.c}</pre>
+                <p>{s.d}</p>
+              </article>
+            ))}
+          </div>
+          <div class="trail">
+            {a.trail.map((t) => (
+              <a href={t.href}>{t.label} →</a>
+            ))}
+          </div>
+        </div>
+      </section>
+    ))}
+  </main>
+  <Footer />
+</Layout>
+
+<style>
+  .hero { padding: 96px 0 48px; }
+  .wrap { max-width: 1080px; margin: 0 auto; padding: 0 24px; }
+  .eyebrow { font-family: var(--font-mono); font-size: 11px; letter-spacing: .22em; color: var(--color-dim); margin-bottom: 14px; }
+  h1 { font-size: clamp(30px, 5vw, 46px); letter-spacing: -0.02em; margin: 0 0 14px; }
+  .lede { color: var(--color-dim); max-width: 640px; font-size: 16px; line-height: 1.6; }
+  .section { padding: 56px 0; border-top: 1px solid rgba(255,255,255,.05); }
+  .head { display: flex; gap: 22px; align-items: flex-start; margin-bottom: 26px; }
+  .head h2 { font-size: 24px; margin: 0 0 8px; letter-spacing: -0.01em; }
+  .head p { color: var(--color-dim); max-width: 720px; line-height: 1.6; margin: 0; font-size: 14.5px; }
+  .verb { font-family: var(--font-mono); font-weight: 700; font-size: 13px; padding: 6px 12px; border-radius: 6px; white-space: nowrap; margin-top: 4px; }
+  .v-see { color: var(--color-see); background: var(--color-see-soft); }
+  .v-control { color: var(--color-control); background: var(--color-control-soft); }
+  .v-break { color: var(--color-break); background: var(--color-break-soft); }
+  .accent-see { border-left: 2px solid rgba(94,227,255,.35); padding-left: 22px; }
+  .accent-control { border-left: 2px solid rgba(242,180,65,.35); padding-left: 22px; }
+  .accent-break { border-left: 2px solid rgba(255,107,92,.35); padding-left: 22px; }
+  .steps { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 16px; }
+  .step { padding: 20px; border-radius: 10px; }
+  .step h3 { font-size: 15px; margin: 0 0 10px; }
+  .step p { color: var(--color-dim); font-size: 12.5px; line-height: 1.55; margin: 10px 0 0; }
+  .cmd { background: rgba(7,9,13,.7); border: 1px solid rgba(255,255,255,.06); border-radius: 6px; padding: 10px 12px; font-family: var(--font-mono); font-size: 11.5px; color: var(--color-text); overflow-x: auto; margin: 0; line-height: 1.45; }
+  .prompt { color: var(--color-break); margin-right: 6px; }
+  .trail { display: flex; gap: 22px; flex-wrap: wrap; margin-top: 18px; }
+  .trail a { font-family: var(--font-mono); font-size: 12px; color: var(--color-see); text-decoration: none; }
+  .trail a:hover { text-decoration: underline; }
+</style>

--- a/website/src/pages/docs.astro
+++ b/website/src/pages/docs.astro
@@ -1,0 +1,188 @@
+---
+// Docs — how to use retrace: install, quickstart, config, actions,
+// streaming, jail, kernel truth. The deep reference stays in the repo.
+import Layout from "../layouts/Layout.astro";
+import Nav from "../components/Nav.astro";
+import Footer from "../components/Footer.astro";
+
+const actions = [
+  ["log_params", "Serialize the call's parameters (one-level derefs) to the trace."],
+  ["call_real", "Invoke the real implementation and time it."],
+  ["modify_in_param_str/int/arr", "Rewrite arguments before the real call."],
+  ["modify_return_value_int", "Fabricate the return value."],
+  ["memory_fuzz", "Fail allocations at a rate, deterministically seeded."],
+  ["fuzz_str", "Dictionary/grammar mutation of string params (@-templates, %1..%9)."],
+  ["incomplete_io", "Short reads/writes — partial I/O injection."],
+  ["delay", "Latency injection per call."],
+  ["call_count_limit", "Resource exhaustion: N calls then fail."],
+  ["sandbox", "The jail: allow_paths/deny_paths, deny_classes, env lists, decoy_dir."],
+  ["addr_deny", "Deny specific address families/ports at connect."],
+  ["filter", "Conditional script routing."],
+  ["decode_http / decode_dns", "Protocol decode into the trace."],
+  ["capture_buffer", "Capture I/O payloads for replay."],
+];
+const cfgSnippet = `{ "intercept_scripts": [
+  { "func_name": "open", "actions": [
+    { "action_name": "log_params" },
+    { "action_name": "call_real" } ] } ] }`;
+---
+
+---
+
+<Layout title="Docs — using retrace" description="Install, five-minute quickstart, config anatomy, the action set, OTLP streaming, jail flow, and kernel-truth grading.">
+  <Nav />
+  <main id="top">
+    <section class="hero">
+      <div class="wrap">
+        <p class="eyebrow">DOCS</p>
+        <h1>Using retrace.</h1>
+        <p class="lede">
+          Everything to go from zero to a jailed, streaming, graded run. The
+          full reference lives in the repo's <code>docs/</code> — this page is
+          the path through it.
+        </p>
+      </div>
+    </section>
+
+    <section class="sec" id="install">
+      <div class="wrap">
+        <h2>1 · Install</h2>
+        <div class="cols">
+          <div>
+            <h3>From source (canonical)</h3>
+            <pre class="cmd">git clone https://github.com/riboseinc/retrace
+cd retrace
+cmake -B build -G Ninja -DRETRACE_BUILD_TESTS=ON
+cmake --build build
+ctest --test-dir build --output-on-failure</pre>
+          </div>
+          <div>
+            <h3>Prebuilt</h3>
+            <pre class="cmd"># release artifacts: .so / .dylib / .dll per platform
+# install.sh detects OS + arch
+curl -fsSL https://github.com/riboseinc/retrace/releases |
+  sh -s -- download</pre>
+            <p>Thirteen platforms: Linux (glibc + musl) x64/arm64, macOS Intel + Apple Silicon, FreeBSD/OpenBSD/NetBSD, Windows MSVC + MinGW x64/arm64, Android, OHOS.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="sec" id="quickstart">
+      <div class="wrap">
+        <h2>2 · Five-minute quickstart</h2>
+        <pre class="cmd"><span class="c"># one env var per platform — the library does the rest</span>
+LD_PRELOAD=build/src/v2/libretrace.so /bin/ls          <span class="c"># Linux/BSD</span>
+DYLD_INSERT_LIBRARIES=build/src/v2/libretrace.dylib /bin/id  <span class="c"># macOS</span>
+retrace-win-run --dll retrace.dll -- target.exe        <span class="c"># Windows</span>
+
+<span class="c"># now with a config: log + call_real on selected functions</span>
+cat > trace.json &lt;&lt;'EOF'
+${cfgSnippet}
+EOF
+RETRACE_JSON_CONFIG=trace.json LD_PRELOAD=build/src/v2/libretrace.so ./tool</pre>
+        <p class="tip">macOS SIP blocks injection into system binaries — <code>csrutil disable</code> in Recovery, or copy the binary somewhere non-protected first.</p>
+      </div>
+    </section>
+
+    <section class="sec" id="config">
+      <div class="wrap">
+        <h2>3 · Config anatomy</h2>
+        <pre class="cmd">{`{ "intercept_scripts": [
+  { "func_name": "getenv",          // exact name, or "sqlite3_*"
+    "actions": [
+      { "action_name": "fuzz_str",
+        "action_params": { "dict": "env.dict", "fuzz_seed": 42 } },
+      { "action_name": "call_real" } ] } ] }`}</pre>
+        <p>Comments are tolerated (parson's comment mode). Without a config you
+        get the default: <code>log_params + call_real</code> for every
+        intercepted function. Validate any config with
+        <code>retrace-profile validate</code> or the on-site validator below.</p>
+      </div>
+    </section>
+
+    <section class="sec" id="actions">
+      <div class="wrap">
+        <h2>4 · The action set</h2>
+        <div class="table">
+          {actions.map(([n, d]) => (
+            <div class="row">
+              <code>{n}</code>
+              <span>{d}</span>
+            </div>
+          ))}
+        </div>
+        <p class="tip">New behaviors are new actions — composable in any order, per script, per function.</p>
+      </div>
+    </section>
+
+    <section class="sec" id="streaming">
+      <div class="wrap">
+        <h2>5 · Live OTLP streaming</h2>
+        <pre class="cmd">RETRACE_OTLP_ENDPOINT=http://collector:4318 \
+RETRACE_LOGGER_DEF_ENA=1 RETRACE_LOGGER_DEF_STDOUT_ENA=0 \
+LD_PRELOAD=build/src/v2/libretrace.so ./service</pre>
+        <p>Spans per call on <code>/v1/traces</code>, jail denials and security
+        events on <code>/v1/logs</code>, campaign/grading metrics on
+        <code>/v1/metrics</code>. At exit: one stderr line with
+        emitted/sent/dropped counters. Schema:
+        <a href="https://github.com/riboseinc/retrace/blob/main/docs/reports.md">docs/reports.md</a>.</p>
+      </div>
+    </section>
+
+    <section class="sec" id="jail">
+      <div class="wrap">
+        <h2>6 · Observe → jail → harden</h2>
+        <pre class="cmd">retrace-profile capture -o p.json -- ./tool      <span class="c"># 1. observe</span>
+retrace-profile --libc p.json --kernel k.json    <span class="c"># 2. grade vs kernel truth</span>
+retrace-profile jail p.json -o jail.json         <span class="c"># 3. emit the jail config</span>
+retrace run --config jail.json -- ./tool         <span class="c"># 4. run confined</span>
+retrace-profile harden p.json -o strict.json     <span class="c"># 5. deny-by-default</span></pre>
+      </div>
+    </section>
+
+    <section class="sec last" id="deep">
+      <div class="wrap">
+        <h2>7 · Going deeper</h2>
+        <ul class="links">
+          <li><a href="https://github.com/riboseinc/retrace/blob/main/docs/cookbook/README.md">The cookbook</a> — 36 recipes, each one workflow</li>
+          <li><a href="https://github.com/riboseinc/retrace/blob/main/docs/reports.md">Output shapes</a> — trace, profile, risk, drift, jail, OTLP schema</li>
+          <li><a href="https://github.com/riboseinc/retrace/blob/main/docs/platforms.md">Platforms</a> — per-OS realities (SIP, ntdll, static CRTs)</li>
+          <li><a href="https://github.com/riboseinc/retrace/blob/main/docs/development.md">Development</a> — build, tests, adding actions and backends</li>
+          <li><a href="https://github.com/riboseinc/retrace/tree/main/docs/adr">ADRs</a> — the decision record</li>
+        </ul>
+      </div>
+    </section>
+  </main>
+  <Footer />
+</Layout>
+
+<style>
+  .hero { padding: 96px 0 40px; }
+  .wrap { max-width: 900px; margin: 0 auto; padding: 0 24px; }
+  .eyebrow { font-family: var(--font-mono); font-size: 11px; letter-spacing: .22em; color: var(--color-dim); margin-bottom: 14px; }
+  h1 { font-size: clamp(30px, 5vw, 46px); letter-spacing: -0.02em; margin: 0 0 14px; }
+  .lede { color: var(--color-dim); max-width: 640px; font-size: 16px; line-height: 1.6; }
+  .lede code { font-family: var(--font-mono); font-size: 13px; color: var(--color-text); background: rgba(255,255,255,.05); padding: 1px 5px; border-radius: 3px; }
+  .sec { padding: 44px 0; border-top: 1px solid rgba(255,255,255,.05); scroll-margin-top: 80px; }
+  .sec.last { padding-bottom: 80px; }
+  h2 { font-size: 22px; margin: 0 0 18px; letter-spacing: -0.01em; }
+  h3 { font-size: 14px; margin: 0 0 10px; color: var(--color-text); }
+  .cols { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; }
+  @media (max-width: 720px) { .cols { grid-template-columns: 1fr; } }
+  .cmd { background: rgba(7,9,13,.75); border: 1px solid rgba(255,255,255,.07); border-radius: 8px; padding: 14px 16px; font-family: var(--font-mono); font-size: 12px; color: var(--color-text); overflow-x: auto; line-height: 1.65; margin: 0 0 12px; }
+  .cmd .c { color: var(--color-dim); }
+  p { color: var(--color-dim); font-size: 13.5px; line-height: 1.65; }
+  p code, .tip code { font-family: var(--font-mono); font-size: 12px; color: var(--color-text); background: rgba(255,255,255,.05); padding: 1px 5px; border-radius: 3px; }
+  a { color: var(--color-see); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  .tip { border-left: 2px solid rgba(242,180,65,.4); padding-left: 14px; margin-top: 14px; }
+  .table { border: 1px solid rgba(255,255,255,.07); border-radius: 10px; overflow: hidden; }
+  .row { display: grid; grid-template-columns: 240px 1fr; gap: 14px; padding: 10px 16px; border-bottom: 1px solid rgba(255,255,255,.05); align-items: baseline; }
+  .row:last-child { border-bottom: none; }
+  .row code { font-family: var(--font-mono); font-size: 11.5px; color: var(--color-see); }
+  .row span { color: var(--color-dim); font-size: 12.5px; line-height: 1.5; }
+  @media (max-width: 640px) { .row { grid-template-columns: 1fr; gap: 3px; } }
+  .links { list-style: none; padding: 0; margin: 0; display: grid; gap: 10px; }
+  .links a { font-family: var(--font-mono); font-size: 13px; }
+</style>

--- a/website/src/pages/examples.astro
+++ b/website/src/pages/examples.astro
@@ -1,0 +1,143 @@
+---
+// Examples — the runnable demos in the repo, as cards with commands.
+import Layout from "../layouts/Layout.astro";
+import Nav from "../components/Nav.astro";
+import Footer from "../components/Footer.astro";
+
+const examples = [
+  {
+    id: "id-redirection",
+    accent: "control",
+    name: "id-redirection",
+    one: "Bypass a root check by rewriting getuid()/geteuid() return values — the classic interposition demo.",
+    run: "cd examples/id-redirection && gcc root-check.c -o root-check && ./test-id-redirection.sh",
+  },
+  {
+    id: "getenv-fuzzing",
+    accent: "break",
+    name: "getenv-fuzzing",
+    one: "Feed garbage, overflow-length, and format-string values into getenv consumers — buffer-overflow hunting without writing a fuzzer.",
+    run: "cd examples/getenv-fuzzing && ./run.sh",
+  },
+  {
+    id: "net-fuzzing",
+    accent: "break",
+    name: "net-fuzzing",
+    one: "Mutate connect() targets and garbage into recv() — protocol confusion and SSRF-path discovery.",
+    run: "cd examples/net-fuzzing && ./run.sh",
+  },
+  {
+    id: "dns-fuzz",
+    accent: "break",
+    name: "dns-fuzz",
+    one: "Serve malformed DNS answers through the resolver path — parser robustness from the outside.",
+    run: "cd examples/dns-fuzz && ./run.sh",
+  },
+  {
+    id: "http-server-overflow",
+    accent: "break",
+    name: "http-server-overflow",
+    one: "Long-request injection against a small http server — find the crash before the internet does.",
+    run: "cd examples/http-server-overflow && make && ./run.sh",
+  },
+  {
+    id: "unsafe-system",
+    accent: "see",
+    name: "unsafe-system",
+    one: "Watch every system()/popen() invocation with full argument capture — command-injection surface mapping.",
+    run: "cd examples/unsafe-system && ./run.sh",
+  },
+  {
+    id: "stringinject",
+    accent: "control",
+    name: "stringinject",
+    one: "Rewrite string arguments mid-flight (paths, hosts, options) — behavioral A/B without recompiling.",
+    run: "cd examples/stringinject && ./run.sh",
+  },
+  {
+    id: "escape-hunting",
+    accent: "see",
+    name: "escape-hunting",
+    one: "Does the app stay in its sandbox? Trace every path touch and diff against the declared world.",
+    run: "cd examples/escape-hunting && ./run-posix.sh",
+  },
+  {
+    id: "trace-profile-quickstart",
+    accent: "see",
+    name: "trace-profile-quickstart",
+    one: "The 10-minute tour: capture → profile → jail → harden, with kernel-truth grading on five platforms.",
+    run: "cd examples/trace-profile-quickstart && ./run-posix.sh   # also: run-macos.sh, run-windows.ps1, run-openbsd.sh",
+  },
+  {
+    id: "packaging-audit",
+    accent: "control",
+    name: "packaging-audit",
+    one: "Audit Snap/Flatpak declared-file sets against observed access — the compliance workflow as one script.",
+    run: "cd examples/packaging-audit && ./audit.sh app.snap",
+  },
+  {
+    id: "fuzz-workbench",
+    accent: "break",
+    name: "fuzz-workbench",
+    one: "Corpus → clustered crash report → per-cluster reproducers → minimized corpus, with the drift oracle.",
+    run: "cd examples/fuzz-workbench && ./run-posix.sh",
+  },
+  {
+    id: "fuzz-target",
+    accent: "break",
+    name: "fuzz-target",
+    one: "A libFuzzer template wired to retrace seeds — continuous fuzzing with deterministic reproduction.",
+    run: "cd examples/fuzz-target && make && ./fuzz corpus/",
+  },
+];
+---
+
+<Layout title="Examples — runnable demos" description="Twelve self-contained examples: from id-redirection to the fuzz workbench. Every one runs from its directory.">
+  <Nav />
+  <main id="top">
+    <section class="hero">
+      <div class="wrap">
+        <p class="eyebrow">EXAMPLES</p>
+        <h1>Twelve demos, zero setup.</h1>
+        <p class="lede">
+          Everything below lives in <code>examples/</code> in the repo,
+          self-contained, with its own runner. Build retrace once; the
+          examples assume <code>build/src/v2/libretrace.so</code> (or the
+          .dylib — the runners find either).
+        </p>
+      </div>
+    </section>
+
+    <div class="wrap grid">
+      {examples.map((e) => (
+        <article class="ex glass" id={e.id}>
+          <span class={`rail r-${e.accent}`}></span>
+          <h2>{e.name}</h2>
+          <p>{e.one}</p>
+          <pre class="cmd"><span class="prompt">$</span> {e.run}</pre>
+        </article>
+      ))}
+    </div>
+  </main>
+  <Footer />
+</Layout>
+
+<style>
+  .hero { padding: 96px 0 40px; }
+  .wrap { max-width: 1080px; margin: 0 auto; padding: 0 24px; }
+  .eyebrow { font-family: var(--font-mono); font-size: 11px; letter-spacing: .22em; color: var(--color-dim); margin-bottom: 14px; }
+  h1 { font-size: clamp(30px, 5vw, 46px); letter-spacing: -0.02em; margin: 0 0 14px; }
+  .lede { color: var(--color-dim); max-width: 680px; font-size: 15.5px; line-height: 1.6; }
+  .lede code { font-family: var(--font-mono); font-size: 13px; color: var(--color-text); background: rgba(255,255,255,.05); padding: 1px 5px; border-radius: 3px; }
+  .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(420px, 1fr)); gap: 16px; padding-bottom: 80px; }
+  @media (max-width: 520px) { .grid { grid-template-columns: 1fr; } }
+  .ex { position: relative; padding: 22px; border-radius: 10px; scroll-margin-top: 80px; }
+  .rail { position: absolute; left: 0; top: 14px; bottom: 14px; width: 2px; border-radius: 2px; }
+  .r-see { background: rgba(94,227,255,.4); }
+  .r-control { background: rgba(242,180,65,.4); }
+  .r-break { background: rgba(255,107,92,.4); }
+  .ex h2 { font-family: var(--font-mono); font-size: 15px; margin: 0 0 8px; color: var(--color-text); }
+  .ex p { color: var(--color-dim); font-size: 13px; line-height: 1.6; margin: 0 0 12px; }
+  .cmd { background: rgba(7,9,13,.7); border: 1px solid rgba(255,255,255,.06); border-radius: 6px; padding: 10px 12px; font-family: var(--font-mono); font-size: 11px; color: var(--color-text); overflow-x: auto; margin: 0; line-height: 1.5; }
+  .prompt { color: var(--color-break); margin-right: 6px; }
+</style>

--- a/website/src/pages/use-cases.astro
+++ b/website/src/pages/use-cases.astro
@@ -1,0 +1,180 @@
+---
+// Use cases — the workflows, end to end. Each is a runnable path.
+import Layout from "../layouts/Layout.astro";
+import Nav from "../components/Nav.astro";
+import Footer from "../components/Footer.astro";
+
+const cases = [
+  {
+    id: "detonation",
+    accent: "break",
+    title: "Live detonation",
+    who: "Malware analysis, sandbox work",
+    body: "Run an unknown binary under observation, then confinement, without losing the live view. Denials surface the instant they happen.",
+    steps: [
+      "retrace-profile capture -o p.json -- ./sample  # observe",
+      "retrace-profile jail p.json -o jail.json       # emit policy",
+      "retrace run --config jail.json -- ./sample     # confine",
+    ],
+    note: "With RETRACE_OTLP_ENDPOINT set, every retrace.jail.denied event streams to your collector while the detonation runs (v2.36+).",
+    more: "Cookbook 34 — profile and jail",
+    href: "https://github.com/riboseinc/retrace/blob/main/docs/cookbook/34-profile-and-jail.md",
+  },
+  {
+    id: "audit",
+    accent: "control",
+    title: "Continuous audit",
+    who: "Supply chain, compliance",
+    body: "Grade a binary's claims against kernel-layer truth and against its packaging manifest's declared set. Violations are headline output, not log spam.",
+    steps: [
+      "strace -f -e trace=file ./tool 2> truth.json    # kernel truth",
+      "retrace-profile --libc t.json --kernel k.json   # grade: libc_only / kernel_only",
+      "retrace-profile --libc t.json --inside declared.json  # confinement check",
+    ],
+    note: "Converters exist for strace, dtrace, truss, ktrace, procmon, and raw ETW — five platforms of ground truth in one shape.",
+    more: "docs/reports.md — output shapes",
+    href: "https://github.com/riboseinc/retrace/blob/main/docs/reports.md",
+  },
+  {
+    id: "fuzzing",
+    accent: "break",
+    title: "Fuzz campaigns",
+    who: "QA, security engineering",
+    body: "Deterministic failure injection plus corpus management: clusters, one reproducer per cluster, a minimized corpus, and a drift oracle for behavior the baseline never saw.",
+    steps: [
+      "retrace fuzz malloc --rate 0.2 --seed 42 -- ./target in.xml",
+      "retrace-fuzz-report --config fuzz.json --seeds corpus/ -o report.json -- ./target",
+      "retrace-fuzz-report --baseline good.json ...    # drift oracle",
+    ],
+    note: "Reports export over OTLP: crash clusters as log records, iteration/crash counters as metrics (--endpoint).",
+    more: "Cookbook 35 — dictionary fuzzing",
+    href: "https://github.com/riboseinc/retrace/blob/main/docs/cookbook/35-dictionary-fuzz.md",
+  },
+  {
+    id: "otlp",
+    accent: "see",
+    title: "OTLP observability",
+    who: "SRE, detection engineering",
+    body: "One env variable turns the traced process into an OpenTelemetry emitter: spans per call, security events, timing metrics — into any otelcol/Tempo/Jaeger stack.",
+    steps: [
+      "RETRACE_OTLP_ENDPOINT=http://collector:4318 retrace trace '*' -- ./svc",
+      "retrace-profile export p.json --endpoint http://collector:4318",
+      "retrace-fuzz-report ... --endpoint http://collector:4318",
+    ],
+    note: "Attribute schema is documented and stable (retrace.func, retrace.jail.*, retrace.fuzz.*, retrace.risk.*) — dashboards can be shared.",
+    more: "Cookbook 36 — live OTLP stream",
+    href: "https://github.com/riboseinc/retrace/blob/main/docs/cookbook/36-live-otlp-stream.md",
+  },
+  {
+    id: "escapes",
+    accent: "see",
+    title: "VFS escape hunting",
+    who: "Container/packaging security",
+    body: "Does the packaged app stay inside its declared world? Trace every path touch, normalize NT forms, diff against the escape set.",
+    steps: [
+      "retrace trace fopen,open,mkdir --log run.json -- ./app",
+      "retrace-correlate --libc run.json           # normalized path truth",
+      "retrace-profile --libc run.json --inside declared.json",
+    ],
+    note: "Works on Flatpak/Snap manifests too: flatpak2inside and snap2inside convert personal-files plugs to declared sets.",
+    more: "Example: escape-hunting",
+    href: "/retrace/examples/#escape-hunting",
+  },
+  {
+    id: "hardening",
+    accent: "control",
+    title: "Zero-trust hardening",
+    who: "Deployment, blue teams",
+    body: "Turn a known-good run into the strictest config that still works: allow-list the observed paths, deny the classes you never granted, redirect reads to decoys.",
+    steps: [
+      "retrace-profile harden p.json -o strict.json",
+      "retrace run --config strict.json -- ./tool   # deny-by-default",
+      "decoy_dir in the sandbox action              # deception mode",
+    ],
+    note: "Fail-closed by design: an unreachable supervisor never relaxes a jail (the planned retraced arc doubles down on this).",
+    more: "About the supervisor roadmap",
+    href: "/retrace/about/#roadmap",
+  },
+  {
+    id: "replay",
+    accent: "see",
+    title: "Time-travel replay",
+    who: "Debugging, CI archaeology",
+    body: "A recorded session replays with identical calls and mutations — the 3am failure reproduces on a laptop at 9am, deterministically.",
+    steps: [
+      "retrace run --config session.json --record r.json -- ./flaky",
+      "retrace replay r.json",
+    ],
+    note: "Seeds are first-class (RETRACE_FUZZ_SEED / fuzz_seed param): randomness is a dial, not a hazard.",
+    more: "Cookbook — replay debugging",
+    href: "https://github.com/riboseinc/retrace/blob/main/docs/cookbook/27-replay-debug.md",
+  },
+  {
+    id: "windows",
+    accent: "control",
+    title: "Windows, including static CRT",
+    who: "Windows IR, software inventory",
+    body: "One injectable retrace.dll for MSVC and MinGW targets; /MT binaries that carry their own CRT are observed and jailed through the ntdll layer.",
+    steps: [
+      "retrace-win-run --dll retrace.dll -- target.exe",
+      "retrace-profile capture -o p.json -- target.exe",
+    ],
+    note: "ETW capture (etw-capture.ps1 → etw2retrace) provides the kernel truth on Windows; procmon CSV is equally first-class.",
+    more: "Docs — platforms",
+    href: "https://github.com/riboseinc/retrace/blob/main/docs/platforms.md",
+  },
+];
+---
+
+<Layout title="Use cases — workflows with retrace" description="Detonation, audit, fuzzing, OTLP observability, escapes, hardening, replay, Windows — every workflow with runnable commands.">
+  <Nav />
+  <main id="top">
+    <section class="hero">
+      <div class="wrap">
+        <p class="eyebrow">USE CASES</p>
+        <h1>Workflows, not features.</h1>
+        <p class="lede">
+          Eight paths through retrace, each a chain of commands you can run
+          today — from first observation to a signed-policy future.
+        </p>
+      </div>
+    </section>
+
+    <div class="wrap grid">
+      {cases.map((c) => (
+        <article class="case glass" id={c.id}>
+          <div class="tag-row">
+            <span class={`tag t-${c.accent}`}>{c.who}</span>
+          </div>
+          <h2>{c.title}</h2>
+          <p class="body">{c.body}</p>
+          <pre class="cmd">{c.steps.map((s) => `# ${s}`).join("\n").replace(/# (# )/g, "# ")}</pre>
+          <p class="note">{c.note}</p>
+          <a class="more" href={c.href}>{c.more} →</a>
+        </article>
+      ))}
+    </div>
+  </main>
+  <Footer />
+</Layout>
+
+<style>
+  .hero { padding: 96px 0 40px; }
+  .wrap { max-width: 1080px; margin: 0 auto; padding: 0 24px; }
+  .eyebrow { font-family: var(--font-mono); font-size: 11px; letter-spacing: .22em; color: var(--color-dim); margin-bottom: 14px; }
+  h1 { font-size: clamp(30px, 5vw, 46px); letter-spacing: -0.02em; margin: 0 0 14px; }
+  .lede { color: var(--color-dim); max-width: 640px; font-size: 16px; line-height: 1.6; }
+  .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(420px, 1fr)); gap: 18px; padding-bottom: 80px; }
+  @media (max-width: 520px) { .grid { grid-template-columns: 1fr; } }
+  .case { padding: 26px; border-radius: 12px; scroll-margin-top: 80px; }
+  .tag { font-family: var(--font-mono); font-size: 10.5px; letter-spacing: .08em; padding: 3px 9px; border-radius: 999px; }
+  .t-see { color: var(--color-see); background: var(--color-see-soft); }
+  .t-control { color: var(--color-control); background: var(--color-control-soft); }
+  .t-break { color: var(--color-break); background: var(--color-break-soft); }
+  .case h2 { font-size: 20px; margin: 12px 0 8px; letter-spacing: -0.01em; }
+  .body { color: var(--color-dim); font-size: 13.5px; line-height: 1.6; margin: 0 0 14px; }
+  .cmd { background: rgba(7,9,13,.7); border: 1px solid rgba(255,255,255,.06); border-radius: 8px; padding: 12px 14px; font-family: var(--font-mono); font-size: 11px; color: var(--color-text); overflow-x: auto; line-height: 1.6; margin: 0 0 12px; }
+  .note { color: var(--color-dim); font-size: 12px; line-height: 1.55; margin: 0 0 12px; }
+  .more { font-family: var(--font-mono); font-size: 12px; color: var(--color-see); text-decoration: none; }
+  .more:hover { text-decoration: underline; }
+</style>


### PR DESCRIPTION
## Summary

**The website gets an information architecture.** The site was one 25-section index — visitors had no path through it. Five focused pages now carry the structure, linked from nav + footer:

| Page | What it carries |
|------|-----------------|
| `/audiences/` | four trails — security research, fuzzing, audit, SRE — each with why-retrace, three runnable steps, and links into use-cases/examples/cookbook |
| `/use-cases/` | eight workflows with real commands: live detonation, continuous audit, fuzz campaigns, OTLP observability, VFS escapes, zero-trust hardening, replay, Windows static-CRT |
| `/examples/` | all twelve repo examples as cards with their runner commands |
| `/docs/` | the usage path: install, 5-minute quickstart (per-OS env vars), config anatomy, the 14-action table, OTLP streaming, observe→jail→harden, deep links into repo `docs/` |
| `/about/` | what retrace is (engine / backends / truth layer / observability bridge), the license story (BSD-2 + vendored otlp-c BSD-3, parson MIT), the `retraced` supervisor roadmap, contributing |

**Stack:** Astro 7.2.6 (bumped from 7.1.6), Vite 8, Tailwind 4 via `@tailwindcss/vite`, Vue islands unchanged (`client:visible` / `client:load`) — verified `astro build` green: **6 pages**.

The new pages use the site's existing design tokens (dark glass, see/control/break accent system, mono command blocks) — no new CSS framework, no visual regression to the home page.

## Test plan

- [x] `astro build` — 6 pages, no errors
- [x] Rendered command snippets spot-checked in `dist/`
- [x] Home page untouched (its What's-New update rides the v2.37.0 PR)
- [ ] CI (website build workflow)
