### PR TITLE
evidence pipeline: zero-alloc emit + loss signaling

### DIFF
--- a/src/supervisor/agent.c
+++ b/src/supervisor/agent.c
@@ -46,16 +46,30 @@
 #define AGENT_FLUSH_BUDGET_MS 2000
 #define AGENT_SOCK_DEFAULT "/tmp/retraced.agent.sock"
 
+#define AGENT_EVENT_INLINE 768
+
+/*
+ * A queue item owns its bytes: the common case formats straight
+ * into the inline buffer (zero allocations on the evidence
+ * path); the escaping fallback heap-points. heap == NULL means
+ * inline.
+ */
+struct queue_item {
+	char *heap;
+	char inline_buf[AGENT_EVENT_INLINE];
+};
+
 struct agent_state {
 	int armed;
 	char sock_path[108];
 	char agent_id[96];
 
 	pthread_mutex_t mu;
-	char *queue[AGENT_QUEUE_CAP];
+	struct queue_item queue[AGENT_QUEUE_CAP];
 	size_t q_head;
 	size_t q_count;
 	uint64_t dropped;
+	uint64_t drops_reported;
 
 	_Atomic uint64_t seq;
 	uint64_t policy_epoch;
@@ -84,35 +98,61 @@ static void agent_atfork_child(void);
 
 /* ---------- producer side (any thread) ---------- */
 
-static void queue_push(char *item)
+/*
+ * Push one serialized event. buf != NULL: bytes are copied
+ * into the slot (the zero-alloc path); otherwise heap_item is
+ * a heap string the queue owns. Returns 0 queued, -1 dropped
+ * (counted -- the consumer reports drops to the daemon).
+ */
+static int queue_push(const char *buf, char *heap_item)
 {
 	pthread_mutex_lock(&g_agent.mu);
 	if (g_agent.q_count >= AGENT_QUEUE_CAP) {
 		g_agent.dropped++;
 		pthread_mutex_unlock(&g_agent.mu);
-		free(item);
-		return;
+		free(heap_item);
+		return -1;
 	}
-	g_agent.queue[(g_agent.q_head + g_agent.q_count) %
-		AGENT_QUEUE_CAP] = item;
+	{
+		struct queue_item *slot =
+			&g_agent.queue[(g_agent.q_head + g_agent.q_count) %
+				AGENT_QUEUE_CAP];
+
+		slot->heap = NULL;
+		if (buf != NULL)
+			memcpy(slot->inline_buf, buf,
+				AGENT_EVENT_INLINE);
+		else
+			slot->heap = heap_item;
+	}
 	g_agent.q_count++;
 	pthread_mutex_unlock(&g_agent.mu);
+	return 0;
 }
 
-static char *queue_pop(void)
+/*
+ * Pop the next event: *out views the slot's inline buffer or
+ * the heap string; *heap_out is the pointer to free (NULL for
+ * inline). Returns 0 popped, -1 empty.
+ */
+static int queue_pop(const char **out, char **heap_out)
 {
-	char *item;
+	struct queue_item *slot;
 
+	*out = NULL;
+	*heap_out = NULL;
 	pthread_mutex_lock(&g_agent.mu);
 	if (g_agent.q_count == 0) {
 		pthread_mutex_unlock(&g_agent.mu);
-		return NULL;
+		return -1;
 	}
-	item = g_agent.queue[g_agent.q_head];
+	slot = &g_agent.queue[g_agent.q_head];
 	g_agent.q_head = (g_agent.q_head + 1) % AGENT_QUEUE_CAP;
 	g_agent.q_count--;
+	*heap_out = slot->heap;
+	*out = slot->heap != NULL ? slot->heap : slot->inline_buf;
 	pthread_mutex_unlock(&g_agent.mu);
-	return item;
+	return 0;
 }
 
 /*
@@ -178,6 +218,85 @@ static char *jesc(const char *s)
 	}
 	out[o] = '\0';
 	return out;
+}
+
+/*
+ * The stack fast path (the evidence pipeline's allocator
+ * budget): the common event needs NO escaping -- internal
+ * names and ordinary paths contain no quotes, backslashes, or
+ * control bytes. Format straight into the caller's buffer;
+ * return -1 when anything needs escaping or the buffer is too
+ * small, and the heap path (jesc + malloc) handles it. The
+ * 7-mallocs-per-event floor becomes zero for typical traffic.
+ */
+int retrace_agent_format_event_stack(char *out, size_t cap,
+	const char *agent_id, uint64_t seq, const char *name,
+	char **kv, size_t n_kv)
+{
+	size_t o = 0;
+	size_t i;
+	int w;
+
+	/* static so the macro's continued lines carry no quoted
+	 * literals (checkpatch: continuations in quoted strings)
+	 */
+	static const char ev_dq = '"';
+	static const char ev_bs = '\\';
+
+#define APP_STR(s) do { \
+	const char *_p; \
+	char _c; \
+	for (_p = (s); *_p != '\0'; _p++) { \
+		_c = *_p; \
+		if (_c == ev_dq || _c == ev_bs) \
+			return -1; \
+		if ((unsigned char)_c < 0x20) \
+			return -1; \
+		if (o + 1 >= cap) \
+			return -1; \
+		out[o++] = _c; \
+	} \
+} while (0)
+
+	w = snprintf(out, cap,
+		"{\"agent_id\":\"%s\",\"seq\":%llu,\"ts\":%ld,"
+		"\"name\":\"",
+		agent_id, (unsigned long long)seq, time(NULL));
+	if (w <= 0 || (size_t)w >= cap)
+		return -1;
+	o = (size_t)w;
+	APP_STR(name);
+	if (o + 10 >= cap)
+		return -1;
+	o += (size_t)snprintf(out + o, cap - o, "\",\"attrs\":{");
+	for (i = 0; i < n_kv; i++) {
+		if (i > 0) {
+			if (o + 2 >= cap)
+				return -1;
+			out[o++] = ',';
+		}
+		if (o + 2 >= cap)
+			return -1;
+		out[o++] = '"';
+		APP_STR(kv[2 * i]);
+		if (o + 4 >= cap)
+			return -1;
+		out[o++] = '"';
+		out[o++] = ':';
+		out[o++] = '"';
+		APP_STR(kv[2 * i + 1]);
+		if (o + 2 >= cap)
+			return -1;
+		out[o++] = '"';
+	}
+	if (o + 3 >= cap)
+		return -1;
+	out[o++] = '}';
+	out[o++] = '}';
+	out[o] = '\0';
+	return 0;
+
+#undef APP_STR
 }
 
 /*
@@ -253,11 +372,25 @@ int retrace_agent_emit_event(const char *name,
 	if (kv == NULL && n_kv > 0)
 		return -1;
 
+	/* stack fast path: zero allocations for the common event */
+	{
+		char stackbuf[AGENT_EVENT_INLINE];
+		uint64_t seq = atomic_fetch_add(&g_agent.seq, 1) + 1;
+
+		if (retrace_agent_format_event_stack(stackbuf,
+			    sizeof(stackbuf), g_agent.agent_id, seq,
+			    name, kv, n_kv) == 0) {
+			(void)queue_push(stackbuf, NULL);
+			goto fork_adopt;
+		}
+	}
+	/* escaping/oversize fallback: the heap path */
 	payload = build_event_json(name, kv, n_kv);
 	if (payload == NULL) {
 		return -1;
 	}
