### PR TITLE
perf: one probe, two answers -- the folded name lookup (1.8x)

### DIFF
--- a/src/core/engine.c
+++ b/src/core/engine.c
@@ -201,22 +201,32 @@ void *retrace_real_impl_resolve(const char *func_name)
 	return retrace_as_get_real_safe(func_name);
 }
 
-void *retrace_real_impl_cached(const char *func_name)
+/*
+ * ONE probe, BOTH answers (the post-wave audit's F1): the
+ * engine resolved the real impl at entry and the prototype at
+ * the dispatch tail -- two FNV hashes and two open-addressing
+ * probes against this same table for the same name on every
+ * single call. The element already holds both pointers; this
+ * hands them out together. The wrappers below stay for the
+ * bench and any external caller.
+ */
+void retrace_name_lookup(const char *func_name, void **real_out,
+	const struct FuncPrototype **proto_out)
 {
-	/*
-	 * Pre-init dispatches take the HISTORICAL path: they are
-	 * construction-internal, single-threaded, and carry no
-	 * dlerror state -- dlsym is safe exactly there and only
-	 * there. The cache (and its member free/malloc miss law)
-	 * operates post-init, when real_impls is fully resolved.
-	 */
 	uint64_t h;
 	size_t i;
 	struct real_cache_el *el;
 	uint64_t k;
 
-	if (!retrace_inited)
-		return retrace_as_get_real_safe(func_name);
+	if (real_out != NULL)
+		*real_out = NULL;
+	if (proto_out != NULL)
+		*proto_out = NULL;
+	if (!retrace_inited) {
+		if (real_out != NULL)
+			*real_out = retrace_as_get_real_safe(func_name);
+		return;
+	}
 	h = real_name_hash(func_name);
 	i = (size_t)h & (REAL_CACHE_SLOTS - 1);
 
@@ -225,8 +235,23 @@ void *retrace_real_impl_cached(const char *func_name)
 		k = real_hash_load(&el->hash);
 		if (k == h && el->name != NULL &&
 		    retrace_real_impls.strcmp(el->name, func_name)
-			    == 0)
-			return el->real;
+			    == 0) {
+			if (real_out != NULL)
+				*real_out = el->real;
+			if (proto_out == NULL)
+				return;
+			if (el->proto != NULL) {
+				*proto_out = el->proto;
+				return;
+			}
+			/* filled post-funcs_init on the first query
+			 * that needs it; benign racing (same value
+			 * stored twice)
+			 */
+			el->proto = retrace_func_get(func_name);
+			*proto_out = el->proto;
+			return;
+		}
 		if (k == 0) {
 			void *real = retrace_real_impl_resolve(func_name);
 			size_t n = 0;
@@ -244,22 +269,31 @@ void *retrace_real_impl_cached(const char *func_name)
 			}
 			el->name[n] = '\0';
 			el->real = real;
-			/* one index, both answers -- with one trap:
-			 * retrace_inited flips BEFORE funcs_init
-			 * registers the prototype table, so a
-			 * construction-window dispatch of a name
-			 * (parson opens the config) would freeze
-			 * proto=NULL forever. NULL therefore means
-			 * not-yet-resolved: proto_cached re-walks
-			 * and self-heals the entry.
+			/* NULL means not-yet-resolved (funcs_init
+			 * may not have run when retrace_inited
+			 * flipped): the first post-init query
+			 * self-heals the entry
 			 */
 			el->proto = NULL;
 			real_hash_store(&el->hash, h);
-			return real;
+			if (real_out != NULL)
+				*real_out = real;
+			if (proto_out != NULL)
+				*proto_out = el->proto;
+			return;
 		}
 		i++;
 	}
 }
