### PR TITLE
jretrace: the JVM runtime agent (04 P1) + wire the orphaned pyretrace test

### DIFF
--- a/bindings/jvm/README.md
+++ b/bindings/jvm/README.md
@@ -1,0 +1,9 @@
+# jretrace — JVM runtime agent
+
+Pure-Java supervisor protocol client for TODO.beyond-libc/04 P1.
+It speaks RTRD framing over Unix domain sockets and emits
+`source=runtime` events (`jvm.file.read`, `jvm.socket.create`, direct
+`emit(...)`) into the same retraced journal as libc/kernel/Python lanes.
+
+This is intentionally dependency-free: Java 16+ for Unix domain sockets,
+no JNI, no external JSON library.

--- a/bindings/jvm/src/main/java/org/retrace/runtime/JRetrace.java
+++ b/bindings/jvm/src/main/java/org/retrace/runtime/JRetrace.java
@@ -1,0 +1,324 @@
+package org.retrace.runtime;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.net.StandardProtocolFamily;
+import java.net.UnixDomainSocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.SocketChannel;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * jretrace -- the JVM runtime agent (TODO.beyond-libc/04 P1).
+ *
+ * A pure-Java implementation of the retrace supervisor protocol:
+ * RTRD framing over UDS, HELLO/HEARTBEAT/EVENT/BYE, source=runtime.
+ * It is intentionally tiny so JVM services can embed it without a
+ * native dependency; the second runtime proves the supervisor seam.
+ */
+public final class JRetrace implements Closeable {
+    private static final byte[] MAGIC = new byte[] {'R', 'T', 'R', 'D'};
+    private static final int HELLO = 1;
+    private static final int HEARTBEAT = 2;
+    private static final int EVENT = 4;
+    private static final int BYE = 6;
+    private static final int WELCOME = 16;
+
+    private final SocketChannel channel;
+    private final String agentId;
+    private final AtomicLong seq = new AtomicLong();
+    private final AtomicBoolean stop = new AtomicBoolean();
+    private final Thread heartbeat;
+
+    private JRetrace(SocketChannel channel, String agentId) {
+        this.channel = channel;
+        this.agentId = agentId;
+        this.heartbeat = new Thread(this::heartbeatLoop, "jretrace-heartbeat");
+        this.heartbeat.setDaemon(true);
+        this.heartbeat.start();
+    }
+
+    public static JRetrace supervise() throws IOException {
+        if (!"1".equals(System.getenv("RETRACE_SUPERVISOR"))) {
+            return null;
+        }
+        String sock = System.getenv("RETRACE_SUPERVISOR_SOCK");
+        if (sock == null || sock.isEmpty()) {
+            return null;
+        }
+        String nonce = System.getenv("RETRACE_SUPERVISOR_NONCE");
+        if (nonce == null) {
+            nonce = "";
+        }
+        SocketChannel ch = SocketChannel.open(StandardProtocolFamily.UNIX);
+        ch.connect(UnixDomainSocketAddress.of(sock));
+        long pid = ProcessHandle.current().pid();
+        long ppid = ProcessHandle.current().parent()
+            .map(ProcessHandle::pid).orElse(0L);
+        Map<String, String> hello = new LinkedHashMap<>();
+        hello.put("session_token", getenv("RETRACE_SESSION"));
+        hello.put("nonce", nonce);
+        hello.put("pid", Long.toString(pid));
+        hello.put("ppid", Long.toString(ppid));
+        hello.put("boot_id", "jvmruntime");
+        hello.put("cmdline", System.getProperty("sun.java.command", "java"));
+        hello.put("retrace_version", "jretrace-1");
+        writeFrame(ch, HELLO, jsonObject(hello));
+        Frame welcome = readFrame(ch);
+        if (welcome.mid != WELCOME) {
+            ch.close();
+            throw new IOException("expected WELCOME, got " + welcome.mid);
+        }
+        String agent = jsonString(welcome.payload, "agent_id");
+        if (agent == null || agent.isEmpty()) {
+            agent = "pending";
+        }
+        ch.configureBlocking(false);
+        drainPolicy(ch);
+        ch.configureBlocking(true);
+        return new JRetrace(ch, agent);
+    }
+
+    public void emit(String name, Map<String, String> attrs) throws IOException {
+        long next = seq.incrementAndGet();
+        Map<String, String> root = new LinkedHashMap<>();
+        root.put("agent_id", agentId);
+        root.put("seq", Long.toString(next));
+        root.put("ts", Long.toString(Instant.now().getEpochSecond()));
+        root.put("name", name);
+        root.put("source", "runtime");
+        synchronized (channel) {
+            writeFrame(channel, EVENT, eventJson(root, attrs));
+        }
+    }
+
+    public void fileRead(String path) throws IOException {
+        Map<String, String> attrs = new LinkedHashMap<>();
+        attrs.put("path", path);
+        emit("jvm.file.read", attrs);
+    }
+
+    public void socketCreate(String family) throws IOException {
+        Map<String, String> attrs = new LinkedHashMap<>();
+        attrs.put("family", family);
+        emit("jvm.socket.create", attrs);
+    }
+
+    @Override
+    public void close() throws IOException {
+        stop.set(true);
+        try {
+            heartbeat.join(1500);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        synchronized (channel) {
+            writeFrame(channel, BYE, "{\"agent_id\":\"" + esc(agentId) + "\"}");
+            channel.close();
+        }
+    }
+
+    private void heartbeatLoop() {
+        while (!stop.get()) {
+            try {
+                Thread.sleep(1000L);
+                synchronized (channel) {
+                    writeFrame(channel, HEARTBEAT,
+                        "{\"agent_id\":\"" + esc(agentId) +
+                        "\",\"seq\":" + seq.get() + "}");
+                }
+            } catch (IOException e) {
+                stop.set(true);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                stop.set(true);
+            }
+        }
+    }
+
+    private static void drainPolicy(SocketChannel ch) throws IOException {
+        ByteBuffer hdr = ByteBuffer.allocate(12).order(ByteOrder.LITTLE_ENDIAN);
+        int n = ch.read(hdr);
+        if (n <= 0) {
+            return;
+        }
+        while (hdr.hasRemaining()) {
+            n = ch.read(hdr);
+            if (n <= 0) {
+                return;
+            }
+        }
+        hdr.flip();
+        hdr.position(8);
+        int len = hdr.getInt();
+        ByteBuffer body = ByteBuffer.allocate(Math.max(0, len));
+        while (body.hasRemaining() && ch.read(body) > 0) {
+            // drain only
+        }
+    }
+
+    private static void writeFrame(SocketChannel ch, int mid, String payload)
+        throws IOException {
+        byte[] b = payload.getBytes(StandardCharsets.UTF_8);
+        ByteBuffer buf = ByteBuffer.allocate(12 + b.length)
+            .order(ByteOrder.LITTLE_ENDIAN);
+        buf.put(MAGIC);
+        buf.putShort((short)1);
+        buf.putShort((short)mid);
+        buf.putInt(b.length);
+        buf.put(b);
+        buf.flip();
+        while (buf.hasRemaining()) {
+            ch.write(buf);
+        }
+    }
+
+    private static Frame readFrame(SocketChannel ch) throws IOException {
+        ByteBuffer hdr = ByteBuffer.allocate(12).order(ByteOrder.LITTLE_ENDIAN);
+        while (hdr.hasRemaining()) {
+            if (ch.read(hdr) < 0) {
+                throw new IOException("eof");
+            }
+        }
+        hdr.flip();
+        byte[] magic = new byte[4];
+        hdr.get(magic);
+        if (magic[0] != 'R' || magic[1] != 'T' || magic[2] != 'R' ||
+            magic[3] != 'D') {
+            throw new IOException("bad magic");
+        }
+        hdr.getShort();
+        int mid = Short.toUnsignedInt(hdr.getShort());
+        int len = hdr.getInt();
+        ByteBuffer body = ByteBuffer.allocate(len);
+        while (body.hasRemaining()) {
+            if (ch.read(body) < 0) {
+                throw new IOException("eof");
+            }
+        }
+        body.flip();
+        return new Frame(mid,
+            StandardCharsets.UTF_8.decode(body).toString());
+    }
+
+    private static String jsonObject(Map<String, String> vals) {
+        StringBuilder sb = new StringBuilder("{");
+        boolean first = true;
+        for (Map.Entry<String, String> e : vals.entrySet()) {
+            if (!first) {
+                sb.append(',');
+            }
+            first = false;
+            sb.append('"').append(esc(e.getKey())).append("\":");
+            if (isNumber(e.getValue())) {
+                sb.append(e.getValue());
+            } else {
+                sb.append('"').append(esc(e.getValue())).append('"');
+            }
+        }
+        sb.append('}');
+        return sb.toString();
+    }
+
+    private static String eventJson(Map<String, String> root,
+        Map<String, String> attrs) {
+        StringBuilder sb = new StringBuilder(jsonObject(root));
+        int insert = sb.length() - 1;
+        StringBuilder a = new StringBuilder(",\"attrs\":{");
+        boolean first = true;
+        if (attrs != null) {
+            for (Map.Entry<String, String> e : attrs.entrySet()) {
+                if (!first) {
+                    a.append(',');
+                }
+                first = false;
+                a.append('"').append(esc(e.getKey())).append("\":\"")
+                    .append(esc(e.getValue())).append('"');
+            }
+        }
+        a.append('}');
+        sb.insert(insert, a);
+        return sb.toString();
+    }
+
+    private static boolean isNumber(String s) {
+        if (s == null || s.isEmpty()) {
+            return false;
+        }
+        for (int i = 0; i < s.length(); i++) {
+            if (!Character.isDigit(s.charAt(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static String getenv(String k) {
+        String v = System.getenv(k);
+        return v == null ? "" : v;
+    }
+
+    private static String jsonString(String json, String key) {
+        String needle = "\"" + key + "\":\"";
+        int i = json.indexOf(needle);
+        if (i < 0) {
+            return null;
+        }
+        i += needle.length();
+        StringBuilder out = new StringBuilder();
+        while (i < json.length()) {
+            char c = json.charAt(i++);
+            if (c == '"') {
+                return out.toString();
+            }
+            if (c == '\\' && i < json.length()) {
+                out.append(json.charAt(i++));
+            } else {
+                out.append(c);
+            }
+        }
+        return null;
+    }
+
+    private static String esc(String s) {
+        if (s == null) {
+            return "";
+        }
+        StringBuilder out = new StringBuilder();
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            switch (c) {
+            case '\\':
+                out.append("\\\\");
+                break;
+            case '"':
+                out.append("\\\"");
+                break;
+            case '\n':
+                out.append("\\n");
+                break;
+            case '\r':
+                out.append("\\r");
+                break;
+            case '\t':
+                out.append("\\t");
+                break;
+            default:
+                if (c < 0x20) {
+                    out.append(String.format("\\u%04x", (int)c));
+                } else {
+                    out.append(c);
+                }
+            }
+        }
+        return out.toString();
+    }
+
+    private record Frame(int mid, String payload) {}
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -204,6 +204,28 @@ if(Python3_Interpreter_FOUND)
 		set_tests_properties(integration-ebpf-agent
 			PROPERTIES LABELS "integration"
 			TIMEOUT 120)
+
+		# Runtime agents (TODO.beyond-libc/04): pyretrace
+		# (Python) and jretrace (JVM, P1) as full peers on the
+		# same session. jretrace self-skips where no JDK is
+		# present; both assert source=runtime events land in
+		# the shared journal.
+		add_test(NAME integration-pyretrace
+			COMMAND ${Python3_EXECUTABLE}
+				${CMAKE_SOURCE_DIR}/test/integration/test_pyretrace.py
+				$<TARGET_FILE:retrace_retraced>
+				${CMAKE_SOURCE_DIR}/bindings/python)
+		set_tests_properties(integration-pyretrace
+			PROPERTIES LABELS "integration"
+			TIMEOUT 120)
+		add_test(NAME integration-jretrace
+			COMMAND ${Python3_EXECUTABLE}
+				${CMAKE_SOURCE_DIR}/test/integration/test_jretrace.py
+				$<TARGET_FILE:retrace_retraced>
+				${CMAKE_SOURCE_DIR}/bindings/jvm/src/main/java)
+		set_tests_properties(integration-jretrace
+			PROPERTIES LABELS "integration"
+			TIMEOUT 120)
 	endif()
 
 	# Kernel enforcement compile (TODO.beyond-libc/01):

--- a/test/integration/test_jretrace.py
+++ b/test/integration/test_jretrace.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""
+E2E: jretrace, the JVM runtime agent (TODO.beyond-libc/04 P1).
+
+This is the second runtime adapter after pyretrace, proving the
+runtime-agent seam: a non-C, non-Python implementation speaks the
+same RTRD supervisor protocol and lands source=runtime events in the
+same hash-chained journal.
+
+Usage: test_jretrace.py <retraced> <java-source-root>
+"""
+import json
+import os
+import signal
+import subprocess
+import sys
+import tempfile
+import textwrap
+import time
+
+
+CHILD = r"""
+import java.util.Map;
+import org.retrace.runtime.JRetrace;
+
+public class JRetraceSmoke {
+    public static void main(String[] args) throws Exception {
+        try (JRetrace rt = JRetrace.supervise()) {
+            if (rt == null) {
+                System.err.println("NO-OP (env absent) is wrong here");
+                System.exit(3);
+            }
+            rt.fileRead(args[0]);
+            rt.socketCreate("inet");
+            rt.emit("jvm.test.marker", Map.of("kind", "direct"));
+            Thread.sleep(1200L);
+        }
+    }
+}
+"""
+
+
+def wait_sock(path, deadline=5.0):
+    end = time.time() + deadline
+    while time.time() < end:
+        if os.path.exists(path):
+            return True
+        time.sleep(0.1)
+    return False
+
+
+def journal_records(path):
+    recs = []
+    with open(path) as f:
+        for ln in f.read().splitlines():
+            try:
+                recs.append(json.loads(ln))
+            except json.JSONDecodeError:
+                pass
+    return recs
+
+
+def main():
+    if len(sys.argv) != 3:
+        print("usage: test_jretrace.py <retraced> <java-source-root>",
+              file=sys.stderr)
+        return 2
+    if subprocess.run(["java", "-version"], capture_output=True).returncode != 0:
+        print("SKIP: java unavailable", file=sys.stderr)
+        return 0
+    if subprocess.run(["javac", "-version"], capture_output=True).returncode != 0:
+        print("SKIP: javac unavailable", file=sys.stderr)
+        return 0
+
+    daemon, srcroot = (os.path.abspath(p) for p in sys.argv[1:3])
+    work = tempfile.mkdtemp(prefix="jrt-")
+    sock = os.path.join(work, "agent.sock")
+    journal = os.path.join(work, "journal.jsonl")
+    nonce_file = os.path.join(work, "nonce.txt")
+    sentinel = os.path.join(work, "sentinel.txt")
+    classes = os.path.join(work, "classes")
+    child_java = os.path.join(work, "JRetraceSmoke.java")
+    os.mkdir(classes)
+    with open(sentinel, "w") as f:
+        f.write("jvm\n")
+    with open(child_java, "w") as f:
+        f.write(CHILD)
+
+    javac = subprocess.run(
+        ["javac", "-d", classes,
+         os.path.join(srcroot, "org/retrace/runtime/JRetrace.java"),
+         child_java],
+        capture_output=True, text=True, timeout=30)
+    if javac.returncode != 0:
+        print(f"FAIL: javac rc={javac.returncode}: {javac.stderr[:400]}",
+              file=sys.stderr)
+        return 1
+
+    d = subprocess.Popen(
+        [daemon, "--sock", sock, "--journal", journal,
+         "--nonce-file", nonce_file],
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    try:
+        if not wait_sock(sock):
+            print("FAIL: daemon never listened", file=sys.stderr)
+            return 1
+        with open(nonce_file) as f:
+            nonce = f.read().strip()
+
+        env = dict(os.environ)
+        env.update({
+            "RETRACE_SUPERVISOR": "1",
+            "RETRACE_SUPERVISOR_SOCK": sock,
+            "RETRACE_SUPERVISOR_NONCE": nonce,
+        })
+        child = subprocess.run(
+            ["java", "-cp", classes, "JRetraceSmoke", sentinel],
+            env=env, capture_output=True, text=True, timeout=30)
+        if child.returncode != 0:
+            print(f"FAIL: child rc={child.returncode}: "
+                  f"{child.stderr[:400]}", file=sys.stderr)
+            return 1
+
+        d.send_signal(signal.SIGTERM)
+        try:
+            d.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            d.kill()
+
+        recs = journal_records(journal)
+        names = [r.get("ev", {}).get("name") for r in recs]
+        for want, label in (
+                ("jvm.file.read", "the JVM file read"),
+                ("jvm.socket.create", "the JVM socket creation"),
+                ("jvm.test.marker", "the direct JVM emit")):
+            if want not in names:
+                print(f"FAIL: {label} not journaled: {names}",
+                      file=sys.stderr)
+                return 1
+        auth = [r for r in recs if r.get("ev", {}).get("name") ==
+                "retrace.auth.agent"]
+        if not auth or auth[-1]["ev"].get("role") != "full":
+            print(f"FAIL: JVM runtime agent not full role: {auth}",
+                  file=sys.stderr)
+            return 1
+
+        print("jretrace: file read + socket + direct emit journaled; "
+              "JVM runtime agent a full peer -- OK")
+        return 0
+    finally:
+        if d.poll() is None:
+            d.send_signal(signal.SIGTERM)
+            try:
+                d.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                d.kill()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/integration/test_jretrace.py
+++ b/test/integration/test_jretrace.py
@@ -11,6 +11,7 @@ Usage: test_jretrace.py <retraced> <java-source-root>
 """
 import json
 import os
+import re
 import signal
 import subprocess
 import sys
@@ -60,16 +61,37 @@ def journal_records(path):
     return recs
 
 
+def jdk_ok():
+    """A usable JDK is one with the UDS API (Java 16+): on
+    runners without java the exec itself raises FileNotFoundError
+    (which used to crash the test instead of skipping), and older
+    default JDKs (11) cannot compile UnixDomainSocketAddress."""
+    for tool, args in (("java", ["-version"]),
+                       ("javac", ["-version"])):
+        try:
+            r = subprocess.run([tool] + args, capture_output=True,
+                               text=True, timeout=15)
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            return False
+        if r.returncode != 0:
+            return False
+        # java: 'openjdk version "17.0.2"'; javac: 'javac 21.0.2';
+        # legacy: 'java version "1.8.0_382"' (1 < 16 -> skip)
+        blob = (r.stderr or "") + (r.stdout or "")
+        m = (re.search(r'version\s+"(\d+)', blob) or
+             re.search(r'javac\s+(\d+)', blob))
+        if not m or int(m.group(1)) < 16:
+            return False
+    return True
+
+
 def main():
     if len(sys.argv) != 3:
         print("usage: test_jretrace.py <retraced> <java-source-root>",
               file=sys.stderr)
         return 2
-    if subprocess.run(["java", "-version"], capture_output=True).returncode != 0:
-        print("SKIP: java unavailable", file=sys.stderr)
-        return 0
-    if subprocess.run(["javac", "-version"], capture_output=True).returncode != 0:
-        print("SKIP: javac unavailable", file=sys.stderr)
+    if not jdk_ok():
+        print("SKIP: no JDK 16+ on PATH", file=sys.stderr)
         return 0
 
     daemon, srcroot = (os.path.abspath(p) for p in sys.argv[1:3])


### PR DESCRIPTION
## Summary
- **jretrace** (TODO.beyond-libc/04 P1): the JVM runtime agent — a dependency-free Java 16+ implementation of the supervisor protocol (RTRD framing over UDS, HELLO/WELCOME/HEARTBEAT/EVENT/BYE, `source=runtime`). Second runtime adapter after pyretrace: one adapter was a hypothetical seam, two make it real.
- Emits `jvm.file.read`, `jvm.socket.create`, and direct `emit()` events into the same hash-chained journal, same session, full peer role (nonce from `RETRACE_SUPERVISOR_NONCE`).
- **Fixes a dead test**: `test_pyretrace.py` existed on disk since the pyretrace merge but was never registered in CTest — CI never ran it. Now registered alongside the new `integration-jretrace` (which self-skips where no JDK is installed).

## Test plan
- [x] Local: `integration-ebpf-agent`, `integration-pyretrace`, `integration-jretrace` all green under one ctest run
- [x] jretrace asserts: file read + socket + direct emit journaled; JVM agent seated as full peer
- [ ] CI matrix (Linux legs have JDK; jretrace skips cleanly elsewhere)
