### PR TITLE
signed policies: Ed25519-wrapped POLICY_SET, fail-closed on a pinned key (supervisor/05)

### DIFF
--- a/src/supervisor/CMakeLists.txt
+++ b/src/supervisor/CMakeLists.txt
@@ -19,11 +19,17 @@ target_include_directories(retrace_supervisor_proto PUBLIC
 # protocol lib verbatim (DRY) and core's public surfaces
 # (logger, real_impls, reentrance_guard) resolved at final
 # link. POSIX body + WIN32 stubs in one file.
-add_library(retrace_supervisor_agent STATIC agent.c)
+add_library(retrace_supervisor_agent STATIC agent.c policy_sig.c)
 target_include_directories(retrace_supervisor_agent PUBLIC
 	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 target_link_libraries(retrace_supervisor_agent PUBLIC
 	retrace_supervisor_proto)
+if(OpenSSL_FOUND)
+	target_compile_definitions(retrace_supervisor_agent PRIVATE
+		RETRACE_HAVE_OPENSSL=1)
+	target_link_libraries(retrace_supervisor_agent PUBLIC
+		OpenSSL::Crypto)
+endif()
 # The per-arch include core computes (engine.h ->
 # arch_spec_macros.h); mirrored here because the agent links
 # core headers without core's CMake context.

--- a/src/supervisor/agent.c
+++ b/src/supervisor/agent.c
@@ -20,6 +20,7 @@
 #include "conf.h"
 #include "parson.h"
 #include "protocol.h"
+#include "policy_sig.h"
 
 #ifndef _WIN32
 #include <dlfcn.h>
@@ -507,18 +508,37 @@ static void set_reason(char *dst, size_t cap, const char *msg)
  * small and swaps are rare, so retention is the bounded price
  * of lock-free readers on the dispatch path.
  */
-int retrace_agent_policy_apply(const char *payload_json,
+int retrace_agent_policy_apply(const char *payload_wrapped,
 	char *reason_out, size_t reason_cap)
 {
+	char payload_buf[8192];
+	const char *payload_json = payload_wrapped;
 	JSON_Value *v;
 	JSON_Object *root, *pol;
 	double epoch, expires;
 
 	if (reason_out != NULL && reason_cap > 0)
 		reason_out[0] = '\0';
-	if (payload_json == NULL) {
+	if (payload_wrapped == NULL) {
 		set_reason(reason_out, reason_cap, "null payload");
 		return -1;
+	}
+
+	/*
+	 * Signed policies (TODO.supervisor/05): a wrapper carries
+	 * the exact policy bytes + an Ed25519 signature; with a key
+	 * pinned (RETRACE_SUPERVISOR_PUBKEY) verification is
+	 * fail-closed. Bare policies pass through unchanged.
+	 */
+	(void)retrace_policy_sig_init();
+	{
+		int src = retrace_policy_sig_check(payload_wrapped,
+			payload_buf, sizeof(payload_buf), reason_out,
+			reason_cap);
+
+		if (src < 0)
+			return -1;
+		payload_json = payload_buf;
 	}
 
 	v = json_parse_string(payload_json);
@@ -1033,6 +1053,7 @@ int retrace_agent_init(void)
 	memset(&g_agent, 0, sizeof(g_agent));
 	pthread_mutex_init(&g_agent.mu, NULL);
 
+	(void)retrace_policy_sig_init();
 	env = retrace_real_impls.getenv("RETRACE_SUPERVISOR");
 	if (env == NULL || env[0] != '1')
 		return 0; /* not armed: silent, zero-delta */
@@ -1339,18 +1360,30 @@ static void w_drop_connection(void)
 
 /* ---- policy (mirrors the POSIX apply) ---- */
 
-int retrace_agent_policy_apply(const char *payload_json,
+int retrace_agent_policy_apply(const char *payload_wrapped,
 	char *reason_out, size_t reason_cap)
 {
+	char payload_buf[8192];
+	const char *payload_json = payload_wrapped;
 	JSON_Value *v;
 	JSON_Object *root, *pol;
 	double epoch;
 
 	if (reason_out != NULL && reason_cap > 0)
 		reason_out[0] = '\0';
-	if (payload_json == NULL) {
+	if (payload_wrapped == NULL) {
 		w_set_reason(reason_out, reason_cap, "null payload");
 		return -1;
+	}
+	(void)retrace_policy_sig_init();
+	{
+		int src = retrace_policy_sig_check(payload_wrapped,
+			payload_buf, sizeof(payload_buf), reason_out,
+			reason_cap);
+
+		if (src < 0)
+			return -1;
+		payload_json = payload_buf;
 	}
 	v = json_parse_string(payload_json);
 	if (v == NULL) {

--- a/src/supervisor/policy_sig.c
+++ b/src/supervisor/policy_sig.c
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+#include "policy_sig.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "parson.h"
+
+#ifdef RETRACE_HAVE_OPENSSL
+#include <openssl/evp.h>
+#include <openssl/pem.h>
+#endif
+
+#define SIG_B64_MAX 128
+
+#define REASON(reason) \
+	do { \
+		if (reason_out != NULL && reason_cap > 0) \
+			snprintf(reason_out, reason_cap, "%s", reason); \
+	} while (0)
+
+#ifdef RETRACE_HAVE_OPENSSL
+static EVP_PKEY *g_key;
+#endif
+static int g_pinned;
+
+static void copy_str_field(JSON_Object *root, const char *key,
+	char *dst, size_t cap)
+{
+	const char *v = json_object_get_string(root, key);
+
+	dst[0] = '\0';
+	if (v != NULL)
+		snprintf(dst, cap, "%s", v);
+}
+
+/*
+ * The pinned key from RETRACE_SUPERVISOR_PUBKEY: a PEM file path
+ * or an inline PEM with literal \n escapes.
+ */
+#ifdef RETRACE_HAVE_OPENSSL
+static EVP_PKEY *load_pubkey(const char *spec)
+{
+	FILE *f = fopen(spec, "r");
+	EVP_PKEY *k = NULL;
+
+	if (f != NULL) {
+		k = PEM_read_PUBKEY(f, NULL, NULL, NULL);
+		fclose(f);
+		return k;
+	}
+	{
+		char buf[4096];
+		size_t o = 0;
+
+		for (; *spec != '\0' && o + 1 < sizeof(buf); spec++) {
+			if (spec[0] == '\\' && spec[1] == 'n') {
+				buf[o++] = '\n';
+				spec++;
+			} else {
+				buf[o++] = *spec;
+			}
+		}
+		buf[o] = '\0';
+		{
+			BIO *b = BIO_new_mem_buf(buf, (int)o);
+
+			if (b != NULL) {
+				k = PEM_read_bio_PUBKEY(b, NULL, NULL,
+					NULL);
+				BIO_free(b);
+			}
+		}
+	}
+	return k;
+}
+
+/* Ed25519 verify: base64 (canonical quartets) over the message */
+static int verify_b64(const char *sig_b64, const char *msg)
+{
+	unsigned char raw[SIG_B64_MAX];
+	size_t blen = strlen(sig_b64);
+	size_t pad = 0;
+	int declen;
+	EVP_MD_CTX *ctx;
+	int ok = 0;
+
+	if (blen == 0 || blen % 4 != 0 || blen >= sizeof(raw) + 8)
+		return 0;
+	while (pad < 2 && sig_b64[blen - 1 - pad] == '=')
+		pad++;
+	declen = EVP_DecodeBlock(raw, (const unsigned char *)sig_b64,
+		(int)blen);
+	if (declen < 0)
+		return 0;
+	declen -= (int)pad;	/* EVP_DecodeBlock decodes '=' as NULs */
+	ctx = EVP_MD_CTX_new();
+	if (ctx != NULL) {
+		if (EVP_DigestVerifyInit(ctx, NULL, NULL, NULL,
+			    g_key) == 1 &&
+		    EVP_DigestVerify(ctx, raw, (size_t)declen,
+			    (const unsigned char *)msg,
+			    strlen(msg)) == 1)
+			ok = 1;
+		EVP_MD_CTX_free(ctx);
+	}
+	return ok;
+}
+#endif
+
+int retrace_policy_sig_init(void)
+{
+	if (g_pinned)
+		return 0;
+#ifdef RETRACE_HAVE_OPENSSL
+	{
+		const char *spec = getenv("RETRACE_SUPERVISOR_PUBKEY");
+
+		if (spec == NULL || spec[0] == '\0')
+			return 0;
+		g_key = load_pubkey(spec);
+		if (g_key == NULL)
+			return -1;
+		g_pinned = 1;
+	}
+#else
+	/*
+	 * No OpenSSL in the build: the pin still arms fail-closed
+	 * for WRAPPED policies (they cannot be verified); bare
+	 * policies keep working (the local PEERCRED+nonce model).
+	 */
+	if (getenv("RETRACE_SUPERVISOR_PUBKEY") != NULL)
+		g_pinned = 1;
+#endif
+	return 0;
+}
+
+int retrace_policy_sig_pinned(void)
+{
+	return g_pinned;
+}
+
+int retrace_policy_sig_check(const char *payload, char *blob_out,
+	size_t blob_cap, char *reason_out, size_t reason_cap)
+{
+	JSON_Value *v;
+	JSON_Object *root, *sig;
+	const char *blob;
+	int rc = -1;
+
+	if (reason_out != NULL && reason_cap > 0)
+		reason_out[0] = '\0';
+
+	v = json_parse_string(payload);
+	if (v == NULL) {
+		REASON("malformed json");
+		return -1;
+	}
+	root = json_value_get_object(v);
+	sig = root != NULL ? json_object_get_object(root, "sig") : NULL;
+	blob = root != NULL ? json_object_get_string(root, "blob")
+		: NULL;
+
+	if (sig == NULL && blob == NULL) {
+		/* bare policy: the caller applies payload as-is */
+		snprintf(blob_out, blob_cap, "%s", payload);
+		json_value_free(v);
+		return 0;
+	}
+	if (sig == NULL || blob == NULL) {
+		REASON("partial signature wrapper");
+		goto out;
+	}
+
+#ifdef RETRACE_HAVE_OPENSSL
+	{
+		char alg[32], sig_b64[SIG_B64_MAX];
+
+		copy_str_field(sig, "alg", alg, sizeof(alg));
+		copy_str_field(sig, "sig", sig_b64, sizeof(sig_b64));
+		if (strcmp(alg, "ed25519") != 0 || sig_b64[0] == '\0') {
+			REASON("unsupported signature");
+			goto out;
+		}
+		if (!g_pinned) {
+			/* nobody armed verification: pass through */
+			snprintf(blob_out, blob_cap, "%s", blob);
+			json_value_free(v);
+			return 1;
+		}
+		if (!verify_b64(sig_b64, blob)) {
+			REASON("signature invalid");
+			goto out;
+		}
+		snprintf(blob_out, blob_cap, "%s", blob);
+		json_value_free(v);
+		return 1;
+	}
+#else
+	(void)blob_out;
+	(void)blob_cap;
+	REASON("build cannot verify signatures");
+	goto out;
+#endif
+out:
+	json_value_free(v);
+	return rc;
+}

--- a/src/supervisor/policy_sig.h
+++ b/src/supervisor/policy_sig.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+#ifndef RETRACE_SUPERVISOR_POLICY_SIG_H_
+#define RETRACE_SUPERVISOR_POLICY_SIG_H_
+
+#include <stddef.h>
+
+/*
+ * Signed policies (TODO.supervisor/05): a POLICY_SET payload (or
+ * the --policy file) may be a WRAPPER instead of bare policy JSON:
+ *
+ *   {"sig":{"alg":"ed25519","key_id":"<hex16>","sig":"<b64>"},
+ *    "blob":"<the exact policy JSON, escaped>"}
+ *
+ * The signature covers the blob STRING BYTES (raw, as serialized --
+ * no canonicalization: what was signed is what ships). The agent
+ * verifies against the public key pinned via
+ * RETRACE_SUPERVISOR_PUBKEY (a PEM path or inline PEM). With a key
+ * pinned, a wrapped policy without a valid signature is REFUSED
+ * (fail-closed: channel compromise cannot relax policy); bare
+ * policies keep working (the local PEERCRED+nonce model). Without a
+ * key pinned, signatures are ignored.
+ *
+ * Returns: 0 = unsigned payload (caller applies as-is, and fills
+ * blob from payload), 1 = signed-and-valid (blob filled from the
+ * wrapper), -1 = rejected (reason filled when reason_out given).
+ */
+int retrace_policy_sig_check(const char *payload, char *blob_out,
+	size_t blob_cap, char *reason_out, size_t reason_cap);
+
+/*
+ * Load + pin the verification key (idempotent). Returns 0 when a
+ * key is pinned (or was already), -1 when the env names a key that
+ * cannot be loaded. Without OpenSSL the pin fails-closed for
+ * wrapped policies only (bare policies pass).
+ */
+int retrace_policy_sig_init(void);
+
+/* 1 when a key is pinned */
+int retrace_policy_sig_pinned(void);
+
+#endif /* RETRACE_SUPERVISOR_POLICY_SIG_H_ */

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -317,6 +317,21 @@ retrace_add_unit_test(modify_return_value_int
 # audited enforcement artifacts (TODO.beyond-libc/01 P2): the
 # hash chain binding exec to spec digest + backends.
 #
+#
+# signed POLICY_SET (TODO.supervisor/05): the wrapper format +
+# fail-closed pin (Ed25519 over the exact blob bytes).
+#
+retrace_add_unit_test(policy_sig
+    EXTRA_SOURCES ${CMAKE_SOURCE_DIR}/src/supervisor/policy_sig.c
+    EXTRA_INCLUDES ${CMAKE_SOURCE_DIR}/src/supervisor)
+if(OpenSSL_FOUND)
+    target_compile_definitions(retrace_test_policy_sig PRIVATE
+        RETRACE_HAVE_OPENSSL=1
+        RETRACE_SOURCE_DIR="${CMAKE_SOURCE_DIR}")
+    target_link_libraries(retrace_test_policy_sig PRIVATE
+        OpenSSL::Crypto)
+endif()
+
 retrace_add_unit_test(enforce_audit
     EXTRA_SOURCES ${CMAKE_SOURCE_DIR}/tools/enforce/artifact_audit.c
     EXTRA_INCLUDES ${CMAKE_SOURCE_DIR}/tools/enforce)

--- a/test/unit/test_policy_sig.c
+++ b/test/unit/test_policy_sig.c
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+/*
+ * Signed POLICY_SET (TODO.supervisor/05): the wrapper format and
+ * the fail-closed pin. The signature covers the blob STRING bytes
+ * exactly (no canonicalization); with RETRACE_SUPERVISOR_PUBKEY
+ * pinned, a wrapper without a valid Ed25519 signature is refused.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "policy_sig.h"
+
+/* fixtures: the committed audit keypair (throwaway, tests only) */
+#define PRIV RETRACE_SOURCE_DIR "/test/fixtures/audit_ed25519_key.pem"
+#define PUB RETRACE_SOURCE_DIR "/test/fixtures/audit_ed25519_pub.pem"
+
+#ifdef RETRACE_HAVE_OPENSSL
+#include <openssl/evp.h>
+#include <openssl/pem.h>
+
+/* sign with the fixture key IN PROCESS: no openssl CLI (its
+ * Ed25519 support varies -- LibreSSL on the mac runners lacks
+ * pkeyutl Ed entirely), no shell, deterministic everywhere.
+ */
+static int sign_b64(const char *msg, char *out, size_t cap)
+{
+	FILE *kf = fopen(PRIV, "r");
+	EVP_PKEY *key;
+	EVP_MD_CTX *ctx;
+	unsigned char sig[128];
+	size_t siglen = sizeof(sig);
+	char enc[256];
+
+	if (kf == NULL)
+		return -1;
+	key = PEM_read_PrivateKey(kf, NULL, NULL, NULL);
+	fclose(kf);
+	if (key == NULL)
+		return -1;
+	ctx = EVP_MD_CTX_new();
+	if (ctx == NULL ||
+	    EVP_DigestSignInit(ctx, NULL, NULL, NULL, key) != 1 ||
+	    EVP_DigestSign(ctx, sig, &siglen,
+		    (const unsigned char *)msg, strlen(msg)) != 1)
+		return -1;
+	EVP_MD_CTX_free(ctx);
+	EVP_EncodeBlock((unsigned char *)enc, sig, (int)siglen);
+	if (strlen(enc) + 1 > cap)
+		return -1;
+	strcpy(out, enc);
+	return 0;
+}
+#endif
+
+static int tests_run;
+static int tests_pass;
+static int tests_fail;
+
+#define TEST(name) do { \
+	tests_run++; \
+	printf("  TEST %s ... ", #name); \
+	test_##name(); \
+	tests_pass++; \
+	printf("OK\n"); \
+} while (0)
+
+#define CHECK(cond) do { \
+	if (!(cond)) { \
+		printf("FAIL [%s:%d] %s\n", __FILE__, __LINE__, #cond); \
+		tests_fail++; \
+		return; \
+	} \
+} while (0)
+
+static const char POLICY[] =
+	"{\"policy\":{\"epoch\":9},\"intercept_scripts\":[]}";
+
+static char wrapped[4096];
+
+/* JSON-escape for the blob value (the blob is a STRING member) */
+static void jesc_to(char *dst, size_t cap, const char *s)
+{
+	size_t o = 0;
+
+	for (; *s != '\0' && o + 7 < cap; s++) {
+		if (*s == '"' || *s == '\\') {
+			dst[o++] = '\\';
+			dst[o++] = *s;
+		} else {
+			dst[o++] = *s;
+		}
+	}
+	dst[o] = '\0';
+}
+
+/* the wrapper with a given signature over a given blob */
+static int build_signed(const char *sig_b64, const char *blob,
+	size_t cap)
+{
+	char esc[1024];
+	int n;
+
+	jesc_to(esc, sizeof(esc), blob);
+	n = snprintf(wrapped, cap,
+		"{\"sig\":{\"alg\":\"ed25519\","
+		"\"key_id\":\"test\",\"sig\":\"%s\"},"
+		"\"blob\":\"%s\"}",
+		sig_b64, esc);
+
+	return n > 0 && (size_t)n < cap ? 0 : -1;
+}
+
+static void test_bare_passthrough(void)
+{
+	char blob[512];
+	char reason[64];
+
+	setenv("RETRACE_SUPERVISOR_PUBKEY", PUB, 1);
+	(void)retrace_policy_sig_init();
+	CHECK(retrace_policy_sig_check(POLICY, blob, sizeof(blob),
+		reason, sizeof(reason)) == 0);
+	CHECK(strcmp(blob, POLICY) == 0);
+}
+
+static void test_wrapper_without_pin_passes(void)
+{
+	char blob[512];
+	char reason[64];
+
+	/* fresh process state: run this before pinning tests order
+	 * matters; main() runs this second with the env REMOVED
+	 */
+	unsetenv("RETRACE_SUPERVISOR_PUBKEY");
+	CHECK(build_signed("AAAA", POLICY, sizeof(wrapped)) == 0);
+	CHECK(retrace_policy_sig_check(wrapped, blob, sizeof(blob),
+		reason, sizeof(reason)) == 1);
+	CHECK(strcmp(blob, POLICY) == 0);
+}
+
+static void test_signed_accept(void)
+{
+	char b64[256];
+	char blob[512];
+	char reason[64];
+
+	CHECK(sign_b64(POLICY, b64, sizeof(b64)) == 0);
+
+	setenv("RETRACE_SUPERVISOR_PUBKEY", PUB, 1);
+	CHECK(retrace_policy_sig_init() == 0);
+	CHECK(retrace_policy_sig_pinned());
+	CHECK(build_signed(b64, POLICY, sizeof(wrapped)) == 0);
+	CHECK(retrace_policy_sig_check(wrapped, blob, sizeof(blob),
+		reason, sizeof(reason)) == 1);
+	CHECK(strcmp(blob, POLICY) == 0);
+}
+
+static void test_tampered_rejected(void)
+{
+	char blob[512];
+	char reason[64];
+	char bad[4096];
+
+	/* the same signature over a DIFFERENT blob: must fail */
+	{
+		const char *alt =
+			"{\"policy\":{\"epoch\":99},"
+			"\"intercept_scripts\":[]}";
+		const char *sig = strstr(wrapped, "\"sig\":\"");
+
+		CHECK(sig != NULL);
+		{
+			const char *sig_end = strchr(sig + 7, '"');
+			char sig_val[256];
+			size_t n;
+
+			CHECK(sig_end != NULL);
+			n = (size_t)(sig_end - (sig + 7));
+			CHECK(n < sizeof(sig_val));
+			memcpy(sig_val, sig + 7, n);
+			sig_val[n] = '\0';
+			CHECK(build_signed(sig_val, alt,
+				sizeof(wrapped)) == 0);
+			snprintf(bad, sizeof(bad), "%s", wrapped);
+		}
+	}
+	CHECK(retrace_policy_sig_check(bad, blob, sizeof(blob),
+		reason, sizeof(reason)) == -1);
+	CHECK(strstr(reason, "signature invalid") != NULL);
+}
+
+static void test_partial_wrapper_rejected(void)
+{
+	char blob[512];
+	char reason[64];
+	char w[512];
+
+	{
+		char esc[1024];
+
+		jesc_to(esc, sizeof(esc), POLICY);
+		snprintf(w, sizeof(w), "{\"blob\":\"%s\"}", esc);
+	}
+	CHECK(retrace_policy_sig_check(w, blob, sizeof(blob),
+		reason, sizeof(reason)) == -1);
+	CHECK(strstr(reason, "partial") != NULL);
+}
+
+int main(void)
+{
+	printf("policy signature tests:\n");
+	/* order: no-pin first (state is process-global) */
+	TEST(wrapper_without_pin_passes);
+	TEST(bare_passthrough);
+	TEST(signed_accept);
+	TEST(tampered_rejected);
+	TEST(partial_wrapper_rejected);
+
+	printf("%d tests: %d pass, %d fail\n", tests_run, tests_pass,
+		tests_fail);
+	return tests_fail == 0 ? 0 : 1;
+}

--- a/tools/retrace-ctl/CMakeLists.txt
+++ b/tools/retrace-ctl/CMakeLists.txt
@@ -15,7 +15,8 @@ target_include_directories(retrace_ctl PRIVATE
 
 if(OpenSSL_FOUND)
 	target_compile_definitions(retrace_ctl PRIVATE
-		RETRACED_HAVE_OPENSSL=1)
+		RETRACED_HAVE_OPENSSL=1
+		RETRACE_HAVE_OPENSSL=1)
 	target_link_libraries(retrace_ctl PRIVATE OpenSSL::SSL)
 	target_include_directories(retrace_ctl PRIVATE
 		${OPENSSL_INCLUDE_DIR})

--- a/tools/retrace-ctl/main.c
+++ b/tools/retrace-ctl/main.c
@@ -43,6 +43,11 @@
 
 #include "../retraced/tls_gate.h"
 
+#ifdef RETRACE_HAVE_OPENSSL
+#include <openssl/evp.h>
+#include <openssl/pem.h>
+#endif
+
 #define CTL_DEFAULT "/tmp/retraced.ctl.sock"
 
 /* JSON string escape (policy blobs are JSON-in-JSON); caller frees */
@@ -239,6 +244,66 @@ out:
 	return rc;
 }
 
+/* sign-policy: wrapper {sig:{alg,key_id,sig},blob} over the file
+ * bytes with Ed25519; the blob string is the exact file text.
+ */
+static int cmd_sign_policy(const char *file, const char *key_path)
+{
+#ifdef RETRACE_HAVE_OPENSSL
+	char *blob = read_file(file);
+	FILE *kf;
+	EVP_PKEY *key;
+	EVP_MD_CTX *ctx;
+	unsigned char sig[128];
+	size_t siglen = sizeof(sig);
+	char enc[256];
+	char *esc;
+	int n;
+
+	if (blob == NULL) {
+		fprintf(stderr, "retrace-ctl: cannot read %s\n", file);
+		return 2;
+	}
+	kf = fopen(key_path, "r");
+	if (kf == NULL) {
+		fprintf(stderr, "retrace-ctl: cannot read %s\n", key_path);
+		return 2;
+	}
+	key = PEM_read_PrivateKey(kf, NULL, NULL, NULL);
+	fclose(kf);
+	if (key == NULL) {
+		fprintf(stderr, "retrace-ctl: bad key %s\n", key_path);
+		return 2;
+	}
+	ctx = EVP_MD_CTX_new();
+	if (ctx == NULL ||
+	    EVP_DigestSignInit(ctx, NULL, NULL, NULL, key) != 1 ||
+	    EVP_DigestSign(ctx, sig, &siglen,
+		    (const unsigned char *)blob, strlen(blob)) != 1) {
+		fprintf(stderr, "retrace-ctl: sign failed\n");
+		return 2;
+	}
+	EVP_MD_CTX_free(ctx);
+	EVP_EncodeBlock((unsigned char *)enc, sig, (int)siglen);
+	esc = jesc(blob);
+	free(blob);
+	if (esc == NULL)
+		return 2;
+	n = printf("{\"sig\":{\"alg\":\"ed25519\",\"key_id\":\"%02x%02x\",\"sig\":\"%s\"},\"blob\":\"%s\"}\n",
+		sig[0], sig[1], enc, esc);
+	free(esc);
+	if (n <= 0)
+		return 2;
+	return 0;
+#else
+	(void)file;
+	(void)key_path;
+	fprintf(stderr,
+		"retrace-ctl: sign-policy needs an OpenSSL build\n");
+	return 2;
+#endif
+}
+
 static int ctl_usage(void)
 {
 	fprintf(stderr,
@@ -251,6 +316,7 @@ static int ctl_usage(void)
 		"  freeze                 hold every agent (wildcard freeze)\n"
 		"  thaw                   restore the pre-freeze policy\n"
 		"  kill PID               SIGTERM one target\n"
+		"  sign-policy FILE KEY   emit a signed wrapper to stdout\n"
 		"  --tls-*: fleet mTLS (all four required together)\n");
 	return 2;
 }
@@ -323,6 +389,9 @@ int main(int argc, char **argv)
 		snprintf(req, sizeof(req), "{\"cmd\":\"freeze\"}\n");
 	} else if (strcmp(argv[i], "thaw") == 0) {
 		snprintf(req, sizeof(req), "{\"cmd\":\"thaw\"}\n");
+	} else if (strcmp(argv[i], "sign-policy") == 0 &&
+		   i + 2 < argc) {
+		return cmd_sign_policy(argv[i + 1], argv[i + 2]);
 	} else if (strcmp(argv[i], "kill") == 0 && i + 1 < argc) {
 		long pid = strtol(argv[i + 1], NULL, 10);
 

--- a/tools/retraced/main.c
+++ b/tools/retraced/main.c
@@ -123,6 +123,17 @@ static int load_policy(const char *path)
 
 	v = json_parse_string(g_ctl.policy_blob);
 	root = v != NULL ? json_value_get_object(v) : NULL;
+	/* signed policies: the wrapper carries the policy in "blob" */
+	if (root != NULL && json_object_get_string(root, "blob") != NULL) {
+		JSON_Value *bv = json_parse_string(
+			json_object_get_string(root, "blob"));
+
+		if (bv != NULL) {
+			json_value_free(v);
+			v = bv;
+			root = json_value_get_object(bv);
+		}
+	}
 	pol = root != NULL ? json_object_get_object(root, "policy") : NULL;
 	epoch = pol != NULL ? json_object_get_number(pol, "epoch") : 0.0;
 	if (epoch < 1.0) {

--- a/tools/retraced/retraced_ctl.c
+++ b/tools/retraced/retraced_ctl.c
@@ -160,6 +160,18 @@ void retraced_ctl_handle_line(struct retraced_ctl_ctx *ctx,
 		}
 		pv = json_parse_string(blob);
 		proot = pv != NULL ? json_value_get_object(pv) : NULL;
+		/* signed policies: validate inside the wrapper's blob */
+		if (proot != NULL &&
+		    json_object_get_string(proot, "blob") != NULL) {
+			JSON_Value *bv = json_parse_string(
+				json_object_get_string(proot, "blob"));
+
+			if (bv != NULL) {
+				json_value_free(pv);
+				pv = bv;
+				proot = json_value_get_object(bv);
+			}
+		}
 		po = proot != NULL ?
 			json_object_get_object(proot, "policy") : NULL;
 		epoch = po != NULL ?


### PR DESCRIPTION
The policy-author trust plane: wrappers sign the exact blob bytes (no canonicalization); agents verify against a pinned env key and refuse invalid/partial wrappers (fail-closed). retrace-ctl sign-policy emits wrappers. Daemon-side loaders descend into the blob. Unit tests 5/5 locally; POSIX supervisor family green.