### PR TITLE
enforce: audited enforcement artifacts -- the in-force chain (01 P2)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,7 @@ install, quick start, and platform support.
 | Trace an Android app via `wrap.sh` or Magisk | [Android guide](android.md) |
 | Understand a design decision | [Architecture decisions (ADR)](adr/README.md) |
 | Read the public API | [`include/retrace/`](../include/retrace/) |
+| Write a runtime agent (Python, JVM, any language) | [Runtime agents](runtime-agents.md) — the supervisor protocol for third-party agents |
 
 ## Documentation map
 
@@ -38,6 +39,7 @@ docs/
 ├── tools.md               ← standalone tooling ecosystem (audit, diff, replay, ws, frida, ebpf, ide plugins)
 ├── development.md         ← building, testing, contributing, debugging retrace
 ├── architecture.md        ← how engine, backends, and actions fit together
+├── runtime-agents.md      ← writing a supervisor runtime agent (protocol, doctrine)
 ├── engine-state-machine.md ← per-call lifecycle (engine_wrapper flow)
 ├── cookbook/              ← 32 recipe-driven walkthroughs
 │   ├── README.md          ← index + compact action reference

--- a/docs/runtime-agents.md
+++ b/docs/runtime-agents.md
@@ -1,0 +1,105 @@
+# Writing a retrace runtime agent
+
+A *runtime agent* attributes runtime-internal semantics onto a retrace
+supervisor session: which module opened the file, which line issued the
+connect — the layer a libc interposer sees only as "an open from pid
+N". Two reference implementations ship in this tree:
+
+- **pyretrace** (`bindings/python/pyretrace.py`) — Python, `sys.audit`
+  hooks. ~190 lines, no dependencies.
+- **jretrace** (`bindings/jvm/src/main/java/org/retrace/runtime/JRetrace.java`)
+  — Java 16+, `java.net.UnixDomainSocketAddress`. No JNI, no external
+  libraries.
+
+Both are accepted by the protocol conformance suite
+(`test/conformance/`) unchanged — that suite is the acceptance test for
+any third-party agent.
+
+## The contract
+
+### Activation: the environment
+
+The spawn environment carries everything the agent needs; with the env
+absent, `supervise()` is a no-op (zero-mandatory-config):
+
+| Variable | Meaning |
+|----------|---------|
+| `RETRACE_SUPERVISOR=1` | opt-in gate; absent ⇒ no-op |
+| `RETRACE_SUPERVISOR_SOCK` | the daemon's agent socket path |
+| `RETRACE_SUPERVISOR_NONCE` | the channel nonce (full role) |
+| `RETRACE_SESSION` | session token (optional) |
+
+The nonce arrives out-of-band from the spawner (`retraced
+--nonce-file`). Presenting it in HELLO seats the agent as a **full**
+peer; omitting it seats a **spectator** — evidence flows, policy and
+commands never do. That is not a failure mode: kernel-observation
+agents (eBPF, ETW) deliberately HELLO without the nonce.
+
+### Transport: RTRD framing over UDS
+
+Little-endian 12-byte header + JSON payload:
+
+```
+"RTRD" | uint16 version (=1) | uint16 type | uint32 payload_len
+```
+
+Message ids (single source of truth: `src/supervisor/protocol.h`;
+the conformance suite greps that block — these values are frozen):
+
+| id | Message | Direction |
+|----|---------|-----------|
+| 1 | HELLO | agent → daemon |
+| 2 | HEARTBEAT | agent → daemon |
+| 3 | POLICY_ACK | agent → daemon |
+| 4 | EVENT | agent → daemon |
+| 5 | RING_DATA | agent → daemon |
+| 6 | BYE | agent → daemon |
+| 16 | WELCOME | daemon → agent |
+| 17 | POLICY_SET | daemon → agent |
+| 18 | CMD | daemon → agent |
+| 19 | PING | daemon → agent |
+
+### The conversation
+
+1. Connect, send **HELLO** (pid, ppid, cmdline, nonce, boot id).
+2. Read **WELCOME** — it carries your `agent_id`; quote it in every
+   later message.
+3. A **POLICY_SET** may follow immediately. An observer reads and
+   drops it; a preload-policy consumer applies it and answers
+   **POLICY_ACK** with the epoch.
+4. Send **HEARTBEAT** (agent_id, last seq) about once a second; the
+   daemon sweeps stale agents after ~15 s.
+5. Send **EVENT** on activity: `{"agent_id", "seq" (monotonic),
+   "ts", "name", "attrs", "source"}`. Set `"source"` to your lane —
+   `"libc"`, `"kernel"`, or `"runtime"` — so the journal keeps the
+   lanes distinct.
+6. On shutdown send **BYE**.
+
+Event names are dotted: the Python agent emits `py.file.read`,
+`py.socket.create`; the JVM agent `jvm.file.read`,
+`jvm.socket.create`; the kernel agents `kernel.syscall.observe`.
+
+## Doctrine (the two rules that are not negotiable)
+
+1. **Never block or crash the host process.** The agent thread is a
+   daemon; a dead supervisor means "no control channel," nothing more.
+2. **Observers ride as spectators.** If your agent cannot honor the
+   POLICY_SET discipline (journal-chain acks, epochs), HELLO without
+   the nonce deliberately. Evidence always; policy never.
+
+## Testing your agent
+
+- Point `RETRACE_SUPERVISOR_SOCK` at a `retraced` started with
+  `--nonce-file`, run your workload, stop the daemon (SIGTERM), and
+  read the journal JSONL: your events must appear with your `source`
+  lane, and `retrace.auth.agent` must show the role you intended.
+- The integration tests `test_pyretrace.py` / `test_jretrace.py` show
+  the full pattern in ~120 lines each.
+
+## Beyond UDS: other lanes
+
+Kernel-observation agents (`retrace-ebpf-agent`,
+`retrace-etw-agent`) speak the same framing as spectators with
+`source: kernel`. The Windows named-pipe transport
+(TODO.supervisor/12) carries the same protocol; until it lands, the
+ETW lane rides the `etw2retrace` loader path.