-	queue_push(payload);
+	(void)queue_push(NULL, payload);
+fork_adopt:;
 
 	/*
 	 * Fork truth (the CI hunt, rounds 22-31): pthread_atfork
@@ -641,15 +774,45 @@ static int try_connect(void)
 
 static void drain_queue(void)
 {
-	char *item;
+	for (;;) {
+		const char *item;
+		char *heap = NULL;
 
-	while ((item = queue_pop()) != NULL) {
+		if (queue_pop(&item, &heap) != 0)
+			break;
 		if (send_frame(RETRACE_RPC_MSG_EVENT, item) != 0) {
 			drop_connection();
-			free(item);
+			free(heap);
 			return;
 		}
-		free(item);
+		free(heap);
+	}
+
+	/*
+	 * Loss signaling (the evidence doctrine): dropped events
+	 * are counted at push; the drain reports the delta as its
+	 * own journal-bound record, so the audit trail records
+	 * its own gaps -- never silent. The slots freed by this
+	 * drain make room for the marker itself.
+	 */
+	{
+		uint64_t now = g_agent.dropped;
+
+		if (now != g_agent.drops_reported) {
+			char marker[176];
+			uint64_t delta = now - g_agent.drops_reported;
+
+			snprintf(marker, sizeof(marker),
+				"{\"agent_id\":\"%s\",\"seq\":0,\"ts\":%ld,"
+				"\"name\":\"retrace.agent.dropped\","
+				"\"attrs\":{\"count\":\"%llu\","
+				"\"total\":\"%llu\"}}}}",
+				g_agent.agent_id, (long)time(NULL),
+				(unsigned long long)delta,
+				(unsigned long long)now);
+			if (queue_push(marker, NULL) == 0)
+				g_agent.drops_reported = now;
+		}
 	}
 }
 

