### PR TITLE
retraced: the ctl plane as a module (command surface unit-tested)

### DIFF
--- a/src/supervisor/agent.c
+++ b/src/supervisor/agent.c
@@ -231,7 +231,7 @@ static char *jesc(const char *s)
  */
 int retrace_agent_format_event_stack(char *out, size_t cap,
 	const char *agent_id, uint64_t seq, const char *name,
-	char **kv, size_t n_kv)
+	const char *const *kv, size_t n_kv)
 {
 	size_t o = 0;
 	size_t i;

--- a/src/supervisor/agent.h
+++ b/src/supervisor/agent.h
@@ -57,7 +57,7 @@ void retrace_agent_kick(void);
  */
 int retrace_agent_format_event_stack(char *out, size_t cap,
 	const char *agent_id, uint64_t seq, const char *name,
-	char **kv, size_t n_kv);
+	const char *const *kv, size_t n_kv);
 
 /*
  * Queue one named security event for the daemon. kv is an

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -310,6 +310,19 @@ retrace_add_unit_test(modify_return_value_int
     EXTRA_INCLUDES ${CMAKE_SOURCE_DIR}/test/helpers)
 
 #
+# retraced ctl-plane command surface, unit-tested through the
+# extracted module (buffer sink, no socket/daemon).
+#
+retrace_add_unit_test(retraced_ctl
+    EXTRA_SOURCES ${CMAKE_SOURCE_DIR}/tools/retraced/retraced_ctl.c
+        ${CMAKE_SOURCE_DIR}/tools/retraced/registry.c
+        ${CMAKE_SOURCE_DIR}/tools/retraced/journal.c
+    EXTRA_INCLUDES ${CMAKE_SOURCE_DIR}/tools/retraced
+        ${CMAKE_SOURCE_DIR}/tools/retraced/../..
+        ${CMAKE_SOURCE_DIR}/src/supervisor
+        ${CMAKE_SOURCE_DIR}/src/config/json)
+
+#
 # evidence-pipeline formatter tests: the zero-alloc stack path
 # and its decline contract (escaping/oversize -> heap path).
 #

--- a/test/unit/test_retraced_ctl.c
+++ b/test/unit/test_retraced_ctl.c
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * The controller plane's command surface, unit-tested through
+ * its module interface (the extraction's whole point): no
+ * socket, no daemon, no poll loop -- a buffer sink collects
+ * replies. These tests are why handle_ctl_line moved out of
+ * main.c.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "retraced_ctl.h"
+
+/*
+ * the connection-plane writer, stubbed: pushes are COUNTED,
+ * not sent
+ */
+int write_frame(int fd, uint16_t type, const char *payload)
+{
+	(void)fd;
+	(void)type;
+	(void)payload;
+	return 0;
+}
+
+static int tests_run;
+static int tests_pass;
+static int tests_fail;
+static int pushes;
+
+#define TEST(name) do { \
+	tests_run++; \
+	printf("  TEST %s ... ", #name); \
+	test_##name(); \
+	tests_pass++; \
+	printf("OK\n"); \
+} while (0)
+
+#define CHECK(cond) do { \
+	if (!(cond)) { \
+		printf("FAIL [%s:%d] %s\n", __FILE__, __LINE__, #cond); \
+		tests_fail++; \
+		return; \
+	} \
+} while (0)
+
+static char reply_buf[4096];
+static size_t reply_len;
+
+static void sink(const char *line, void *user)
+{
+	(void)user;
+	reply_len = 0;
+	while (*line != '\0' && reply_len + 1 < sizeof(reply_buf))
+		reply_buf[reply_len++] = *line++;
+	reply_buf[reply_len] = '\0';
+}
+
+static void feed(struct retraced_ctl_ctx *ctx, const char *line)
+{
+	char buf[1024];
+
+	snprintf(buf, sizeof(buf), "%s", line);
+	reply_buf[0] = '\0';
+	reply_len = 0;
+	retraced_ctl_handle_line(ctx, buf);
+}
+
+static struct retraced_ctl_ctx ctx;
+static struct conn conns[MAX_AGENTS];
+
+static void setup(void)
+{
+	static struct retraced_registry reg;
+	static struct retraced_journal jr;
+
+	memset(&ctx, 0, sizeof(ctx));
+	memset(conns, 0, sizeof(conns));
+	memset(&reg, 0, sizeof(reg));
+	memset(&jr, 0, sizeof(jr));
+	pushes = 0;
+	retraced_journal_open(&jr, "/dev/null");
+	ctx.conns = conns;
+	ctx.reg = &reg;
+	ctx.jr = &jr;
+	ctx.reply_sink = sink;
+}
+
+static void test_malformed(void)
+{
+	setup();
+	feed(&ctx, "not json at all");
+	CHECK(strstr(reply_buf, "\"error\":\"malformed json\"") != NULL);
+}
+
+static void test_no_cmd(void)
+{
+	setup();
+	feed(&ctx, "{}");
+	CHECK(strstr(reply_buf, "\"error\":\"no cmd\"") != NULL);
+}
+
+static void test_unknown(void)
+{
+	setup();
+	feed(&ctx, "{\"cmd\":\"teleport\"}");
+	CHECK(strstr(reply_buf, "\"error\":\"unknown cmd\"") != NULL);
+}
+
+static void test_status(void)
+{
+	setup();
+	feed(&ctx, "{\"cmd\":\"status\"}");
+	CHECK(strstr(reply_buf, "\"ok\":1") != NULL);
+	CHECK(strstr(reply_buf, "\"agents\":0") != NULL);
+	CHECK(strstr(reply_buf, "\"frozen\":0") != NULL);
+}
+
+static void test_ps(void)
+{
+	setup();
+	feed(&ctx, "{\"cmd\":\"ps\"}");
+	CHECK(strstr(reply_buf, "\"ok\":1") != NULL);
+	CHECK(strstr(reply_buf, "\"registry\"") != NULL);
+}
+
+static void test_policy_push_valid(void)
+{
+	setup();
+	feed(&ctx, "{\"cmd\":\"policy_push\",\"blob\":"
+		   "\"{\\\"policy\\\":{\\\"epoch\\\":7},"
+		   "\\\"intercept_scripts\\\":[{\\\"func_name\\\":\\\"*\\\","
+		   "\\\"actions\\\":[{\\\"action_name\\\":\\\"log_params\\\"}]}]}\"}");
+	CHECK(strstr(reply_buf, "\"ok\":1") != NULL);
+	CHECK(strstr(reply_buf, "\"epoch\":7") != NULL);
+	CHECK(ctx.policy_epoch == 7);
+	CHECK(ctx.policy_blob != NULL);
+	CHECK(ctx.frozen == 0);
+	CHECK(ctx.thaw_blob != NULL);
+}
+
+static void test_policy_push_bad(void)
+{
+	setup();
+	feed(&ctx, "{\"cmd\":\"policy_push\",\"blob\":\"{}\"}");
+	CHECK(strstr(reply_buf, "\"error\":\"bad policy") != NULL);
+	CHECK(ctx.policy_blob == NULL);
+}
+
+static void test_freeze_thaw(void)
+{
+	setup();
+	feed(&ctx, "{\"cmd\":\"policy_push\",\"blob\":"
+		   "\"{\\\"policy\\\":{\\\"epoch\\\":3},"
+		   "\\\"intercept_scripts\\\":[]}\"}");
+	feed(&ctx, "{\"cmd\":\"freeze\"}");
+	CHECK(ctx.frozen == 1);
+	CHECK(ctx.policy_epoch == 4);
+	feed(&ctx, "{\"cmd\":\"thaw\"}");
+	CHECK(ctx.frozen == 0);
+	CHECK(ctx.policy_epoch == 5);
+	/* thaw restores the pre-freeze policy's shape */
+	CHECK(ctx.policy_blob != NULL &&
+	      strstr(ctx.policy_blob, "intercept_scripts") != NULL);
+}
+
+static void test_kill_no_pid(void)
+{
+	setup();
+	feed(&ctx, "{\"cmd\":\"kill\"}");
+	CHECK(strstr(reply_buf, "\"error\":\"no pid\"") != NULL);
+}
+
+int main(void)
+{
+	printf("retraced ctl plane tests:\n");
+	TEST(malformed);
+	TEST(no_cmd);
+	TEST(unknown);
+	TEST(status);
+	TEST(ps);
+	TEST(policy_push_valid);
+	TEST(policy_push_bad);
+	TEST(freeze_thaw);
+	TEST(kill_no_pid);
+
+	printf("%d tests: %d pass, %d fail\n", tests_run, tests_pass,
+		tests_fail);
+	return tests_fail == 0 ? 0 : 1;
+}

