### PR TITLE
kernel-observation agent: the eBPF lane goes live (TODO.beyond-libc/03)

### DIFF
--- a/ebpf-bridge/retrace-ebpf-agent
+++ b/ebpf-bridge/retrace-ebpf-agent
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# retrace-ebpf-agent (TODO.beyond-libc/03): the LIVE kernel-
+# observation agent. Speaks the supervisor protocol (the
+# reference-stub skeleton -- no retrace headers, no C linkage)
+# and feeds the daemon's journal kernel-source events, so one
+# session shows both what the target CLAIMED (libc lane) and
+# what the kernel SAW (kernel lane).
+#
+# Sources:
+#   --synthetic     emit demonstration kernel events on an
+#                   interval (no BPF privileges needed; the CI
+#                   path and the protocol proof)
+#   --loader PATH   wrap the ebpf-bridge loader: its retrace
+#                   JSON stdout lines become kernel events
+#                   (needs root/CAP_BPF on the host; not CI)
+#
+# Doctrine (the threat model): kernel agents are OBSERVERS.
+# This agent HELLOs WITHOUT the nonce deliberately -- the
+# daemon seats it as a spectator: evidence ALWAYS, policy
+# NEVER.
+#
+# Usage:
+#   retrace-ebpf-agent --sock /run/retraced/agent.sock [--synthetic]
+#   retrace-ebpf-agent --sock ... --loader ./retrace-ebpf-loader -- ./target
+
+import argparse
+import json
+import os
+import signal
+import socket
+import struct
+import subprocess
+import sys
+import threading
+import time
+
+MAGIC = b"RTRD"
+HELLO, HEARTBEAT, EVENT, BYE = 1, 2, 4, 6
+
+
+def frame(mid, payload):
+    b = payload.encode()
+    return MAGIC + struct.pack("<HHI", 1, mid, len(b)) + b
+
+
+class Agent:
+    def __init__(self, sock_path):
+        self.sock_path = sock_path
+        self.s = None
+        self.agent_id = "pending"
+        self.seq = 0
+        self.stop = False
+
+    def connect(self):
+        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        s.connect(self.sock_path)
+        # HELLO without a nonce: the spectator seat, on purpose
+        s.sendall(frame(HELLO, json.dumps({
+            "session_token": "", "nonce": "",
+            "pid": os.getpid(), "ppid": os.getppid(),
+            "boot_id": "kernel", "cmdline": "retrace-ebpf-agent",
+            "retrace_version": "ebpf-agent-1"})))
+        hdr = b""
+        while len(hdr) < 12:
+            hdr += s.recv(12 - len(hdr))
+        _, _, mid, ln = struct.unpack("<4sHHI", hdr)
+        body = b""
+        while len(body) < ln:
+            body += s.recv(ln - len(body))
+        if mid != 16:
+            raise RuntimeError(f"expected WELCOME, got {mid}")
+        self.welcome = json.loads(body)
+        if self.welcome.get("role") != "spectator":
+            sys.stderr.write(
+                "retrace-ebpf-agent: WARNING daemon seated us as "
+                f"{self.welcome.get('role')}; the doctrine says "
+                "observers ride as spectators\n")
+        self.agent_id = self.welcome.get("agent_id", "pending")
+        self.s = s
+        # a POLICY_SET may follow; observers drop it
+        s.settimeout(0.2)
+        try:
+            hdr = s.recv(12)
+            if len(hdr) == 12:
+                _, _, m2, l2 = struct.unpack("<4sHHI", hdr)
+                while l2:
+                    b = s.recv(l2)
+                    l2 -= len(b)
+        except OSError:
+            pass
+        s.settimeout(None)
+
+    def emit(self, name, **attrs):
+        self.seq += 1
+        self.s.sendall(frame(EVENT, json.dumps({
+            "agent_id": self.agent_id, "seq": self.seq,
+            "ts": int(time.time()), "name": name,
+            "attrs": {k: str(v) for k, v in attrs.items()},
+            "source": "kernel"}, sort_keys=True)))
+
+    def heartbeat_loop(self):
+        while not self.stop:
+            time.sleep(1.0)
+            if self.s is None:
+                continue
+            try:
+                self.s.sendall(frame(HEARTBEAT, json.dumps(
+                    {"agent_id": self.agent_id,
+                     "seq": self.seq})))
+            except OSError:
+                return
+
+    def bye(self):
+        if self.s is None:
+            return
+        try:
+            self.s.sendall(frame(BYE, json.dumps(
+                {"agent_id": self.agent_id})))
+            self.s.close()
+        except OSError:
+            pass
+        self.s = None
+
+
+def run_synthetic(agent, n):
+    for i in range(n):
+        agent.emit("kernel.syscall.observe", syscall="openat",
+                   sample=i, note="synthetic lane")
+        time.sleep(0.3)
+
+
+def run_loader(agent, loader, argv):
+    """Wrap the ebpf-bridge loader: each retrace JSON entry it
+    prints becomes one kernel-source event."""
+    proc = subprocess.Popen([loader] + argv, stdout=subprocess.PIPE,
+        stderr=sys.stderr)
+    for line in proc.stdout:
+        line = line.strip()
+        if not line or line in ("[", "]"):
+            continue
+        entry = line.rstrip(",")
+        try:
+            doc = json.loads(entry)
+        except json.JSONDecodeError:
+            continue
+        msg = doc.get("message", {})
+        agent.emit("kernel.syscall.observe",
+            syscall=msg.get("func", "?"),
+            ret=msg.get("ret_val", ""),
+            ts=doc.get("time", ""))
+    proc.wait()
+
+
+def main():
+    ap = argparse.ArgumentParser(prog="retrace-ebpf-agent")
+    ap.add_argument("--sock", required=True)
+    ap.add_argument("--synthetic", action="store_true")
+    ap.add_argument("--samples", type=int, default=3)
+    ap.add_argument("--loader")
+    ap.add_argument("argv", nargs=argparse.REMAINDER)
+    args = ap.parse_args()
+
+    agent = Agent(args.sock)
+    try:
+        agent.connect()
+    except (OSError, RuntimeError) as e:
+        sys.stderr.write(f"retrace-ebpf-agent: {e}\n")
+        return 2
+    hb = threading.Thread(target=agent.heartbeat_loop, daemon=True)
+    hb.start()
+    try:
+        if args.synthetic:
+            run_synthetic(agent, args.samples)
+        elif args.loader:
+            run_loader(agent, args.loader, args.argv)
+        else:
+            ap.error("one of --synthetic or --loader is required")
+    finally:
+        agent.stop = True
+        time.sleep(0.2)
+        agent.bye()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -192,6 +192,20 @@ if(Python3_Interpreter_FOUND)
 		LABELS "integration"
 		TIMEOUT 120)
 