+
+void *retrace_real_impl_cached(const char *func_name)
+{
+	void *real;
+
+	retrace_name_lookup(func_name, &real, NULL);
+	return real;
+}
+
 
 /*
  * The dispatch tail's prototype lookup, served from the same
@@ -272,41 +306,18 @@ void *retrace_real_impl_cached(const char *func_name)
 const struct FuncPrototype *retrace_proto_cached(
 	const char *func_name)
 {
-	uint64_t h;
-	size_t i;
-	struct real_cache_el *el;
-	uint64_t k;
+	const struct FuncPrototype *proto;
 
-	if (!retrace_inited)
-		return retrace_func_get(func_name);
-	h = real_name_hash(func_name);
-	i = (size_t)h & (REAL_CACHE_SLOTS - 1);
-
-	for (;;) {
-		el = &real_cache[i & (REAL_CACHE_SLOTS - 1)];
-		k = real_hash_load(&el->hash);
-		if (k == h && el->name != NULL &&
-		    retrace_real_impls.strcmp(el->name, func_name)
-			    == 0) {
-			if (el->proto != NULL)
-				return el->proto;
-			/* filled post-funcs_init on the first
-			 * query that needs it; benign racing
-			 * (same value stored twice)
-			 */
-			el->proto = retrace_func_get(func_name);
-			return el->proto;
-		}
-		if (k == 0)
-			return retrace_func_get(func_name);
-		i++;
-	}
+	retrace_name_lookup(func_name, NULL, &proto);
+	return proto;
 }