--- a/etw-bridge/retrace-etw-agent
+++ b/etw-bridge/retrace-etw-agent
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# retrace-etw-agent (TODO.beyond-libc/03 P1): the Windows
+# kernel-observation agent. Same doctrine as the eBPF lane:
+# an OBSERVER -- HELLO without the nonce deliberately, seated
+# as a spectator (evidence ALWAYS, policy NEVER) -- feeding
+# kernel-source events into the supervisor's journal so one
+# session shows the libc CLAIMS and the kernel TRUTH.
+#
+# Sources:
+#   --synthetic     emit demonstration kernel events (no Windows
+#                   needed; the CI path and the protocol proof)
+#   --loader PATH   wrap etw2retrace: its retrace JSON stdout
+#                   lines become kernel events. The full Windows
+#                   chain is: pwsh scripts/win/etw-capture.ps1
+#                   -> etw2retrace -> this agent. (The native
+#                   named-pipe transport rides TODO.supervisor/12;
+#                   until then the loader path carries the lane.)
+#
+# Usage:
+#   retrace-etw-agent --sock /run/retraced/agent.sock [--synthetic]
+#   retrace-etw-agent --sock ... --loader ./etw2retrace -- args...
+
+import argparse
+import json
+import os
+import signal
+import socket
+import struct
+import subprocess
+import sys
+import threading
+import time
+
+MAGIC = b"RTRD"
+HELLO, HEARTBEAT, EVENT, BYE = 1, 2, 4, 6
+
+
+def frame(mid, payload):
+    b = payload.encode()
+    return MAGIC + struct.pack("<HHI", 1, mid, len(b)) + b
+
+
+class Agent:
+    def __init__(self, sock_path):
+        self.sock_path = sock_path
+        self.s = None
+        self.agent_id = "pending"
+        self.seq = 0
+        self.stop = False
+
+    def connect(self):
+        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        s.connect(self.sock_path)
+        # HELLO without a nonce: the spectator seat, on purpose
+        s.sendall(frame(HELLO, json.dumps({
+            "session_token": "", "nonce": "",
+            "pid": os.getpid(), "ppid": os.getppid(),
+            "boot_id": "kernel", "cmdline": "retrace-etw-agent",
+            "retrace_version": "etw-agent-1"})))
+        hdr = b""
+        while len(hdr) < 12:
+            hdr += s.recv(12 - len(hdr))
+        _, _, mid, ln = struct.unpack("<4sHHI", hdr)
+        body = b""
+        while len(body) < ln:
+            body += s.recv(ln - len(body))
+        if mid != 16:
+            raise RuntimeError(f"expected WELCOME, got {mid}")
+        self.welcome = json.loads(body)
+        if self.welcome.get("role") != "spectator":
+            sys.stderr.write(
+                "retrace-etw-agent: WARNING daemon seated us as "
+                f"{self.welcome.get('role')}; the doctrine says "
+                "observers ride as spectators\n")
+        self.agent_id = self.welcome.get("agent_id", "pending")
+        self.s = s
+        # a POLICY_SET may follow; observers drop it
+        s.settimeout(0.2)
+        try:
+            hdr = s.recv(12)
+            if len(hdr) == 12:
+                _, _, m2, l2 = struct.unpack("<4sHHI", hdr)
+                while l2:
+                    b = s.recv(l2)
+                    l2 -= len(b)
+        except OSError:
+            pass
+        s.settimeout(None)
+
+    def emit(self, name, **attrs):
+        self.seq += 1
+        self.s.sendall(frame(EVENT, json.dumps({
+            "agent_id": self.agent_id, "seq": self.seq,
+            "ts": int(time.time()), "name": name,
+            "attrs": {k: str(v) for k, v in attrs.items()},
+            "source": "kernel"}, sort_keys=True)))
+
+    def heartbeat_loop(self):
+        while not self.stop:
+            time.sleep(1.0)
+            if self.s is None:
+                continue
+            try:
+                self.s.sendall(frame(HEARTBEAT, json.dumps(
+                    {"agent_id": self.agent_id,
+                     "seq": self.seq})))
+            except OSError:
+                return
+
+    def bye(self):
+        if self.s is None:
+            return
+        try:
+            self.s.sendall(frame(BYE, json.dumps(
+                {"agent_id": self.agent_id})))
+            self.s.close()
+        except OSError:
+            pass
+        self.s = None
+
+
+def run_synthetic(agent, n):
+    for i in range(n):
+        agent.emit("kernel.syscall.observe", syscall="NtCreateFile",
+                   sample=i, note="etw synthetic lane")
+        time.sleep(0.3)
+
+
+def run_loader(agent, loader, argv):
+    """Wrap etw2retrace: each retrace JSON entry it prints becomes
+    one kernel-source event."""
+    proc = subprocess.Popen([loader] + argv, stdout=subprocess.PIPE,
+        stderr=sys.stderr, text=True)
+    for line in proc.stdout:
+        line = line.strip()
+        if not line or line in ("[", "]"):
+            continue
+        entry = line.rstrip(",")
+        try:
+            doc = json.loads(entry)
+        except json.JSONDecodeError:
+            continue
+        msg = doc.get("message", {})
+        agent.emit("kernel.syscall.observe",
+            syscall=msg.get("func", "?"),
+            ret=msg.get("ret_val", ""),
+            ts=doc.get("time", ""))
+    proc.wait()
+
+
+def main():
+    ap = argparse.ArgumentParser(prog="retrace-etw-agent")
+    ap.add_argument("--sock", required=True)
+    ap.add_argument("--synthetic", action="store_true")
+    ap.add_argument("--samples", type=int, default=3)
+    ap.add_argument("--loader")
+    ap.add_argument("argv", nargs=argparse.REMAINDER)
+    args = ap.parse_args()
+
+    agent = Agent(args.sock)
+    try:
+        agent.connect()
+    except (OSError, RuntimeError) as e:
+        sys.stderr.write(f"retrace-etw-agent: {e}\n")
+        return 2
+    hb = threading.Thread(target=agent.heartbeat_loop, daemon=True)
+    hb.start()
+    try:
+        if args.synthetic:
+            run_synthetic(agent, args.samples)
+        elif args.loader:
+            run_loader(agent, args.loader, args.argv)
+        else:
+            ap.error("one of --synthetic or --loader is required")
+    finally:
+        agent.stop = True
+        time.sleep(0.2)
+        agent.bye()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -205,6 +205,21 @@ if(Python3_Interpreter_FOUND)
 			PROPERTIES LABELS "integration"
 			TIMEOUT 120)
 
+		# The ETW kernel-observation agent (TODO.beyond-libc/03 P1):
+		# the Windows lane as a spectator peer; --synthetic proves
+		# the pipe on POSIX CI (the --loader source carries the
+		# real Windows chain; pipes ride supervisor/12).
+		if(NOT WIN32)
+			add_test(NAME integration-etw-agent
+				COMMAND ${Python3_EXECUTABLE}
+					${CMAKE_SOURCE_DIR}/test/integration/test_etw_agent.py
+					$<TARGET_FILE:retrace_retraced>
+					${CMAKE_SOURCE_DIR}/etw-bridge/retrace-etw-agent)
+			set_tests_properties(integration-etw-agent
+				PROPERTIES LABELS "integration"
+				TIMEOUT 120)
+		endif()
+
 		# Runtime agents (TODO.beyond-libc/04): pyretrace
 		# (Python) and jretrace (JVM, P1) as full peers on the
 		# same session. jretrace self-skips where no JDK is

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -275,6 +275,18 @@ if(Python3_Interpreter_FOUND)
 	# Journal durability (the writer deepening): durable
 	# control-plane records, recorded gaps on unclean shutdown,
 	# clean-close markers, chain across boots.
