### PR TITLE
v2.50.0 version bump

### DIFF
--- a/include/retrace/version.h
+++ b/include/retrace/version.h
@@ -37,10 +37,10 @@
 #define RETRACE_VERSION_H
 
 #define RETRACE_VERSION_MAJOR 2
-#define RETRACE_VERSION_MINOR 49
+#define RETRACE_VERSION_MINOR 50
 #define RETRACE_VERSION_PATCH 0
 
-#define RETRACE_VERSION_STRING "2.49.0"
+#define RETRACE_VERSION_STRING "2.50.0"
 
 #define RETRACE_VERSION_ATLEAST(maj, min, pat)                  \
 	(RETRACE_VERSION_MAJOR > (maj) ||                       \


### PR DESCRIPTION
Version bump to 2.50.0 for the Windows named-pipe transport release (PR #730). Fields stay consistent (2.50.0 / "2.50.0").