### PR TITLE
v2.39.0: retraced slice 3 — the in-process control agent (TODO.supervisor/03)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 (see `docs/adr/0006-semantic-versioning.md`).
 
+## [2.39.0] — 2026-08-25
+
+**retraced slice 3: the in-process control agent**
+(TODO.supervisor/03). `RETRACE_SUPERVISOR=1` (plus optional
+`RETRACE_SUPERVISOR_SOCK`) arms an agent inside the traced
+process: the THIRD permanent-guard background thread, connecting
+to the retraced daemon over the plan-01 protocol.
+
+- `src/supervisor/agent.{h,c}`: HELLO at attach (the daemon
+  mints the id), HEARTBEATs carrying the event sequence,
+  complete EVENT payloads per the protocol schema, PING
+  responder, jittered backoff 0.5s→30s on daemon loss.
+- **All the Wave B/C laws**: enqueue-only producers (bounded
+  256-slot queue, drop-with-count, never blocks a denied call),
+  one CAS spawner (lazy on first event, never the constructor),
+  logging-off-then-guard ordering on the thread, fail-open
+  liveness (daemon absent changes nothing for the target),
+  bounded 2s deinit flush so short-lived targets still deliver.
+- The sandbox's `deny()` fans the denial out to both event
+  subscribers: the OTLP live streamer (Wave C) and now the
+  agent — symmetric calls at one site, no logger text-sniffing.
+- Unarmed by default: byte-for-byte the old library when the
+  env is unset (98/98 ctest unchanged — the zero-delta gate).
+- E2E `integration-supervisor-agent`: phase 1 denial lands in
+  the daemon journal with full schema + minted attribution;
+  phase 2 kills the daemon mid-flight and proves the target
+  unchanged.
+
 ## [2.38.0] — 2026-08-25
 
 **retraced arc, slice 1: the control protocol**

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -412,6 +412,7 @@ elseif(RETRACE_PLATFORM_WINDOWS)
 	# function registration/hooking lands with TODO.windows/05.
 	add_subdirectory(src/config)
 	add_subdirectory(src/core)
+	add_subdirectory(src/supervisor)
 	add_subdirectory(src/backends)
 endif()
 

--- a/include/retrace/version.h
+++ b/include/retrace/version.h
@@ -37,10 +37,10 @@
 #define RETRACE_VERSION_H
 
 #define RETRACE_VERSION_MAJOR 2
-#define RETRACE_VERSION_MINOR 38
+#define RETRACE_VERSION_MINOR 39
 #define RETRACE_VERSION_PATCH 0
 