+	# Socket activation + privilege drop (TODO.supervisor/08
+	# P2 / TODO.beyond-libc/05 P2): inherited listener served and
+	# not unlinked; the drop section runs where the runner is
+	# root (the Alpine container leg) and skips elsewhere.
+	add_test(NAME integration-retraced-fd
+		COMMAND ${Python3_EXECUTABLE}
+			${CMAKE_SOURCE_DIR}/test/integration/test_retraced_fd.py
+			$<TARGET_FILE:retrace_retraced>)
+	set_tests_properties(integration-retraced-fd PROPERTIES
+		LABELS "integration"
+		TIMEOUT 120)
+
 	add_test(NAME integration-journal-durability
 		COMMAND ${Python3_EXECUTABLE}
 			${CMAKE_SOURCE_DIR}/test/integration/test_journal_durability.py

--- a/test/integration/test_etw_agent.py
+++ b/test/integration/test_etw_agent.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""
+E2E: the ETW kernel-observation agent (TODO.beyond-libc/03 P1).
+
+The Windows sibling of the eBPF lane, proven the same way on CI:
+the --synthetic source joins the supervisor as a SPECTATOR
+(observer doctrine -- HELLO without the nonce deliberately) and
+its kernel-source events land in the same hash-chained journal as
+the libc lane, feeding the live drift grading. The --loader
+source (etw2retrace output) carries the real Windows lane; the
+native named-pipe transport rides TODO.supervisor/12.
+
+Usage: test_etw_agent.py <retraced> <agent-script>
+"""
+import json
+import os
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+
+
+def wait_sock(path, deadline=5.0):
+    end = time.time() + deadline
+    while time.time() < end:
+        if os.path.exists(path):
+            return True
+        time.sleep(0.1)
+    return False
+
+
+def journal_records(path):
+    recs = []
+    with open(path) as f:
+        for ln in f.read().splitlines():
+            try:
+                recs.append(json.loads(ln))
+            except json.JSONDecodeError:
+                pass
+    return recs
+
+
+def main():
+    if len(sys.argv) != 3:
+        print("usage: test_etw_agent.py <retraced> <agent>",
+              file=sys.stderr)
+        return 2
+    daemon, agent = (os.path.abspath(p) for p in sys.argv[1:3])
+
+    work = tempfile.mkdtemp(prefix="etw-ag-")
+    sock = os.path.join(work, "agent.sock")
+    journal = os.path.join(work, "journal.jsonl")
+
+    d = subprocess.Popen(
+        [daemon, "--sock", sock, "--journal", journal],
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    try:
+        if not wait_sock(sock):
+            print("FAIL: daemon never listened", file=sys.stderr)
+            return 1
+
+        r = subprocess.run(
+            [sys.executable, agent, "--sock", sock,
+             "--synthetic", "--samples", "3"],
+            capture_output=True, timeout=30)
+        if r.returncode != 0:
+            print(f"FAIL: agent rc={r.returncode}: "
+                  f"{r.stderr.decode()[:300]}", file=sys.stderr)
+            return 1
+
+        d.send_signal(signal.SIGTERM)
+        try:
+            d.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            d.kill()
+
+        recs = journal_records(journal)
+        names = [r.get("ev", {}).get("name") for r in recs]
+        obs = [r for r in recs
+               if r.get("ev", {}).get("name") ==
+               "kernel.syscall.observe"]
+        if len(obs) != 3:
+            print(f"FAIL: expected 3 kernel observations, "
+                  f"got {len(obs)}: {names}", file=sys.stderr)
+            return 1
+        auth = [r for r in recs
+                if r.get("ev", {}).get("name") == "retrace.auth.agent"]
+        if not auth or auth[-1]["ev"].get("role") != "spectator":
+            print(f"FAIL: ETW agent not seated as spectator: "
+                  f"{auth}", file=sys.stderr)
+            return 1
+        if any(r.get("ev", {}).get("name") == "retrace.policy.pushed"
+               for r in recs):
+            print("FAIL: policy reached an observer",
+                  file=sys.stderr)
+            return 1
+        drift = [r for r in recs
+                 if r.get("ev", {}).get("name") ==
+                 "retrace.drift.summary"]
+        d_kernel = [int(r["ev"].get("kernel_obs", 0)) for r in drift]
+        d_delta = [int(r["ev"].get("delta", 0)) for r in drift]
+        if max(d_kernel, default=0) < 3 or sum(d_delta) < 3:
+            print(f"FAIL: drift summaries under-count observations: "
+                  f"{[r['ev'] for r in drift]}", file=sys.stderr)
+            return 1
+
+        print("etw-agent: 3 kernel observations journaled; "
+              "spectator seat; zero policy reach; drift summary "
+              "-- OK")
+        return 0
+    finally:
+        if d.poll() is None:
+            d.send_signal(signal.SIGTERM)
+            try:
+                d.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                d.kill()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/integration/test_retraced_fd.py
+++ b/test/integration/test_retraced_fd.py
@@ -92,6 +92,21 @@ def read_file(path):
         return ""
 
 
+def pick_unprivileged_user():
+    """An existing non-root account (images differ: Alpine CI has
+    no 'nobody'); None when none exists."""
+    try:
+        with open("/etc/passwd") as f:
+            for ln in f:
+                parts = ln.strip().split(":")
+                if len(parts) >= 3 and parts[0] and \
+                        parts[2].isdigit() and 0 < int(parts[2]) < 65534:
+                    return parts[0]
+    except OSError:
+        pass
+    return None
+
+
 def main():
     if len(sys.argv) != 2:
         print("usage: test_retraced_fd.py <retraced>", file=sys.stderr)
@@ -162,13 +177,19 @@ def main():
             print("fd-activation: inherited socket served; no "
                   "unlink; drop section skipped (not root) -- OK")
             return 0
+        drop_user = pick_unprivileged_user()
+        if drop_user is None:
+            print("fd-activation: inherited socket served; no "
+                  "unlink; drop section skipped (no unprivileged "
+                  "account) -- OK")
+            return 0
 
         d2_out = os.path.join(work, "d2.out")
         with open(d2_out, "w") as df:
             d2 = subprocess.Popen(
                 [daemon, "--sock", os.path.join(work, "a2.sock"),
                  "--journal", os.path.join(work, "j2.jsonl"),
-                 "--user", "nobody"],
+                 "--user", drop_user],
                 stdin=subprocess.DEVNULL, stdout=df,
                 stderr=subprocess.STDOUT)
         try:

--- a/test/integration/test_retraced_fd.py
+++ b/test/integration/test_retraced_fd.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""
+E2E: retraced socket activation + privilege drop
+(TODO.supervisor/08 P2 / TODO.beyond-libc/05 P2).
+
+--fd N: the daemon serves an already-bound, listening agent
+socket handed to it (socket activation; systemd's LISTEN_FDS
+convention maps to the same path). The daemon must NOT unlink a
+socket it did not create.
+
+--user/--group: after every socket is bound the daemon drops
+privileges; a requested drop that fails exits 2 (fail-closed).
+Root-only section, self-skips otherwise.
+
+Usage: test_retraced_fd.py <retraced>
+"""
+import json
+import os
+import signal
+import socket
+import struct
+import subprocess
+import sys
+import tempfile
+import time
+
+MAGIC = b"RTRD"
+HELLO, HEARTBEAT, EVENT, BYE = 1, 2, 4, 6
+
+
+def frame(mid, payload):
+    b = payload.encode()
+    return MAGIC + struct.pack("<HHI", 1, mid, len(b)) + b
+
+
+def stub_agent(sock_path, nonce=""):
+    """HELLO + one event + BYE; returns the WELCOME role."""
+    s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    s.connect(sock_path)
+    s.sendall(frame(HELLO, json.dumps({
+        "session_token": "", "nonce": nonce,
+        "pid": os.getpid(), "ppid": os.getppid(),
+        "boot_id": "test", "cmdline": "stub",
+        "retrace_version": "stub"})))
+    hdr = b""
+    while len(hdr) < 12:
+        hdr += s.recv(12 - len(hdr))
+    _, _, mid, ln = struct.unpack("<4sHHI", hdr)
+    body = b""
+    while len(body) < ln:
+        body += s.recv(ln - len(body))
+    if mid != 16:
+        raise RuntimeError("no WELCOME")
+    welcome = json.loads(body)
+    s.sendall(frame(EVENT, json.dumps({
+        "agent_id": welcome.get("agent_id", "?"), "seq": 1,
+        "ts": int(time.time()), "name": "fd.test.event",
+        "attrs": {}, "source": "libc"})))
+    s.sendall(frame(BYE, json.dumps(
+        {"agent_id": welcome.get("agent_id", "?")})))
+    s.close()
+    return welcome.get("role", "?")
+
+
+def wait_file(path, deadline=5.0):
+    end = time.time() + deadline
+    while time.time() < end:
+        if os.path.exists(path):
+            return True
+        time.sleep(0.1)
+    return False
+
+
+def wait_output(path, needle, deadline=5.0):
+    end = time.time() + deadline
+    while time.time() < end:
+        try:
+            with open(path, errors="replace") as f:
+                if needle in f.read():
+                    return True
+        except OSError:
+            pass
+        time.sleep(0.1)
+    return False
+
+
+def read_file(path):
+    try:
+        with open(path, errors="replace") as f:
+            return f.read()
+    except OSError:
+        return ""
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("usage: test_retraced_fd.py <retraced>", file=sys.stderr)
+        return 2
+    daemon = os.path.abspath(sys.argv[1])
+
+    work = tempfile.mkdtemp(prefix="fd-act-")
+    sock = os.path.join(work, "agent.sock")
+    journal = os.path.join(work, "journal.jsonl")
+    d_out = os.path.join(work, "d.out")
+
+    # 1. socket activation: WE bind + listen, hand the fd over.
+    # pass_fds preserves the fd NUMBER; the child must be told
+    # the same number.
+    listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    listener.bind(sock)
+    listener.listen(8)
+    os.chmod(sock, 0o660)
+    fdnum = listener.fileno()
+
+    with open(d_out, "w") as df:
+        d = subprocess.Popen(
+            [daemon, "--sock", sock, "--journal", journal,
+             "--fd", str(fdnum)],
+            stdin=subprocess.DEVNULL, stdout=df,
+            stderr=subprocess.STDOUT,
+            pass_fds=(fdnum,))
+    try:
+        if not wait_output(d_out, "inherited on fd"):
+            print(f"FAIL: daemon never adopted the fd: "
+                  f"{read_file(d_out)[:300]}", file=sys.stderr)
+            return 1
+        # the round trip itself proves the daemon serves OUR
+        # listener (this process never accept()s)
+        role = None
+        end = time.time() + 5
+        while time.time() < end:
+            try:
+                role = stub_agent(sock)
+                break
+            except OSError:
+                time.sleep(0.1)
+        if role not in ("spectator", "full"):
+            print(f"FAIL: unexpected role {role}", file=sys.stderr)
+            return 1
+        d.send_signal(signal.SIGTERM)
+        try:
+            d.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            d.kill()
+
+        # the daemon must NOT unlink a socket it inherited
+        if not os.path.exists(sock):
+            print("FAIL: daemon unlinked the inherited socket",
+                  file=sys.stderr)
+            return 1
+        with open(journal) as f:
+            recs = [json.loads(ln) for ln in f if ln.strip()]
+        if not any(r.get("ev", {}).get("name") == "fd.test.event"
+                   for r in recs):
+            print("FAIL: event not journaled via inherited socket",
+                  file=sys.stderr)
+            return 1
+        listener.close()
+
+        # 2. privilege drop: root-only, self-skips
+        if os.geteuid() != 0:
+            print("fd-activation: inherited socket served; no "
+                  "unlink; drop section skipped (not root) -- OK")
+            return 0
+
+        d2_out = os.path.join(work, "d2.out")
+        with open(d2_out, "w") as df:
+            d2 = subprocess.Popen(
+                [daemon, "--sock", os.path.join(work, "a2.sock"),
+                 "--journal", os.path.join(work, "j2.jsonl"),
+                 "--user", "nobody"],
+                stdin=subprocess.DEVNULL, stdout=df,
+                stderr=subprocess.STDOUT)
+        try:
+            if not wait_output(d2_out, "running as uid="):
+                print(f"FAIL: no drop line: "
+                      f"{read_file(d2_out)[:300]}", file=sys.stderr)
+                return 1
+        finally:
+            d2.send_signal(signal.SIGTERM)
+            try:
+                d2.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                d2.kill()
+        # a bad user must fail-closed (exit 2), not run elevated
+        d3 = subprocess.run(
+            [daemon, "--sock", os.path.join(work, "a3.sock"),
+             "--journal", os.path.join(work, "j3.jsonl"),
+             "--user", "no-such-user-xyz"],
+            capture_output=True, text=True, timeout=10)
+        if d3.returncode != 2:
+            print(f"FAIL: unknown user must exit 2, got "
+                  f"{d3.returncode}: {d3.stdout[:200]}",
+                  file=sys.stderr)
+            return 1
+        print("fd-activation: inherited socket served; no unlink; "
+              "drop to nobody ok; unknown user fail-closed -- OK")
+        return 0
+    finally:
+        if d.poll() is None:
+            d.send_signal(signal.SIGTERM)
+            try:
+                d.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                d.kill()
+        if os.path.exists(sock):
+            os.unlink(sock)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -313,6 +313,14 @@ retrace_add_unit_test(modify_return_value_int
 # retraced ctl-plane command surface, unit-tested through the
 # extracted module (buffer sink, no socket/daemon).
 #
+#
+# audited enforcement artifacts (TODO.beyond-libc/01 P2): the
+# hash chain binding exec to spec digest + backends.
+#
+retrace_add_unit_test(enforce_audit
+    EXTRA_SOURCES ${CMAKE_SOURCE_DIR}/tools/enforce/artifact_audit.c
+    EXTRA_INCLUDES ${CMAKE_SOURCE_DIR}/tools/enforce)
+
 retrace_add_unit_test(retraced_ctl
     EXTRA_SOURCES ${CMAKE_SOURCE_DIR}/tools/retraced/retraced_ctl.c
         ${CMAKE_SOURCE_DIR}/tools/retraced/registry.c

--- a/test/unit/test_enforce_audit.c
+++ b/test/unit/test_enforce_audit.c
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+/*
+ * Audited enforcement artifacts (TODO.beyond-libc/01 P2): the
+ * chain that answers "which filter was in force when". Append
+ * builds the chain; verify replays it; any tamper (reordered
+ * line, edited field, torn tail) fails verification; a broken
+ * chain refuses further appends (fail-closed).
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "artifact_audit.h"
+
+static int tests_run;
+static int tests_pass;
+static int tests_fail;
+
+#define TEST(name) do { \
+	tests_run++; \
+	printf("  TEST %s ... ", #name); \
+	test_##name(); \
+	tests_pass++; \
+	printf("OK\n"); \
+} while (0)
+
+#define CHECK(cond) do { \
+	if (!(cond)) { \
+		printf("FAIL [%s:%d] %s\n", __FILE__, __LINE__, #cond); \
+		tests_fail++; \
+		return; \
+	} \
+} while (0)
+
+static char trail[256];
+
+static void fresh_trail(void)
+{
+	unlink(trail);
+}
+
+static void test_append_and_verify(void)
+{
+	char digest[ENFORCE_DIGEST_HEX_MAX];
+	const char *alg = NULL;
+	char head[ENFORCE_DIGEST_HEX_MAX];
+	long n;
+	int i;
+
+	fresh_trail();
+	CHECK(enforce_spec_digest("{\"spec\":1}", 10, digest, &alg) == 0);
+	CHECK(alg != NULL && alg[0] != '\0');
+	for (i = 0; i < 3; i++)
+		CHECK(enforce_audit_append(trail, 1000 + i, 42 + i,
+			digest, alg, "landlock+seccomp",
+			(char *[]){"/bin/true", NULL}) == 0);
+	n = enforce_audit_verify(trail, head);
+	CHECK(n == 3);
+	CHECK(head[0] != '\0');
+}
+
+static void test_tampered_field_fails(void)
+{
+	FILE *f;
+	char buf[8192];
+	size_t n;
+	char digest[ENFORCE_DIGEST_HEX_MAX];
+
+	fresh_trail();
+	CHECK(enforce_spec_digest("x", 1, digest, NULL) == 0);
+	CHECK(enforce_audit_append(trail, 1, 1, digest, "sha256",
+		"landlock", (char *[]){"/bin/ls", NULL}) == 0);
+	/* edit one field of the committed record */
+	f = fopen(trail, "r");
+	CHECK(f != NULL);
+	n = fread(buf, 1, sizeof(buf) - 1, f);
+	fclose(f);
+	buf[n] = '\0';
+	{
+		char *pid = strstr(buf, "\"pid\":1");
+
+		CHECK(pid != NULL);
+		pid[6] = '9';		/* pid 1 -> 9 */
+	}
+	f = fopen(trail, "w");
+	CHECK(f != NULL);
+	fwrite(buf, 1, n, f);
+	fclose(f);
+	CHECK(enforce_audit_verify(trail, NULL) == -2);
+}
+
+static void test_torn_tail_fails(void)
+{
+	FILE *f;
+	char buf[8192];
+	size_t n;
+	char digest[ENFORCE_DIGEST_HEX_MAX];
+
+	fresh_trail();
+	CHECK(enforce_spec_digest("y", 1, digest, NULL) == 0);
+	CHECK(enforce_audit_append(trail, 1, 7, digest, "fnv1a64",
+		"seccomp", (char *[]){"/bin/true", NULL}) == 0);
+	f = fopen(trail, "r");
+	CHECK(f != NULL);
+	n = fread(buf, 1, sizeof(buf) - 1, f);
+	fclose(f);
+	f = fopen(trail, "w");
+	CHECK(f != NULL);
+	fwrite(buf, 1, n - 5, f);	/* drop the last 5 bytes */
+	fclose(f);
+	CHECK(enforce_audit_verify(trail, NULL) == -2);
+}
+
+static void test_append_refuses_after_tamper(void)
+{
+	FILE *f;
+	char digest[ENFORCE_DIGEST_HEX_MAX];
+
+	fresh_trail();
+	CHECK(enforce_spec_digest("z", 1, digest, NULL) == 0);
+	CHECK(enforce_audit_append(trail, 1, 1, digest, NULL,
+		"landlock", NULL) == 0);
+	/* break the sole line */
+	f = fopen(trail, "w");
+	CHECK(f != NULL);
+	fputs("{\"garbage\":1}\n", f);
+	fclose(f);
+	CHECK(enforce_audit_append(trail, 2, 2, digest, NULL,
+		"landlock", NULL) == -1);
+}
+
+static void test_missing_file_verifies_empty(void)
+{
+	fresh_trail();
+	CHECK(enforce_audit_verify(trail, NULL) == 0);
+}
+
+static void test_digest_stable_and_sensitive(void)
+{
+	char a[ENFORCE_DIGEST_HEX_MAX], b[ENFORCE_DIGEST_HEX_MAX];
+
+	CHECK(enforce_spec_digest("same", 4, a, NULL) == 0);
+	CHECK(enforce_spec_digest("same", 4, b, NULL) == 0);
+	CHECK(strcmp(a, b) == 0);
+	CHECK(enforce_spec_digest("same2", 5, b, NULL) == 0);
+	CHECK(strcmp(a, b) != 0);
+}
+
+int main(void)
+{
+	snprintf(trail, sizeof(trail), "%s",
+		"/tmp/.retrace-audit-test.jsonl");
+
+	printf("enforce artifact audit tests:\n");
+	TEST(append_and_verify);
+	TEST(tampered_field_fails);
+	TEST(torn_tail_fails);
+	TEST(append_refuses_after_tamper);
+	TEST(missing_file_verifies_empty);
+	TEST(digest_stable_and_sensitive);
+
+	printf("%d tests: %d pass, %d fail\n", tests_run, tests_pass,
+		tests_fail);
+	return tests_fail == 0 ? 0 : 1;
+}

--- a/tools/enforce/CMakeLists.txt
+++ b/tools/enforce/CMakeLists.txt
@@ -8,7 +8,7 @@ set(_parson_source ${CMAKE_SOURCE_DIR}/src/config/json/parson.c)
 
 add_executable(retrace_enforce
 	main.c enforce_spec.c landlock_apply.c seccomp_apply.c
-	sandbox_apply.c
+	sandbox_apply.c artifact_audit.c
 	${_parson_source})
 set_target_properties(retrace_enforce PROPERTIES
 	OUTPUT_NAME retrace-enforce)
@@ -21,6 +21,16 @@ target_include_directories(retrace_enforce PRIVATE
 if(NOT RETRACE_PLATFORM_LINUX)
 	target_compile_definitions(retrace_enforce PRIVATE
 		RETRACE_ENFORCE_NO_KERNEL)
+endif()
+
+# Audited artifacts (01 P2): SHA-256 digests when OpenSSL is
+# linked; FNV-1a-64 fallback otherwise (the record says which).
+if(OpenSSL_FOUND)
+	target_compile_definitions(retrace_enforce PRIVATE
+		RETRACE_HAVE_OPENSSL=1)
+	target_link_libraries(retrace_enforce PRIVATE OpenSSL::Crypto)
+	target_include_directories(retrace_enforce PRIVATE
+		${OPENSSL_INCLUDE_DIR})
 endif()
 
 install(TARGETS retrace_enforce

--- a/tools/enforce/artifact_audit.c
+++ b/tools/enforce/artifact_audit.c
@@ -1,0 +1,284 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+#include "artifact_audit.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+#ifdef RETRACE_HAVE_OPENSSL
+#include <openssl/sha.h>
+#endif
+
+#define AUDIT_LINE_MAX 4200
+
+/*
+ * FNV-1a 64 -- the fallback digest when the build has no
+ * OpenSSL (same discipline as the supervisor journal: tamper
+ * EVIDENCE now, signatures with the policy-signing plan).
+ */
+static uint64_t fnv1a64(const char *s, uint64_t h)
+{
+	for (; *s != '\0'; s++) {
+		h ^= (unsigned char)*s;
+		h *= 0x01000193ULL;
+	}
+	return h;
+}
+
+static void hex32(const unsigned char *md, char out[ENFORCE_DIGEST_HEX_MAX])
+{
+	size_t i;
+
+	for (i = 0; i < 32; i++)
+		snprintf(out + i * 2, 3, "%02x", md[i]);
+	out[64] = '\0';
+}
+
+int enforce_audit_hash(const char *prev_hex, const char *payload,
+	char out[ENFORCE_DIGEST_HEX_MAX])
+{
+#ifdef RETRACE_HAVE_OPENSSL
+	unsigned char md[32];
+	char input[AUDIT_LINE_MAX];
+	size_t plen = strlen(payload);
+	size_t prevlen = strlen(prev_hex);
+
+	if (prevlen + plen + 1 > sizeof(input))
+		return -1;
+	memcpy(input, prev_hex, prevlen);
+	memcpy(input + prevlen, payload, plen + 1);
+	if (SHA256((const unsigned char *)input, prevlen + plen, md)
+	    == NULL)
+		return -1;
+	hex32(md, out);
+	return 0;
+#else
+	uint64_t h = fnv1a64(payload,
+		fnv1a64(prev_hex, 0xcbf29ce484222325ULL));
+
+	snprintf(out, ENFORCE_DIGEST_HEX_MAX, "%016llx",
+		(unsigned long long)h);
+	return 0;
+#endif
+}
+
+static const char *digest_alg(void)
+{
+#ifdef RETRACE_HAVE_OPENSSL
+	return "sha256";
+#else
+	return "fnv1a64";
+#endif
+}
+
+int enforce_spec_digest(const char *spec_json, size_t len,
+	char out[ENFORCE_DIGEST_HEX_MAX], const char **alg_out)
+{
+	if (alg_out != NULL)
+		*alg_out = digest_alg();
+#ifdef RETRACE_HAVE_OPENSSL
+	{
+		unsigned char md[32];
+
+		if (SHA256((const unsigned char *)spec_json, len, md)
+		    == NULL)
+			return -1;
+		hex32(md, out);
+	}
+#else
+	{
+		uint64_t h = 0xcbf29ce484222325ULL;
+		size_t i;
+
+		for (i = 0; i < len; i++) {
+			h ^= (unsigned char)spec_json[i];
+			h *= 0x01000193ULL;
+		}
+		snprintf(out, ENFORCE_DIGEST_HEX_MAX, "%016llx",
+			(unsigned long long)h);
+	}
+#endif
+	return 0;
+}
+
+/* JSON string escape for argv elements (bounded) */
+static int jesc(char *dst, size_t cap, const char *s)
+{
+	size_t o = 0;
+
+	if (cap < 3)
+		return -1;
+	dst[o++] = '"';
+	if (s != NULL) {
+		for (; *s != '\0'; s++) {
+			if (o + 7 >= cap)
+				return -1;
+			if (*s == '"' || *s == '\\') {
+				dst[o++] = '\\';
+				dst[o++] = *s;
+			} else if ((unsigned char)*s < 0x20) {
+				o += (size_t)snprintf(dst + o, 7,
+					"\\u%04x",
+					(unsigned int)(unsigned char)*s);
+			} else {
+				dst[o++] = *s;
+			}
+		}
+	}
+	dst[o++] = '"';
+	dst[o] = '\0';
+	return 0;
+}
+
+static void extract_hash(const char *line, char out[ENFORCE_DIGEST_HEX_MAX])
+{
+	const char *h = strstr(line, "{\"hash\":\"");
+	size_t n = 0;
+
+	if (h == NULL) {
+		out[0] = '\0';
+		return;
+	}
+	h += 9;
+	while (h[n] != '\0' && h[n] != '"' &&
+	       n + 1 < ENFORCE_DIGEST_HEX_MAX)
+		n++;
+	memcpy(out, h, n);
+	out[n] = '\0';
+}
+
+static long verify_chain(const char *path,
+	char last_hash[ENFORCE_DIGEST_HEX_MAX])
+{
+	FILE *f = fopen(path, "r");
+	char line[AUDIT_LINE_MAX];
+	char prev[ENFORCE_DIGEST_HEX_MAX] = "0";
+	long count = 0;
+
+	if (last_hash != NULL)
+		last_hash[0] = '\0';
+	if (f == NULL)
+		return 0;		/* no trail yet: zero records */
+	while (fgets(line, sizeof(line), f) != NULL) {
+		size_t len = strlen(line);
+		const char *hp;
+		char want[ENFORCE_DIGEST_HEX_MAX];
+		char stored[ENFORCE_DIGEST_HEX_MAX];
+		size_t plen;
+
+		if (len == 0 || line[len - 1] != '\n')
+			return -2;	/* torn tail */
+		hp = strstr(line, "{\"hash\":\"");
+		if (hp == NULL || hp == line)
+			return -2;	/* no payload or no hash */
+		plen = (size_t)(hp - line);
+		if (plen >= sizeof(line))	/* keeps gcc quiet */
+			return -2;
+		{
+			char payload[AUDIT_LINE_MAX];
+
+			memcpy(payload, line, plen);
+			payload[plen] = '\0';
+			extract_hash(line, stored);
+			if (stored[0] == '\0' ||
+			    enforce_audit_hash(prev, payload, want) != 0 ||
+			    strcmp(want, stored) != 0)
+				return -2;
+		}
+		snprintf(prev, sizeof(prev), "%s", stored);
+		count++;
+	}
+	fclose(f);
+	if (last_hash != NULL)
+		snprintf(last_hash, ENFORCE_DIGEST_HEX_MAX, "%s", prev);
+	return count;
+}
+
+int enforce_audit_append(const char *path, long ts, long pid,
+	const char digest[ENFORCE_DIGEST_HEX_MAX], const char *alg,
+	const char *backends, char *const argv[])
+{
+	char prev[ENFORCE_DIGEST_HEX_MAX];
+	char hash[ENFORCE_DIGEST_HEX_MAX];
+	char payload[2048];
+	char av[1024];
+	char line[AUDIT_LINE_MAX];
+	char tail[ENFORCE_DIGEST_HEX_MAX] = "";
+	FILE *f;
+	int i;
+
+	/* fail-closed: a broken existing trail refuses new records;
+	 * the same replay yields the chain head
+	 */
+	{
+		long rc = verify_chain(path, tail);
+
+		if (rc == -2) {
+			fprintf(stderr,
+				"retrace-enforce: audit trail tampered; refusing\n");
+			return -1;
+		}
+		if (rc < 0)
+			return -1;
+	}
+
+	av[0] = '\0';
+	for (i = 0; argv != NULL && argv[i] != NULL; i++) {
+		char one[512];
+
+		if (jesc(one, sizeof(one), argv[i]) != 0)
+			return -1;
+		if (av[0] != '\0')
+			strncat(av, ",", sizeof(av) - strlen(av) - 1);
+		strncat(av, one, sizeof(av) - strlen(av) - 1);
+	}
+	{
+		int n = snprintf(payload, sizeof(payload),
+			"{\"ts\":%ld,\"pid\":%ld,\"digest\":\"%s\","
+			"\"alg\":\"%s\",\"backends\":\"%s\","
+			"\"argv\":[%s]}",
+			ts, pid, digest, alg != NULL ? alg : digest_alg(),
+			backends != NULL ? backends : "", av);
+
+		if (n <= 0 || (size_t)n >= sizeof(payload))
+			return -1;
+	}
+
+	/* chain head: the last record's hash, "0" when fresh */
+	if (tail[0] != '\0')
+		snprintf(prev, sizeof(prev), "%s", tail);
+	else
+		snprintf(prev, sizeof(prev), "0");
+	if (enforce_audit_hash(prev, payload, hash) != 0)
+		return -1;
+	{
+		int n = snprintf(line, sizeof(line), "%s{\"hash\":\"%s\"}\n",
+			payload, hash);
+
+		if (n <= 0 || (size_t)n >= sizeof(line))
+			return -1;
+	}
+	f = fopen(path, "a");
+	if (f == NULL)
+		return -1;
+	if (fputs(line, f) == EOF || fflush(f) != 0) {
+		fclose(f);
+		return -1;
+	}
+	fclose(f);
+	return 0;
+}
+
+long enforce_audit_verify(const char *path,
+	char last_hash[ENFORCE_DIGEST_HEX_MAX])
+{
+	return verify_chain(path, last_hash);
+}

--- a/tools/enforce/artifact_audit.h
+++ b/tools/enforce/artifact_audit.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+/*
+ * Audited enforcement artifacts (TODO.beyond-libc/01 P2): the
+ * audit story -- WHICH filter was in force WHEN. Every
+ * retrace-enforce exec appends a hash-chained record binding
+ * (timestamp, pid, spec digest, backends, argv); --verify-audit
+ * replays the chain. A tampered or truncated trail fails
+ * verification, and an explicitly requested trail that cannot
+ * be appended fail-closes the exec.
+ *
+ * Chain discipline mirrors the supervisor journal: each line
+ * carries the previous line's hash; the digest is SHA-256 when
+ * the build links OpenSSL, FNV-1a-64 otherwise (the "alg" field
+ * says which; signatures ride the policy-signing plan).
+ */
+
+#ifndef RETRACE_TOOLS_ENFORCE_ARTIFACT_AUDIT_H_
+#define RETRACE_TOOLS_ENFORCE_ARTIFACT_AUDIT_H_
+
+#include <stddef.h>
+
+#define ENFORCE_DIGEST_HEX_MAX 65	/* 64 hex + NUL */
+
+/*
+ * Digest of the spec artifact (raw file bytes). out holds
+ * lowercase hex; alg_out (may be NULL) receives "sha256" or
+ * "fnv1a64". Returns 0 on success.
+ */
+int enforce_spec_digest(const char *spec_json, size_t len,
+	char out[ENFORCE_DIGEST_HEX_MAX], const char **alg_out);
+
+/*
+ * Append one chained record. path: the audit JSONL. backends:
+ * e.g. "landlock+seccomp". argv: the exec'd command line (may
+ * be NULL). Returns 0 on success; -1 on I/O error or a broken
+ * pre-existing chain (fail-closed: the caller must not exec).
+ */
+int enforce_audit_append(const char *path, long ts, long pid,
+	const char digest[ENFORCE_DIGEST_HEX_MAX],
+	const char *alg, const char *backends, char *const argv[]);
+
+/*
+ * Replay + verify the chain. Returns the number of intact
+ * records (>= 0), or -1 on I/O error, -2 on a broken chain /
+ * torn tail. last_hash (may be NULL) receives the head.
+ */
+long enforce_audit_verify(const char *path,
+	char last_hash[ENFORCE_DIGEST_HEX_MAX]);
+
+/* the chain hash of one record (test seam + verify) */
+int enforce_audit_hash(const char *prev_hex, const char *payload,
+	char out[ENFORCE_DIGEST_HEX_MAX]);
+
+#endif /* RETRACE_TOOLS_ENFORCE_ARTIFACT_AUDIT_H_ */

--- a/tools/enforce/main.c
+++ b/tools/enforce/main.c
@@ -16,33 +16,64 @@
  * Fail-closed: if a requested plane cannot be installed, the
  * exec never happens (exit 2) -- unless --allow-missing is
  * given for dev workflows.
+ *
+ * Audited artifacts (01 P2): --audit PATH appends a hash-chained
+ * record binding (ts, pid, spec digest, backends, argv) to the
+ * trail; --verify-audit PATH replays it. A requested trail that
+ * cannot be appended (or whose existing chain is broken)
+ * fail-closes the exec.
  */
 
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 #include <unistd.h>
 
 #include "enforce_spec.h"
 #include "landlock_apply.h"
 #include "seccomp_apply.h"
 #include "sandbox_apply.h"
+#include "artifact_audit.h"
 
 static void enforce_usage(void)
 {
 	fprintf(stderr,
-		"usage: retrace-enforce [--allow-missing] spec.json"
-		" -- cmd [args...]\n"
+		"usage: retrace-enforce [--allow-missing] [--audit PATH]"
+		" spec.json -- cmd [args...]\n"
+		"       retrace-enforce --verify-audit PATH\n"
 		"  installs the spec's kernel filters, then execs cmd\n"
 		"  --allow-missing: proceed when the kernel lacks a"
-		" plane (dev only)\n");
+		" plane (dev only)\n"
+		"  --audit PATH: append a hash-chained record of this\n"
+		"    exec (spec digest + backends + argv); a broken\n"
+		"    trail refuses the exec\n"
+		"  --verify-audit PATH: replay + verify a trail\n");
+}
+
+static void spec_backends(const struct enforce_spec *spec, char *out,
+	size_t cap)
+{
+	size_t o = 0;
+
+	out[0] = '\0';
+	if (spec->rules_n > 0)
+		o += (size_t)snprintf(out + o, cap - o, "landlock");
+	if (spec->deny_n > 0)
+		o += (size_t)snprintf(out + o, cap - o, "%sseccomp",
+			o > 0 ? "+" : "");
+	if (spec->sandbox_exec[0] != '\0')
+		(void)snprintf(out + o, cap - o, "%ssandbox-exec",
+			o > 0 ? "+" : "");
 }
 
 int main(int argc, char **argv)
 {
 	struct enforce_spec spec;
 	const char *spec_path = NULL;
+	const char *audit_path = NULL;
+	const char *verify_path = NULL;
 	int allow_missing = 0;
 	int i;
 	int rc;
@@ -53,6 +84,12 @@ int main(int argc, char **argv)
 	for (i = 1; i < argc; i++) {
 		if (strcmp(argv[i], "--allow-missing") == 0) {
 			allow_missing = 1;
+		} else if (strcmp(argv[i], "--audit") == 0 &&
+			   i + 1 < argc) {
+			audit_path = argv[++i];
+		} else if (strcmp(argv[i], "--verify-audit") == 0 &&
+			   i + 1 < argc) {
+			verify_path = argv[++i];
 		} else if (strcmp(argv[i], "--") == 0) {
 			break;
 		} else if (argv[i][0] != '-' && spec_path == NULL) {
@@ -61,6 +98,22 @@ int main(int argc, char **argv)
 			enforce_usage();
 			return 2;
 		}
+	}
+	if (verify_path != NULL) {
+		char head[ENFORCE_DIGEST_HEX_MAX];
+		long n = enforce_audit_verify(verify_path, head);
+
+		if (n < 0) {
+			fprintf(stderr,
+				"retrace-enforce: audit trail %s: %s\n",
+				verify_path,
+				n == -2 ? "chain broken (tampered or torn)"
+					: "unreadable");
+			return 1;
+		}
+		printf("retrace-enforce: audit ok: %ld records, head %s\n",
+			n, head);
+		return 0;
 	}
 	if (spec_path == NULL || i + 1 >= argc) {
 		enforce_usage();
@@ -85,20 +138,19 @@ int main(int argc, char **argv)
 		return 2;
 	}
 	fclose(f);
-	json[sz] = '\\0';
+	json[sz] = '\0';
 	if (enforce_spec_parse(&spec, json) != 0) {
-		fprintf(stderr, "retrace-enforce: spec unparseable\\n");
+		fprintf(stderr, "retrace-enforce: spec unparseable\n");
 		return 2;
 	}
-	free(json);
 
 	rc = enforce_landlock_apply(&spec);
 	if (rc == 1)
 		fprintf(stderr,
-			"retrace-enforce: kernel lacks landlock\\n");
+			"retrace-enforce: kernel lacks landlock\n");
 	if (rc < 0) {
 		fprintf(stderr,
-			"retrace-enforce: landlock apply failed: %s\\n",
+			"retrace-enforce: landlock apply failed: %s\n",
 			strerror(errno));
 		return 2;
 	}
@@ -109,10 +161,10 @@ int main(int argc, char **argv)
 	rc = enforce_seccomp_apply(&spec);
 	if (rc == 1)
 		fprintf(stderr,
-			"retrace-enforce: kernel lacks the seccomp floor\\n");
+			"retrace-enforce: kernel lacks the seccomp floor\n");
 	if (rc < 0) {
 		fprintf(stderr,
-			"retrace-enforce: seccomp apply failed: %s\\n",
+			"retrace-enforce: seccomp apply failed: %s\n",
 			strerror(errno));
 		return 2;
 	}
@@ -120,14 +172,41 @@ int main(int argc, char **argv)
 	    spec.sandbox_exec[0] == '\0')
 		return 2;
 
+	/*
+	 * The audit record lands only when the planes are in force:
+	 * it binds the exec to (digest, backends, argv). A
+	 * requested-but-unwritable or tampered trail fail-closes
+	 * the exec (the evidence discipline).
+	 */
+	if (audit_path != NULL) {
+		char digest[ENFORCE_DIGEST_HEX_MAX];
+		const char *alg = NULL;
+		char backends[64];
+
+		if (enforce_spec_digest(json, (size_t)sz, digest,
+			    &alg) != 0) {
+			fprintf(stderr,
+				"retrace-enforce: spec digest failed\n");
+			return 2;
+		}
+		spec_backends(&spec, backends, sizeof(backends));
+		if (enforce_audit_append(audit_path, (long)time(NULL),
+			    (long)getpid(), digest, alg, backends,
+			    &argv[i + 1]) != 0) {
+			fprintf(stderr,
+				"retrace-enforce: audit append failed; refusing exec\n");
+			return 2;
+		}
+	}
+	free(json);
+
 	if (spec.sandbox_exec[0] != '\0') {
 		static char wrap[16384];
 
 		if (enforce_sandbox_exec_wrap(spec.sandbox_exec,
 			    argc - i - 1, &argv[i + 1], wrap,
 			    sizeof(wrap)) != 0) {
-			fprintf(stderr,
-				"retrace-enforce: sandbox wrap overflow\n");
+			fprintf(stderr, "retrace-enforce: sandbox wrap overflow\n");
 			return 2;
 		}
 		{

--- a/tools/retraced/main.c
+++ b/tools/retraced/main.c
@@ -24,7 +24,10 @@
  */
 
 #include <errno.h>
+#include <fcntl.h>
 #include <poll.h>
+#include <grp.h>
+#include <pwd.h>
 #include <stdarg.h>
 #include <signal.h>
 #include <stdio.h>
@@ -515,6 +518,10 @@ int main(int argc, char **argv)
 	const char *tls_cert = NULL;
 	const char *tls_key = NULL;
 	const char *tls_ca = NULL;
+	const char *drop_user = NULL;
+	const char *drop_group = NULL;
+	int inherit_fd = -1;
+	int unlink_sock = 1;
 	struct retraced_registry reg;
 	struct retraced_journal jr;
 	struct conn *conns;
@@ -560,6 +567,15 @@ int main(int argc, char **argv)
 		else if (strcmp(argv[i], "--tls-ca") == 0 &&
 			 i + 1 < argc)
 			tls_ca = argv[++i];
+		else if (strcmp(argv[i], "--user") == 0 &&
+			 i + 1 < argc)
+			drop_user = argv[++i];
+		else if (strcmp(argv[i], "--group") == 0 &&
+			 i + 1 < argc)
+			drop_group = argv[++i];
+		else if (strcmp(argv[i], "--fd") == 0 &&
+			 i + 1 < argc)
+			inherit_fd = atoi(argv[++i]);
 		else {
 			fprintf(stderr,
 				"Usage: retraced [--sock <path>] [--journal <path>]\n"
@@ -567,6 +583,7 @@ int main(int argc, char **argv)
 				"                 [--nonce <hex32>] [--nonce-file <path>]\n"
 				"                 [--tls-listen host:port --tls-cert c\n"
 				"                  --tls-key k --tls-ca ca]\n"
+				"                 [--user u] [--group g] [--fd N]\n"
 				"  --policy: a policy file (header + full\n"
 				"    retrace config) pushed to every agent\n"
 				"    at registration; POLICY_ACKs are\n"
@@ -576,11 +593,36 @@ int main(int argc, char **argv)
 				"    (0600) for spawners to inject\n"
 				"  --tls-*: fleet TLS 1.3 mutual-auth ctl\n"
 				"    (all four flags required together; no\n"
-				"    plaintext remote mode exists)\n");
+				"    plaintext remote mode exists)\n"
+				"  --user/--group: drop privileges after every\n"
+				"    socket is bound (fail-closed: a failed\n"
+				"    drop exits, never continues elevated)\n"
+				"  --fd N: inherit an already-bound, listening\n"
+				"    agent socket on fd N (socket activation;\n"
+				"    --sock names it for clients only)\n");
 			return 2;
 		}
 	}
 
+	/*
+	 * Socket activation (05 P2): an explicit --fd, else the
+	 * systemd convention (LISTEN_FDS=1 -> fd 3 when LISTEN_PID
+	 * is ours). An inherited listener is never bound or
+	 * unlinked by this process.
+	 */
+	if (inherit_fd < 0) {
+		const char *lf = getenv("LISTEN_FDS");
+		const char *lp = getenv("LISTEN_PID");
+
+		if (lf != NULL && strcmp(lf, "1") == 0 && lp != NULL &&
+		    (long)strtol(lp, NULL, 10) == (long)getpid())
+			inherit_fd = 3;		/* SD_LISTEN_FDS_START */
+	}
+
+	/* stdout may be a file or pipe (service managers): the
+	 * readiness/diagnostic lines must not sit in a buffer
+	 */
+	setvbuf(stdout, NULL, _IOLBF, 0);
 	signal(SIGINT, on_signal);
 	signal(SIGTERM, on_signal);
 	signal(SIGPIPE, SIG_IGN);
@@ -682,25 +724,44 @@ int main(int argc, char **argv)
 	g_ctl.reply_user = &g_ctl_fd;
 	g_ctl.scopes = RETRACED_SCOPE_ALL; /* local UDS default */
 
-	unlink(sock_path);
-	listen_fd = socket(AF_UNIX, SOCK_STREAM, 0);
-	if (listen_fd < 0) {
-		perror("socket");
-		return 1;
+	if (inherit_fd >= 0) {
+		/* socket activation: the listener is ours to serve,
+		 * not to bind or unlink. Fail-closed on a bad fd --
+		 * poll would silently spin on POLLNVAL.
+		 */
+		if (fcntl(inherit_fd, F_GETFD) == -1) {
+			fprintf(stderr,
+				"retraced: --fd %d is not an open descriptor\n",
+				inherit_fd);
+			return 2;
+		}
+		listen_fd = inherit_fd;
+		unlink_sock = 0;
+		printf("retraced: agent socket inherited on fd %d (%s)\n",
+			inherit_fd, sock_path);
+	} else {
+		unlink(sock_path);
+		listen_fd = socket(AF_UNIX, SOCK_STREAM, 0);
+		if (listen_fd < 0) {
+			perror("socket");
+			return 1;
+		}
+		memset(&sa, 0, sizeof(sa));
+		sa.sun_family = AF_UNIX;
+		snprintf(sa.sun_path, sizeof(sa.sun_path), "%s",
+			sock_path);
+		if (bind(listen_fd, (struct sockaddr *)&sa,
+			    sizeof(sa)) != 0) {
+			perror("bind");
+			return 1;
+		}
+		if (listen(listen_fd, 16) != 0) {
+			perror("listen");
+			return 1;
+		}
+		chmod(sock_path, 0660);
+		printf("retraced: listening on %s (agents)\n", sock_path);
 	}
-	memset(&sa, 0, sizeof(sa));
-	sa.sun_family = AF_UNIX;
-	snprintf(sa.sun_path, sizeof(sa.sun_path), "%s", sock_path);
-	if (bind(listen_fd, (struct sockaddr *)&sa, sizeof(sa)) != 0) {
-		perror("bind");
-		return 1;
-	}
-	if (listen(listen_fd, 16) != 0) {
-		perror("listen");
-		return 1;
-	}
-	chmod(sock_path, 0660);
-	printf("retraced: listening on %s (agents)\n", sock_path);
 
 	if (ctl_path != NULL) {
 		unlink(ctl_path);
@@ -762,6 +823,53 @@ int main(int argc, char **argv)
 			printf("retraced: TLS controller on %s (TLS 1.3 mTLS)\n",
 				tls_listen);
 		}
+	}
+
+	/*
+	 * Privilege drop (05 P2): every privileged operation is
+	 * done -- sockets bound, nonce file written, journal
+	 * open. A requested drop that cannot complete exits
+	 * (fail-closed: the daemon never continues elevated).
+	 * Without --user the daemon keeps its caller's rights,
+	 * which for a systemd unit means whatever User= says.
+	 */
+	if (drop_user != NULL || drop_group != NULL) {
+		uid_t uid = getuid();
+		gid_t gid = getgid();
+
+		if (drop_group != NULL) {
+			struct group *gr = getgrnam(drop_group);
+
+			if (gr == NULL) {
+				fprintf(stderr,
+					"retraced: unknown group %s\n",
+					drop_group);
+				return 2;
+			}
+			gid = gr->gr_gid;
+		}
+		if (drop_user != NULL) {
+			struct passwd *pw = getpwnam(drop_user);
+
+			if (pw == NULL) {
+				fprintf(stderr,
+					"retraced: unknown user %s\n",
+					drop_user);
+				return 2;
+			}
+			if (drop_group == NULL)
+				gid = pw->pw_gid;
+			uid = pw->pw_uid;
+		}
+		if (setgid(gid) != 0 || setuid(uid) != 0 ||
+		    getuid() != uid || getgid() != gid) {
+			fprintf(stderr,
+				"retraced: privilege drop failed: %s\n",
+				strerror(errno));
+			return 2;
+		}
+		printf("retraced: running as uid=%ld gid=%ld\n",
+			(long)uid, (long)gid);
 	}
 
 	last_sweep = now_ms();
@@ -977,7 +1085,8 @@ int main(int argc, char **argv)
 	if (g_tls_listen >= 0)
 		close(g_tls_listen);
 	retraced_tls_free(g_tls_ctx);
-	unlink(sock_path);
+	if (unlink_sock)
+		unlink(sock_path);
 	free(conns);
 	return 0;
 }


