### PR TITLE
perf: dispatch-tail prototype lookup joins the name cache (143x)

### DIFF
--- a/src/core/engine.c
+++ b/src/core/engine.c
@@ -47,6 +47,7 @@
 #endif
 
 #include "engine.h"
+#include "funcs.h"
 #include "agent.h"
 #include "real_impls.h"
 #include "arch_spec.h"
@@ -145,7 +146,8 @@ static char *strip_darwin_extsn(char *name, char *buf, size_t bufsz)
 struct real_cache_el {
 	volatile uint64_t hash;
 	void *real;
-	const char *name;
+	char name[MAXLEN_FUNC_NAME];
+	const struct FuncPrototype *proto;
 };
 
 #define real_hash_load(p)	(*(p))
@@ -154,7 +156,8 @@ struct real_cache_el {
 struct real_cache_el {
 	_Atomic(uint64_t) hash;
 	void *real;
-	const char *name;
+	char name[MAXLEN_FUNC_NAME];
+	const struct FuncPrototype *proto;
 };
 
 #define real_hash_load(p)	atomic_load_explicit((p), \
@@ -162,6 +165,8 @@ struct real_cache_el {
 #define real_hash_store(p, v)	atomic_store_explicit((p), (v), \
 	memory_order_release)
 #endif
+
+struct FuncPrototype;
 
 static struct real_cache_el real_cache[REAL_CACHE_SLOTS];
 
@@ -224,12 +229,76 @@ void *retrace_real_impl_cached(const char *func_name)
 			return el->real;
 		if (k == 0) {
 			void *real = retrace_real_impl_resolve(func_name);
+			size_t n = 0;
 
-			el->name = func_name;
+			/* COPY the name -- never store the caller's
+			 * pointer: on macOS strip_darwin_extsn hands
+			 * back a buffer on the engine frame, dead
+			 * the moment this returns. Manual loop: a
+			 * libc copy here would itself dispatch.
+			 */
+			while (func_name[n] != '\0' &&
+			       n + 1 < sizeof(el->name)) {
+				el->name[n] = func_name[n];
+				n++;
+			}
+			el->name[n] = '\0';
 			el->real = real;
+			/* one index, both answers -- with one trap:
+			 * retrace_inited flips BEFORE funcs_init
+			 * registers the prototype table, so a
+			 * construction-window dispatch of a name
+			 * (parson opens the config) would freeze
+			 * proto=NULL forever. NULL therefore means
+			 * not-yet-resolved: proto_cached re-walks
+			 * and self-heals the entry.
+			 */
+			el->proto = NULL;
 			real_hash_store(&el->hash, h);
 			return real;
 		}
+		i++;
+	}
+}
+
+/*
+ * The dispatch tail's prototype lookup, served from the same
+ * name->slot index the real-impl pointer comes from: one probe
+ * per dispatch answers both. Only runs post-init (after the
+ * guard), where the entry was just inserted by the real-impl
+ * lookup earlier in this same dispatch -- the fallback covers
+ * ordering drift, never inserts.
+ */
+const struct FuncPrototype *retrace_proto_cached(
+	const char *func_name)
+{
+	uint64_t h;
+	size_t i;
+	struct real_cache_el *el;
+	uint64_t k;
+
+	if (!retrace_inited)
+		return retrace_func_get(func_name);
+	h = real_name_hash(func_name);
+	i = (size_t)h & (REAL_CACHE_SLOTS - 1);
+
+	for (;;) {
+		el = &real_cache[i & (REAL_CACHE_SLOTS - 1)];
+		k = real_hash_load(&el->hash);
+		if (k == h && el->name != NULL &&
+		    retrace_real_impls.strcmp(el->name, func_name)
+			    == 0) {
+			if (el->proto != NULL)
+				return el->proto;
+			/* filled post-funcs_init on the first
+			 * query that needs it; benign racing
+			 * (same value stored twice)
+			 */
+			el->proto = retrace_func_get(func_name);
+			return el->proto;
+		}
+		if (k == 0)
+			return retrace_func_get(func_name);
 		i++;
 	}
 }