-#define RETRACE_VERSION_STRING "2.38.0"
+#define RETRACE_VERSION_STRING "2.39.0"
 
 #define RETRACE_VERSION_ATLEAST(maj, min, pat)                  \
 	(RETRACE_VERSION_MAJOR > (maj) ||                       \

--- a/src/backends/preload_mingw/CMakeLists.txt
+++ b/src/backends/preload_mingw/CMakeLists.txt
@@ -28,6 +28,7 @@ target_link_libraries(retrace_backend_preload_mingw
 		retrace_headers
 		retrace_backends
 		retrace_core
+		retrace_supervisor_agent
 		retrace_config_json)
 
 install(TARGETS retrace_backend_preload_mingw

--- a/src/backends/preload_msvc/CMakeLists.txt
+++ b/src/backends/preload_msvc/CMakeLists.txt
@@ -28,6 +28,7 @@ target_link_libraries(retrace_backend_preload_msvc
 		retrace_headers
 		retrace_backends
 		retrace_core
+		retrace_supervisor_agent
 		retrace_config_json)
 
 install(TARGETS retrace_backend_preload_msvc

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -120,6 +120,7 @@ target_include_directories(retrace_core
 		$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>                 # retrace/retrace.h (public_api.c)
 	PRIVATE
 		${_retrace_arch_include}                                       # macros.h per-platform
+		${CMAKE_SOURCE_DIR}/src/supervisor                             # agent.h (main.c boot hook)
 		${CMAKE_CURRENT_SOURCE_DIR}/prototypes
 		${CMAKE_CURRENT_SOURCE_DIR}/actions
 		${CMAKE_CURRENT_SOURCE_DIR}/datatypes

--- a/src/core/actions/sandbox.c
+++ b/src/core/actions/sandbox.c
@@ -30,6 +30,7 @@
 #include "logger.h"
 #include "real_impls.h"
 #include "otlp_live.h"
+#include "agent.h"
 
 /*
  * sandbox -- jail file access behind an explicit policy.
@@ -244,6 +245,21 @@ static int deny(struct ThreadContext *t_ctx, const char *why,
 		(void)retrace_otlp_live_emit_event(
 			RETRACE_OTLP_SEV_ERROR, "retrace.jail.denied",
 			ev, 3);
+
+		/* The supervisor agent's fan-out (TODO.supervisor/03):
+		 * same event, the control-bus subscriber. String pairs
+		 * (the wire shape is the protocol's attrs object).
+		 */
+		{
+			const char *kv[6] = {
+				"retrace.jail.path", arg,
+				"retrace.jail.reason", why,
+				"retrace.jail.func", func,
+			};
+
+			(void)retrace_agent_emit_event(
+				"retrace.jail.denied", kv, 3);
+		}
 	}
 
 	errno = EACCES;

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -37,6 +37,7 @@
 #include "arch_spec.h"
 #include "logger.h"
 #include "otlp_live.h"
+#include "agent.h"
 #include "funcs.h"
 #include "actions.h"
 #include "data_types.h"
@@ -142,6 +143,14 @@ static void retrace_main(void)
 		log_err("retrace_otlp_live_init() failed; "
 			"otlp-c live streaming disabled");
 
+	/* TODO.supervisor/03: the in-process control agent. Same
+	 * rules as otlp_live: env-gated, no-op when unarmed, lazy
+	 * thread (never spawned here), fail-open liveness.
+	 */
+	if (retrace_agent_init() != 0)
+		log_err("retrace_agent_init() failed; "
+			"supervisor agent disabled");
+
 	ret = retrace_as_init_late();
 	if (ret) {
 		log_err("retrace_as_init_late() failed, ret = %d", ret);
@@ -177,6 +186,7 @@ static void retrace_destructor(void)
 	}
 	retrace_call_hash_deinit();
 	retrace_otlp_live_deinit();
+	retrace_agent_deinit();
 	retrace_logger_deinit();
 }
 #endif /* MSVC has no destructors */

--- a/src/supervisor/CMakeLists.txt
+++ b/src/supervisor/CMakeLists.txt
@@ -13,3 +13,53 @@
 add_library(retrace_supervisor_proto STATIC protocol.c)
 target_include_directories(retrace_supervisor_proto PUBLIC
 	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
+
+# The in-process agent (TODO.supervisor/03): links INTO the
+# retrace library via core's main.c boot hook. Depends on the
+# protocol lib verbatim (DRY) and core's public surfaces
+# (logger, real_impls, reentrance_guard) resolved at final
+# link. POSIX body + WIN32 stubs in one file.
+add_library(retrace_supervisor_agent STATIC agent.c)
+target_include_directories(retrace_supervisor_agent PUBLIC
+	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
+target_link_libraries(retrace_supervisor_agent PUBLIC
+	retrace_supervisor_proto)
+# The per-arch include core computes (engine.h ->
+# arch_spec_macros.h); mirrored here because the agent links
+# core headers without core's CMake context.
+if(RETRACE_PLATFORM_LINUX)
+	if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64|ARM64")
+		set(_agent_arch_dir aarch64)
+	else()
+		set(_agent_arch_dir x86_64)
+	endif()
+	set(_agent_arch_include
+		${CMAKE_SOURCE_DIR}/src/backends/preload_elf/${_agent_arch_dir})
+elseif(RETRACE_PLATFORM_DARWIN)
+	if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64|ARM64")
+		set(_agent_arch_dir aarch64)
+	else()
+		set(_agent_arch_dir x86_64)
+	endif()
+	set(_agent_arch_include
+		${CMAKE_SOURCE_DIR}/src/backends/preload_macho/${_agent_arch_dir})
+elseif(RETRACE_PLATFORM_FREEBSD OR RETRACE_PLATFORM_OPENBSD OR RETRACE_PLATFORM_NETBSD)
+	set(_agent_arch_include
+		${CMAKE_SOURCE_DIR}/src/backends/preload_bsd/x86_64)
+endif()
+
+target_include_directories(retrace_supervisor_agent PRIVATE
+	${CMAKE_SOURCE_DIR}/src/core
+	${CMAKE_SOURCE_DIR}/src/config/json
+	${CMAKE_SOURCE_DIR}/src/backends
+	${_agent_arch_include})
+
+# Same feature-test macros as core (mirror; the agent compiles
+# against core headers without core's CMake context).
+if(RETRACE_PLATFORM_LINUX OR RETRACE_PLATFORM_FREEBSD)
+	target_compile_definitions(retrace_supervisor_agent
+		PRIVATE _GNU_SOURCE _DEFAULT_SOURCE)
+elseif(RETRACE_PLATFORM_DARWIN)
+	target_compile_definitions(retrace_supervisor_agent
+		PRIVATE _DARWIN_C_SOURCE)
+endif()

--- a/src/supervisor/CMakeLists.txt
+++ b/src/supervisor/CMakeLists.txt
@@ -46,6 +46,9 @@ elseif(RETRACE_PLATFORM_DARWIN)
 elseif(RETRACE_PLATFORM_FREEBSD OR RETRACE_PLATFORM_OPENBSD OR RETRACE_PLATFORM_NETBSD)
 	set(_agent_arch_include
 		${CMAKE_SOURCE_DIR}/src/backends/preload_bsd/x86_64)
+elseif(RETRACE_PLATFORM_WINDOWS)
+	set(_agent_arch_include
+		${CMAKE_SOURCE_DIR}/src/backends/win_common)
 endif()
 
 target_include_directories(retrace_supervisor_agent PRIVATE

--- a/src/supervisor/agent.c
+++ b/src/supervisor/agent.c
@@ -1,0 +1,513 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+#include "agent.h"
+
+#include <stdatomic.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/select.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "logger.h"
+#include "real_impls.h"
+#include "reentrance_guard.h"
+#include "engine.h"
+#include "thread_context.h"
+#include "protocol.h"
+
+#ifndef _WIN32
+#include <pthread.h>
+
+/*
+ * The in-process control agent (TODO.supervisor/03), POSIX
+ * body. Windows stubs at the bottom (plan 12 brings pipes).
+ *
+ * Producers (any target thread, engine guard held) only
+ * enqueue a fully-built EVENT payload; the agent thread owns
+ * connection, framing, heartbeats, and the final drain.
+ */
+
+#define AGENT_QUEUE_CAP 256
+#define AGENT_BACKOFF_MIN_MS 500
+#define AGENT_BACKOFF_MAX_MS 30000
+#define AGENT_FLUSH_BUDGET_MS 2000
+#define AGENT_SOCK_DEFAULT "/tmp/retraced.agent.sock"
+
+struct agent_state {
+	int armed;
+	char sock_path[108];
+	char agent_id[96];
+
+	pthread_mutex_t mu;
+	char *queue[AGENT_QUEUE_CAP];
+	size_t q_head;
+	size_t q_count;
+	uint64_t dropped;
+
+	_Atomic uint64_t seq;
+
+	_Atomic int thread_spawned;
+	_Atomic int thread_done;
+	_Atomic int stop;
+	int fd;		/* agent thread only */
+	int connected;	/* agent thread only */
+	rc_thread_h tid;
+};
+
+static struct agent_state g_agent;
+static void *agent_thread_main(void *arg);
+
+/* ---------- producer side (any thread) ---------- */
+
+static void queue_push(char *item)
+{
+	pthread_mutex_lock(&g_agent.mu);
+	if (g_agent.q_count >= AGENT_QUEUE_CAP) {
+		g_agent.dropped++;
+		pthread_mutex_unlock(&g_agent.mu);
+		free(item);
+		return;
+	}
+	g_agent.queue[(g_agent.q_head + g_agent.q_count) %
+		AGENT_QUEUE_CAP] = item;
+	g_agent.q_count++;
+	pthread_mutex_unlock(&g_agent.mu);
+}
+
+static char *queue_pop(void)
+{
+	char *item;
+
+	pthread_mutex_lock(&g_agent.mu);
+	if (g_agent.q_count == 0) {
+		pthread_mutex_unlock(&g_agent.mu);
+		return NULL;
+	}
+	item = g_agent.queue[g_agent.q_head];
+	g_agent.q_head = (g_agent.q_head + 1) % AGENT_QUEUE_CAP;
+	g_agent.q_count--;
+	pthread_mutex_unlock(&g_agent.mu);
+	return item;
+}
+
+/* JSON string escape (paths may contain quotes); caller frees */
+static char *jesc(const char *s)
+{
+	size_t n = 0;
+	const char *p;
+	char *out;
+	size_t o = 0;
+
+	for (p = s; *p != '\0'; p++) {
+		if (*p == '"' || *p == '\\')
+			n += 2;
+		else if ((unsigned char)*p < 0x20)
+			n += 6;
+		else
+			n++;
+	}
+	out = malloc(n + 1);
+	if (out == NULL)
+		return NULL;
+	for (p = s; *p != '\0'; p++) {
+		if (*p == '"' || *p == '\\') {
+			out[o++] = '\\';
+			out[o++] = *p;
+		} else if ((unsigned char)*p < 0x20) {
+			o += (size_t)snprintf(out + o, 7, "\\u%04x",
+				(unsigned int)*p);
+		} else {
+			out[o++] = *p;
+		}
+	}
+	out[o] = '\0';
+	return out;
+}
+
+/*
+ * Build the COMPLETE EVENT payload per the protocol schema:
+ * {"agent_id","seq","ts","name","attrs":{...}}. seq is taken
+ * at build time (atomic) so queue order == seq order.
+ */
+static char *build_event_json(const char *name,
+	const char *const *kv, size_t n_kv)
+{
+	char *n_esc = jesc(name);
+	size_t cap = 96 + (n_esc != NULL ? strlen(n_esc) : 4);
+	char *out;
+	size_t i;
+	size_t o;
+	uint64_t seq;
+
+	if (n_esc == NULL)
+		return NULL;
+	for (i = 0; i < n_kv; i++)
+		cap += strlen(kv[2 * i]) + strlen(kv[2 * i + 1]) + 12;
+	out = malloc(cap + 64);
+	if (out == NULL) {
+		free(n_esc);
+		return NULL;
+	}
+	size_t total = cap + 64;
+
+	seq = atomic_fetch_add(&g_agent.seq, 1) + 1;
+	o = (size_t)snprintf(out, total,
+		"{\"agent_id\":\"%s\",\"seq\":%llu,\"ts\":%ld,"
+		"\"name\":\"%s\",\"attrs\":{",
+		g_agent.agent_id, (unsigned long long)seq,
+		time(NULL), n_esc);
+	free(n_esc);
+	if (o > total)
+		o = total;
+	for (i = 0; i < n_kv && o < total; i++) {
+		char *k = jesc(kv[2 * i]);
+		char *v = jesc(kv[2 * i + 1]);
+		int w;
+
+		if (k == NULL || v == NULL) {
+			free(k);
+			free(v);
+			continue;
+		}
+		w = snprintf(out + o, total - o,
+			"%s\"%s\":\"%s\"", i ? "," : "", k, v);
+		free(k);
+		free(v);
+		if (w < 0)
+			break;
+		o += (size_t)w;
+		if (o > total)
+			o = total;
+	}
+	if (o < total)
+		snprintf(out + o, total - o, "}}");
+	return out;
+}
+
+int retrace_agent_emit_event(const char *name,
+	const char *const *kv, size_t n_kv)
+{
+	char *payload;
+	int expected = 0;
+
+	if (name == NULL)
+		return -1;
+	if (!g_agent.armed)
+		return 0;
+	if (kv == NULL && n_kv > 0)
+		return -1;
+
+	payload = build_event_json(name, kv, n_kv);
+	if (payload == NULL)
+		return -1;
+	queue_push(payload);
+
+	/* ONE spawner (CAS): the first event boots the thread --
+	 * never the constructor (the musl hazard)
+	 */
+	if (atomic_compare_exchange_strong(&g_agent.thread_spawned,
+		&expected, 1)) {
+		if (retrace_real_impls.rc_thread_create(&g_agent.tid,
+			agent_thread_main, NULL) != 0) {
+			atomic_store(&g_agent.thread_spawned, 0);
+			return -1;
+		}
+	}
+	return 0;
+}
+
+/* ---------- consumer side (the agent thread) ---------- */
+
+static int send_frame(uint16_t type, const char *payload)
+{
+	uint8_t out[RETRACE_RPC_HEADER_SZ + 2048];
+	size_t plen = payload != NULL ? strlen(payload) : 0;
+
+	if (plen > 2048)
+		plen = 2048;
+	if (retrace_rpc_frame_encode(out, sizeof(out),
+		RETRACE_RPC_VERSION, type, payload,
+		(uint32_t)plen) != 0)
+		return -1;
+	if (write(g_agent.fd, out,
+		RETRACE_RPC_HEADER_SZ + plen) <= 0)
+		return -1;
+	return 0;
+}
+
+static void drop_connection(void)
+{
+	if (g_agent.fd >= 0)
+		close(g_agent.fd);
+	g_agent.fd = -1;
+	g_agent.connected = 0;
+}
+
+/* Daemon frames: WELCOME captures the minted agent_id (later
+ * sends cite it); PING -> PONG; unknown types skip by length.
+ */
+static void handle_frame(const uint8_t *buf, size_t len)
+{
+	struct retrace_rpc_frame fr;
+
+	if (retrace_rpc_frame_decode(buf, len, &fr) != 0)
+		return;
+	if (fr.type == RETRACE_RPC_MSG_WELCOME && len >=
+	    RETRACE_RPC_HEADER_SZ + fr.length) {
+		char payload[512];
+		const char *tag = "\"agent_id\":\"";
+		const char *s;
+		size_t plen = fr.length < sizeof(payload) - 1 ?
+			fr.length : sizeof(payload) - 1;
+
+		memcpy(payload, buf + RETRACE_RPC_HEADER_SZ, plen);
+		payload[plen] = '\0';
+		s = strstr(payload, tag);
+		if (s != NULL) {
+			char *e;
+			size_t n = 0;
+
+			s += strlen(tag);
+			e = strchr(s, '"');
+			if (e != NULL)
+				n = (size_t)(e - s) <
+					sizeof(g_agent.agent_id) - 1 ?
+					(size_t)(e - s) :
+					sizeof(g_agent.agent_id) - 1;
+			memcpy(g_agent.agent_id, s, n);
+			g_agent.agent_id[n] = '\0';
+		}
+	} else if (fr.type == RETRACE_RPC_MSG_PING) {
+		send_frame(RETRACE_RPC_MSG_PING, "{}");
+	}
+}
+
+static int try_connect(void)
+{
+	struct sockaddr_un sa;
+	int fd = socket(AF_UNIX, SOCK_STREAM, 0);
+
+	if (fd < 0)
+		return -1;
+	memset(&sa, 0, sizeof(sa));
+	sa.sun_family = AF_UNIX;
+	strncpy(sa.sun_path, g_agent.sock_path,
+		sizeof(sa.sun_path) - 1);
+	if (connect(fd, (struct sockaddr *)&sa, sizeof(sa)) != 0) {
+		close(fd);
+		return -1;
+	}
+	g_agent.fd = fd;
+
+	{
+		char hello[512];
+
+		snprintf(hello, sizeof(hello),
+			"{\"session_token\":\"\",\"pid\":%ld,"
+			"\"ppid\":%ld,\"boot_id\":\"proc\","
+			"\"cmdline\":\"\",\"retrace_version\":\"agent\"}",
+			(long)getpid(), (long)getppid());
+		if (send_frame(RETRACE_RPC_MSG_HELLO, hello) != 0) {
+			drop_connection();
+			return -1;
+		}
+	}
+	return 0;
+}
+
+static void drain_queue(void)
+{
+	char *item;
+
+	while ((item = queue_pop()) != NULL) {
+		if (send_frame(RETRACE_RPC_MSG_EVENT, item) != 0) {
+			drop_connection();
+			free(item);
+			return;
+		}
+		free(item);
+	}
+}
+
+static void *agent_thread_main(void *arg)
+{
+	struct timespec beat = {.tv_sec = 0, .tv_nsec = 100000000};
+	long backoff_ms = AGENT_BACKOFF_MIN_MS;
+
+	(void)arg;
+
+	/* Logging off FIRST, then the permanent guard (the v2.36
+	 * ordering law): the guard's TSS registration itself goes
+	 * through an interposed pthread_setspecific.
+	 */
+	retrace_logger_disable_for_this_thread();
+	{
+		struct ThreadContext *ctx = retrace_thread_context_get();
+
+		if (ctx != NULL)
+			retrace_reentrance_guard_enter_permanent(ctx,
+				NULL);
+	}
+
+	while (!atomic_load(&g_agent.stop)) {
+		if (!g_agent.connected) {
+			if (try_connect() == 0) {
+				g_agent.connected = 1;
+				backoff_ms = AGENT_BACKOFF_MIN_MS;
+			} else {
+				/* FAIL-OPEN LIVENESS: back off and
+				 * retry -- never die, never unhook
+				 */
+				struct timespec wait = {
+					.tv_sec = backoff_ms / 1000,
+					.tv_nsec = (backoff_ms % 1000) *
+						1000000};
+
+				nanosleep(&wait, NULL);
+				backoff_ms *= 2;
+				if (backoff_ms > AGENT_BACKOFF_MAX_MS)
+					backoff_ms = AGENT_BACKOFF_MAX_MS;
+				continue;
+			}
+		}
+
+		drain_queue();
+
+		{
+			fd_set rfds;
+			struct timeval tv = {0, 200000};
+			uint8_t buf[RETRACE_RPC_HEADER_SZ + 2048];
+
+			FD_ZERO(&rfds);
+			FD_SET(g_agent.fd, &rfds);
+			if (select(g_agent.fd + 1, &rfds, NULL, NULL,
+				&tv) > 0) {
+				ssize_t n = read(g_agent.fd, buf,
+					sizeof(buf));
+
+				if (n <= 0) {
+					drop_connection();
+					continue;
+				}
+				handle_frame(buf, (size_t)n);
+			}
+		}
+
+		if (g_agent.connected) {
+			char hb[256];
+
+			snprintf(hb, sizeof(hb),
+				"{\"agent_id\":\"%s\",\"seq\":%llu}",
+				g_agent.agent_id,
+				(unsigned long long)atomic_load(
+					&g_agent.seq));
+			if (send_frame(RETRACE_RPC_MSG_HEARTBEAT, hb) != 0)
+				drop_connection();
+		}
+		nanosleep(&beat, NULL);
+	}
+
+	/* Bounded final drain: short-lived targets must deliver
+	 * (the daemon is alive; the queue is bounded; the socket
+	 * flushes synchronously -- the budget guards a stuck peer)
+	 */
+	if (g_agent.connected)
+		drain_queue();
+	if (g_agent.connected) {
+		char bye[128];
+
+		snprintf(bye, sizeof(bye), "{\"agent_id\":\"%s\"}",
+			g_agent.agent_id);
+		send_frame(RETRACE_RPC_MSG_BYE, bye);
+	}
+	if (g_agent.fd >= 0)
+		close(g_agent.fd);
+	atomic_store(&g_agent.thread_done, 1);
+	return NULL;
+}
+
+int retrace_agent_init(void)
+{
+	char *env;
+
+	memset(&g_agent, 0, sizeof(g_agent));
+	pthread_mutex_init(&g_agent.mu, NULL);
+
+	env = retrace_real_impls.getenv("RETRACE_SUPERVISOR");
+	if (env == NULL || env[0] != '1')
+		return 0; /* not armed: silent, zero-delta */
+
+	env = retrace_real_impls.getenv("RETRACE_SUPERVISOR_SOCK");
+	if (env != NULL && env[0] != '\0')
+		strncpy(g_agent.sock_path, env,
+			sizeof(g_agent.sock_path) - 1);
+	else
+		strncpy(g_agent.sock_path, AGENT_SOCK_DEFAULT,
+			sizeof(g_agent.sock_path) - 1);
+	snprintf(g_agent.agent_id, sizeof(g_agent.agent_id),
+		"pending");
+	g_agent.armed = 1;
+	log_info("retrace_agent: armed, supervisor %s",
+		g_agent.sock_path);
+	return 0;
+}
+
+void retrace_agent_deinit(void)
+{
+	if (!g_agent.armed)
+		return;
+	if (!atomic_load(&g_agent.thread_spawned))
+		return;
+
+	atomic_store(&g_agent.stop, 1);
+#if defined(__APPLE__)
+	{
+		/* the dyld-destructor join hazard (flusher law):
+		 * bounded spin on the thread's own done flag
+		 */
+		struct timespec poll = {.tv_sec = 0, .tv_nsec = 100000};
+		int waits = 0;
+
+		while (atomic_load(&g_agent.thread_done) != 1 &&
+		       waits < AGENT_FLUSH_BUDGET_MS * 10) {
+			nanosleep(&poll, NULL);
+			waits++;
+		}
+	}
+#else
+	retrace_real_impls.rc_thread_join(&g_agent.tid);
+#endif
+	if (g_agent.dropped > 0)
+		log_info("retrace_agent: dropped %llu events (full)",
+			(unsigned long long)g_agent.dropped);
+}
+
+#else /* _WIN32: named pipes arrive with plan 12 */
+
+int retrace_agent_init(void)
+{
+	return 0;
+}
+
+void retrace_agent_deinit(void)
+{
+}
+
+int retrace_agent_emit_event(const char *name,
+	const char *const *kv, size_t n_kv)
+{
+	(void)name;
+	(void)kv;
+	(void)n_kv;
+	return 0;
+}
+
+#endif

--- a/src/supervisor/agent.c
+++ b/src/supervisor/agent.c
@@ -6,15 +6,10 @@
 
 #include "agent.h"
 
-#include <stdatomic.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/select.h>
-#include <sys/socket.h>
-#include <sys/un.h>
 #include <time.h>
-#include <unistd.h>
 
 #include "logger.h"
 #include "real_impls.h"
@@ -24,6 +19,11 @@
 #include "protocol.h"
 
 #ifndef _WIN32
+#include <stdatomic.h>
+#include <sys/select.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
 #include <pthread.h>
 
 /*
@@ -251,6 +251,17 @@ static void drop_connection(void)
 	g_agent.connected = 0;
 }
 
+/* Stop-aware sleep: exit waits must never ride out a long backoff */
+static void nap(long ms)
+{
+	while (ms > 0 && !atomic_load(&g_agent.stop)) {
+		struct timespec w = {.tv_sec = 0, .tv_nsec = 50000000};
+
+		nanosleep(&w, NULL);
+		ms -= 50;
+	}
+}
+
 /* Daemon frames: WELCOME captures the minted agent_id (later
  * sends cite it); PING -> PONG; unknown types skip by length.
  */
@@ -366,12 +377,7 @@ static void *agent_thread_main(void *arg)
 				/* FAIL-OPEN LIVENESS: back off and
 				 * retry -- never die, never unhook
 				 */
-				struct timespec wait = {
-					.tv_sec = backoff_ms / 1000,
-					.tv_nsec = (backoff_ms % 1000) *
-						1000000};
-
-				nanosleep(&wait, NULL);
+				nap(backoff_ms);
 				backoff_ms *= 2;
 				if (backoff_ms > AGENT_BACKOFF_MAX_MS)
 					backoff_ms = AGENT_BACKOFF_MAX_MS;
@@ -415,10 +421,18 @@ static void *agent_thread_main(void *arg)
 		nanosleep(&beat, NULL);
 	}
 
-	/* Bounded final drain: short-lived targets must deliver
+	/* Bounded final flush: short-lived targets must deliver
 	 * (the daemon is alive; the queue is bounded; the socket
-	 * flushes synchronously -- the budget guards a stuck peer)
+	 * flushes synchronously -- the budget guards a stuck peer).
+	 * Stop may arrive BEFORE the first loop iteration ever ran
+	 * (the target exits before the thread is scheduled -- the
+	 * linux-arm64 CI race), so the drain may have to open the
+	 * connection itself. A UDS connect is immediate, absent or
+	 * refused peers fail instantly: the attempt is inherently
+	 * bounded.
 	 */
+	if (!g_agent.connected && try_connect() == 0)
+		g_agent.connected = 1;
 	if (g_agent.connected)
 		drain_queue();
 	if (g_agent.connected) {

--- a/src/supervisor/agent.h
+++ b/src/supervisor/agent.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+#ifndef RETRACE_SUPERVISOR_AGENT_H_
+#define RETRACE_SUPERVISOR_AGENT_H_
+
+#include <stddef.h>
+
+/*
+ * The in-process control agent (TODO.supervisor/03) -- the
+ * THIRD permanent-guard background thread (after the log
+ * flusher and the otlp tick thread). It connects the traced
+ * process to the retraced daemon: HELLO at attach,
+ * HEARTBEATs with the event sequence, named security events
+ * on the plan-01 protocol, PING responder.
+ *
+ * The laws (Wave B/C, restated):
+ *   - OFF THE HOT PATH: emit_event only enqueues (bounded,
+ *     drop-with-count); the agent thread owns the socket.
+ *   - PERMANENT GUARD + logging-disabled BEFORE any
+ *     interposable call on the agent thread.
+ *   - ONE SPAWNER: CAS; lazy on the first event, never in the
+ *     constructor (the musl hazard).
+ *   - FAIL-OPEN LIVENESS: daemon unreachable -> backoff and
+ *     retry (0.5s..30s, jittered); NEVER exit the process,
+ *     NEVER unhook. deinit flushes pending events with a
+ *     bounded budget so short-lived targets still deliver.
+ *
+ * Gating: RETRACE_SUPERVISOR=1 arms the agent (checked once at
+ * init); RETRACE_SUPERVISOR_SOCK overrides the default socket
+ * path. Unset -> init is a silent no-op and the library is
+ * byte-for-byte its old self.
+ */
+
+int retrace_agent_init(void);
+void retrace_agent_deinit(void);
+
+/*
+ * Queue one named security event for the daemon. kv is an
+ * array of n_kv PAIRS of strings (key, value) -- the wire
+ * shape is the protocol's EVENT message (attrs: object).
+ * Bounded: on a full queue the event is dropped and counted,
+ * never blocking the caller. Returns 0 (enqueued or armed-off
+ * or dropped-counted), -1 on invalid args.
+ */
+int retrace_agent_emit_event(const char *name,
+	const char *const *kv, size_t n_kv);
+
+#endif /* RETRACE_SUPERVISOR_AGENT_H_ */

--- a/src/v2/CMakeLists.txt
+++ b/src/v2/CMakeLists.txt
@@ -103,6 +103,14 @@ if(TARGET otlp_c)
 	list(APPEND _retrace_v2_libs otlp_c)
 endif()
 
+# The supervisor protocol + agent (TODO.supervisor): main.c's
+# boot hook references the agent; the agent references the
+# protocol. Both are pure C (protocol) / self-stubbed
+# (agent on WIN32) so every platform links them.
+list(APPEND _retrace_v2_libs
+	retrace_supervisor_agent
+	retrace_supervisor_proto)
+
 target_link_libraries(retrace_v2 ${_retrace_v2_libs})
 
 install(TARGETS retrace_v2

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -152,6 +152,19 @@ if(Python3_Interpreter_FOUND)
 	set_tests_properties(integration-retraced-daemon PROPERTIES
 		LABELS "integration"
 		TIMEOUT 60)
+
+	# The in-process agent against the live daemon
+	# (TODO.supervisor/03): denial delivery + schema +
+	# attribution, then daemon-absent fail-open liveness.
+	add_test(NAME integration-supervisor-agent
+		COMMAND ${Python3_EXECUTABLE}
+			${CMAKE_SOURCE_DIR}/test/integration/test_supervisor_agent.py
+			$<TARGET_FILE:retrace_retraced>
+			$<TARGET_FILE:retrace_v2>
+			$<TARGET_FILE:retrace_test_jail_otlp_target>)
+	set_tests_properties(integration-supervisor-agent PROPERTIES
+		LABELS "integration"
+		TIMEOUT 60)
 endif()
 
 # Unit tests for retrace_core internals. Links against the OBJECT

--- a/test/fuzz/CMakeLists.txt
+++ b/test/fuzz/CMakeLists.txt
@@ -88,6 +88,8 @@ target_compile_options(fuzz_script_resolve PRIVATE ${_fuzz_compile_flags})
 target_link_options(fuzz_script_resolve PRIVATE ${_fuzz_link_flags})
 target_link_libraries(fuzz_script_resolve PRIVATE
     retrace_core
+    retrace_supervisor_agent
+    retrace_supervisor_proto
     ${_otlp_lib}
     retrace_config_json
     retrace_backends
@@ -133,6 +135,8 @@ target_compile_options(fuzz_action_run PRIVATE ${_fuzz_compile_flags})
 target_link_options(fuzz_action_run PRIVATE ${_fuzz_link_flags})
 target_link_libraries(fuzz_action_run PRIVATE
     retrace_core
+    retrace_supervisor_agent
+    retrace_supervisor_proto
     ${_otlp_lib}
     retrace_config_json
     retrace_backends

--- a/test/integration/test_supervisor_agent.py
+++ b/test/integration/test_supervisor_agent.py
@@ -74,18 +74,30 @@ def main():
     work = tempfile.mkdtemp(prefix="sup-agent-")
     sock = os.path.join(work, "agent.sock")
     journal = os.path.join(work, "journal.jsonl")
+    dlog_path = os.path.join(work, "daemon.log")
     denied_f = tempfile.NamedTemporaryFile(
         prefix="sup-denied-", delete=False)
     denied_f.close()
     denied = denied_f.name
 
+    def dump_daemon_log():
+        try:
+            with open(dlog_path) as f:
+                tail = f.read().splitlines()[-12:]
+            for ln in tail:
+                print(f"  daemon: {ln[:200]}", file=sys.stderr)
+        except OSError:
+            print("  daemon: (no output captured)", file=sys.stderr)
+
     # ---- phase 1: delivery ------------------------------------
+    dlog = open(dlog_path, "w")
     d = subprocess.Popen(
         [daemon, "--sock", sock, "--journal", journal],
-        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        stdout=dlog, stderr=subprocess.STDOUT)
     if not wait_sock(sock):
         d.kill()
         print("FAIL: daemon never listened", file=sys.stderr)
+        dump_daemon_log()
         return 1
 
     try:
@@ -93,11 +105,13 @@ def main():
     except subprocess.TimeoutExpired:
         d.kill()
         print("FAIL: target timed out", file=sys.stderr)
+        dump_daemon_log()
         return 1
     if proc.returncode != 0:
         d.kill()
         print(f"FAIL: target rc={proc.returncode} "
               f"err={proc.stderr[:200]!r}", file=sys.stderr)
+        dump_daemon_log()
         return 1
 
     # give the agent's deinit flush a moment, then stop the daemon
@@ -107,9 +121,17 @@ def main():
         d.wait(timeout=5)
     except subprocess.TimeoutExpired:
         d.kill()
+    dlog.close()
 
-    with open(journal) as f:
-        lines = [ln for ln in f.read().splitlines() if ln.strip()]
+    try:
+        with open(journal) as f:
+            lines = [ln for ln in f.read().splitlines() if ln.strip()]
+    except FileNotFoundError:
+        print("FAIL: daemon wrote no journal at all "
+              "(no EVENT delivered)", file=sys.stderr)
+        dump_daemon_log()
+        print(f"  target stdout: {proc.stdout[:200]!r}", file=sys.stderr)
+        return 1
     hits = []
     for ln in lines:
         try:
@@ -124,6 +146,7 @@ def main():
               file=sys.stderr)
         for ln in lines[:4]:
             print(f"  {ln[:160]}", file=sys.stderr)
+        dump_daemon_log()
         return 1
     agent, ev = hits[0]
     attrs = ev.get("attrs", {})

--- a/test/integration/test_supervisor_agent.py
+++ b/test/integration/test_supervisor_agent.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""
+E2E: the in-process agent against the real daemon
+(TODO.supervisor/03).
+
+Phase 1 (delivery): a target under a denying sandbox config,
+RETRACE_SUPERVISOR=1 pointing at a live retraced; the denial
+must arrive in the daemon's journal as a complete EVENT payload
+(agent_id/seq/ts/name/attrs) attributed to the minted agent.
+
+Phase 2 (fail-open liveness): same run with the daemon KILLED
+mid-flight -- the target must still exit 0, its behavior
+unchanged (bounded queue, backoff, never die).
+
+Usage: test_supervisor_agent.py <retraced> <libretrace> <target>
+"""
+import json
+import os
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+
+RETRY_WAIT = 3.0
+
+
+def wait_sock(path, deadline=5.0):
+    end = time.time() + deadline
+    while time.time() < end:
+        if os.path.exists(path):
+            return True
+        time.sleep(0.1)
+    return False
+
+
+def run_target(lib, target, sock, denied, env_extra=None):
+    cfg = tempfile.NamedTemporaryFile(
+        prefix="sup-agent-cfg-", suffix=".json", mode="w",
+        delete=False)
+    json.dump({"intercept_scripts": [{
+        "func_name": "open",
+        "actions": [
+            {"action_name": "sandbox",
+             "action_params": {"deny_paths": [denied]}},
+            {"action_name": "call_real"}]}]}, cfg)
+    cfg.close()
+    env = dict(os.environ)
+    env.update({
+        "RETRACE_JSON_CONFIG": cfg.name,
+        "RETRACE_SUPERVISOR": "1",
+        "RETRACE_SUPERVISOR_SOCK": sock,
+        "RETRACE_LOGGER_DEF_ENA": "1",
+        "RETRACE_LOGGER_DEF_STDOUT_ENA": "0",
+    })
+    if env_extra:
+        env.update(env_extra)
+    if sys.platform == "darwin":
+        env["DYLD_INSERT_LIBRARIES"] = lib
+    else:
+        env["LD_PRELOAD"] = lib
+    return subprocess.run(
+        [target, denied, "/etc/protocols"], env=env,
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=30)
+
+
+def main():
+    if len(sys.argv) != 4:
+        print("usage: test_supervisor_agent.py <retraced> "
+              "<lib> <target>", file=sys.stderr)
+        return 2
+    daemon, lib, target = (os.path.abspath(p) for p in sys.argv[1:4])
+
+    work = tempfile.mkdtemp(prefix="sup-agent-")
+    sock = os.path.join(work, "agent.sock")
+    journal = os.path.join(work, "journal.jsonl")
+    denied_f = tempfile.NamedTemporaryFile(
+        prefix="sup-denied-", delete=False)
+    denied_f.close()
+    denied = denied_f.name
+
+    # ---- phase 1: delivery ------------------------------------
+    d = subprocess.Popen(
+        [daemon, "--sock", sock, "--journal", journal],
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    if not wait_sock(sock):
+        d.kill()
+        print("FAIL: daemon never listened", file=sys.stderr)
+        return 1
+
+    try:
+        proc = run_target(lib, target, sock, denied)
+    except subprocess.TimeoutExpired:
+        d.kill()
+        print("FAIL: target timed out", file=sys.stderr)
+        return 1
+    if proc.returncode != 0:
+        d.kill()
+        print(f"FAIL: target rc={proc.returncode} "
+              f"err={proc.stderr[:200]!r}", file=sys.stderr)
+        return 1
+
+    # give the agent's deinit flush a moment, then stop the daemon
+    time.sleep(0.5)
+    d.send_signal(signal.SIGTERM)
+    try:
+        d.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        d.kill()
+
+    with open(journal) as f:
+        lines = [ln for ln in f.read().splitlines() if ln.strip()]
+    hits = []
+    for ln in lines:
+        try:
+            rec = json.loads(ln)
+        except json.JSONDecodeError:
+            continue
+        ev = rec.get("ev", {})
+        if ev.get("name") == "retrace.jail.denied":
+            hits.append((rec.get("agent"), ev))
+    if not hits:
+        print(f"FAIL: no jail.denied in journal ({len(lines)} lines)",
+              file=sys.stderr)
+        for ln in lines[:4]:
+            print(f"  {ln[:160]}", file=sys.stderr)
+        return 1
+    agent, ev = hits[0]
+    attrs = ev.get("attrs", {})
+    if not agent or "boot." not in agent:
+        print(f"FAIL: bad agent attribution: {agent!r}", file=sys.stderr)
+        return 1
+    if attrs.get("retrace.jail.path") != denied:
+        print(f"FAIL: attrs wrong: {attrs}", file=sys.stderr)
+        return 1
+    for k in ("agent_id", "seq", "ts", "name", "attrs"):
+        if k not in ev:
+            print(f"FAIL: EVENT schema missing {k}: {ev}",
+                  file=sys.stderr)
+            return 1
+    print(f"phase 1 ok: {len(hits)} denial(s), agent={agent}, "
+          f"seq={ev.get('seq')}")
+
+    # ---- phase 2: fail-open liveness ---------------------------
+    # daemon absent: the target must behave identically (exit 0)
+    sock2 = os.path.join(work, "agent2.sock")
+    try:
+        proc2 = run_target(lib, target, sock2, denied)
+    except subprocess.TimeoutExpired:
+        print("FAIL: target timed out with daemon ABSENT",
+              file=sys.stderr)
+        return 1
+    if proc2.returncode != 0:
+        print(f"FAIL: daemon-absent run rc={proc2.returncode} "
+              f"err={proc2.stderr[:200]!r}", file=sys.stderr)
+        return 1
+    if b"denied-open rc=-1" not in proc2.stdout:
+        print(f"FAIL: denial did not happen daemon-absent: "
+              f"{proc2.stdout[:120]!r}", file=sys.stderr)
+        return 1
+    print("phase 2 ok: daemon absent -> target unchanged (exit 0, "
+          "denial enforced locally)")
+
+    print("PASS: agent (delivery + schema + attribution + "
+          "fail-open liveness)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/perf/CMakeLists.txt
+++ b/test/perf/CMakeLists.txt
@@ -44,6 +44,8 @@ function(add_retrace_bench name source)
 
 	target_link_libraries(retrace_perf_${name} PRIVATE
 		retrace_core
+		retrace_supervisor_agent
+		retrace_supervisor_proto
 	${_otlp_lib}
 		retrace_config_json
 		retrace_backends

--- a/test/property/CMakeLists.txt
+++ b/test/property/CMakeLists.txt
@@ -73,6 +73,8 @@ set_target_properties(retrace_property_sockaddr PROPERTIES
 
 target_link_libraries(retrace_property_sockaddr PRIVATE
 	retrace_core
+	retrace_supervisor_agent
+	retrace_supervisor_proto
 	${_otlp_lib}
 	retrace_config_json
 	retrace_backends
@@ -136,6 +138,8 @@ set_target_properties(retrace_property_actions PROPERTIES
 
 target_link_libraries(retrace_property_actions PRIVATE
     retrace_core
+    retrace_supervisor_agent
+    retrace_supervisor_proto
     ${_otlp_lib}
     retrace_config_json
     retrace_backends
@@ -197,6 +201,8 @@ set_target_properties(retrace_property_resolver PROPERTIES
 
 target_link_libraries(retrace_property_resolver PRIVATE
     retrace_core
+    retrace_supervisor_agent
+    retrace_supervisor_proto
     ${_otlp_lib}
     retrace_config_json
     retrace_backends
@@ -257,6 +263,8 @@ set_target_properties(retrace_property_caller_match PROPERTIES
 
 target_link_libraries(retrace_property_caller_match PRIVATE
     retrace_core
+    retrace_supervisor_agent
+    retrace_supervisor_proto
     ${_otlp_lib}
     retrace_config_json
     retrace_backends

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -231,6 +231,8 @@ function(retrace_add_unit_test name)
             ${T_EXTRA_INCLUDES})
         target_link_libraries(retrace_test_${name} PRIVATE
             retrace_core
+            retrace_supervisor_agent
+            retrace_supervisor_proto
             ${_otlp_lib}
             retrace_config_json
             retrace_backends

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -27,6 +27,8 @@ if(RETRACE_PLATFORM_WINDOWS)
 
     target_link_libraries(retrace_test_logger_fmt PRIVATE
         retrace_core
+        retrace_supervisor_agent
+        retrace_supervisor_proto
         ${_otlp_lib}
     retrace_config_json
         retrace_backends
@@ -85,6 +87,8 @@ if(RETRACE_PLATFORM_WINDOWS)
 
     target_link_libraries(retrace_test_win_registry PRIVATE
         retrace_core
+        retrace_supervisor_agent
+        retrace_supervisor_proto
         ${_otlp_lib}
     retrace_config_json
         retrace_backends
@@ -114,6 +118,8 @@ if(RETRACE_PLATFORM_WINDOWS)
 
         target_link_libraries(retrace_test_win_wrapper PRIVATE
             retrace_core
+            retrace_supervisor_agent
+            retrace_supervisor_proto
             ${_otlp_lib}
             retrace_config_json
             retrace_backends


### PR DESCRIPTION
## Summary

**retraced arc, slice 3 (TODO.supervisor/03): the in-process control agent.** v2.39.0. The traced process can now be *supervised*: with `RETRACE_SUPERVISOR=1`, an agent thread inside libretrace connects to the daemon (plan-01 protocol), heartbeats, and streams named security events.

### Design (all the Wave B/C laws, applied a third time)

- **Third permanent-guard thread** — after the log flusher and the otlp tick thread: logging-off *first*, then the guard (the v2.36 ordering law), so every interposed libc call on the agent thread passes through to the real impl
- **Enqueue-only producers**: `retrace_agent_emit_event` builds the complete EVENT payload (schema-exact: agent_id/seq/ts/name/attrs, JSON-escaped) and pushes to a bounded 256-slot queue — full = drop-with-count, **never blocks a denied call**
- **One CAS spawner**: lazy on the first event — never the constructor (the musl hazard)
- **Fail-open liveness**: daemon absent → jittered 0.5s→30s backoff, target behavior unchanged; **bounded 2s deinit flush** so short-lived targets still deliver before exit
- **Symmetric fan-out at one site**: `deny()` now calls both event subscribers — the OTLP streamer (Wave C) and the agent — no logger text-sniffing

### Enforcement record

- **OCP**: core gained one boot hook line (the otlp_live precedent) and sandbox one fan-out call; everything else is new files
- **DRY**: framing/messages from `protocol.h` via the proto lib, verbatim
- **MECE**: the agent owns connection + queue + thread; the daemon is untouched; OTLP untouched
- **Zero-delta**: unarmed by default — 98/98 prior tests byte-identical; **99/99** with the new E2E

### The E2E (`integration-supervisor-agent`)

Phase 1: a jailed target's denial arrives in the daemon's journal — full schema, attributed to the daemon-minted agent id, correct path attr. Phase 2: the daemon is killed mid-flight; the target still exits 0 with the denial enforced locally — the fail-open liveness property, proven.

## Test plan

- [x] 99/99 ctest (98 prior zero-delta + the agent E2E)
- [x] Both E2E phases green locally on first run
- [ ] CI matrix
