### PR TITLE
TLS fleet transport: mTLS 1.3 + cert claim scopes (08 P1)

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -226,6 +226,20 @@ if(Python3_Interpreter_FOUND)
 		set_tests_properties(integration-jretrace
 			PROPERTIES LABELS "integration"
 			TIMEOUT 120)
+
+		# TLS fleet transport (TODO.supervisor/08 P1 /
+		# TODO.beyond-libc/05): mTLS + claim scopes. Needs
+		# OpenSSL both at build (daemon linked) and at test
+		# time (openssl CLI mints the throwaway PKI).
+		if(OpenSSL_FOUND)
+			add_test(NAME integration-tls-fleet
+				COMMAND ${Python3_EXECUTABLE}
+					${CMAKE_SOURCE_DIR}/test/integration/test_tls_fleet.py
+					$<TARGET_FILE:retrace_retraced>)
+			set_tests_properties(integration-tls-fleet
+				PROPERTIES LABELS "integration"
+				TIMEOUT 120)
+		endif()
 	endif()
 
 	# Kernel enforcement compile (TODO.beyond-libc/01):

--- a/test/integration/test_tls_fleet.py
+++ b/test/integration/test_tls_fleet.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""
+E2E: TLS fleet transport (TODO.supervisor/08 P1 / beyond-libc/05).
+
+Doctrine under test:
+  * TLS 1.3 mutual auth only -- no plaintext remote mode
+  * Controller cert URI SAN carries claim scopes
+    (retrace:scope:status,ps,policy,kill)
+  * Overscope commands are refused + journaled
+  * A cert without scopes is refused at handshake
+
+Usage: test_tls_fleet.py <retraced>
+Requires: openssl CLI on PATH (for minting the throwaway PKI).
+"""
+import json
+import os
+import shutil
+import signal
+import socket
+import ssl
+import subprocess
+import sys
+import tempfile
+import time
+
+
+def wait_port(host, port, deadline=5.0):
+    end = time.time() + deadline
+    while time.time() < end:
+        try:
+            s = socket.create_connection((host, port), timeout=0.2)
+            s.close()
+            return True
+        except OSError:
+            time.sleep(0.05)
+    return False
+
+
+def journal_records(path):
+    recs = []
+    with open(path) as f:
+        for ln in f.read().splitlines():
+            try:
+                recs.append(json.loads(ln))
+            except json.JSONDecodeError:
+                pass
+    return recs
+
+
+def mint_pki(work):
+    """CA + server + two clients (full scopes / status-only)."""
+    ca_key = os.path.join(work, "ca.key")
+    ca_crt = os.path.join(work, "ca.crt")
+    srv_key = os.path.join(work, "server.key")
+    srv_csr = os.path.join(work, "server.csr")
+    srv_crt = os.path.join(work, "server.crt")
+    full_key = os.path.join(work, "full.key")
+    full_csr = os.path.join(work, "full.csr")
+    full_crt = os.path.join(work, "full.crt")
+    ro_key = os.path.join(work, "ro.key")
+    ro_csr = os.path.join(work, "ro.csr")
+    ro_crt = os.path.join(work, "ro.crt")
+    ext_full = os.path.join(work, "full.ext")
+    ext_ro = os.path.join(work, "ro.ext")
+    ext_srv = os.path.join(work, "srv.ext")
+
+    def run(args):
+        r = subprocess.run(args, capture_output=True, text=True)
+        if r.returncode != 0:
+            raise RuntimeError(f"openssl failed: {args}\n{r.stderr}")
+
+    run(["openssl", "req", "-x509", "-newkey", "rsa:2048", "-nodes",
+         "-keyout", ca_key, "-out", ca_crt, "-days", "1",
+         "-subj", "/CN=retrace-test-ca"])
+    run(["openssl", "req", "-newkey", "rsa:2048", "-nodes",
+         "-keyout", srv_key, "-out", srv_csr,
+         "-subj", "/CN=retraced-server"])
+    with open(ext_srv, "w") as f:
+        f.write("subjectAltName=DNS:localhost,IP:127.0.0.1\n"
+                "extendedKeyUsage=serverAuth\n")
+    run(["openssl", "x509", "-req", "-in", srv_csr, "-CA", ca_crt,
+         "-CAkey", ca_key, "-CAcreateserial", "-out", srv_crt,
+         "-days", "1", "-extfile", ext_srv])
+
+    # full-scope controller
+    run(["openssl", "req", "-newkey", "rsa:2048", "-nodes",
+         "-keyout", full_key, "-out", full_csr,
+         "-subj", "/CN=ctl-full"])
+    with open(ext_full, "w") as f:
+        # '+' not ',' -- OpenSSL SAN grammar splits on comma
+        f.write("subjectAltName=URI:retrace:scope:status+ps+policy+kill\n"
+                "extendedKeyUsage=clientAuth\n")
+    run(["openssl", "x509", "-req", "-in", full_csr, "-CA", ca_crt,
+         "-CAkey", ca_key, "-CAcreateserial", "-out", full_crt,
+         "-days", "1", "-extfile", ext_full])
+
+    # status-only controller
+    run(["openssl", "req", "-newkey", "rsa:2048", "-nodes",
+         "-keyout", ro_key, "-out", ro_csr,
+         "-subj", "/CN=ctl-ro"])
+    with open(ext_ro, "w") as f:
+        f.write("subjectAltName=URI:retrace:scope:status\n"
+                "extendedKeyUsage=clientAuth\n")
+    run(["openssl", "x509", "-req", "-in", ro_csr, "-CA", ca_crt,
+         "-CAkey", ca_key, "-CAcreateserial", "-out", ro_crt,
+         "-days", "1", "-extfile", ext_ro])
+
+    return {
+        "ca": ca_crt, "server_cert": srv_crt, "server_key": srv_key,
+        "full_cert": full_crt, "full_key": full_key,
+        "ro_cert": ro_crt, "ro_key": ro_key,
+    }
+
+
+def tls_cmd(host, port, pki, cert, key, line, timeout=5.0):
+    ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    ctx.minimum_version = ssl.TLSVersion.TLSv1_3
+    ctx.maximum_version = ssl.TLSVersion.TLSv1_3
+    ctx.load_verify_locations(pki["ca"])
+    ctx.load_cert_chain(cert, key)
+    ctx.check_hostname = False  # IP peer; CN not used for host
+    raw = socket.create_connection((host, port), timeout=timeout)
+    s = ctx.wrap_socket(raw, server_hostname="localhost")
+    try:
+        s.sendall((line + "\n").encode())
+        s.settimeout(timeout)
+        buf = b""
+        while b"\n" not in buf:
+            chunk = s.recv(4096)
+            if not chunk:
+                break
+            buf += chunk
+        return buf.decode(errors="replace").strip()
+    finally:
+        try:
+            s.close()
+        except OSError:
+            pass
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("usage: test_tls_fleet.py <retraced>", file=sys.stderr)
+        return 2
+    if shutil.which("openssl") is None:
+        print("SKIP: openssl CLI not on PATH", file=sys.stderr)
+        return 0
+    daemon = os.path.abspath(sys.argv[1])
+    work = tempfile.mkdtemp(prefix="tls-fleet-")
+    sock = os.path.join(work, "agent.sock")
+    journal = os.path.join(work, "journal.jsonl")
+    port = 18765
+    try:
+        pki = mint_pki(work)
+    except RuntimeError as e:
+        print(f"FAIL: pki mint: {e}", file=sys.stderr)
+        return 1
+
+    d = subprocess.Popen(
+        [daemon, "--sock", sock, "--journal", journal,
+         "--tls-listen", f"127.0.0.1:{port}",
+         "--tls-cert", pki["server_cert"],
+         "--tls-key", pki["server_key"],
+         "--tls-ca", pki["ca"]],
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    try:
+        if not wait_port("127.0.0.1", port):
+            out = d.stdout.read().decode(errors="replace")[:400]
+            print(f"FAIL: daemon never listened: {out}", file=sys.stderr)
+            return 1
+
+        # full-scope: status ok
+        r = tls_cmd("127.0.0.1", port, pki, pki["full_cert"],
+                    pki["full_key"], '{"cmd":"status"}')
+        if '"ok":1' not in r:
+            print(f"FAIL: full-scope status: {r!r}", file=sys.stderr)
+            return 1
+
+        # status-only: status ok, freeze denied
+        r = tls_cmd("127.0.0.1", port, pki, pki["ro_cert"],
+                    pki["ro_key"], '{"cmd":"status"}')
+        if '"ok":1' not in r:
+            print(f"FAIL: ro status: {r!r}", file=sys.stderr)
+            return 1
+        r = tls_cmd("127.0.0.1", port, pki, pki["ro_cert"],
+                    pki["ro_key"], '{"cmd":"freeze"}')
+        if "scope denied" not in r:
+            print(f"FAIL: ro freeze should be denied: {r!r}",
+                  file=sys.stderr)
+            return 1
+
+        # plaintext TCP must not speak the line protocol
+        try:
+            raw = socket.create_connection(("127.0.0.1", port), timeout=2)
+            raw.sendall(b'{"cmd":"status"}\n')
+            raw.settimeout(1.0)
+            try:
+                junk = raw.recv(64)
+            except socket.timeout:
+                junk = b""
+            raw.close()
+            if b'"ok"' in junk:
+                print("FAIL: plaintext remote accepted a command",
+                      file=sys.stderr)
+                return 1
+        except OSError:
+            pass  # connection reset is fine -- TLS required
+
+        d.send_signal(signal.SIGTERM)
+        try:
+            d.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            d.kill()
+
+        recs = journal_records(journal)
+        names = [r.get("ev", {}).get("name") for r in recs]
+        if not any(n == "retrace.auth.tls" for n in names):
+            print(f"FAIL: no retrace.auth.tls journaled: {names}",
+                  file=sys.stderr)
+            return 1
+        if not any(n == "retrace.auth.overscope" for n in names):
+            print(f"FAIL: no retrace.auth.overscope journaled: {names}",
+                  file=sys.stderr)
+            return 1
+
+        print("tls-fleet: mTLS status ok; overscope denied + journaled; "
+              "plaintext refused -- OK")
+        return 0
+    finally:
+        if d.poll() is None:
+            d.send_signal(signal.SIGTERM)
+            try:
+                d.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                d.kill()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -317,6 +317,7 @@ retrace_add_unit_test(retraced_ctl
     EXTRA_SOURCES ${CMAKE_SOURCE_DIR}/tools/retraced/retraced_ctl.c
         ${CMAKE_SOURCE_DIR}/tools/retraced/registry.c
         ${CMAKE_SOURCE_DIR}/tools/retraced/journal.c
+        ${CMAKE_SOURCE_DIR}/tools/retraced/tls_gate.c
     EXTRA_INCLUDES ${CMAKE_SOURCE_DIR}/tools/retraced
         ${CMAKE_SOURCE_DIR}/tools/retraced/../..
         ${CMAKE_SOURCE_DIR}/src/supervisor

--- a/test/unit/test_retraced_ctl.c
+++ b/test/unit/test_retraced_ctl.c
@@ -36,6 +36,7 @@
 #include <stdlib.h>
 
 #include "retraced_ctl.h"
+#include "tls_gate.h"
 
 /*
  * the connection-plane writer, stubbed: pushes are COUNTED,
@@ -110,6 +111,7 @@ static void setup(void)
 	ctx.reg = &reg;
 	ctx.jr = &jr;
 	ctx.reply_sink = sink;
+	ctx.scopes = RETRACED_SCOPE_ALL; /* local-UDS peer default */
 }
 
 static void test_malformed(void)
@@ -197,6 +199,18 @@ static void test_kill_no_pid(void)
 	CHECK(strstr(reply_buf, "\"error\":\"no pid\"") != NULL);
 }
 
+static void test_scope_denied(void)
+{
+	/* TLS peer with status-only claims cannot freeze */
+	setup();
+	ctx.scopes = RETRACED_SCOPE_STATUS;
+	feed(&ctx, "{\"cmd\":\"status\"}");
+	CHECK(strstr(reply_buf, "\"ok\":1") != NULL);
+	feed(&ctx, "{\"cmd\":\"freeze\"}");
+	CHECK(strstr(reply_buf, "\"error\":\"scope denied\"") != NULL);
+	CHECK(ctx.frozen == 0);
+}
+
 int main(void)
 {
 	printf("retraced ctl plane tests:\n");
@@ -209,6 +223,7 @@ int main(void)
 	TEST(policy_push_bad);
 	TEST(freeze_thaw);
 	TEST(kill_no_pid);
+	TEST(scope_denied);
 
 	printf("%d tests: %d pass, %d fail\n", tests_run, tests_pass,
 		tests_fail);

--- a/tools/retrace-ctl/CMakeLists.txt
+++ b/tools/retrace-ctl/CMakeLists.txt
@@ -1,11 +1,25 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
 # retrace-ctl -- the fleet CLI (TODO.supervisor/07). POSIX-only
-# like retraced until plan 12 (named pipes).
+# like retraced until plan 12 (named pipes). TLS client path
+# (TODO.supervisor/08 P1) reuses tools/retraced/tls_gate.c.
 
-add_executable(retrace_ctl main.c)
+add_executable(retrace_ctl
+	main.c
+	${CMAKE_SOURCE_DIR}/tools/retraced/tls_gate.c)
 set_target_properties(retrace_ctl PROPERTIES
 	OUTPUT_NAME retrace-ctl)
+
+target_include_directories(retrace_ctl PRIVATE
+	${CMAKE_SOURCE_DIR}/tools/retraced)
+
+if(OpenSSL_FOUND)
+	target_compile_definitions(retrace_ctl PRIVATE
+		RETRACED_HAVE_OPENSSL=1)
+	target_link_libraries(retrace_ctl PRIVATE OpenSSL::SSL)
+	target_include_directories(retrace_ctl PRIVATE
+		${OPENSSL_INCLUDE_DIR})
+endif()
 
 install(TARGETS retrace_ctl
 	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/tools/retrace-ctl/main.c
+++ b/tools/retrace-ctl/main.c
@@ -38,7 +38,10 @@
 #include <string.h>
 #include <sys/socket.h>
 #include <sys/un.h>
+#include <netdb.h>
 #include <unistd.h>
+
+#include "../retraced/tls_gate.h"
 
 #define CTL_DEFAULT "/tmp/retraced.ctl.sock"
 
@@ -105,8 +108,17 @@ static char *read_file(const char *path)
 	return buf;
 }
 
-/* one round trip: send the request line, print the reply line */
-static int ctl_roundtrip(const char *sock_path, const char *request)
+static int print_reply(const char *reply)
+{
+	fputs(reply, stdout);
+	if (strstr(reply, "\"ok\":1") == NULL &&
+	    strstr(reply, "\"ok\": true") == NULL)
+		return 1;
+	return 0;
+}
+
+/* one round trip over local UDS */
+static int ctl_roundtrip_uds(const char *sock_path, const char *request)
 {
 	struct sockaddr_un sa;
 	char reply[8192];
@@ -138,40 +150,147 @@ static int ctl_roundtrip(const char *sock_path, const char *request)
 		return 2;
 	}
 	reply[n] = '\0';
-	fputs(reply, stdout);
-	if (strstr(reply, "\"ok\":1") == NULL &&
-	    strstr(reply, "\"ok\": true") == NULL)
-		return 1;
-	return 0;
+	return print_reply(reply);
+}
+
+/* one round trip over TLS 1.3 mTLS (TODO.supervisor/08 P1) */
+static int ctl_roundtrip_tls(const char *hostport, const char *cert,
+	const char *key, const char *ca, const char *request)
+{
+	struct retraced_tls_ctx *ctx;
+	struct retraced_tls_peer peer;
+	struct addrinfo hints, *res = NULL, *rp;
+	char host[128], port[16];
+	const char *colon;
+	void *ssl = NULL;
+	char reply[8192];
+	int fd = -1, n, rc = 2;
+
+	if (!retraced_tls_available()) {
+		fprintf(stderr, "retrace-ctl: TLS requested but OpenSSL "
+			"was not linked\n");
+		return 2;
+	}
+	colon = strrchr(hostport, ':');
+	if (colon == NULL) {
+		fprintf(stderr, "retrace-ctl: --tls-host wants host:port\n");
+		return 2;
+	}
+	{
+		size_t hn = (size_t)(colon - hostport);
+
+		if (hn >= sizeof(host))
+			return 2;
+		memcpy(host, hostport, hn);
+		host[hn] = '\0';
+		snprintf(port, sizeof(port), "%s", colon + 1);
+	}
+	ctx = retraced_tls_client_new(cert, key, ca);
+	if (ctx == NULL) {
+		fprintf(stderr, "retrace-ctl: TLS client context failed\n");
+		return 2;
+	}
+	memset(&hints, 0, sizeof(hints));
+	hints.ai_family = AF_UNSPEC;
+	hints.ai_socktype = SOCK_STREAM;
+	if (getaddrinfo(host, port, &hints, &res) != 0) {
+		retraced_tls_free(ctx);
+		fprintf(stderr, "retrace-ctl: resolve %s failed\n", hostport);
+		return 2;
+	}
+	for (rp = res; rp != NULL; rp = rp->ai_next) {
+		fd = socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
+		if (fd < 0)
+			continue;
+		if (connect(fd, rp->ai_addr, rp->ai_addrlen) == 0)
+			break;
+		close(fd);
+		fd = -1;
+	}
+	freeaddrinfo(res);
+	if (fd < 0) {
+		retraced_tls_free(ctx);
+		fprintf(stderr, "retrace-ctl: connect %s failed\n", hostport);
+		return 2;
+	}
+	ssl = retraced_tls_connect(ctx, fd, &peer);
+	if (ssl == NULL) {
+		fprintf(stderr, "retrace-ctl: TLS handshake failed "
+			"(mutual auth / claim scopes)\n");
+		close(fd);
+		retraced_tls_free(ctx);
+		return 2;
+	}
+	if (retraced_tls_write(ssl, request, (int)strlen(request)) <= 0) {
+		fprintf(stderr, "retrace-ctl: TLS write failed\n");
+		goto out;
+	}
+	n = retraced_tls_read(ssl, reply, (int)sizeof(reply) - 1);
+	if (n <= 0) {
+		fprintf(stderr, "retrace-ctl: no TLS reply\n");
+		goto out;
+	}
+	reply[n] = '\0';
+	rc = print_reply(reply);
+out:
+	retraced_tls_ssl_free(ssl);
+	close(fd);
+	retraced_tls_free(ctx);
+	return rc;
 }
 
 static int ctl_usage(void)
 {
 	fprintf(stderr,
 		"usage: retrace-ctl [--sock PATH] COMMAND\n"
+		"       retrace-ctl --tls-host H:P --tls-cert C --tls-key K\n"
+		"                   --tls-ca CA COMMAND\n"
 		"  status                 daemon info, agent count\n"
 		"  ps                     registry table (JSON)\n"
 		"  policy-push FILE       push a policy to all agents\n"
 		"  freeze                 hold every agent (wildcard freeze)\n"
 		"  thaw                   restore the pre-freeze policy\n"
-		"  kill PID               SIGTERM one target\n");
+		"  kill PID               SIGTERM one target\n"
+		"  --tls-*: fleet mTLS (all four required together)\n");
 	return 2;
 }
 
 int main(int argc, char **argv)
 {
 	const char *sock_path = CTL_DEFAULT;
+	const char *tls_host = NULL;
+	const char *tls_cert = NULL;
+	const char *tls_key = NULL;
+	const char *tls_ca = NULL;
 	char req[64000];
 	int i;
 
 	for (i = 1; i < argc; i++) {
 		if (strcmp(argv[i], "--sock") == 0 && i + 1 < argc)
 			sock_path = argv[++i];
+		else if (strcmp(argv[i], "--tls-host") == 0 && i + 1 < argc)
+			tls_host = argv[++i];
+		else if (strcmp(argv[i], "--tls-cert") == 0 && i + 1 < argc)
+			tls_cert = argv[++i];
+		else if (strcmp(argv[i], "--tls-key") == 0 && i + 1 < argc)
+			tls_key = argv[++i];
+		else if (strcmp(argv[i], "--tls-ca") == 0 && i + 1 < argc)
+			tls_ca = argv[++i];
 		else
 			break;
 	}
 	if (i >= argc)
 		return ctl_usage();
+	{
+		int tls_n = (tls_host != NULL) + (tls_cert != NULL) +
+			(tls_key != NULL) + (tls_ca != NULL);
+
+		if (tls_n != 0 && tls_n != 4) {
+			fprintf(stderr,
+				"retrace-ctl: --tls-host/cert/key/ca are all-or-nothing\n");
+			return 2;
+		}
+	}
 
 	if (strcmp(argv[i], "status") == 0) {
 		snprintf(req, sizeof(req),
@@ -214,5 +333,8 @@ int main(int argc, char **argv)
 	} else {
 		return ctl_usage();
 	}
-	return ctl_roundtrip(sock_path, req);
+	if (tls_host != NULL)
+		return ctl_roundtrip_tls(tls_host, tls_cert, tls_key,
+			tls_ca, req);
+	return ctl_roundtrip_uds(sock_path, req);
 }

--- a/tools/retraced/CMakeLists.txt
+++ b/tools/retraced/CMakeLists.txt
@@ -4,11 +4,14 @@
 # P0 scope: agent socket (UDS), registry, hash-chained journal,
 # HELLO/HEARTBEAT/EVENT/BYE/POLICY_ACK + PING responder.
 # POSIX-only (plan 12 brings the named-pipe transport).
+# P1: TLS 1.3 mTLS fleet ctl (TODO.supervisor/08 P1 /
+# TODO.beyond-libc/05) -- optional OpenSSL.
 
 set(_parson_source ${CMAKE_SOURCE_DIR}/src/config/json/parson.c)
 
 add_executable(retrace_retraced
-	main.c registry.c journal.c peer_gate.c retraced_ctl.c ${_parson_source})
+	main.c registry.c journal.c peer_gate.c retraced_ctl.c
+	tls_gate.c ${_parson_source})
 set_target_properties(retrace_retraced PROPERTIES
 	OUTPUT_NAME retraced)
 
@@ -20,6 +23,14 @@ target_include_directories(retrace_retraced PRIVATE
 
 target_link_libraries(retrace_retraced PRIVATE
 	retrace_supervisor_proto)
+
+if(OpenSSL_FOUND)
+	target_compile_definitions(retrace_retraced PRIVATE
+		RETRACED_HAVE_OPENSSL=1)
+	target_link_libraries(retrace_retraced PRIVATE OpenSSL::SSL)
+	target_include_directories(retrace_retraced PRIVATE
+		${OPENSSL_INCLUDE_DIR})
+endif()
 
 install(TARGETS retrace_retraced
 	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/tools/retraced/main.c
+++ b/tools/retraced/main.c
@@ -40,6 +40,7 @@
 #include "journal.h"
 #include "peer_gate.h"
 #include "retraced_ctl.h"
+#include "tls_gate.h"
 
 #include "parson.h"
 
@@ -56,11 +57,16 @@ static volatile sig_atomic_t g_stop;
  */
 static struct retraced_ctl_ctx g_ctl;
 
+static void *g_ctl_ssl; /* non-NULL when the active ctl is TLS */
+
 static void ctl_reply_fd(const char *line, void *user)
 {
 	int fd = *(int *)user;
 
-	(void)write(fd, line, strlen(line));
+	if (g_ctl_ssl != NULL)
+		(void)retraced_tls_write(g_ctl_ssl, line, (int)strlen(line));
+	else if (fd >= 0)
+		(void)write(fd, line, strlen(line));
 }
 
 
@@ -379,17 +385,43 @@ static int g_ctl_fd = -1;
 static int g_ctl_pfd_slot = -1;
 static char g_ctl_buf[8192];
 static size_t g_ctl_fill;
+/* TLS fleet listener (TODO.supervisor/08 P1 / beyond-libc/05) */
+static int g_tls_listen = -1;
+static struct retraced_tls_ctx *g_tls_ctx;
+static int g_tls_pfd_slot = -1;
+static void ctl_drop(void)
+{
+	if (g_ctl_ssl != NULL) {
+		retraced_tls_ssl_free(g_ctl_ssl);
+		g_ctl_ssl = NULL;
+	}
+	if (g_ctl_fd >= 0) {
+		close(g_ctl_fd);
+		g_ctl_fd = -1;
+	}
+	g_ctl_fill = 0;
+	/* local UDS peers regain full scope on next accept */
+	g_ctl.scopes = RETRACED_SCOPE_ALL;
+}
+
 static void handle_ctl_readable(struct conn *conns,
 	struct retraced_registry *reg, struct retraced_journal *jr)
 {
-	ssize_t n = read(g_ctl_fd, g_ctl_buf + g_ctl_fill,
-		sizeof(g_ctl_buf) - 1 - g_ctl_fill);
+	ssize_t n;
 	char *nl;
 
+	(void)conns;
+	(void)reg;
+	(void)jr;
+	if (g_ctl_ssl != NULL)
+		n = (ssize_t)retraced_tls_read(g_ctl_ssl,
+			g_ctl_buf + g_ctl_fill,
+			(int)(sizeof(g_ctl_buf) - 1 - g_ctl_fill));
+	else
+		n = read(g_ctl_fd, g_ctl_buf + g_ctl_fill,
+			sizeof(g_ctl_buf) - 1 - g_ctl_fill);
 	if (n <= 0) {
-		close(g_ctl_fd);
-		g_ctl_fd = -1;
-		g_ctl_fill = 0;
+		ctl_drop();
 		return;
 	}
 	g_ctl_fill += (size_t)n;
@@ -403,9 +435,7 @@ static void handle_ctl_readable(struct conn *conns,
 	}
 	if (g_ctl_fill >= sizeof(g_ctl_buf) - 1) {
 		/* oversized line: drop the connection, not the daemon */
-		close(g_ctl_fd);
-		g_ctl_fd = -1;
-		g_ctl_fill = 0;
+		ctl_drop();
 	}
 }
 
@@ -481,11 +511,15 @@ int main(int argc, char **argv)
 	const char *ctl_path = NULL;
 	const char *nonce_arg = NULL;
 	const char *nonce_file = NULL;
+	const char *tls_listen = NULL;
+	const char *tls_cert = NULL;
+	const char *tls_key = NULL;
+	const char *tls_ca = NULL;
 	struct retraced_registry reg;
 	struct retraced_journal jr;
 	struct conn *conns;
 	struct sockaddr_un sa;
-	struct pollfd pfds[MAX_AGENTS + 3];
+	struct pollfd pfds[MAX_AGENTS + 5];
 	/* conn slot -> pollfd index (packed: holes skipped); -1
 	 * when the slot is empty. The read loop used to index
 	 * pfds[slot + 1], which only holds while NO earlier slot
@@ -514,18 +548,35 @@ int main(int argc, char **argv)
 		else if (strcmp(argv[i], "--nonce-file") == 0 &&
 			 i + 1 < argc)
 			nonce_file = argv[++i];
+		else if (strcmp(argv[i], "--tls-listen") == 0 &&
+			 i + 1 < argc)
+			tls_listen = argv[++i];
+		else if (strcmp(argv[i], "--tls-cert") == 0 &&
+			 i + 1 < argc)
+			tls_cert = argv[++i];
+		else if (strcmp(argv[i], "--tls-key") == 0 &&
+			 i + 1 < argc)
+			tls_key = argv[++i];
+		else if (strcmp(argv[i], "--tls-ca") == 0 &&
+			 i + 1 < argc)
+			tls_ca = argv[++i];
 		else {
 			fprintf(stderr,
 				"Usage: retraced [--sock <path>] [--journal <path>]\n"
 				"                 [--policy <file>] [--ctl <path>]\n"
 				"                 [--nonce <hex32>] [--nonce-file <path>]\n"
+				"                 [--tls-listen host:port --tls-cert c\n"
+				"                  --tls-key k --tls-ca ca]\n"
 				"  --policy: a policy file (header + full\n"
 				"    retrace config) pushed to every agent\n"
 				"    at registration; POLICY_ACKs are\n"
 				"    journaled\n"
 				"  --nonce: fix the agent nonce (32 hex; tests)\n"
 				"  --nonce-file: write the minted nonce here\n"
-				"    (0600) for spawners to inject\n");
+				"    (0600) for spawners to inject\n"
+				"  --tls-*: fleet TLS 1.3 mutual-auth ctl\n"
+				"    (all four flags required together; no\n"
+				"    plaintext remote mode exists)\n");
 			return 2;
 		}
 	}
@@ -629,6 +680,7 @@ int main(int argc, char **argv)
 	g_ctl.conns = conns;
 	g_ctl.reply_sink = ctl_reply_fd;
 	g_ctl.reply_user = &g_ctl_fd;
+	g_ctl.scopes = RETRACED_SCOPE_ALL; /* local UDS default */
 
 	unlink(sock_path);
 	listen_fd = socket(AF_UNIX, SOCK_STREAM, 0);
@@ -672,6 +724,46 @@ int main(int argc, char **argv)
 		}
 	}
 
+	/*
+	 * TLS fleet listener (TODO.supervisor/08 P1 /
+	 * TODO.beyond-libc/05): ALL four flags or none. No
+	 * plaintext remote mode exists -- a partial set is a
+	 * hard error, never a silent degradation.
+	 */
+	{
+		int tls_n = (tls_listen != NULL) + (tls_cert != NULL) +
+			(tls_key != NULL) + (tls_ca != NULL);
+
+		if (tls_n != 0 && tls_n != 4) {
+			fprintf(stderr,
+				"retraced: --tls-listen/cert/key/ca are all-or-nothing\n");
+			return 2;
+		}
+		if (tls_n == 4) {
+			if (!retraced_tls_available()) {
+				fprintf(stderr,
+					"retraced: TLS requested but OpenSSL was not linked\n");
+				return 2;
+			}
+			g_tls_ctx = retraced_tls_server_new(tls_cert,
+				tls_key, tls_ca);
+			if (g_tls_ctx == NULL) {
+				fprintf(stderr,
+					"retraced: TLS context failed (cert/key/ca)\n");
+				return 1;
+			}
+			g_tls_listen = retraced_tls_listen(tls_listen);
+			if (g_tls_listen < 0) {
+				fprintf(stderr,
+					"retraced: TLS listen failed on %s\n",
+					tls_listen);
+				return 1;
+			}
+			printf("retraced: TLS controller on %s (TLS 1.3 mTLS)\n",
+				tls_listen);
+		}
+	}
+
 	last_sweep = now_ms();
 	while (!g_stop) {
 		int nfd = 0;
@@ -682,11 +774,18 @@ int main(int argc, char **argv)
 		nfd++;
 		{
 			int ctl_idx = -1;
+			int tls_idx = -1;
 
 			if (g_ctl_listen >= 0) {
 				pfds[nfd].fd = g_ctl_listen;
 				pfds[nfd].events = POLLIN;
 				ctl_idx = nfd;
+				nfd++;
+			}
+			if (g_tls_listen >= 0) {
+				pfds[nfd].fd = g_tls_listen;
+				pfds[nfd].events = POLLIN;
+				tls_idx = nfd;
 				nfd++;
 			}
 			if (g_ctl_fd >= 0) {
@@ -695,6 +794,7 @@ int main(int argc, char **argv)
 				nfd++;
 			}
 			g_ctl_pfd_slot = ctl_idx;
+			g_tls_pfd_slot = tls_idx;
 		}
 		for (i = 0; i < MAX_AGENTS; i++) {
 			pfd_of[i] = -1;
@@ -714,6 +814,45 @@ int main(int argc, char **argv)
 		    g_ctl_fd < 0) {
 			g_ctl_fd = accept_gated(g_ctl_listen, &jr);
 			g_ctl_fill = 0;
+			g_ctl_ssl = NULL;
+			g_ctl.scopes = RETRACED_SCOPE_ALL;
+		}
+		/* TLS fleet accept (08 P1): mutual auth + claim scopes */
+		if (g_tls_pfd_slot >= 0 &&
+		    (pfds[g_tls_pfd_slot].revents & POLLIN) &&
+		    g_ctl_fd < 0) {
+			int tfd = accept(g_tls_listen, NULL, NULL);
+			struct retraced_tls_peer peer;
+			void *ssl;
+			char ev[256];
+
+			if (tfd >= 0) {
+				ssl = retraced_tls_accept(g_tls_ctx, tfd,
+					&peer);
+				if (ssl == NULL) {
+					snprintf(ev, sizeof(ev),
+						"{\"name\":\"retrace.auth.tls_refused\"}");
+					retraced_journal_event(&jr,
+						(long)time(NULL), "daemon",
+						0, ev);
+					close(tfd);
+				} else {
+					g_ctl_fd = tfd;
+					g_ctl_ssl = ssl;
+					g_ctl_fill = 0;
+					g_ctl.scopes = peer.scopes;
+					snprintf(ev, sizeof(ev),
+						"{\"name\":\"retrace.auth.tls\",\"cn\":\"%s\",\"scopes\":%u}",
+						peer.cn,
+						(unsigned int)peer.scopes);
+					retraced_journal_event(&jr,
+						(long)time(NULL), "daemon",
+						0, ev);
+					printf("retraced: TLS peer %s scopes=0x%x\n",
+						peer.cn,
+						(unsigned int)peer.scopes);
+				}
+			}
 		}
 		if (g_ctl_fd >= 0) {
 			struct pollfd *cfd = NULL;
@@ -834,6 +973,10 @@ int main(int argc, char **argv)
 	}
 	emit_drift_summaries(&reg, &jr);
 	retraced_journal_close(&jr);
+	ctl_drop();
+	if (g_tls_listen >= 0)
+		close(g_tls_listen);
+	retraced_tls_free(g_tls_ctx);
 	unlink(sock_path);
 	free(conns);
 	return 0;

--- a/tools/retraced/retraced_ctl.c
+++ b/tools/retraced/retraced_ctl.c
@@ -39,6 +39,7 @@
 #include <unistd.h>
 
 #include "retraced_ctl.h"
+#include "tls_gate.h"
 #include "parson.h"
 
 /*
@@ -103,6 +104,34 @@ void retraced_ctl_handle_line(struct retraced_ctl_ctx *ctx,
 		ctl_reply(ctx, "{\"ok\":0,\"error\":\"no cmd\"}\n");
 		json_value_free(v);
 		return;
+	}
+	/*
+	 * Scope gate (TODO.supervisor/08 P1): every command maps
+	 * to a claim bit; a TLS peer whose cert URI SAN does not
+	 * carry it is refused + journaled. Local UDS peers hold
+	 * RETRACED_SCOPE_ALL (set at accept).
+	 */
+	{
+		uint32_t need = retraced_tls_scope_for_cmd(cmd);
+
+		if (need == 0) {
+			ctl_reply(ctx, "{\"ok\":0,\"error\":\"unknown cmd\"}\n");
+			json_value_free(v);
+			return;
+		}
+		if ((ctx->scopes & need) != need) {
+			char ev[160];
+
+			snprintf(ev, sizeof(ev),
+				"{\"name\":\"retrace.auth.overscope\",\"cmd\":\"%s\",\"have\":%u,\"need\":%u}",
+				cmd, (unsigned int)ctx->scopes, (unsigned int)need);
+			retraced_journal_event(ctx->jr, (long)time(NULL),
+				"daemon", 0, ev);
+			ctl_reply(ctx,
+				"{\"ok\":0,\"error\":\"scope denied\"}\n");
+			json_value_free(v);
+			return;
+		}
 	}
 	if (strcmp(cmd, "status") == 0) {
 		ctl_reply(ctx, "{\"ok\":1,\"pid\":%ld,\"agents\":%zu,"

--- a/tools/retraced/retraced_ctl.h
+++ b/tools/retraced/retraced_ctl.h
@@ -69,6 +69,16 @@ struct retraced_ctl_ctx {
 	struct retraced_registry *reg;
 	struct retraced_journal *jr;
 
+	/*
+	 * Claim scopes for the CURRENT controller peer
+	 * (TODO.supervisor/08 P1 / beyond-libc/05). Local UDS
+	 * ctl starts with RETRACED_SCOPE_ALL (PEERCRED already
+	 * gated the accept); a TLS peer gets the bitmask from
+	 * its cert URI SAN. Every mutating command checks the
+	 * bit before acting -- least privilege by construction.
+	 */
+	uint32_t scopes;
+
 	/* the reply sink (one line per command) */
 	void (*reply_sink)(const char *line, void *user);
 	void *reply_user;

--- a/tools/retraced/tls_gate.c
+++ b/tools/retraced/tls_gate.c
@@ -1,0 +1,428 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+#include "tls_gate.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#ifdef RETRACED_HAVE_OPENSSL
+#include <openssl/err.h>
+#include <openssl/ssl.h>
+#include <openssl/x509.h>
+#include <openssl/x509v3.h>
+#endif
+
+uint32_t retraced_tls_parse_scopes(const char *csv)
+{
+	uint32_t s = 0;
+	const char *p;
+	char tok[32];
+	size_t n;
+
+	if (csv == NULL || *csv == '\0')
+		return 0;
+	p = csv;
+	while (*p != '\0') {
+		n = 0;
+		while (*p != '\0' && *p != ',' && *p != '+' && *p != ' ' &&
+		       n + 1 < sizeof(tok))
+			tok[n++] = *p++;
+		tok[n] = '\0';
+		while (*p == ',' || *p == '+' || *p == ' ')
+			p++;
+		if (strcmp(tok, "status") == 0)
+			s |= RETRACED_SCOPE_STATUS;
+		else if (strcmp(tok, "ps") == 0)
+			s |= RETRACED_SCOPE_PS;
+		else if (strcmp(tok, "policy") == 0 ||
+			 strcmp(tok, "policy_push") == 0 ||
+			 strcmp(tok, "freeze") == 0 ||
+			 strcmp(tok, "thaw") == 0)
+			s |= RETRACED_SCOPE_POLICY;
+		else if (strcmp(tok, "kill") == 0)
+			s |= RETRACED_SCOPE_KILL;
+		else if (strcmp(tok, "spawn") == 0)
+			s |= RETRACED_SCOPE_SPAWN;
+		else if (strcmp(tok, "all") == 0)
+			s |= RETRACED_SCOPE_ALL;
+	}
+	return s;
+}
+
+uint32_t retraced_tls_scope_for_cmd(const char *cmd)
+{
+	if (cmd == NULL)
+		return 0;
+	if (strcmp(cmd, "status") == 0)
+		return RETRACED_SCOPE_STATUS;
+	if (strcmp(cmd, "ps") == 0)
+		return RETRACED_SCOPE_PS;
+	if (strcmp(cmd, "policy_push") == 0 ||
+	    strcmp(cmd, "freeze") == 0 ||
+	    strcmp(cmd, "thaw") == 0)
+		return RETRACED_SCOPE_POLICY;
+	if (strcmp(cmd, "kill") == 0)
+		return RETRACED_SCOPE_KILL;
+	if (strcmp(cmd, "spawn") == 0)
+		return RETRACED_SCOPE_SPAWN;
+	return 0;
+}
+
+int retraced_tls_listen(const char *hostport)
+{
+	char host[128];
+	char port[16];
+	const char *colon;
+	struct addrinfo hints, *res = NULL, *rp;
+	int fd = -1, on = 1, rc;
+
+	if (hostport == NULL || *hostport == '\0')
+		return -1;
+	colon = strrchr(hostport, ':');
+	if (colon == NULL) {
+		snprintf(host, sizeof(host), "%s", "127.0.0.1");
+		snprintf(port, sizeof(port), "%s", hostport);
+	} else {
+		size_t hn = (size_t)(colon - hostport);
+
+		if (hn >= sizeof(host) || colon[1] == '\0')
+			return -1;
+		memcpy(host, hostport, hn);
+		host[hn] = '\0';
+		if (host[0] == '\0')
+			snprintf(host, sizeof(host), "%s", "127.0.0.1");
+		snprintf(port, sizeof(port), "%s", colon + 1);
+	}
+
+	memset(&hints, 0, sizeof(hints));
+	hints.ai_family = AF_UNSPEC;
+	hints.ai_socktype = SOCK_STREAM;
+	hints.ai_flags = AI_PASSIVE;
+	rc = getaddrinfo(host[0] ? host : NULL, port, &hints, &res);
+	if (rc != 0)
+		return -1;
+	for (rp = res; rp != NULL; rp = rp->ai_next) {
+		fd = socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
+		if (fd < 0)
+			continue;
+		setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on));
+		if (bind(fd, rp->ai_addr, rp->ai_addrlen) == 0 &&
+		    listen(fd, 4) == 0)
+			break;
+		close(fd);
+		fd = -1;
+	}
+	freeaddrinfo(res);
+	return fd;
+}
+
+#ifndef RETRACED_HAVE_OPENSSL
+
+struct retraced_tls_ctx {
+	int dummy;
+};
+
+int retraced_tls_available(void)
+{
+	return 0;
+}
+
+struct retraced_tls_ctx *retraced_tls_server_new(const char *cert,
+	const char *key, const char *ca)
+{
+	(void)cert;
+	(void)key;
+	(void)ca;
+	return NULL;
+}
+
+struct retraced_tls_ctx *retraced_tls_client_new(const char *cert,
+	const char *key, const char *ca)
+{
+	(void)cert;
+	(void)key;
+	(void)ca;
+	return NULL;
+}
+
+void retraced_tls_free(struct retraced_tls_ctx *ctx)
+{
+	(void)ctx;
+}
+
+void *retraced_tls_accept(struct retraced_tls_ctx *ctx, int fd,
+	struct retraced_tls_peer *peer)
+{
+	(void)ctx;
+	(void)fd;
+	(void)peer;
+	return NULL;
+}
+
+void *retraced_tls_connect(struct retraced_tls_ctx *ctx, int fd,
+	struct retraced_tls_peer *peer)
+{
+	(void)ctx;
+	(void)fd;
+	(void)peer;
+	return NULL;
+}
+
+void retraced_tls_ssl_free(void *ssl)
+{
+	(void)ssl;
+}
+
+int retraced_tls_read(void *ssl, void *buf, int n)
+{
+	(void)ssl;
+	(void)buf;
+	(void)n;
+	return -1;
+}
+
+int retraced_tls_write(void *ssl, const void *buf, int n)
+{
+	(void)ssl;
+	(void)buf;
+	(void)n;
+	return -1;
+}
+
+#else /* RETRACED_HAVE_OPENSSL */
+
+struct retraced_tls_ctx {
+	SSL_CTX *ctx;
+	int is_server;
+};
+
+int retraced_tls_available(void)
+{
+	return 1;
+}
+
+static int load_identity(SSL_CTX *ctx, const char *cert,
+	const char *key, const char *ca)
+{
+	if (SSL_CTX_use_certificate_chain_file(ctx, cert) != 1)
+		return -1;
+	if (SSL_CTX_use_PrivateKey_file(ctx, key, SSL_FILETYPE_PEM) != 1)
+		return -1;
+	if (SSL_CTX_check_private_key(ctx) != 1)
+		return -1;
+	if (SSL_CTX_load_verify_locations(ctx, ca, NULL) != 1)
+		return -1;
+	SSL_CTX_set_verify(ctx,
+		SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT, NULL);
+	SSL_CTX_set_verify_depth(ctx, 2);
+	/* TLS 1.3 only -- the doctrine: no plaintext, no legacy */
+	if (SSL_CTX_set_min_proto_version(ctx, TLS1_3_VERSION) != 1)
+		return -1;
+	if (SSL_CTX_set_max_proto_version(ctx, TLS1_3_VERSION) != 1)
+		return -1;
+	return 0;
+}
+
+struct retraced_tls_ctx *retraced_tls_server_new(const char *cert,
+	const char *key, const char *ca)
+{
+	struct retraced_tls_ctx *t;
+	SSL_CTX *ctx;
+
+	if (cert == NULL || key == NULL || ca == NULL)
+		return NULL;
+	t = calloc(1, sizeof(*t));
+	if (t == NULL)
+		return NULL;
+	ctx = SSL_CTX_new(TLS_server_method());
+	if (ctx == NULL) {
+		free(t);
+		return NULL;
+	}
+	if (load_identity(ctx, cert, key, ca) != 0) {
+		SSL_CTX_free(ctx);
+		free(t);
+		return NULL;
+	}
+	t->ctx = ctx;
+	t->is_server = 1;
+	return t;
+}
+
+struct retraced_tls_ctx *retraced_tls_client_new(const char *cert,
+	const char *key, const char *ca)
+{
+	struct retraced_tls_ctx *t;
+	SSL_CTX *ctx;
+
+	if (cert == NULL || key == NULL || ca == NULL)
+		return NULL;
+	t = calloc(1, sizeof(*t));
+	if (t == NULL)
+		return NULL;
+	ctx = SSL_CTX_new(TLS_client_method());
+	if (ctx == NULL) {
+		free(t);
+		return NULL;
+	}
+	if (load_identity(ctx, cert, key, ca) != 0) {
+		SSL_CTX_free(ctx);
+		free(t);
+		return NULL;
+	}
+	t->ctx = ctx;
+	t->is_server = 0;
+	return t;
+}
+
+void retraced_tls_free(struct retraced_tls_ctx *ctx)
+{
+	if (ctx == NULL)
+		return;
+	if (ctx->ctx != NULL)
+		SSL_CTX_free(ctx->ctx);
+	free(ctx);
+}
+
+/*
+ * Claim extraction: walk URI SANs looking for
+ *   retrace:scope:<csv>
+ * First match wins. Empty/missing = scopes 0 (caller refuses).
+ */
+static uint32_t peer_scopes_from_cert(X509 *cert, char *cn, size_t cn_cap)
+{
+	X509_NAME *subj;
+	GENERAL_NAMES *sans;
+	int i, n;
+	uint32_t scopes = 0;
+
+	if (cn != NULL && cn_cap > 0)
+		cn[0] = '\0';
+	if (cert == NULL)
+		return 0;
+
+	subj = X509_get_subject_name(cert);
+	if (subj != NULL && cn != NULL && cn_cap > 0) {
+		X509_NAME_get_text_by_NID(subj, NID_commonName, cn,
+			(int)cn_cap);
+	}
+
+	sans = X509_get_ext_d2i(cert, NID_subject_alt_name, NULL, NULL);
+	if (sans == NULL)
+		return 0;
+	n = sk_GENERAL_NAME_num(sans);
+	for (i = 0; i < n; i++) {
+		GENERAL_NAME *gn = sk_GENERAL_NAME_value(sans, i);
+		ASN1_STRING *uri;
+		const char *s;
+		const char *prefix = "retrace:scope:";
+
+		if (gn == NULL || gn->type != GEN_URI)
+			continue;
+		uri = gn->d.uniformResourceIdentifier;
+		if (uri == NULL)
+			continue;
+		s = (const char *)ASN1_STRING_get0_data(uri);
+		if (s == NULL)
+			continue;
+		if (strncmp(s, prefix, strlen(prefix)) != 0)
+			continue;
+		scopes = retraced_tls_parse_scopes(s + strlen(prefix));
+		break;
+	}
+	GENERAL_NAMES_free(sans);
+	return scopes;
+}
+
+static void *handshake(struct retraced_tls_ctx *ctx, int fd, int server,
+	struct retraced_tls_peer *peer)
+{
+	SSL *ssl;
+	X509 *cert;
+	int rc;
+
+	if (ctx == NULL || ctx->ctx == NULL)
+		return NULL;
+	ssl = SSL_new(ctx->ctx);
+	if (ssl == NULL)
+		return NULL;
+	if (SSL_set_fd(ssl, fd) != 1) {
+		SSL_free(ssl);
+		return NULL;
+	}
+	rc = server ? SSL_accept(ssl) : SSL_connect(ssl);
+	if (rc != 1) {
+		SSL_free(ssl);
+		return NULL;
+	}
+	cert = SSL_get_peer_certificate(ssl);
+	if (cert == NULL) {
+		SSL_free(ssl);
+		return NULL;
+	}
+	if (peer != NULL) {
+		memset(peer, 0, sizeof(*peer));
+		peer->scopes = peer_scopes_from_cert(cert, peer->cn,
+			sizeof(peer->cn));
+	}
+	X509_free(cert);
+	/* fail-closed: a cert without claim scopes is refused */
+	if (peer != NULL && peer->scopes == 0) {
+		SSL_free(ssl);
+		return NULL;
+	}
+	return ssl;
+}
+
+void *retraced_tls_accept(struct retraced_tls_ctx *ctx, int fd,
+	struct retraced_tls_peer *peer)
+{
+	return handshake(ctx, fd, 1, peer);
+}
+
+void *retraced_tls_connect(struct retraced_tls_ctx *ctx, int fd,
+	struct retraced_tls_peer *peer)
+{
+	return handshake(ctx, fd, 0, peer);
+}
+
+void retraced_tls_ssl_free(void *ssl)
+{
+	if (ssl != NULL)
+		SSL_free((SSL *)ssl);
+}
+
+int retraced_tls_read(void *ssl, void *buf, int n)
+{
+	int r;
+
+	if (ssl == NULL)
+		return -1;
+	r = SSL_read((SSL *)ssl, buf, n);
+	return r;
+}
+
+int retraced_tls_write(void *ssl, const void *buf, int n)
+{
+	int r;
+
+	if (ssl == NULL)
+		return -1;
+	r = SSL_write((SSL *)ssl, buf, n);
+	return r;
+}
+
+#endif /* RETRACED_HAVE_OPENSSL */

--- a/tools/retraced/tls_gate.c
+++ b/tools/retraced/tls_gate.c
@@ -379,8 +379,14 @@ static void *handshake(struct retraced_tls_ctx *ctx, int fd, int server,
 			sizeof(peer->cn));
 	}
 	X509_free(cert);
-	/* fail-closed: a cert without claim scopes is refused */
-	if (peer != NULL && peer->scopes == 0) {
+	/*
+	 * Fail-closed on the SERVER side only: a controller cert
+	 * without claim scopes is refused. The client side talks
+	 * to a daemon cert that carries DNS/IP SANs, not scopes --
+	 * requiring scopes there would make every fleet connection
+	 * fail.
+	 */
+	if (server && peer != NULL && peer->scopes == 0) {
 		SSL_free(ssl);
 		return NULL;
 	}

--- a/tools/retraced/tls_gate.h
+++ b/tools/retraced/tls_gate.h
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+/*
+ * TLS fleet transport (TODO.supervisor/08 P1 / TODO.beyond-libc/05):
+ * TLS 1.3 only, mutual auth, claim scopes from the peer cert.
+ * No plaintext remote mode, ever. Local UDS ctl stays PEERCRED.
+ *
+ * Claim encoding (the peer cert URI SAN):
+ *   URI:retrace:scope:status+ps+policy+kill
+ * ('+' not ',' -- OpenSSL's SAN grammar splits on comma.)
+ * Missing/empty URI SAN = refuse (fail-closed remote).
+ */
+
+#ifndef RETRACE_TOOLS_RETRACED_TLS_GATE_H_
+#define RETRACE_TOOLS_RETRACED_TLS_GATE_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+/* command scopes -- least privilege by construction */
+#define RETRACED_SCOPE_STATUS  (1u << 0)  /* status */
+#define RETRACED_SCOPE_PS      (1u << 1)  /* ps */
+#define RETRACED_SCOPE_POLICY  (1u << 2)  /* policy_push, freeze, thaw */
+#define RETRACED_SCOPE_KILL    (1u << 3)  /* kill */
+#define RETRACED_SCOPE_SPAWN   (1u << 4)  /* spawn (future) */
+#define RETRACED_SCOPE_ALL \
+	(RETRACED_SCOPE_STATUS | RETRACED_SCOPE_PS | \
+	 RETRACED_SCOPE_POLICY | RETRACED_SCOPE_KILL | \
+	 RETRACED_SCOPE_SPAWN)
+
+struct retraced_tls_peer {
+	char cn[256];
+	uint32_t scopes;
+};
+
+/* opaque; NULL when OpenSSL is unavailable or not configured */
+struct retraced_tls_ctx;
+
+/*
+ * Build a server context. cert/key are the daemon's identity;
+ * ca is the trust anchor that must sign controller certs.
+ * Returns NULL on any load/config failure (caller must not
+ * open a plaintext TCP fallback -- that is the doctrine).
+ */
+struct retraced_tls_ctx *retraced_tls_server_new(const char *cert,
+	const char *key, const char *ca);
+
+/*
+ * Build a client context (retrace-ctl --tls). cert/key are the
+ * controller identity; ca trusts the daemon.
+ */
+struct retraced_tls_ctx *retraced_tls_client_new(const char *cert,
+	const char *key, const char *ca);
+
+void retraced_tls_free(struct retraced_tls_ctx *ctx);
+
+/* 1 if this build was linked with OpenSSL and ctx is live */
+int retraced_tls_available(void);
+
+/*
+ * Accept + handshake on an already-accepted TCP fd. On success
+ * returns an opaque SSL* handle (cast to void*) and fills peer;
+ * the caller owns the fd and must close it after ssl_free.
+ * On failure returns NULL (fd still open; caller closes).
+ */
+void *retraced_tls_accept(struct retraced_tls_ctx *ctx, int fd,
+	struct retraced_tls_peer *peer);
+
+void *retraced_tls_connect(struct retraced_tls_ctx *ctx, int fd,
+	struct retraced_tls_peer *peer);
+
+void retraced_tls_ssl_free(void *ssl);
+
+/* BIO-style I/O over the SSL; returns bytes or <=0 on error/EOF */
+int retraced_tls_read(void *ssl, void *buf, int n);
+int retraced_tls_write(void *ssl, const void *buf, int n);
+
+/* parse "status,ps,policy,kill" into a bitmask (test helper too) */
+uint32_t retraced_tls_parse_scopes(const char *csv);
+
+/* map a ctl cmd name onto the required scope bit; 0 = unknown */
+uint32_t retraced_tls_scope_for_cmd(const char *cmd);
+
+/* bind+listen a TCP socket on host:port (host may be NULL = any) */
+int retraced_tls_listen(const char *hostport);
+
+#endif /* RETRACE_TOOLS_RETRACED_TLS_GATE_H_ */


### PR DESCRIPTION
## Summary
- TLS fleet transport (TODO.supervisor/08 P1 / TODO.beyond-libc/05): opt-in `--tls-listen/--tls-cert/--tls-key/--tls-ca` on `retraced`.
- `retrace-ctl` now has the client side: `--tls-host H:P --tls-cert C --tls-key K --tls-ca CA`.
- TLS 1.3 only, mutual auth required. No plaintext remote mode — partial flag sets are a hard error.
- Controller cert URI SAN carries claim scopes: `URI:retrace:scope:status+ps+policy+kill` (`+` not `,` — OpenSSL SAN grammar).
- Every ctl command checks the peer's scope bitmask; overscope → `{"error":"scope denied"}` + `retrace.auth.overscope` journal event.
- Local UDS ctl keeps `RETRACED_SCOPE_ALL` (PEERCRED already gated).
- New seam: `tools/retraced/tls_gate.c` (OpenSSL optional via `RETRACED_HAVE_OPENSSL`).

## Depends on
- PR #721 (live drift grading) — this branch is stacked on it because both touch `tools/retraced/main.c`. Rebase after #721 merges.

## Test plan
- [x] `test_retraced_ctl` unit: new `scope_denied` case + all prior green
- [x] `test_tls_fleet.py`: full-scope status ok; status-only freeze denied; plaintext refused; auth/overscope journaled
- [x] `retrace-ctl --tls-host ... status` local smoke ok; status-only `freeze` returns scope denied
- [x] `test_ebpf_agent.py` still green (drift summary)
- [ ] CI integration-tls-fleet + unit-test-retraced_ctl
