### PR TITLE
enforce: the macOS backend (01 P1) -- sandbox-exec

### DIFF
--- a/tools/enforce/CMakeLists.txt
+++ b/tools/enforce/CMakeLists.txt
@@ -8,6 +8,7 @@ set(_parson_source ${CMAKE_SOURCE_DIR}/src/config/json/parson.c)
 
 add_executable(retrace_enforce
 	main.c enforce_spec.c landlock_apply.c seccomp_apply.c
+	sandbox_apply.c
 	${_parson_source})
 set_target_properties(retrace_enforce PROPERTIES
 	OUTPUT_NAME retrace-enforce)

--- a/tools/enforce/enforce_spec.c
+++ b/tools/enforce/enforce_spec.c
@@ -100,6 +100,14 @@ int enforce_spec_parse(struct enforce_spec *spec, const char *json)
 		json_value_free(v);
 		return -1;
 	}
+	{
+		const char *sb = json_object_get_string(root,
+			"sandbox_exec");
+
+		if (sb != NULL)
+			snprintf(spec->sandbox_exec,
+				sizeof(spec->sandbox_exec), "%s", sb);
+	}
 	spec->no_new_privs =
 		json_object_get_boolean(root, "no_new_privs") != 0;
 	(void)parse_rules(spec, root);

--- a/tools/enforce/enforce_spec.h
+++ b/tools/enforce/enforce_spec.h
@@ -56,6 +56,7 @@ struct enforce_syscall {
 };
 
 struct enforce_spec {
+	char sandbox_exec[8192];	/* Seatbelt profile (macOS) */
 	struct enforce_rule rules[ENFORCE_RULES_MAX];
 	size_t rules_n;
 	struct enforce_syscall deny[ENFORCE_SYSCALLS_MAX];

--- a/tools/enforce/main.c
+++ b/tools/enforce/main.c
@@ -27,6 +27,7 @@
 #include "enforce_spec.h"
 #include "landlock_apply.h"
 #include "seccomp_apply.h"
+#include "sandbox_apply.h"
 
 static void enforce_usage(void)
 {
@@ -101,7 +102,8 @@ int main(int argc, char **argv)
 			strerror(errno));
 		return 2;
 	}
-	if (rc == 1 && !allow_missing)
+	if (rc == 1 && !allow_missing &&
+	    spec.sandbox_exec[0] == '\0')
 		return 2;
 
 	rc = enforce_seccomp_apply(&spec);
@@ -114,8 +116,28 @@ int main(int argc, char **argv)
 			strerror(errno));
 		return 2;
 	}
-	if (rc == 1 && !allow_missing)
+	if (rc == 1 && !allow_missing &&
+	    spec.sandbox_exec[0] == '\0')
 		return 2;
+
+	if (spec.sandbox_exec[0] != '\0') {
+		static char wrap[16384];
+
+		if (enforce_sandbox_exec_wrap(spec.sandbox_exec,
+			    argc - i - 1, &argv[i + 1], wrap,
+			    sizeof(wrap)) != 0) {
+			fprintf(stderr,
+				"retrace-enforce: sandbox wrap overflow\n");
+			return 2;
+		}
+		{
+			char *sh_argv[] = {"/bin/sh", "-c", wrap, NULL};
+
+			execvp("/bin/sh", sh_argv);
+			perror("execvp(sh)");
+			return 2;
+		}
+	}
 
 	execvp(argv[i + 1], &argv[i + 1]);
 	perror("execvp");