@@ -297,7 +366,7 @@ void retrace_engine_wrapper(char *func_name,
 	 */
 	retrace_agent_kick();
 
-	thread_ctx->prototype = retrace_func_get(func_name);
+	thread_ctx->prototype = retrace_proto_cached(func_name);
 	retrace_win_diag("proto", func_name,
 		thread_ctx->prototype != NULL);
 

--- a/src/core/engine.h
+++ b/src/core/engine.h
@@ -69,6 +69,8 @@ void retrace_core_boot(void);
  * benched head-to-head in test/perf/bench_real_impl_lookup.c.
  */
 void *retrace_real_impl_cached(const char *func_name);
+const struct FuncPrototype *retrace_proto_cached(
+	const char *func_name);
 void *retrace_real_impl_resolve(const char *func_name);
 
 /*

--- a/test/perf/bench_real_impl_lookup.c
+++ b/test/perf/bench_real_impl_lookup.c
@@ -34,6 +34,7 @@
 #include <time.h>
 
 #include "engine.h"
+#include "funcs.h"
 
 #define DLSYM_ITERS 100000
 #define CACHE_ITERS 10000000
@@ -71,6 +72,34 @@ int main(void)
 		printf("FAIL: cache slower than dlsym\n");
 		return 1;
 	}
-	printf("PASS: real-impl cache\n");
+
+	/*
+	 * The dispatch-tail prototype lookup, same harness: the
+	 * historical per-dispatch table walk vs the shared index.
+	 */
+	{
+		double walk_ns, proto_ns;
+
+		t0 = now_ns();
+		for (i = 0; i < DLSYM_ITERS; i++)
+			sink = retrace_func_get("open");
+		t1 = now_ns();
+		walk_ns = (t1 - t0) / DLSYM_ITERS;
+
+		t0 = now_ns();
+		for (i = 0; i < CACHE_ITERS; i++)
+			sink = retrace_proto_cached("open");
+		t1 = now_ns();
+		proto_ns = (t1 - t0) / CACHE_ITERS;
+
+		printf("proto(walk)  : %.1f ns/op\n", walk_ns);
+		printf("proto(cached): %.1f ns/op\n", proto_ns);
+		printf("proto speedup: %.1fx\n", walk_ns / proto_ns);
+		if (proto_ns > walk_ns) {
+			printf("FAIL: proto cache slower than walk\n");
+			return 1;
+		}
+	}
+	printf("PASS: real-impl + prototype caches\n");
 	return 0;
 }


### PR DESCRIPTION
## What

Architecture-review candidate A. Every intercepted call ended with
`retrace_func_get(func_name)` — a strlen + hash + chained strcmp walk of the
128-slot table, ~1.9us per dispatch. The real-impl cache (v2.43.0) now carries
the prototype pointer too: **one FNV-1a probe answers both questions**; the walk
shrinks to ~13ns (measured **143x** on the bench's new proto leg).

## Two latent bugs the extension surfaced (both fixed here)

1. `retrace_inited` flips BEFORE `funcs_init` registers prototypes, so
   construction-window dispatches (parson opening the config) would have
   inserted `proto=NULL` forever. NULL in the cache now means
   not-yet-resolved: the first post-`funcs_init` query re-walks and
   self-heals the entry.
2. The cache stored the caller's name POINTER. On macOS, `strip_darwin_extsn`
   hands back a buffer on the engine frame (dead on return) for
   `$DARWIN_EXTSN` names — the strcmp key read dead stack. This latent UB
   shipped in the v2.43 real-impl cache. Names are now COPIED into the
   element, libc-free (a plain copy would itself dispatch).

## Verification

- bench_real_impl_lookup gains a prototype leg: 143.7x locally
- full local suite green (incl. all supervisor E2Es + otlp)
- checkpatch clean
