### PR TITLE
supervisor playbooks P0 (TODO.supervisor/09)

### DIFF
--- a/docs/cookbook/37-detonation-farm.md
+++ b/docs/cookbook/37-detonation-farm.md
@@ -1,0 +1,91 @@
+# 37 — Supervised detonation farm
+
+## Problem
+
+> I need to run hundreds of untrusted samples and know — per
+> sample, live — what they touched, with the ability to cut
+> network or freeze a cell the moment it misbehaves. Post-mortem
+> logs are too late.
+
+`retrace` (≥ 2.39.0) grew a supervisor plane for exactly this:
+`retraced` (the daemon), an in-process agent preloaded into
+every cell, and `retrace-ctl` as the operator's hand.
+
+## The one-script tour
+
+```
+cd examples/supervisor-quickstart
+./run-linux.sh ../../build        # macOS: ./run-macos.sh
+```
+
+Boot the daemon, detonate under supervision, watch events land,
+tighten policy mid-run, freeze, bundle. Every step below is one
+line of that script.
+
+## The farm pattern
+
+Each cell is one `exec` under the supervisor env:
+
+```sh
+retraced --sock /run/retraced/agent.sock \
+         --ctl /run/retraced/ctl.sock \
+         --journal /var/log/retrace/journal.jsonl \
+         --nonce-file /run/retraced/nonce &
+
+# per sample (the nonce is how the daemon tells your cells
+# from a traced process pretending to be one):
+RETRACE_SUPERVISOR=1 RETRACE_SUPERVISOR_EAGER=1 \
+RETRACE_SUPERVISOR_SOCK=/run/retraced/agent.sock \
+RETRACE_SUPERVISOR_NONCE=$(cat /run/retraced/nonce) \
+RETRACE_JSON_CONFIG=detonation-default.json \
+LD_PRELOAD=libretrace.so ./sample.exe &
+```
+
+The operator side is `retrace-ctl`:
+
+| Command | What it does |
+|---|---|
+| `ps` | Live registry: agent id, session, policy epoch, state |
+| `policy-push tight.json` | Tighten EVERY cell mid-run — no restarts |
+| `freeze` | Hold all agents: fabricated returns, zero real execution |
+| `kill PID` | End one cell |
+
+Process trees are stitched, not guessed: forked and exec'd
+children inherit the session token; an exec that strips it is
+recorded as a scrub; an untraced hop in the middle leaves a
+labeled hole. One detonation = one session id = one trace.
+
+## Mid-run tightening
+
+The moment the first beacon appears:
+
+```sh
+cat > cut-net.json <<EOF
+{"policy":{"epoch":2},
+ "intercept_scripts":[
+   {"func_name":"connect",
+    "actions":[{"action_name":"addr_deny",
+                "action_params":{"mode":"allowlist"}}]},
+   {"func_name":"open","actions":[{"action_name":"call_real"}]}]}
+EOF
+retrace-ctl --sock ctl.sock policy-push cut-net.json
+```
+
+Epochs only move forward: a captured POLICY_SET replayed at a
+cell is refused.
+
+## Where the events go
+
+Every denial, scrub, and policy ack lands in the daemon's
+hash-chained journal — tamper-evident by construction. For a
+farm-wide view, set `RETRACE_OTLP_ENDPOINT` and every span
+carries the session and agent labels (recipes 23, 36): one
+waterfall per detonation tree in your OTel backend.
+
+## Notes
+
+- The transport is local-only today (UDS, peer-credential
+  gated); the TLS fleet transport is the next slice — see
+  `docs/threat-model-control-plane.md`.
+- `freeze` freezes `sleep` too: a frozen cell spins hot. Freeze
+  to capture the bundle, then `kill`.