--- a/tools/enforce/sandbox_apply.c
+++ b/tools/enforce/sandbox_apply.c
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+/*
+ * Seatbelt application (TODO.beyond-libc/01 P1, macOS). The
+ * C sandbox API (sandbox_compile_string/sandbox_apply) is
+ * private and version-fragile; the SUPPORTED interface is
+ * /usr/bin/sandbox-exec, so the installer wraps the exec:
+ * sandbox-exec -p '<profile>' -- <cmd>. The profile carries
+ * no single quotes (our generator emits only paths and
+ * parentheses) -- quoting stays trivial by construction.
+ */
+
+#include <string.h>
+#include <unistd.h>
+
+#include "sandbox_apply.h"
+
+#ifdef __APPLE__
+
+int enforce_sandbox_exec_wrap(const char *profile, int argc,
+	char **argv, char *out, size_t cap)
+{
+	size_t o = 0;
+	int i;
+	int n;
+
+	n = snprintf(out + o, cap - o,
+		"/usr/bin/sandbox-exec -p '%s' --", profile);
+	if (n <= 0 || (size_t)n >= cap - o)
+		return -1;
+	o += (size_t)n;
+	for (i = 0; i < argc; i++) {
+		n = snprintf(out + o, cap - o, " '%s'", argv[i]);
+		if (n <= 0 || (size_t)n >= cap - o)
+			return -1;
+		o += (size_t)n;
+	}
+	return 0;
+}
+
+#else
+
+int enforce_sandbox_exec_wrap(const char *profile, int argc,
+	char **argv, char *out, size_t cap)
+{
+	(void)profile;
+	(void)argc;
+	(void)argv;
+	(void)out;
+	(void)cap;
+	return -1;
+}
+
+#endif

--- a/tools/enforce/sandbox_apply.h
+++ b/tools/enforce/sandbox_apply.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+#ifndef RETRACE_ENFORCE_SANDBOX_H_
+#define RETRACE_ENFORCE_SANDBOX_H_
+
+#include <stdio.h>
+
+/*
+ * Apply a Seatbelt (sandbox-exec) profile to THIS process's
+ * children on macOS (01 P1). profile must be a NUL-terminated
+ * (version 1) S-expression. The C API (sandbox_compile +
+ * sandbox_apply) is private; the supported interface is the
+ * /usr/bin/sandbox-exec wrapper, so this returns an argv the
+ * caller execs INSTEAD of the target:
+ *
+ *   enforce_sandbox_exec_wrap(profile, argc, argv, out, cap)
+ *     -> "/usr/bin/sandbox-exec -p '<profile>' -- <cmd...>"
+ * assembled with proper quoting. Returns 0 built, -1 overflow.
+ */
+int enforce_sandbox_exec_wrap(const char *profile, int argc,
+	char **argv, char *out, size_t cap);
+
+#endif /* RETRACE_ENFORCE_SANDBOX_H_ */

--- a/tools/profiler/enforce.c
+++ b/tools/profiler/enforce.c
@@ -52,7 +52,7 @@ static void usage(void)
 {
 	fprintf(stderr,
 "Usage: retrace-profile enforce <profile.json> [--inside d.json]\n"
-"        [--backend landlock|seccomp|both] [--exec <path>]\n"
+"        [--backend landlock|seccomp|sandbox-exec|all] [--exec <path>]\n"
 "        [-o spec.json]\n");
 }
 
@@ -69,7 +69,7 @@ static int profile_uses(const struct Profile *p, const char *fn)
 
 static JSON_Value *build_spec(const struct Profile *allow_src,
 	const struct Profile *usage_src, const char *exec_path,
-	int want_landlock, int want_seccomp)
+	int want_landlock, int want_seccomp, int want_sb)
 {
 	JSON_Value *root_v = json_value_init_object();
 	JSON_Object *root = json_value_get_object(root_v);
@@ -133,6 +133,51 @@ static JSON_Value *build_spec(const struct Profile *allow_src,
 		}
 	}
 