--- a/tools/retraced/CMakeLists.txt
+++ b/tools/retraced/CMakeLists.txt
@@ -8,7 +8,7 @@
 set(_parson_source ${CMAKE_SOURCE_DIR}/src/config/json/parson.c)
 
 add_executable(retrace_retraced
-	main.c registry.c journal.c peer_gate.c ${_parson_source})
+	main.c registry.c journal.c peer_gate.c retraced_ctl.c ${_parson_source})
 set_target_properties(retrace_retraced PROPERTIES
 	OUTPUT_NAME retraced)
 

--- a/tools/retraced/main.c
+++ b/tools/retraced/main.c
@@ -39,10 +39,10 @@
 #include "protocol.h"
 #include "journal.h"
 #include "peer_gate.h"
+#include "retraced_ctl.h"
 
 #include "parson.h"
 
-#define MAX_AGENTS 128
 #define HB_TIMEOUT_MS 15000
 #define SWEEP_INTERVAL_MS 1000
 #define POLICY_MAX_BYTES 4000	/* the agent's inbound budget */
@@ -54,8 +54,15 @@ static volatile sig_atomic_t g_stop;
  * Pushed to every agent on registration; POLICY_ACKs update
  * the registry's per-agent epoch.
  */
-static char *g_policy_blob;
-static long g_policy_epoch;
+static struct retraced_ctl_ctx g_ctl;
+
+static void ctl_reply_fd(const char *line, void *user)
+{
+	int fd = *(int *)user;
+
+	(void)write(fd, line, strlen(line));
+}
+
 
 /* Agent-plane nonce (TODO.supervisor/08 P0): minted at startup
  * (or injected via --nonce for reproducible runs), delivered to
@@ -89,23 +96,23 @@ static int load_policy(const char *path)
 		fclose(f);
 		return -1;
 	}
-	g_policy_blob = malloc((size_t)sz + 1);
-	if (g_policy_blob == NULL) {
+	g_ctl.policy_blob = malloc((size_t)sz + 1);
+	if (g_ctl.policy_blob == NULL) {
 		fclose(f);
 		return -1;
 	}
-	if (fread(g_policy_blob, 1, (size_t)sz, f) != (size_t)sz) {
+	if (fread(g_ctl.policy_blob, 1, (size_t)sz, f) != (size_t)sz) {
 		fprintf(stderr, "retraced: policy %s read failed\n",
 			path);
-		free(g_policy_blob);
-		g_policy_blob = NULL;
+		free(g_ctl.policy_blob);
+		g_ctl.policy_blob = NULL;
 		fclose(f);
 		return -1;
 	}
 	fclose(f);
-	g_policy_blob[sz] = '\0';
+	g_ctl.policy_blob[sz] = '\0';
 
-	v = json_parse_string(g_policy_blob);
+	v = json_parse_string(g_ctl.policy_blob);
 	root = v != NULL ? json_value_get_object(v) : NULL;
 	pol = root != NULL ? json_object_get_object(root, "policy") : NULL;
 	epoch = pol != NULL ? json_object_get_number(pol, "epoch") : 0.0;
@@ -114,13 +121,13 @@ static int load_policy(const char *path)
 			"retraced: policy %s: policy.epoch >= 1 required\n",
 			path);
 		json_value_free(v);
-		free(g_policy_blob);
-		g_policy_blob = NULL;
+		free(g_ctl.policy_blob);
+		g_ctl.policy_blob = NULL;
 		return -1;
 	}
-	g_policy_epoch = (long)epoch;
+	g_ctl.policy_epoch = (long)epoch;
 	json_value_free(v);
-	printf("retraced: policy loaded: epoch %ld\n", g_policy_epoch);
+	printf("retraced: policy loaded: epoch %ld\n", g_ctl.policy_epoch);
 	return 0;
 }
 
@@ -138,16 +145,7 @@ static long now_ms(void)
 	return (long)(ts.tv_sec * 1000 + ts.tv_nsec / 1000000);
 }
 
-struct conn {
-	int fd;
-	uint8_t buf[RETRACE_RPC_PAYLOAD_MAX + RETRACE_RPC_HEADER_SZ];
-	size_t fill;
-	char agent_id[RETRACED_AGENT_ID_MAX];
-	int helloed;
-	int spectator;
-};
-
-static int write_frame(int fd, uint16_t type, const char *payload)
+int write_frame(int fd, uint16_t type, const char *payload)
 {
 	size_t plen = payload != NULL ? strlen(payload) : 0;
 	uint8_t *out = malloc(RETRACE_RPC_HEADER_SZ + plen);
@@ -264,7 +262,7 @@ static void handle_agent_frame(struct conn *c,
 
 		snprintf(welcome, sizeof(welcome),
 			"{\"agent_id\":\"%s\",\"session_token\":\"%s\",\"policy_epoch\":%ld,\"heartbeat_ms\":1000,\"role\":\"%s\"}",
-			e->id, e->session, g_policy_epoch,
+			e->id, e->session, g_ctl.policy_epoch,
 			c->spectator ? "spectator" : "full");
 		write_frame(c->fd, RETRACE_RPC_MSG_WELCOME, welcome);
 		/* the policy rides every registration: an agent
@@ -273,9 +271,9 @@ static void handle_agent_frame(struct conn *c,
 		 * already holds a newer one). Spectators never
 		 * receive policy or commands.
 		 */