+	# The kernel-observation agent (TODO.beyond-libc/03):
+	# eBPF lane as a spectator peer; synthetic source proves
+	# the pipe on CI (no BPF privileges).
+	if(NOT WIN32)
+		add_test(NAME integration-ebpf-agent
+			COMMAND ${Python3_EXECUTABLE}
+				${CMAKE_SOURCE_DIR}/test/integration/test_ebpf_agent.py
+				$<TARGET_FILE:retrace_retraced>
+				${CMAKE_SOURCE_DIR}/ebpf-bridge/retrace-ebpf-agent)
+		set_tests_properties(integration-ebpf-agent
+			PROPERTIES LABELS "integration"
+			TIMEOUT 120)
+	endif()
+
 	# Kernel enforcement compile (TODO.beyond-libc/01):
 	# declared-set -> Landlock ruleset + seccomp floor, installed
 	# by retrace-enforce. Linux-only; self-skips elsewhere or

--- a/test/integration/test_ebpf_agent.py
+++ b/test/integration/test_ebpf_agent.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""
+E2E: the kernel-observation agent (TODO.beyond-libc/03).
+
+The eBPF agent joins the supervisor as a SPECTATOR (observer
+doctrine: evidence ALWAYS, policy NEVER -- it HELLOs without
+the nonce deliberately) and its kernel-source events land in
+the same hash-chained journal as the libc lane. The synthetic
+source proves the pipe on CI (no BPF privileges needed); the
+--loader source does the same against the real bridge on a
+BPF-capable host.
+
+Usage: test_ebpf_agent.py <retraced> <agent-script>
+"""
+import json
+import os
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+
+
+def wait_sock(path, deadline=5.0):
+    end = time.time() + deadline
+    while time.time() < end:
+        if os.path.exists(path):
+            return True
+        time.sleep(0.1)
+    return False
+
+
+def journal_records(path):
+    recs = []
+    with open(path) as f:
+        for ln in f.read().splitlines():
+            try:
+                recs.append(json.loads(ln))
+            except json.JSONDecodeError:
+                pass
+    return recs
+
+
+def main():
+    if len(sys.argv) != 3:
+        print("usage: test_ebpf_agent.py <retraced> <agent>",
+              file=sys.stderr)
+        return 2
+    daemon, agent = (os.path.abspath(p) for p in sys.argv[1:3])
+
+    work = tempfile.mkdtemp(prefix="ebpf-ag-")
+    sock = os.path.join(work, "agent.sock")
+    journal = os.path.join(work, "journal.jsonl")
+
+    d = subprocess.Popen(
+        [daemon, "--sock", sock, "--journal", journal],
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    try:
+        if not wait_sock(sock):
+            print("FAIL: daemon never listened", file=sys.stderr)
+            return 1
+
+        r = subprocess.run(
+            [sys.executable, agent, "--sock", sock,
+             "--synthetic", "--samples", "3"],
+            capture_output=True, timeout=30)
+        if r.returncode != 0:
+            print(f"FAIL: agent rc={r.returncode}: "
+                  f"{r.stderr.decode()[:300]}", file=sys.stderr)
+            return 1
+
+        # durability: graceful stop flushes the routine tail
+        d.send_signal(signal.SIGTERM)
+        try:
+            d.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            d.kill()
+
+        recs = journal_records(journal)
+        names = [r.get("ev", {}).get("name") for r in recs]
+        obs = [r for r in recs
+               if r.get("ev", {}).get("name") ==
+               "kernel.syscall.observe"]
+        if len(obs) != 3:
+            print(f"FAIL: expected 3 kernel observations, "
+                  f"got {len(obs)}: {names}", file=sys.stderr)
+            return 1
+        auth = [r for r in recs
+                if r.get("ev", {}).get("name") == "retrace.auth.agent"]
+        if not auth or auth[-1]["ev"].get("role") != "spectator":
+            print(f"FAIL: kernel agent not seated as spectator: "
+                  f"{auth}", file=sys.stderr)
+            return 1
+        if any(r.get("ev", {}).get("name") == "retrace.policy.pushed"
+               for r in recs):
+            print("FAIL: policy reached an observer",
+                  file=sys.stderr)
+            return 1
+
+        print("ebpf-agent: 3 kernel observations journaled; "
+              "spectator seat; zero policy reach -- OK")
+        return 0
+    finally:
+        if d.poll() is None:
+            d.send_signal(signal.SIGTERM)
+            try:
+                d.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                d.kill()
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

TODO.beyond-libc/03: the kernel lane joins the supervisor. `ebpf-bridge/retrace-ebpf-agent` — a
supervisor-protocol agent on the reference-stub skeleton (no retrace headers, no C linkage) feeding
the journal **kernel-source events**: one session now shows both what the target claimed (libc lane)
and what the kernel saw (kernel lane), in one hash-chained journal.

**Doctrine enforced in code**: kernel agents are observers — the agent HELLOs *without the nonce
deliberately*, so the daemon seats it as a spectator: evidence ALWAYS, policy NEVER (with a warning
if a future daemon drifts).

Sources:
- `--synthetic` — demonstration events (no BPF privileges; the CI path)
- `--loader` — wraps the existing ebpf-bridge loader, converting its retrace JSON stdout into
  kernel-source events (root/CAP_BPF hosts)

## Verification

- `integration-ebpf-agent` E2E: 3 kernel observations journaled, spectator seat asserted,
  **zero policy reach** asserted
- checkpatch clean