+#ifdef __APPLE__
+	if (want_sb) {
+		/*
+		 * Seatbelt (01 P1): allow default, then deny writes
+		 * under the mutable roots, then re-allow each
+		 * declared write path (deny-before-allow ordering;
+		 * macOS resolves /tmp -> /private/tmp so both
+		 * spellings are denied). Reads ride "allow default"
+		 * -- the P0 honesty documented in the slice.
+		 */
+		static const char *const roots[] = {
+			"/private/tmp", "/tmp", "/Users", "/var",
+			"/Library", "/private/var", NULL,
+		};
+		char prof[8192];
+		size_t o = 0;
+		size_t k;
+
+		o += (size_t)snprintf(prof + o, sizeof(prof) - o,
+			"(version 1)(allow default)");
+		for (k = 0; roots[k] != NULL; k++)
+			o += (size_t)snprintf(prof + o,
+				sizeof(prof) - o,
+				"(deny file-write* (subpath \"%s\"))",
+				roots[k]);
+		for (i = 0; i < allow_src->accesses.count; i++) {
+			const struct ProfAccess *a =
+				&allow_src->accesses.items[i];
+
+			if (!a->class_write || a->path[0] != '/')
+				continue;
+			o += (size_t)snprintf(prof + o,
+				sizeof(prof) - o,
+				"(allow file-write* (subpath \"%s\"))",
+				a->path);
+		}
+		{
+			JSON_Value *sb_v =
+				json_value_init_string(prof);
+
+			json_object_set_value(root, "sandbox_exec",
+				sb_v);
+		}
+	}
+#endif
 	if (want_seccomp) {
 		JSON_Value *sc_v = json_value_init_object();
 		JSON_Object *sc = json_value_get_object(sc_v);
@@ -169,6 +214,12 @@ int enforce_mode(int argc, char **argv)
 	JSON_Value *spec;
 	int i;
 	int want_ll = 1, want_sc = 1;
+#ifdef __APPLE__
+	int want_sb = 0;
+#else
+	int want_sb_unused = 0;
+#define want_sb want_sb_unused
+#endif
 
 	memset(&feed, 0, sizeof(feed));
 	memset(&inside_feed, 0, sizeof(inside_feed));
@@ -198,6 +249,12 @@ int enforce_mode(int argc, char **argv)
 		want_sc = 0;
 	} else if (strcmp(backend, "seccomp") == 0) {
 		want_ll = 0;
+	} else if (strcmp(backend, "sandbox-exec") == 0) {
+		want_sb = 1;
+		want_ll = 0;
+		want_sc = 0;
+	} else if (strcmp(backend, "all") == 0) {
+		want_sb = 1;
 	} else if (strcmp(backend, "both") != 0) {
 		usage();
 		return 2;
@@ -221,7 +278,7 @@ int enforce_mode(int argc, char **argv)
 	}
 
 	spec = build_spec(allow_src, &feed.prof, exec_path,
-		want_ll, want_sc);
+		want_ll, want_sc, want_sb);
 	{
 		char *ser = json_serialize_to_string_pretty(spec);
 


### PR DESCRIPTION
## What

TODO.beyond-libc/01 P1: `retrace-profile enforce --backend sandbox-exec` compiles the declared-set
into a **Seatbelt** profile — allow default, deny file-write* under the mutable roots
(/private/tmp, /tmp, /Users, /var, /Library, /private/var), then re-allow each declared write-path
subpath (deny-before-allow ordering). `retrace-enforce` wraps the exec through
`/usr/bin/sandbox-exec` (the C sandbox API is private; the wrapper is the supported interface).

When a `sandbox_exec` section is present, the landlock/seccomp planes become advisory-only on
macOS instead of blocking the exec (their kernels lack them by definition there).

## Verified live (this Mac)

- declared write (`$HOME`-based): **passes** (`hi` echoed through the filter)
- undeclared write: **`Operation not permitted`**, file not created

## Known note (documented in the commit)

Seatbelt evaluates resolved paths — declared paths under symlinked roots (/tmp → /private/tmp,
/var → /private/var) need their resolved spelling in the allow rule. The generator emits both
spellings for the denies; a follow-up normalizes declared paths.

## Verification

- checkpatch clean
- local build green