--- a/docs/cookbook/38-continuous-audit.md
+++ b/docs/cookbook/38-continuous-audit.md
@@ -1,0 +1,82 @@
+# 38 — Continuous audit: attestable "what was in force when"
+
+## Problem
+
+> Compliance asks: prove what a production service was ALLOWED
+> to do last quarter, prove what it actually did, and prove the
+> evidence wasn't edited. An editable local log answers none of
+> that.
+
+The supervisor plane (≥ 2.39.0) makes retrace output
+audit-grade:
+
+- **Policy as a versioned artifact.** The policy a service runs
+  under is a file with an epoch; the daemon only ever moves
+  epochs forward and refuses replays.
+- **Every violation is an event.** A supervised process that
+  touches a denied path emits `retrace.jail.denied` — live,
+  not post-mortem.
+- **The journal chains itself.** `retraced --journal` writes a
+  hash-chained JSONL: each record cites the previous record's
+  digest. Edit line 400 and every later `prev` breaks; the
+  daemon refuses to start on a broken chain (fail-closed).
+
+## The supervised-service setup
+
+```sh
+retraced --sock /run/retraced/agent.sock \
+         --ctl /run/retraced/ctl.sock \
+         --policy baseline-policy.json \
+         --journal /var/log/retrace/journal.jsonl \
+         --nonce-file /run/retraced/nonce &
+
+RETRACE_SUPERVISOR=1 RETRACE_SUPERVISOR_EAGER=1 \
+RETRACE_SUPERVISOR_SOCK=/run/retraced/agent.sock \
+RETRACE_SUPERVISOR_NONCE=$(cat /run/retraced/nonce) \
+RETRACE_JSON_CONFIG=baseline-policy.json \
+LD_PRELOAD=libretrace.so /usr/sbin/the-service
+```
+
+`--policy` pushes the policy to every agent at registration and
+on each re-HELLO; agents ack with the epoch they hold.
+
+## The quarterly export
+
+```sh
+retrace-ctl --sock ctl.sock ps > quarter-registry.json
+cp /var/log/retrace/journal.jsonl quarter-evidence.jsonl
+sha256sum quarter-evidence.jsonl >> chain-of-custody.txt
+```
+
+- `quarter-registry.json` — the supervised population and each
+  agent's last policy epoch.
+- `quarter-evidence.jsonl` — the chained event stream: denials,
+  policy pushes, freezes, auth decisions (`retrace.auth.*`).
+- Verification is mechanical: recompute each record's digest and
+  compare to the next record's `prev`. Any mismatch localizes
+  the edit to one record.
+
+## "What was in force when"
+
+Every `retrace.policy.pushed` and `retrace.policy.freeze` event
+carries the epoch; every `retrace.jail.denied` carries the
+agent and its session. Policy file + journal together answer the
+auditor's question exactly: at timestamp T, the service ran
+epoch E, and here is everything E denied.
+
+## Identity of the plane itself
+
+The journal also records who talked to the daemon: peer-uid
+refusals (`retrace.auth.refused`), the role of every agent
+(`retrace.auth.agent` — `full` or `spectator`). See
+`docs/threat-model-control-plane.md` for the full adversary
+table and the honest limits of the current (local) transport.
+
+## Notes
+
+- Signed policies (the compliance-grade variant) are planned
+  work — today the artifact is a file, and the journal proves
+  when each epoch landed, not who signed it.
+- Long-running services should supervise from exec (the env
+  must be present at process start); attaching to a running
+  PID is the incident-response flow (recipe 39).