### PR DESCRIPTION
## Summary
The remaining TODO.beyond-libc work, four slices:

1. **01 P2 — audited enforcement artifacts**: `retrace-enforce --audit PATH` appends a hash-chained record binding each exec to `(ts, pid, spec digest, backends, argv)`; `--verify-audit` replays. SHA-256 where OpenSSL links, FNV-1a-64 otherwise (record names its algorithm). Tampered/torn/unwritable trail fail-closes the exec. Also fixes a latent spec-loader bug: the JSON terminator was the multi-char constant backslash-backslash-zero (garbage assignment, buffer ran into heap; parson tolerated it by luck).
2. **03 P1 — retrace-etw-agent**: the Windows kernel-observation lane, same spectator doctrine and shape as the eBPF agent; `--synthetic` proves the pipe on POSIX CI, `--loader` wraps etw2retrace output for the real chain (named pipes ride supervisor/12).
3. **05 P2 — retraced socket activation + privilege drop**: `--fd N` serves an inherited listener (LISTEN_FDS convention; never unlinks it; bad fd exits 2 instead of spinning poll); `--user/--group` drops after all sockets bound, fail-closed; stdout line-buffered so readiness lines reach service managers.
4. **04 P2 — docs/runtime-agents.md**: the community contract for third-party agents (env activation, RTRD framing, frozen message table, conversation, source lanes, the two doctrines), with pyretrace/jretrace as references.

## Test plan
- [x] `unit-test-enforce-audit` (append/verify/tamper/torn/refuse/digest) 6/6
- [x] E2E audit: 2 chained execs verify ok; one appended byte breaks the chain (rc=1)
- [x] `integration-etw-agent` green (spectator, 3 observations, drift summary)
- [x] `integration-retraced-fd` green unprivileged (inherited fd served, no unlink); root drop section self-skips and will run on the Alpine (root) leg
- [x] supervisor regression set 7/7 green
- [ ] CI matrix