-		if (g_policy_blob != NULL && !c->spectator)
+		if (g_ctl.policy_blob != NULL && !c->spectator)
 			write_frame(c->fd, RETRACE_RPC_MSG_POLICY_SET,
-				g_policy_blob);
+				g_ctl.policy_blob);
 		{
 			char ev[224];
 
@@ -358,210 +356,6 @@ static int g_ctl_fd = -1;
 static int g_ctl_pfd_slot = -1;
 static char g_ctl_buf[8192];
 static size_t g_ctl_fill;
-static char *g_thaw_blob;	/* last user policy, for thaw */
-static int g_frozen;
-
-static void set_policy_blob(const char *blob, long epoch)
-{
-	free(g_policy_blob);
-	g_policy_blob = strdup(blob);
-	g_policy_epoch = epoch;
-}
-
-static int push_policy_to_agents(struct conn *conns,
-	const char *blob)
-{
-	int i, pushed = 0;
-
-	for (i = 0; i < MAX_AGENTS; i++) {
-		if (conns[i].fd >= 0 && conns[i].helloed &&
-		    !conns[i].spectator) {
-			write_frame(conns[i].fd,
-				RETRACE_RPC_MSG_POLICY_SET, blob);
-			pushed++;
-		}
-	}
-	return pushed;
-}
-
-static void ctl_reply(const char *fmt, ...)
-{
-	char out[1024];
-	va_list ap;
-	int n;
-
-	va_start(ap, fmt);
-	n = vsnprintf(out, sizeof(out), fmt, ap);
-	va_end(ap);
-	if (n > 0)
-		(void)write(g_ctl_fd, out, (size_t)n);
-}
-
-static void handle_ctl_line(char *line, struct conn *conns,
-	struct retraced_registry *reg, struct retraced_journal *jr)
-{
-	JSON_Value *v = json_parse_string(line);
-	JSON_Object *o;
-	const char *cmd;
-
-	if (v == NULL) {
-		ctl_reply("{\"ok\":0,\"error\":\"malformed json\"}\n");
-		return;
-	}
-	o = json_value_get_object(v);
-	cmd = json_object_get_string(o, "cmd");
-	if (cmd == NULL) {
-		ctl_reply("{\"ok\":0,\"error\":\"no cmd\"}\n");
-		json_value_free(v);
-		return;
-	}
-	if (strcmp(cmd, "status") == 0) {
-		ctl_reply("{\"ok\":1,\"pid\":%ld,\"agents\":%zu,"
-			"\"policy_epoch\":%ld,\"frozen\":%d}\n",
-			(long)getpid(), reg->count, g_policy_epoch,
-			g_frozen);
-	} else if (strcmp(cmd, "ps") == 0) {
-		JSON_Value *snap = retraced_registry_to_json(reg);
-		char *s = json_serialize_to_string(snap);
-
-		ctl_reply("{\"ok\":1,\"registry\":%s}\n",
-			s != NULL ? s : "null");
-		json_free_serialized_string(s);
-		json_value_free(snap);
-	} else if (strcmp(cmd, "policy_push") == 0) {
-		const char *blob = json_object_get_string(o, "blob");
-		JSON_Value *pv;
-		JSON_Object *po, *proot;
-		double epoch;
-		int pushed;
-
-		if (blob == NULL) {
-			ctl_reply("{\"ok\":0,\"error\":\"no blob\"}\n");
-			json_value_free(v);
-			return;
-		}
-		pv = json_parse_string(blob);
-		proot = pv != NULL ? json_value_get_object(pv) : NULL;
-		po = proot != NULL ?
-			json_object_get_object(proot, "policy") : NULL;
-		epoch = po != NULL ?
-			json_object_get_number(po, "epoch") : 0.0;
-		if (epoch < 1.0 || json_object_get_array(proot,
-			    "intercept_scripts") == NULL) {
-			ctl_reply("{\"ok\":0,\"error\":\"bad policy"
-				" (need policy.epoch + scripts)\"}\n");
-			json_value_free(pv);
-			json_value_free(v);
-			return;
-		}
-		set_policy_blob(blob, (long)epoch);
-		g_frozen = 0;
-		free(g_thaw_blob);
-		g_thaw_blob = strdup(blob);
-		pushed = push_policy_to_agents(conns, blob);
-		{
-			char ev[160];
-
-			snprintf(ev, sizeof(ev),
-				"{\"name\":\"retrace.policy.pushed\",\"epoch\":%ld,\"agents\":%d}",
-				(long)epoch, pushed);
-			retraced_journal_event(jr, (long)time(NULL),
-				"daemon", 0, ev);
-		}
-		ctl_reply("{\"ok\":1,\"epoch\":%ld,\"pushed\":%d}\n",
-			(long)epoch, pushed);
-		json_value_free(pv);
-	} else if (strcmp(cmd, "freeze") == 0) {
-		char blob[256];
-		long epoch = g_policy_epoch + 1;
-		int pushed;
-
-		snprintf(blob, sizeof(blob),
-			"{\"policy\":{\"epoch\":%ld},"
-			"\"intercept_scripts\":[{\"func_name\":\"*\","
-			"\"actions\":[{\"action_name\":\"freeze\"}]}]}",
-			epoch);
-		set_policy_blob(blob, epoch);
-		g_frozen = 1;
-		pushed = push_policy_to_agents(conns, blob);
-		{
-			char ev[128];
-
-			snprintf(ev, sizeof(ev),
-				"{\"name\":\"retrace.policy.freeze\",\"epoch\":%ld,\"agents\":%d}",
-				epoch, pushed);
-			retraced_journal_event(jr, (long)time(NULL),
-				"daemon", 0, ev);
-		}
-		ctl_reply("{\"ok\":1,\"epoch\":%ld,\"pushed\":%d}\n",
-			epoch, pushed);
-	} else if (strcmp(cmd, "thaw") == 0) {
-		long epoch = g_policy_epoch + 1;
-		char thawed[8192];
-		const char *src = g_thaw_blob != NULL ? g_thaw_blob :
-			"{\"policy\":{\"epoch\":1},\"intercept_scripts\":[]}";
-		JSON_Value *tv = json_parse_string(src);
-		int pushed;
-
-		/* re-stamp the saved policy at a fresh epoch: agents
-		 * only ever accept strictly-greater epochs
-		 */
-		if (tv != NULL) {
-			JSON_Object *troot = json_value_get_object(tv);
-			JSON_Object *tpo = json_object_get_object(troot,
-				"policy");
-
-			if (tpo != NULL)
-				json_object_set_number(tpo, "epoch",
-					(double)epoch);
-		}
-		{
-			char *s = json_serialize_to_string(tv);
-
-			snprintf(thawed, sizeof(thawed), "%s",
-				s != NULL ? s : src);
-			json_free_serialized_string(s);
-		}
-		json_value_free(tv);
-		set_policy_blob(thawed, epoch);
-		g_frozen = 0;
-		pushed = push_policy_to_agents(conns, thawed);
-		{
-			char ev[128];
-
-			snprintf(ev, sizeof(ev),
-				"{\"name\":\"retrace.policy.thaw\",\"epoch\":%ld,\"agents\":%d}",
-				epoch, pushed);
-			retraced_journal_event(jr, (long)time(NULL),
-				"daemon", 0, ev);
-		}
-		ctl_reply("{\"ok\":1,\"epoch\":%ld,\"pushed\":%d}\n",
-			epoch, pushed);
-	} else if (strcmp(cmd, "kill") == 0) {
-		long pid = (long)json_object_get_number(o, "pid");
-
-		if (pid <= 0) {
-			ctl_reply("{\"ok\":0,\"error\":\"no pid\"}\n");
-			json_value_free(v);
-			return;
-		}
-		kill((pid_t)pid, SIGTERM);
-		{
-			char ev[128];
-
-			snprintf(ev, sizeof(ev),
-				"{\"name\":\"retrace.ctl.kill\",\"pid\":%ld}",
-				pid);
-			retraced_journal_event(jr, (long)time(NULL),
-				"daemon", 0, ev);
-		}
-		ctl_reply("{\"ok\":1,\"pid\":%ld}\n", pid);
-	} else {
-		ctl_reply("{\"ok\":0,\"error\":\"unknown cmd\"}\n");
-	}
-	json_value_free(v);
-}
-
 static void handle_ctl_readable(struct conn *conns,
 	struct retraced_registry *reg, struct retraced_journal *jr)
 {
@@ -579,7 +373,7 @@ static void handle_ctl_readable(struct conn *conns,
 	g_ctl_buf[g_ctl_fill] = '\0';
 	while ((nl = strchr(g_ctl_buf, '\n')) != NULL) {
 		*nl = '\0';
-		handle_ctl_line(g_ctl_buf, conns, reg, jr);
+		retraced_ctl_handle_line(&g_ctl, g_ctl_buf);
 		memmove(g_ctl_buf, nl + 1,
 			g_ctl_fill - (size_t)(nl + 1 - g_ctl_buf));
 		g_ctl_fill -= (size_t)(nl + 1 - g_ctl_buf);
@@ -773,6 +567,11 @@ int main(int argc, char **argv)
 	}
 	for (i = 0; i < MAX_AGENTS; i++)
 		conns[i].fd = -1;
+	g_ctl.reg = &reg;
+	g_ctl.jr = &jr;
+	g_ctl.conns = conns;
+	g_ctl.reply_sink = ctl_reply_fd;
+	g_ctl.reply_user = &g_ctl_fd;
 
 	unlink(sock_path);
 	listen_fd = socket(AF_UNIX, SOCK_STREAM, 0);

--- a/tools/retraced/retraced_ctl.c
+++ b/tools/retraced/retraced_ctl.c
@@ -1,0 +1,253 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * The controller plane's command surface (extracted from
+ * main.c -- the architecture-review testability candidate): one
+ * newline-JSON line in, one reply line out through the injected
+ * sink. No socket, no daemon, no poll loop -- unit-testable.
+ */
+
+#include <signal.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "retraced_ctl.h"
+#include "parson.h"
+
+/*
+ * write_frame lives in main.c's TU (the connection-plane
+ * writer); declared here for the policy push
+ */
+int write_frame(int fd, uint16_t type, const char *payload);
+
+void retraced_ctl_set_policy(struct retraced_ctl_ctx *ctx,
+	const char *blob, long epoch)
+{
+	free(ctx->policy_blob);
+	ctx->policy_blob = strdup(blob);
+	ctx->policy_epoch = epoch;
+}
+
+int retraced_ctl_push_policy(struct retraced_ctl_ctx *ctx,
+	const char *blob)
+{
+	int i, pushed = 0;
+
+	for (i = 0; i < MAX_AGENTS; i++) {
+		if (ctx->conns[i].fd >= 0 &&
+		    ctx->conns[i].helloed &&
+		    !ctx->conns[i].spectator) {
+			write_frame(ctx->conns[i].fd,
+				RETRACE_RPC_MSG_POLICY_SET, blob);
+			pushed++;
+		}
+	}
+	return pushed;
+}
+
+static void ctl_reply(struct retraced_ctl_ctx *ctx,
+	const char *fmt, ...)
+{
+	char out[1024];
+	va_list ap;
+	int n;
+
+	va_start(ap, fmt);
+	n = vsnprintf(out, sizeof(out), fmt, ap);
+	va_end(ap);
+	if (n > 0 && ctx->reply_sink != NULL)
+		ctx->reply_sink(out, ctx->reply_user);
+}
+
+void retraced_ctl_handle_line(struct retraced_ctl_ctx *ctx,
+	char *line)
+{
+	JSON_Value *v = json_parse_string(line);
+	JSON_Object *o;
+	const char *cmd;
+
+	if (v == NULL) {
+		ctl_reply(ctx, "{\"ok\":0,\"error\":\"malformed json\"}\n");
+		return;
+	}
+	o = json_value_get_object(v);
+	cmd = json_object_get_string(o, "cmd");
+	if (cmd == NULL) {
+		ctl_reply(ctx, "{\"ok\":0,\"error\":\"no cmd\"}\n");
+		json_value_free(v);
+		return;
+	}
+	if (strcmp(cmd, "status") == 0) {
+		ctl_reply(ctx, "{\"ok\":1,\"pid\":%ld,\"agents\":%zu,"
+			"\"policy_epoch\":%ld,\"frozen\":%d}\n",
+			(long)getpid(), ctx->reg->count, ctx->policy_epoch,
+			ctx->frozen);
+	} else if (strcmp(cmd, "ps") == 0) {
+		JSON_Value *snap = retraced_registry_to_json(ctx->reg);
+		char *s = json_serialize_to_string(snap);
+
+		ctl_reply(ctx, "{\"ok\":1,\"registry\":%s}\n",
+			s != NULL ? s : "null");
+		json_free_serialized_string(s);
+		json_value_free(snap);
+	} else if (strcmp(cmd, "policy_push") == 0) {
+		const char *blob = json_object_get_string(o, "blob");
+		JSON_Value *pv;
+		JSON_Object *po, *proot;
+		double epoch;
+		int pushed;
+
+		if (blob == NULL) {
+			ctl_reply(ctx, "{\"ok\":0,\"error\":\"no blob\"}\n");
+			json_value_free(v);
+			return;
+		}
+		pv = json_parse_string(blob);
+		proot = pv != NULL ? json_value_get_object(pv) : NULL;
+		po = proot != NULL ?
+			json_object_get_object(proot, "policy") : NULL;
+		epoch = po != NULL ?
+			json_object_get_number(po, "epoch") : 0.0;
+		if (epoch < 1.0 || json_object_get_array(proot,
+			    "intercept_scripts") == NULL) {
+			ctl_reply(ctx, "{\"ok\":0,\"error\":\"bad policy"
+				" (need policy.epoch + scripts)\"}\n");
+			json_value_free(pv);
+			json_value_free(v);
+			return;
+		}
+		retraced_ctl_set_policy(ctx, blob, (long)epoch);
+		ctx->frozen = 0;
+		free(ctx->thaw_blob);
+		ctx->thaw_blob = strdup(blob);
+		pushed = retraced_ctl_push_policy(ctx, blob);
+		{
+			char ev[160];
+
+			snprintf(ev, sizeof(ev),
+				"{\"name\":\"retrace.policy.pushed\",\"epoch\":%ld,\"agents\":%d}",
+				(long)epoch, pushed);
+			retraced_journal_event(ctx->jr, (long)time(NULL),
+				"daemon", 0, ev);
+		}
+		ctl_reply(ctx, "{\"ok\":1,\"epoch\":%ld,\"pushed\":%d}\n",
+			(long)epoch, pushed);
+		json_value_free(pv);
+	} else if (strcmp(cmd, "freeze") == 0) {
+		char blob[256];
+		long epoch = ctx->policy_epoch + 1;
+		int pushed;
+
+		snprintf(blob, sizeof(blob),
+			"{\"policy\":{\"epoch\":%ld},"
+			"\"intercept_scripts\":[{\"func_name\":\"*\","
+			"\"actions\":[{\"action_name\":\"freeze\"}]}]}",
+			epoch);
+		retraced_ctl_set_policy(ctx, blob, epoch);
+		ctx->frozen = 1;
+		pushed = retraced_ctl_push_policy(ctx, blob);
+		{
+			char ev[128];
+
+			snprintf(ev, sizeof(ev),
+				"{\"name\":\"retrace.policy.freeze\",\"epoch\":%ld,\"agents\":%d}",
+				epoch, pushed);
+			retraced_journal_event(ctx->jr, (long)time(NULL),
+				"daemon", 0, ev);
+		}
+		ctl_reply(ctx, "{\"ok\":1,\"epoch\":%ld,\"pushed\":%d}\n",
+			epoch, pushed);
+	} else if (strcmp(cmd, "thaw") == 0) {
+		long epoch = ctx->policy_epoch + 1;
+		char thawed[8192];
+		const char *src = ctx->thaw_blob != NULL ? ctx->thaw_blob :
+			"{\"policy\":{\"epoch\":1},\"intercept_scripts\":[]}";
+		JSON_Value *tv = json_parse_string(src);
+		int pushed;
+
+		/* re-stamp the saved policy at a fresh epoch: agents
+		 * only ever accept strictly-greater epochs
+		 */
+		if (tv != NULL) {
+			JSON_Object *troot = json_value_get_object(tv);
+			JSON_Object *tpo = json_object_get_object(troot,
+				"policy");
+
+			if (tpo != NULL)
+				json_object_set_number(tpo, "epoch",
+					(double)epoch);
+		}
+		{
+			char *s = json_serialize_to_string(tv);
+
+			snprintf(thawed, sizeof(thawed), "%s",
+				s != NULL ? s : src);
+			json_free_serialized_string(s);
+		}
+		json_value_free(tv);
+		retraced_ctl_set_policy(ctx, thawed, epoch);
+		ctx->frozen = 0;
+		pushed = retraced_ctl_push_policy(ctx, thawed);
+		{
+			char ev[128];
+
+			snprintf(ev, sizeof(ev),
+				"{\"name\":\"retrace.policy.thaw\",\"epoch\":%ld,\"agents\":%d}",
+				epoch, pushed);
+			retraced_journal_event(ctx->jr, (long)time(NULL),
+				"daemon", 0, ev);
+		}
+		ctl_reply(ctx, "{\"ok\":1,\"epoch\":%ld,\"pushed\":%d}\n",
+			epoch, pushed);
+	} else if (strcmp(cmd, "kill") == 0) {
+		long pid = (long)json_object_get_number(o, "pid");
+
+		if (pid <= 0) {
+			ctl_reply(ctx, "{\"ok\":0,\"error\":\"no pid\"}\n");
+			json_value_free(v);
+			return;
+		}
+		kill((pid_t)pid, SIGTERM);
+		{
+			char ev[128];
+
+			snprintf(ev, sizeof(ev),
+				"{\"name\":\"retrace.ctl.kill\",\"pid\":%ld}",
+				pid);
+			retraced_journal_event(ctx->jr, (long)time(NULL),
+				"daemon", 0, ev);
+		}
+		ctl_reply(ctx, "{\"ok\":1,\"pid\":%ld}\n", pid);
+	} else {
+		ctl_reply(ctx, "{\"ok\":0,\"error\":\"unknown cmd\"}\n");
+	}
+	json_value_free(v);
+}
+

--- a/tools/retraced/retraced_ctl.h
+++ b/tools/retraced/retraced_ctl.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef RETRACE_TOOLS_RETRACED_CTL_H_
+#define RETRACE_TOOLS_RETRACED_CTL_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "registry.h"
+#include "journal.h"
+#include "protocol.h"
+
+#define MAX_AGENTS 128
+
+/* one accepted agent connection (the frame buffer is the conn's
+ * own: field-init on accept, never a whole-struct memset)
+ */
+struct conn {
+	int fd;
+	uint8_t buf[RETRACE_RPC_PAYLOAD_MAX + RETRACE_RPC_HEADER_SZ];
+	size_t fill;
+	char agent_id[RETRACED_AGENT_ID_MAX];
+	int helloed;
+	int spectator;
+};
+
+/*
+ * The controller plane (TODO.supervisor/07), extracted as a
+ * module (the architecture-review testability candidate): all
+ * command state lives here, replies go through an injected sink
+ * so the whole command surface is unit-testable without a
+ * socket or a daemon.
+ */
+struct retraced_ctl_ctx {
+	/*
+	 * policy state (the SSOT: load_policy and the WELCOME
+	 * epoch read these too)
+	 */
+	char *policy_blob;
+	long policy_epoch;
+	int frozen;
+	char *thaw_blob;
+
+	/* collaborators */
+	struct conn *conns;
+	struct retraced_registry *reg;
+	struct retraced_journal *jr;
+
+	/* the reply sink (one line per command) */
+	void (*reply_sink)(const char *line, void *user);
+	void *reply_user;
+};
+
+void retraced_ctl_set_policy(struct retraced_ctl_ctx *ctx,
+	const char *blob, long epoch);
+int retraced_ctl_push_policy(struct retraced_ctl_ctx *ctx,
+	const char *blob);
+void retraced_ctl_handle_line(struct retraced_ctl_ctx *ctx,
+	char *line);
+
+#endif /* RETRACE_TOOLS_RETRACED_CTL_H_ */


### PR DESCRIPTION
## What

Architecture-review candidate E (testability). `handle_ctl_line` and its
helpers move out of main.c into `retraced_ctl.c`:

- the policy state (blob, epoch, frozen, thaw blob) lives in a
  `struct retraced_ctl_ctx` — the SSOT that `load_policy` and the WELCOME
  epoch read too;
- every reply goes through an injected sink — no socket, no daemon, no poll
  loop;
- the whole command surface is now **unit-tested**
  (`test_retraced_ctl.c`, 9 cases: status, ps, policy_push validation,
  freeze/thaw epoch semantics, kill, and the error paths);
- main.c keeps the connection plane only (958 → ~740 lines).

The extraction caught one wiring-order trap en route: the ctx is populated
only AFTER the conns array is allocated (an earlier placement meant a NULL
conns deref on the first policy push).

## Verification

- all 8 supervisor/daemon/journal E2Es + full local suite green
- ctl unit tests 9/9; checkpatch clean