--- a/docs/cookbook/39-incident-response.md
+++ b/docs/cookbook/39-incident-response.md
@@ -1,0 +1,72 @@
+# 39 — Incident response: the specimen hold
+
+## Problem
+
+> A production process is behaving badly RIGHT NOW. I need it
+> inert — zero further real syscalls — but alive for memory
+> capture, with the last thing it did already on disk. `kill
+> -9` destroys both the specimen and the evidence.
+
+Plain retrace cannot offer this: it must be present from
+`exec`, and its trace dies with the process. The supervisor
+plane (≥ 2.39.0) changes both.
+
+## The hold
+
+```
+freeze   every intercepted call returns a fabricated value —
+         the process keeps "running" but nothing real happens
+ps       registry: which agents live, which session
+kill     end the hold after the bundle is captured
+```
+
+```sh
+retrace-ctl --sock ctl.sock freeze
+retrace-ctl --sock ctl.sock ps | head
+retrace-ctl --sock ctl.sock kill $PID
+```
+
+The freeze is a POLICY, not a signal: it lands as the next
+epoch, every agent acks it, and the journal records
+`retrace.policy.freeze` with the epoch. From freeze to kill,
+the process makes no real intercepted calls — the memory image
+you capture between the two is the specimen.
+
+## The bundle
+
+By the time you freeze, the daemon already holds the story:
+
+- the hash-chained journal (denials, session stitching, policy
+  epochs, auth decisions),
+- the live registry (`ps`) — agent ids, sessions, parentage,
+- the target's own captured buffers (recipe 15's
+  `capture_buffer` action), if the policy included them.
+
+```sh
+retrace-ctl --sock ctl.sock ps > ir-registry.json
+cp /var/log/retrace/journal.jsonl ir-evidence.jsonl
+# ... memory capture of the frozen process ...
+retrace-ctl --sock ctl.sock kill $PID
+```
+
+## Freeze semantics — the quiet hold (v2.44.0)
+
+Freeze fabricates returns for every intercepted call EXCEPT the
+pure timeouts: `sleep`/`usleep` pass through, so a frozen polling
+loop idles instead of spinning (earlier releases spun frozen
+targets hot — that amplification is gone). Everything real still
+stops: no file, socket, or memory progress. `thaw` exists for
+controlled detonation — unfreezing under a tightened policy when
+you WANT the next stage to run.
+
+## Future work (honesty section)
+
+- **attach PID** — supervising an already-running process
+  (injection/ptrace) is planned, not shipped; today the env
+  must be present at exec.
+- **ring pull** — a bounded black-box pull of the last N calls
+  before the freeze; today the journal + capture buffers cover
+  the ground.
+- The P1 TLS transport and certificate-scoped controllers are
+  what make this a cross-host procedure — see
+  `docs/threat-model-control-plane.md`.

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -13,6 +13,11 @@
 if(RETRACE_PLATFORM_WINDOWS)
 	add_executable(getenv getenv-fuzzing/getenv.c)
 	add_executable(escape-demo escape-hunting/escape-demo.c)
+
+# supervisor-quickstart (TODO.supervisor/09): app.c is built by
+# the runner script itself (self-contained demo); nothing to
+# build here -- the flow is exercised by
+# integration-supervisor-quickstart.
 	add_executable(quickstart-app
 		trace-profile-quickstart/app.c)
 	return()

--- a/examples/supervisor-quickstart/README.md
+++ b/examples/supervisor-quickstart/README.md
@@ -1,0 +1,33 @@
+# supervisor-quickstart (TODO.supervisor/09)
+
+The one-script tour of the retrace control plane: a supervised
+detonation from supervisor boot to evidence bundle.
+
+```
+./run-linux.sh /path/to/build     # Linux
+./run-macos.sh /path/to/build     # macOS
+```
+
+What you should see, step by step:
+
+1. `retraced` boots and publishes the agent nonce (`--nonce-file`).
+2. A small "detonation" runs under `RETRACE_SUPERVISOR=1` +
+   preload; every denied path read is a supervised security
+   event that lands in the daemon's hash-chained journal.
+3. `retrace-ctl ps` shows the registration (role `full`, one
+   session).
+4. `retrace-ctl policy-push` tightens the policy MID-RUN —
+   the live target picks it up without restart.
+5. `retrace-ctl freeze` holds every agent (the incident-
+   response hold: fabricated returns, no real execution).
+6. The journal bundle names the whole story: session minted,
+   denial, policy push, freeze.
+7. The target is killed after the hold — evidence first.
+
+Cookbook recipes built on this flow: 37 (detonation farm),
+38 (continuous audit), 39 (incident response) under
+`docs/cookbook/`.
+
+Note on `freeze`: pure timeouts (`sleep`/`usleep`) pass through
+(v2.44.0 quiet hold), so a frozen target sits quiet — end the
+hold with `kill` once the bundle is captured.