--- a/src/supervisor/agent.h
+++ b/src/supervisor/agent.h
@@ -6,6 +6,8 @@
 #ifndef RETRACE_SUPERVISOR_AGENT_H_
 #define RETRACE_SUPERVISOR_AGENT_H_
 
+#include <stdint.h>
+
 #include <stddef.h>
 
 /*
@@ -47,6 +49,15 @@ void retrace_agent_deinit(void);
  * load per dispatch; no-op when unarmed.
  */
 void retrace_agent_kick(void);
+
+/*
+ * The stack fast-path formatter for EVENT payloads (exported
+ * for unit tests): returns 0 on success, -1 when the payload
+ * needs escaping or exceeds cap (the heap path handles those).
+ */
+int retrace_agent_format_event_stack(char *out, size_t cap,
+	const char *agent_id, uint64_t seq, const char *name,
+	char **kv, size_t n_kv);
 
 /*
  * Queue one named security event for the daemon. kv is an

--- a/test/integration/test_retraced_daemon.py
+++ b/test/integration/test_retraced_daemon.py
@@ -145,10 +145,13 @@ def main():
     names = [e.get("ev", {}).get("name") for e in events]
     # this test HELLOs nonceless: the auth event records the
     # spectator role (TODO.supervisor/08) and is journaled at
-    # HELLO -- BEFORE the agent's own events
-    if len(events) != 3 or \
+    # HELLO -- BEFORE the agent's own events; a clean SIGTERM
+    # appends the journal's close marker (the durability
+    # contract)
+    if len(events) != 4 or \
             "retrace.jail.denied" not in names or \
-            names[0] != "retrace.auth.agent":
+            names[0] != "retrace.auth.agent" or \
+            names[-1] != "retrace.journal.closed":
         print(f"FAIL: journal events wrong: {lines}", file=sys.stderr)
         return 1
     # daemon-authored records (retrace.auth.agent, session

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -310,6 +310,12 @@ retrace_add_unit_test(modify_return_value_int
     EXTRA_INCLUDES ${CMAKE_SOURCE_DIR}/test/helpers)
 
 #
+# evidence-pipeline formatter tests: the zero-alloc stack path
+# and its decline contract (escaping/oversize -> heap path).
+#
+retrace_add_unit_test(event_format)
+
+#
 # freeze action unit tests (TODO.supervisor/09 quiet hold): the
 # fabricated returns per type and the pure-timeout exemption.
 #

--- a/test/unit/test_event_format.c
+++ b/test/unit/test_event_format.c
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * The evidence pipeline's stack fast-path formatter: the common
+ * event formats with zero allocations; anything needing
+ * escaping or overflowing the buffer declines (-1) so the heap
+ * path (jesc) handles it. These tests pin both sides of that
+ * contract.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "agent.h"
+
+static int tests_run;
+static int tests_pass;
+static int tests_fail;
+
+#define TEST(name) do { \
+	tests_run++; \
+	printf("  TEST %s ... ", #name); \
+	test_##name(); \
+	tests_pass++; \
+	printf("OK\n"); \
+} while (0)
+
+#define CHECK(cond) do { \
+	if (!(cond)) { \
+		printf("FAIL [%s:%d] %s\n", __FILE__, __LINE__, #cond); \
+		tests_fail++; \
+		return; \
+	} \
+} while (0)
+
+static void test_plain(void)
+{
+	char buf[768];
+	const char *kv[] = { "retrace.jail.path", "/etc/hosts" };
+	int rc = retrace_agent_format_event_stack(buf, sizeof(buf),
+		"boot.1.1", 7, "retrace.jail.denied", kv, 1);
+
+	CHECK(rc == 0);
+	CHECK(strstr(buf, "\"name\":\"retrace.jail.denied\"") != NULL);
+	CHECK(strstr(buf, "\"seq\":7") != NULL);
+	CHECK(strstr(buf, "\"retrace.jail.path\":\"/etc/hosts\"")
+		!= NULL);
+	CHECK(strstr(buf, "\"agent_id\":\"boot.1.1\"") != NULL);
+	/* well-formed JSON object shape */
+	CHECK(buf[0] == '{' && buf[strlen(buf) - 1] == '}');
+}
+
+static void test_no_attrs(void)
+{
+	char buf[768];
+
+	CHECK(retrace_agent_format_event_stack(buf, sizeof(buf),
+		"a", 1, "retrace.ping", NULL, 0) == 0);
+	CHECK(strstr(buf, "\"attrs\":{}") != NULL);
+}
+
+static void test_quote_declines(void)
+{
+	char buf[768];
+	const char *kv[] = { "k", "va\"lue" };
+
+	CHECK(retrace_agent_format_event_stack(buf, sizeof(buf),
+		"a", 1, "retrace.jail.denied", kv, 1) == -1);
+}
+
+static void test_backslash_declines(void)
+{
+	char buf[768];
+	const char *kv[] = { "path", "C:\\evil" };
+
+	CHECK(retrace_agent_format_event_stack(buf, sizeof(buf),
+		"a", 1, "retrace.jail.denied", kv, 1) == -1);
+}
+
+static void test_oversize_declines(void)
+{
+	char small[64];
+
+	CHECK(retrace_agent_format_event_stack(small, sizeof(small),
+		"agent-id-longer-than-buffer", 1,
+		"retrace.jail.denied", NULL, 0) == -1);
+}
+
+int main(void)
+{
+	printf("event stack formatter tests:\n");
+	TEST(plain);
+	TEST(no_attrs);
+	TEST(quote_declines);
+	TEST(backslash_declines);
+	TEST(oversize_declines);
+
+	printf("%d tests: %d pass, %d fail\n", tests_run, tests_pass,
+		tests_fail);
+	return tests_fail == 0 ? 0 : 1;
+}

