### PR TITLE
v2.49.0 version bump

### DIFF
--- a/include/retrace/version.h
+++ b/include/retrace/version.h
@@ -37,10 +37,10 @@
 #define RETRACE_VERSION_H
 
 #define RETRACE_VERSION_MAJOR 2
-#define RETRACE_VERSION_MINOR 45
+#define RETRACE_VERSION_MINOR 49
 #define RETRACE_VERSION_PATCH 0
 
-#define RETRACE_VERSION_STRING "2.39.0"
+#define RETRACE_VERSION_STRING "2.49.0"
 
 #define RETRACE_VERSION_ATLEAST(maj, min, pat)                  \
 	(RETRACE_VERSION_MAJOR > (maj) ||                       \


### PR DESCRIPTION
## Summary
Version bump to 2.49.0 for the beyond-libc completion release: the P1 wave (macOS sandbox-exec + dual-path allows, live drift grading, TLS fleet transport with cert claim scopes + retrace-ctl --tls client, jretrace, sandbox path-set content validation), the P2 wave (audited enforcement artifacts, ETW agent, retraced socket activation + privilege drop, runtime-agent guide), and the follow-ups (Ed25519 signatures on the audit chain, the Windows AppContainer backend).

Also repairs the version.h drift: RETRACE_VERSION_STRING said "2.39.0" while MINOR said 45 — release artifacts derive their names from the STRING, so this is the first release since then whose artifacts will carry the tag's version.

## Test plan
- [x] version.h fields consistent (2.49.0 / "2.49.0")
- [x] build + integration suite green on main at the tagged content
- [ ] release.yml artifacts named retrace-2.49.0-*