--- a/examples/supervisor-quickstart/app.c
+++ b/examples/supervisor-quickstart/app.c
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * supervisor-quickstart target (TODO.supervisor/09): a small
+ * "detonation" -- a loop that keeps touching a denied path
+ * (each denial is a supervised security event) while the
+ * supervisor watches, tightens, and freezes. Runs until it has
+ * probed BEATS times (default 10, ~1/s), then exits 0.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+int main(int argc, char **argv)
+{
+	int beats = argc > 1 ? atoi(argv[1]) : 10;
+	int i;
+
+	for (i = 0; i < beats; i++) {
+		int fd = open("/etc/hosts", O_RDONLY);
+
+		if (fd >= 0)
+			close(fd);
+		printf("beat %d/%d denied=%d\n", i + 1, beats, fd < 0);
+		fflush(stdout);
+		sleep(1);
+	}
+	return 0;
+}

--- a/examples/supervisor-quickstart/run-linux.sh
+++ b/examples/supervisor-quickstart/run-linux.sh
@@ -1,0 +1,73 @@
+#!/bin/sh
+# supervisor-quickstart: the farm loop in one script
+# (TODO.supervisor/09, cookbook recipe 37). Platform: Linux.
+#   retraced up -> supervise a detonation -> watch events land
+#   -> tighten policy mid-run -> freeze -> bundle the journal
+# usage: run-linux.sh [path-to-build-dir]
+set -eu
+HERE=$(cd "$(dirname "$0")" && pwd)
+BUILD=${1:-$HERE/../../build}
+case "$BUILD" in /*) ;; *) BUILD=$(cd "$BUILD" && pwd);; esac
+WORK=$(mktemp -d)
+cd "$WORK"
+trap 'kill $DAEMON_PID 2>/dev/null || true' EXIT
+
+echo "=== 1. supervisor up (nonce published for the spawner)"
+"$BUILD/tools/retraced/retraced" \
+	--sock agent.sock --journal journal.jsonl \
+	--ctl ctl.sock --nonce-file nonce.txt > daemon.log 2>&1 &
+DAEMON_PID=$!
+i=0
+while [ ! -S ctl.sock ]; do
+	i=$((i + 1)); [ "$i" -gt 50 ] && { echo "daemon never listened"; exit 1; }
+	sleep 0.1
+done
+NONCE=$(cat nonce.txt)
+
+echo "=== 2. detonate under supervision (denials are events)"
+cc -O1 -o app "$HERE/app.c"
+cat > boot.json <<EOF
+{"intercept_scripts":[{"func_name":"open","actions":[
+ {"action_name":"sandbox","action_params":{"deny_paths":["/etc/hosts"]}},
+ {"action_name":"call_real"}]}]}
+EOF
+RETRACE_JSON_CONFIG="$WORK/boot.json" \
+RETRACE_SUPERVISOR=1 RETRACE_SUPERVISOR_EAGER=1 \
+RETRACE_SUPERVISOR_SOCK="$WORK/agent.sock" \
+RETRACE_SUPERVISOR_NONCE="$NONCE" \
+RETRACE_LOGGER_DEF_ENA=0 \
+LD_PRELOAD="$BUILD/src/v2/libretrace.so" \
+	./app 8 > app.out 2>&1 &
+APP_PID=$!
+
+echo "=== 3. it registered (poll the registry)"
+i=0
+while :; do
+	N=$("$BUILD/tools/retrace-ctl/retrace-ctl" --sock ctl.sock ps | \
+		grep -o '"count":[0-9]*' | head -1 | tr -dc 0-9)
+	[ "${N:-0}" -ge 1 ] 2>/dev/null && break
+	i=$((i + 1)); [ "$i" -gt 100 ] && { echo "never registered"; exit 1; }
+	sleep 0.1
+done
+"$BUILD/tools/retrace-ctl/retrace-ctl" --sock ctl.sock ps | head -3
+
+echo "=== 4. mid-run tightening (deny writes too)"
+cat > tight.json <<EOF
+{"policy":{"epoch":2},"intercept_scripts":[{"func_name":"open","actions":[
+ {"action_name":"sandbox","action_params":{"deny_paths":["/etc/hosts","$WORK"]}},
+ {"action_name":"call_real"}]}]}
+EOF
+"$BUILD/tools/retrace-ctl/retrace-ctl" --sock ctl.sock policy-push tight.json
+
+echo "=== 5. freeze (the incident-response hold)"
+"$BUILD/tools/retrace-ctl/retrace-ctl" --sock ctl.sock freeze
+"$BUILD/tools/retrace-ctl/retrace-ctl" --sock ctl.sock status
+
+echo "=== 6. the evidence bundle (hash-chained journal)"
+grep -o '"name":"retrace[^"]*"' journal.jsonl | sort | uniq -c | sort -rn | head -8
+
+echo "=== 7. kill --after-ring (end the hold)"
+kill $APP_PID 2>/dev/null || true
+wait $APP_PID 2>/dev/null || true
+kill $DAEMON_PID 2>/dev/null || true
+echo "=== done: journal + registry under $WORK (bundle on freeze)"

--- a/examples/supervisor-quickstart/run-macos.sh
+++ b/examples/supervisor-quickstart/run-macos.sh
@@ -1,0 +1,73 @@
+#!/bin/sh
+# supervisor-quickstart: the farm loop in one script
+# (TODO.supervisor/09, cookbook recipe 37). Platform: macOS.
+#   retraced up -> supervise a detonation -> watch events land
+#   -> tighten policy mid-run -> freeze -> bundle the journal
+# usage: run-macos.sh [path-to-build-dir]
+set -eu
+HERE=$(cd "$(dirname "$0")" && pwd)
+BUILD=${1:-$HERE/../../build}
+case "$BUILD" in /*) ;; *) BUILD=$(cd "$BUILD" && pwd);; esac
+WORK=$(mktemp -d)
+cd "$WORK"
+trap 'kill $DAEMON_PID 2>/dev/null || true' EXIT
+
+echo "=== 1. supervisor up (nonce published for the spawner)"
+"$BUILD/tools/retraced/retraced" \
+	--sock agent.sock --journal journal.jsonl \
+	--ctl ctl.sock --nonce-file nonce.txt > daemon.log 2>&1 &
+DAEMON_PID=$!
+i=0
+while [ ! -S ctl.sock ]; do
+	i=$((i + 1)); [ "$i" -gt 50 ] && { echo "daemon never listened"; exit 1; }
+	sleep 0.1
+done
+NONCE=$(cat nonce.txt)
+
+echo "=== 2. detonate under supervision (denials are events)"
+cc -O1 -o app "$HERE/app.c"
+cat > boot.json <<EOF
+{"intercept_scripts":[{"func_name":"open","actions":[
+ {"action_name":"sandbox","action_params":{"deny_paths":["/etc/hosts"]}},
+ {"action_name":"call_real"}]}]}
+EOF
+RETRACE_JSON_CONFIG="$WORK/boot.json" \
+RETRACE_SUPERVISOR=1 RETRACE_SUPERVISOR_EAGER=1 \
+RETRACE_SUPERVISOR_SOCK="$WORK/agent.sock" \
+RETRACE_SUPERVISOR_NONCE="$NONCE" \
+RETRACE_LOGGER_DEF_ENA=0 \
+DYLD_INSERT_LIBRARIES="$BUILD/src/v2/libretrace.dylib" \
+	./app 8 > app.out 2>&1 &
+APP_PID=$!
+
+echo "=== 3. it registered (poll the registry)"
+i=0
+while :; do
+	N=$("$BUILD/tools/retrace-ctl/retrace-ctl" --sock ctl.sock ps | \
+		grep -o '"count":[0-9]*' | head -1 | tr -dc 0-9)
+	[ "${N:-0}" -ge 1 ] 2>/dev/null && break
+	i=$((i + 1)); [ "$i" -gt 100 ] && { echo "never registered"; exit 1; }
+	sleep 0.1
+done
+"$BUILD/tools/retrace-ctl/retrace-ctl" --sock ctl.sock ps | head -3
+
+echo "=== 4. mid-run tightening (deny writes too)"
+cat > tight.json <<EOF
+{"policy":{"epoch":2},"intercept_scripts":[{"func_name":"open","actions":[
+ {"action_name":"sandbox","action_params":{"deny_paths":["/etc/hosts","$WORK"]}},
+ {"action_name":"call_real"}]}]}
+EOF
+"$BUILD/tools/retrace-ctl/retrace-ctl" --sock ctl.sock policy-push tight.json
+
+echo "=== 5. freeze (the incident-response hold)"
+"$BUILD/tools/retrace-ctl/retrace-ctl" --sock ctl.sock freeze
+"$BUILD/tools/retrace-ctl/retrace-ctl" --sock ctl.sock status
+
+echo "=== 6. the evidence bundle (hash-chained journal)"
+grep -o '"name":"retrace[^"]*"' journal.jsonl | sort | uniq -c | sort -rn | head -8
+
+echo "=== 7. kill --after-ring (end the hold)"
+kill $APP_PID 2>/dev/null || true
+wait $APP_PID 2>/dev/null || true
+kill $DAEMON_PID 2>/dev/null || true
+echo "=== done: journal + registry under $WORK (bundle on freeze)"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -192,6 +192,20 @@ if(Python3_Interpreter_FOUND)
 		LABELS "integration"
 		TIMEOUT 120)
 
+	# The farm/IR playbook, end to end (TODO.supervisor/09):
+	# register, tighten mid-run, freeze, journal the story.
+	if(NOT WIN32)
+		add_test(NAME integration-supervisor-quickstart
+			COMMAND ${CMAKE_COMMAND}
+				-DDEMO_DIR=${CMAKE_SOURCE_DIR}/examples/supervisor-quickstart
+				-DBUILD_DIR=${CMAKE_BINARY_DIR}
+				-DCMAKE_SYSTEM_NAME=${CMAKE_SYSTEM_NAME}
+				-P ${CMAKE_SOURCE_DIR}/test/RunQuickstart.cmake)
+		set_tests_properties(integration-supervisor-quickstart
+			PROPERTIES LABELS "integration"
+			TIMEOUT 120)
+	endif()
+
 	# Transport auth (TODO.supervisor/08 P0): socket mode
 	# gates, nonce roles (spectator vs full), peer-uid refusal.
 	add_test(NAME integration-supervisor-auth

--- a/test/RunQuickstart.cmake
+++ b/test/RunQuickstart.cmake
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Runs examples/supervisor-quickstart's platform runner with the
+# build tree (integration-supervisor-quickstart).
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+	set(RUNNER ${DEMO_DIR}/run-macos.sh)
+else()
+	set(RUNNER ${DEMO_DIR}/run-linux.sh)
+endif()
+
+execute_process(
+	COMMAND /bin/sh ${RUNNER} ${BUILD_DIR}
+	RESULT_VARIABLE rc
+	OUTPUT_VARIABLE out
+	ERROR_VARIABLE out
+	TIMEOUT 100)
+if(NOT rc EQUAL 0)
+	message(FATAL_ERROR
+		"supervisor-quickstart failed (${rc}):\n${out}")
+endif()


### PR DESCRIPTION
## What

Architecture-review task #6 / TODO.supervisor/09 P0 — the product surface of
the control plane, one command each:

- **examples/supervisor-quickstart**: the farm loop in one script (Linux +
  macOS runners) — retraced up with a published nonce, a detonation under
  supervision, live registry, mid-run policy tightening, the freeze hold, the
  hash-chained evidence bundle, kill-after-hold. CI-executed as
  `integration-supervisor-quickstart`.
- **Cookbook 37** (detonation farm), **38** (continuous audit: the
  hash-chained journal as attestable what-was-in-force-when evidence), **39**
  (incident response: freeze = the specimen hold — updated for v2.44.0's
  quiet hold, with an honesty section for attach/ring/TLS still to come).

## Verification

- all 6 supervisor E2Es green locally (quickstart included)
- checkpatch clean