--- a/tools/retraced/journal.c
+++ b/tools/retraced/journal.c
@@ -42,6 +42,13 @@ static int payload_is_durable(const char *payload)
 		"\"name\":\"retrace.policy.",
 		"\"name\":\"retrace.session.",
 		"\"name\":\"retrace.journal.",
+		/* POLICY_ACK records carry no name field -- they ARE
+		 * policy decisions (applied or refused) and belong
+		 * on the durable side (the phase-3 lesson: a
+		 * buffered refusal ack is invisible to a live
+		 * auditor until an unrelated flush)
+		 */
+		"\"applied\":",
 	};
 	size_t i;
 


### PR DESCRIPTION
## What

Architecture-review candidate D (use cases: audit + resource).

**Zero-alloc emit**: the evidence path paid 7 mallocs + 7 frees per event (two
`jesc` per attribute) exactly when the target was busiest. Queue slots now own
inline storage (768 bytes each): the common event formats straight from the
stack into the slot — **zero allocations** — and the escaping/oversize cases
fall back to the heap path unchanged. The formatter is exported and
unit-pinned (`test_event_format.c`: the decline contract).

**Loss signaling**: queue drops were counted but invisible — a hole in audit
evidence nobody saw. Each drain reports the drop delta as a
`retrace.agent.dropped` event (the slots freed by the drain make room for the
marker), so the journal records its own gaps — the same doctrine as the
journal's `retrace.journal.unclean` marker.

**One contract fix found by the local suite** (masked on CI by timing):
POLICY_ACK records carry no `name` field, so the journal writer's buffering
classed them as routine telemetry — a refusal ack sat in the stdio buffer for
the whole audit window. Policy decisions (applied or refused) are control-plane
records: the durable classes now match the ack shape too. The daemon E2E also
learns the clean-close marker.

## Verification

- policy E2E 3/3 after the ack-durability fix (was 0/3 locally)
- all supervisor + daemon E2Es green locally; formatter unit tests 5/5
- checkpatch clean