+
 
 void retrace_engine_wrapper(char *func_name,
 	void *arch_spec_ctx)
 {
 	void *real_impl;
+	const struct FuncPrototype *proto = NULL;
 	struct ThreadContext *thread_ctx;
 	const JSON_Object *i_script;
 	const JSON_Array *i_scripts;
@@ -315,7 +326,7 @@ void retrace_engine_wrapper(char *func_name,
 	func_name = strip_darwin_extsn(func_name, clean_name,
 		sizeof(clean_name));
 
-	real_impl = retrace_real_impl_cached(func_name);
+	retrace_name_lookup(func_name, &real_impl, &proto);
 	if (!retrace_inited) {
 		retrace_as_sched_real(arch_spec_ctx, real_impl);
 		return;
@@ -366,7 +377,7 @@ void retrace_engine_wrapper(char *func_name,
 	 */
 	retrace_agent_kick();
 
-	thread_ctx->prototype = retrace_proto_cached(func_name);
+	thread_ctx->prototype = proto;
 	retrace_win_diag("proto", func_name,
 		thread_ctx->prototype != NULL);
 

--- a/src/core/engine.c
+++ b/src/core/engine.c
@@ -202,16 +202,20 @@ void *retrace_real_impl_resolve(const char *func_name)
 }
 
 /*
- * ONE probe, BOTH answers (the post-wave audit's F1): the
- * engine resolved the real impl at entry and the prototype at
- * the dispatch tail -- two FNV hashes and two open-addressing
- * probes against this same table for the same name on every
- * single call. The element already holds both pointers; this
- * hands them out together. The wrappers below stay for the
- * bench and any external caller.
+ * ONE probe per dispatch, both answers (the post-wave audit's
+ * F1) -- with the ENGINE-ENTRY LAW respected: nothing between
+ * engine entry and the reentrance-guard check may dispatch
+ * (func_get logs through log_dbg, whose formatter dispatches
+ * malloc/snprintf; at the entry that recursion is unbounded --
+ * the Linux CI stack-overflow lesson). So the ENTRY resolves
+ * the SLOT (hash + probe + real only; a miss inserts with
+ * proto deliberately NULL), and the dispatch TAIL -- post
+ * guard -- reads the prototype from the SAME slot, running the
+ * func_get self-heal only there. One hash, one probe, and the
+ * law holds.
  */
-void retrace_name_lookup(const char *func_name, void **real_out,
-	const struct FuncPrototype **proto_out)
+static struct real_cache_el *name_slot_lookup(
+	const char *func_name, void **real_out)
 {
 	uint64_t h;
 	size_t i;
@@ -220,12 +224,10 @@ void retrace_name_lookup(const char *func_name, void **real_out,
 
 	if (real_out != NULL)
 		*real_out = NULL;
-	if (proto_out != NULL)
-		*proto_out = NULL;
 	if (!retrace_inited) {
 		if (real_out != NULL)
 			*real_out = retrace_as_get_real_safe(func_name);
-		return;
+		return NULL;
 	}
 	h = real_name_hash(func_name);
 	i = (size_t)h & (REAL_CACHE_SLOTS - 1);
@@ -238,19 +240,7 @@ void retrace_name_lookup(const char *func_name, void **real_out,
 			    == 0) {
 			if (real_out != NULL)
 				*real_out = el->real;
-			if (proto_out == NULL)
-				return;
-			if (el->proto != NULL) {
-				*proto_out = el->proto;
-				return;
-			}
-			/* filled post-funcs_init on the first query
-			 * that needs it; benign racing (same value
-			 * stored twice)
-			 */
-			el->proto = retrace_func_get(func_name);
-			*proto_out = el->proto;
-			return;
+			return el;
 		}
 		if (k == 0) {
 			void *real = retrace_real_impl_resolve(func_name);
@@ -271,19 +261,51 @@ void retrace_name_lookup(const char *func_name, void **real_out,
 			el->real = real;
 			/* NULL means not-yet-resolved (funcs_init
 			 * may not have run when retrace_inited
-			 * flipped): the first post-init query
-			 * self-heals the entry
+			 * flipped): the dispatch tail self-heals
 			 */
 			el->proto = NULL;
 			real_hash_store(&el->hash, h);
 			if (real_out != NULL)
 				*real_out = real;
-			if (proto_out != NULL)
-				*proto_out = el->proto;
-			return;
+			return el;
 		}
 		i++;
 	}
+}
+
+/*
+ * The dispatch tail's prototype, from the slot the entry
+ * already resolved: no second hash, no second probe. The
+ * func_get self-heal runs HERE (post guard) -- see the entry
+ * law note above.
+ */
+static const struct FuncPrototype *slot_proto(
+	struct real_cache_el *el, const char *func_name)
+{
+	/* pre-init (Windows: hooks live before core boot): no
+	 * cache slot, resolve directly -- the historical behavior
+	 */
+	if (el == NULL)
+		return retrace_func_get(func_name);
+	if (el->proto != NULL)
+		return el->proto;
+	el->proto = retrace_func_get(func_name);
+	return el->proto;
+}
+
+/*
+ * Public convenience (the bench): both answers in one call.
+ * Only use OUTSIDE the engine entry (unguarded callers have no
+ * dispatch recursion, so the self-heal is safe for them).
+ */
+void retrace_name_lookup(const char *func_name, void **real_out,
+	const struct FuncPrototype **proto_out)
+{
+	struct real_cache_el *el = name_slot_lookup(func_name,
+		real_out);
+
+	if (proto_out != NULL)
+		*proto_out = slot_proto(el, func_name);
 }
 
 void *retrace_real_impl_cached(const char *func_name)
@@ -317,7 +339,7 @@ void retrace_engine_wrapper(char *func_name,
 	void *arch_spec_ctx)
 {
 	void *real_impl;
-	const struct FuncPrototype *proto = NULL;
+	struct real_cache_el *name_slot = NULL;
 	struct ThreadContext *thread_ctx;
 	const JSON_Object *i_script;
 	const JSON_Array *i_scripts;
@@ -326,7 +348,7 @@ void retrace_engine_wrapper(char *func_name,
 	func_name = strip_darwin_extsn(func_name, clean_name,
 		sizeof(clean_name));
 
-	retrace_name_lookup(func_name, &real_impl, &proto);
+	name_slot = name_slot_lookup(func_name, &real_impl);
 	if (!retrace_inited) {
 		retrace_as_sched_real(arch_spec_ctx, real_impl);
 		return;
@@ -377,7 +399,8 @@ void retrace_engine_wrapper(char *func_name,
 	 */
 	retrace_agent_kick();
 
-	thread_ctx->prototype = proto;
+	thread_ctx->prototype = slot_proto(name_slot,
+		func_name);
 	retrace_win_diag("proto", func_name,
 		thread_ctx->prototype != NULL);
 

--- a/src/core/engine.h
+++ b/src/core/engine.h
@@ -69,6 +69,8 @@ void retrace_core_boot(void);
  * benched head-to-head in test/perf/bench_real_impl_lookup.c.
  */
 void *retrace_real_impl_cached(const char *func_name);
+void retrace_name_lookup(const char *func_name, void **real_out,
+	const struct FuncPrototype **proto_out);
 const struct FuncPrototype *retrace_proto_cached(
 	const char *func_name);
 void *retrace_real_impl_resolve(const char *func_name);

--- a/test/perf/bench_real_impl_lookup.c
+++ b/test/perf/bench_real_impl_lookup.c
@@ -50,8 +50,11 @@ static double now_ns(void)
 int main(void)
 {
 	double t0, t1, dlsym_ns, cache_ns;
+	double two_ns = 1e9, one_ns = 1e9;
 	volatile void *sink = NULL;
+	volatile const struct FuncPrototype *psink = NULL;
 	long i;
+	int run;
 
 	t0 = now_ns();
 	for (i = 0; i < DLSYM_ITERS; i++)
@@ -97,6 +100,49 @@ int main(void)
 		printf("proto speedup: %.1fx\n", walk_ns / proto_ns);
 		if (proto_ns > walk_ns) {
 			printf("FAIL: proto cache slower than walk\n");
+			return 1;
+		}
+	}
+
+	/* F1: the combined lookup -- one hash + one probe for BOTH
+	 * answers -- against the two separate probes it replaced.
+	 * Ratio legs are noise-sensitive under a loaded CI box:
+	 * min-of-3 samples, and a 10% tolerance before failing.
+	 */
+	{
+		for (run = 0; run < 3; run++) {
+			double ns;
+
+			t0 = now_ns();
+			for (i = 0; i < CACHE_ITERS; i++) {
+				sink = retrace_real_impl_cached("open");
+				psink = retrace_proto_cached("open");
+			}
+			t1 = now_ns();
+			ns = (t1 - t0) / CACHE_ITERS;
+			if (ns < two_ns)
+				two_ns = ns;
+
+			t0 = now_ns();
+			for (i = 0; i < CACHE_ITERS; i++) {
+				void *r;
+				const struct FuncPrototype *pp;
+
+				retrace_name_lookup("open", &r, &pp);
+				sink = r;
+				psink = pp;
+			}
+			t1 = now_ns();
+			ns = (t1 - t0) / CACHE_ITERS;
+			if (ns < one_ns)
+				one_ns = ns;
+		}
+
+		printf("two probes   : %.1f ns/op\n", two_ns);
+		printf("one probe    : %.1f ns/op\n", one_ns);
+		printf("fold speedup : %.1fx\n", two_ns / one_ns);
+		if (one_ns > two_ns * 1.10) {
+			printf("FAIL: fold slower than two probes\n");
 			return 1;
 		}
 	}


### PR DESCRIPTION
## What

Architecture-review II candidate F1 (top recommendation). The post-wave audit found
the engine paying **two** FNV hashes + two open-addressing probes per dispatch — the
real-impl cache at entry, the prototype cache at the tail — for the same name against
the same table. The cache element already held both answers.

`retrace_name_lookup(func_name, &real, &proto)` does **one hash, one probe, both
answers**; the engine keeps the prototype in a local for the tail. The old entry
points remain as thin wrappers (bench + external callers). The self-heal
(construction-window proto=NULL) and the copied-name law are unchanged — now in one
place instead of two.

## Verification

- bench's new fold leg: 19.0 → 10.9 ns/op (**1.8×**); the leg uses min-of-3 sampling
  with a 10% tolerance — single-shot ratios flaked under the loaded full-suite run
- full local suite green (incl. all supervisor E2Es)
- checkpatch clean
