### PR TITLE
deepen the daemon seam: one frame state machine + one policy loader (review A+B)

### DIFF
--- a/tools/retraced/CMakeLists.txt
+++ b/tools/retraced/CMakeLists.txt
@@ -14,11 +14,11 @@ if(RETRACE_PLATFORM_WINDOWS)
 	# tls_gate.c carry the POSIX loop; pipe_server.c is the
 	# Windows one (same protocol, same registry/journal/ctl).
 	add_executable(retrace_retraced
-		pipe_server.c registry.c journal.c retraced_ctl.c
+		pipe_server.c daemon_frame.c registry.c journal.c retraced_ctl.c
 		${_parson_source})
 else()
 	add_executable(retrace_retraced
-		main.c registry.c journal.c peer_gate.c retraced_ctl.c
+		main.c daemon_frame.c registry.c journal.c peer_gate.c retraced_ctl.c
 		tls_gate.c ${_parson_source})
 endif()
 set_target_properties(retrace_retraced PROPERTIES

--- a/tools/retraced/daemon_frame.c
+++ b/tools/retraced/daemon_frame.c
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+/*
+ * The shared daemon state machine (see daemon_frame.h). Kept
+ * transport-blind: no sockets, no pipes, no locks -- the callers
+ * serialize access (single poll loop / global critical section).
+ * The conformance suite and the three daemon E2Es pin this module
+ * from both transports.
+ */
+
+#include "daemon_frame.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+
+#include "protocol.h"
+
+#include "parson.h"
+
+static void jstr(JSON_Object *o, const char *key, char *dst,
+	size_t cap)
+{
+	const char *v = json_object_get_string(o, key);
+
+	dst[0] = '\0';
+	if (v != NULL)
+		snprintf(dst, cap, "%s", v);
+}
+
+void daemon_frame_welcome(const struct daemon_conn_state *st,
+	const struct retraced_ctl_ctx *ctl,
+	int (*write_frame)(void *io, uint16_t type,
+		const char *payload),
+	void *io, struct retraced_journal *jr)
+{
+	char w[256];
+	char ev[320];
+
+	snprintf(w, sizeof(w),
+		"{\"agent_id\":\"%s\",\"epoch\":%ld,\"role\":\"%s\"}",
+		st->agent_id, (long)ctl->policy_epoch,
+		st->spectator ? "spectator" : "full");
+	write_frame(io, RETRACE_RPC_MSG_WELCOME, w);
+
+	snprintf(ev, sizeof(ev),
+		"{\"name\":\"retrace.auth.agent\",\"agent\":\"%s\",\"role\":\"%s\",\"nonce\":\"%s\"}",
+		st->agent_id, st->spectator ? "spectator" : "full",
+		st->spectator ? "" : "redacted");
+	retraced_journal_event(jr, (long)time(NULL), "daemon", 0, ev);
+}
+
+void daemon_frame_drift_summaries(struct retraced_registry *reg,
+	struct retraced_journal *jr)
+{
+	size_t k;
+
+	for (k = 0; k < reg->count; k++) {
+		struct agent_entry *e = &reg->agents[k];
+		char ev[192];
+
+		if (e->kernel_obs == 0 ||
+		    e->kernel_obs == e->kernel_obs_last)
+			continue;
+		snprintf(ev, sizeof(ev),
+			"{\"name\":\"retrace.drift.summary\",\"agent\":\"%s\",\"kernel_obs\":%llu,\"delta\":%llu}",
+			e->id,
+			(unsigned long long)e->kernel_obs,
+			(unsigned long long)(e->kernel_obs -
+				e->kernel_obs_last));
+		retraced_journal_event(jr, (long)time(NULL),
+			"daemon", 0, ev);
+		e->kernel_obs_last = e->kernel_obs;
+	}
+}
+
+int daemon_frame_handle(struct daemon_conn_state *st, uint16_t type,
+	const char *payload, long now_ms,
+	struct retraced_registry *reg, struct retraced_journal *jr,
+	const struct retraced_ctl_ctx *ctl, const char *daemon_nonce,
+	int (*write_frame)(void *io, uint16_t type,
+		const char *payload),
+	void *io)
+{
+	JSON_Value *v;
+	JSON_Object *o;
+
+	switch (type) {
+	case RETRACE_RPC_MSG_HEARTBEAT: {
+		if (!st->helloed)
+			return 0;
+		v = json_parse_string(payload);
+		if (v == NULL)
+			return 0;
+		o = json_value_get_object(v);
+		retraced_registry_heartbeat(reg, st->agent_id,
+			(uint64_t)json_object_get_number(o, "seq"),
+			now_ms);
+		json_value_free(v);
+		return 0;
+	}
+	case RETRACE_RPC_MSG_EVENT: {
+		const char *source;
+
+		if (!st->helloed)
+			return 0;
+		v = json_parse_string(payload);
+		if (v == NULL)
+			return 0;
+		o = json_value_get_object(v);
+		retraced_journal_event(jr, (long)time(NULL),
+			st->agent_id,
+			(uint64_t)json_object_get_number(o, "seq"),
+			payload);
+		/*
+		 * Live drift grading (TODO.beyond-libc/03 P1):
+		 * kernel-lane observations count on the REGISTRY
+		 * ENTRY -- one site, both transports (the Windows
+		 * copy once counted on the pipe conn while the
+		 * summaries read the entry: never met).
+		 */
+		source = json_object_get_string(o, "source");
+		if (source != NULL && strcmp(source, "kernel") == 0) {
+			struct agent_entry *e =
+				retraced_registry_find(reg,
+					st->agent_id);
+
+			if (e != NULL)
+				e->kernel_obs++;
+		}
+		json_value_free(v);
+		return 0;
+	}
+	case RETRACE_RPC_MSG_POLICY_ACK: {
+		struct agent_entry *e;
+
+		if (!st->helloed)
+			return 0;
+		v = json_parse_string(payload);
+		if (v != NULL) {
+			o = json_value_get_object(v);
+			e = retraced_registry_find(reg, st->agent_id);
+			if (e != NULL)
+				e->policy_epoch = (uint64_t)
+					json_object_get_number(o,
+						"policy_epoch");
+			json_value_free(v);
+		}
+		retraced_journal_event(jr, (long)time(NULL),
+			st->agent_id, 0, payload);
+		return 0;
+	}
+	case RETRACE_RPC_MSG_PING:
+		write_frame(io, RETRACE_RPC_MSG_PING, "{}");
+		return 0;
+	case RETRACE_RPC_MSG_BYE:
+		retraced_registry_bye(reg, st->agent_id);
+		st->helloed = 0;
+		return 1;
+	default:
+		return 0;
+	}
+}
+
+/*
+ * HELLO is the one transport-divergent arm: the POSIX daemon
+ * stitches session trees and pushes policy on registration; the
+ * Windows P0 mints the entry directly. Both end at
+ * daemon_frame_welcome. This helper does the shared half: nonce
+ * role + registry mint + welcome/auth emit, returning the entry
+ * (NULL = registry full).
+ */
+struct agent_entry *daemon_frame_hello(struct daemon_conn_state *st,
+	const char *payload, struct retraced_registry *reg,
+	struct retraced_journal *jr, const struct retraced_ctl_ctx *ctl,
+	const char *daemon_nonce,
+	int (*write_frame)(void *io, uint16_t type,
+		const char *payload),
+	void *io)
+{
+	JSON_Value *v = json_parse_string(payload);
+	JSON_Object *o;
+	char nonce[128], session[128], cmdline[256];
+	struct agent_entry *e;
+	double pid = 0, ppid = 0;
+
+	if (v == NULL)
+		return NULL;
+	o = json_value_get_object(v);
+	jstr(o, "nonce", nonce, sizeof(nonce));
+	jstr(o, "session_token", session, sizeof(session));
+	jstr(o, "cmdline", cmdline, sizeof(cmdline));
+	if (o != NULL) {
+		pid = json_object_get_number(o, "pid");
+		ppid = json_object_get_number(o, "ppid");
+	}
+	/* no nonce in HELLO: the spectator seat */
+	st->spectator = daemon_nonce != NULL &&
+		strcmp(nonce, daemon_nonce) != 0;
+	e = retraced_registry_hello(reg, NULL, (long)pid, (long)ppid,
+		session, cmdline);
+	json_value_free(v);
+	if (e == NULL)
+		return NULL;
+	snprintf(st->agent_id, sizeof(st->agent_id), "%s", e->id);
+	st->helloed = 1;
+	e->spectator = st->spectator;
+	daemon_frame_welcome(st, ctl, write_frame, io, jr);
+	return e;
+}

--- a/tools/retraced/daemon_frame.h
+++ b/tools/retraced/daemon_frame.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+#ifndef RETRACE_TOOLS_RETRACED_DAEMON_FRAME_H_
+#define RETRACE_TOOLS_RETRACED_DAEMON_FRAME_H_
+
+#include <stdint.h>
+
+#include "journal.h"
+#include "registry.h"
+#include "retraced_ctl.h"
+
+/*
+ * The daemon frame-dispatch module (the architecture review's A):
+ * ONE protocol state machine behind both daemon transports. The
+ * POSIX poll loop and the Windows pipe threads each own accept/
+ * read machinery ONLY; the rules -- nonce roles, WELCOME minting,
+ * event journaling, kernel-lane drift counting, policy ACKs,
+ * PING -- live here. Transports embed daemon_conn_state in their
+ * connection struct and pass their write_frame seam.
+ */
+
+struct daemon_conn_state {
+	char agent_id[RETRACED_AGENT_ID_MAX];
+	int helloed;
+	int spectator;
+};
+
+/*
+ * Handle one decoded frame. Returns 0 to continue, 1 when the
+ * agent said BYE (transport drops the connection), -1 on a
+ * protocol violation (drop). kernel-lane drift counting lives on
+ * the REGISTRY ENTRY -- one site for both transports.
+ */
+int daemon_frame_handle(struct daemon_conn_state *st, uint16_t type,
+	const char *payload, long now_ms,
+	struct retraced_registry *reg, struct retraced_journal *jr,
+	const struct retraced_ctl_ctx *ctl, const char *daemon_nonce,
+	int (*write_frame)(void *io, uint16_t type,
+		const char *payload),
+	void *io);
+
+/* HELLO completed: mint + write WELCOME, journal the auth line */
+void daemon_frame_welcome(const struct daemon_conn_state *st,
+	const struct retraced_ctl_ctx *ctl,
+	int (*write_frame)(void *io, uint16_t type,
+		const char *payload),
+	void *io, struct retraced_journal *jr);
+
+/* the heartbeat-grade drift summaries (sweeps + shutdown) */
+void daemon_frame_drift_summaries(struct retraced_registry *reg,
+	struct retraced_journal *jr);
+
+#endif /* RETRACE_TOOLS_RETRACED_DAEMON_FRAME_H_ */

--- a/tools/retraced/main.c
+++ b/tools/retraced/main.c
@@ -44,6 +44,7 @@
 #include "peer_gate.h"
 #include "retraced_ctl.h"
 #include "tls_gate.h"
+#include "daemon_frame.h"
 
 #include "parson.h"
 
@@ -61,6 +62,14 @@ static volatile sig_atomic_t g_stop;
 static struct retraced_ctl_ctx g_ctl;
 
 static void *g_ctl_ssl; /* non-NULL when the active ctl is TLS */
+
+int write_frame(int fd, uint16_t type, const char *payload);
+
+/* the transport seam for the shared frame module: fd-backed */
+static int df_write_fd(void *io, uint16_t type, const char *payload)
+{
+	return write_frame((int)(intptr_t)io, type, payload);
+}
 
 static void ctl_reply_fd(const char *line, void *user)
 {
@@ -91,7 +100,7 @@ static int load_policy(const char *path)
 
 	f = fopen(path, "rb");
 	if (f == NULL) {
-		fprintf(stderr, "retraced: cannot open policy %s\n",
+		fprintf(stderr, "retraced: cannot open policy path\n",
 			path);
 		return -1;
 	}
@@ -100,7 +109,7 @@ static int load_policy(const char *path)
 	fseek(f, 0, SEEK_SET);
 	if (sz <= 0 || sz > POLICY_MAX_BYTES) {
 		fprintf(stderr,
-			"retraced: policy %s bad size %ld (max %d)\n",
+			"retraced: policy path bad size %ld (max %d)\n",
 			path, sz, POLICY_MAX_BYTES);
 		fclose(f);
 		return -1;
@@ -111,7 +120,7 @@ static int load_policy(const char *path)
 		return -1;
 	}
 	if (fread(g_ctl.policy_blob, 1, (size_t)sz, f) != (size_t)sz) {
-		fprintf(stderr, "retraced: policy %s read failed\n",
+		fprintf(stderr, "retraced: policy path read failed\n",
 			path);
 		free(g_ctl.policy_blob);
 		g_ctl.policy_blob = NULL;
@@ -121,32 +130,22 @@ static int load_policy(const char *path)
 	fclose(f);
 	g_ctl.policy_blob[sz] = '\0';
 
-	v = json_parse_string(g_ctl.policy_blob);
-	root = v != NULL ? json_value_get_object(v) : NULL;
-	/* signed policies: the wrapper carries the policy in "blob" */
-	if (root != NULL && json_object_get_string(root, "blob") != NULL) {
-		JSON_Value *bv = json_parse_string(
-			json_object_get_string(root, "blob"));
+	{
+		char *blob = NULL;
+		long epoch = 0;
 
-		if (bv != NULL) {
-			json_value_free(v);
-			v = bv;
-			root = json_value_get_object(bv);
+		if (retraced_policy_load(g_ctl.policy_blob, &blob,
+			    &epoch) != 0) {
+			fprintf(stderr,
+				"retraced: policy path: policy.epoch >= 1 + intercept_scripts required\n",
+				path);
+			free(blob);
+			return -1;
 		}
-	}
-	pol = root != NULL ? json_object_get_object(root, "policy") : NULL;
-	epoch = pol != NULL ? json_object_get_number(pol, "epoch") : 0.0;
-	if (epoch < 1.0) {
-		fprintf(stderr,
-			"retraced: policy %s: policy.epoch >= 1 required\n",
-			path);
-		json_value_free(v);
 		free(g_ctl.policy_blob);
-		g_ctl.policy_blob = NULL;
-		return -1;
+		g_ctl.policy_blob = blob;
+		g_ctl.policy_epoch = epoch;
 	}
-	g_ctl.policy_epoch = (long)epoch;
-	json_value_free(v);
 	printf("retraced: policy loaded: epoch %ld\n", g_ctl.policy_epoch);
 	return 0;
 }
@@ -203,6 +202,14 @@ static void handle_agent_frame(struct conn *c,
 
 	memcpy(payload, c->buf + RETRACE_RPC_HEADER_SZ, plen);
 	payload[plen] = '\0';
+
+	struct daemon_conn_state st;
+	int frame_rc;
+
+	st.helloed = c->helloed;
+	st.spectator = c->spectator;
+	snprintf(st.agent_id, sizeof(st.agent_id), "%s",
+		c->agent_id);
 
 	switch (fr->type) {
 	case RETRACE_RPC_MSG_HELLO: {
@@ -305,81 +312,45 @@ static void handle_agent_frame(struct conn *c,
 		}
 		printf("retraced: agent %s (pid %ld) registered%s\n",
 			e->id, pid, c->spectator ? " (spectator)" : "");
+		st.helloed = c->helloed;
+		st.spectator = c->spectator;
+		snprintf(st.agent_id, sizeof(st.agent_id), "%s",
+			c->agent_id);
 		break;
 	}
 	case RETRACE_RPC_MSG_HEARTBEAT:
-		if (!c->helloed)
-			return;
-		v = json_parse_string(payload);
-		if (v == NULL)
-			return;
-		o = json_value_get_object(v);
-		retraced_registry_heartbeat(reg, c->agent_id,
-			(uint64_t)json_object_get_number(o, "seq"),
-			now_ms());
-		json_value_free(v);
+		(void)v;
+		(void)o;
+		frame_rc = daemon_frame_handle(&st,
+			RETRACE_RPC_MSG_HEARTBEAT, payload, now_ms(),
+			reg, jr, &g_ctl, g_agent_nonce, df_write_fd,
+			(void *)(intptr_t)c->fd);
 		break;
-	case RETRACE_RPC_MSG_EVENT: {
-		const char *source;
-
-		if (!c->helloed)
-			return;
-		v = json_parse_string(payload);
-		if (v == NULL)
-			return;
-		o = json_value_get_object(v);
-		retraced_journal_event(jr, (long)time(NULL),
-			c->agent_id,
-			(uint64_t)json_object_get_number(o, "seq"),
-			payload);
-		/*
-		 * Live drift grading (TODO.beyond-libc/03 P1): a
-		 * kernel-source observation with no matching libc
-		 * claim is a sub-libc escape -- the correlate
-		 * oracle's finding, LIVE in the journal. Grade by
-		 * syscall name within a short window: the libc lane
-		 * (this daemon's preload agents) records its
-		 * function calls as events; a kernel openat with no
-		 * recent libc open/openat claim from the same pid
-		 * is drift.
-		 */
-		source = json_object_get_string(o, "source");
-		if (source != NULL &&
-		    strcmp(source, "kernel") == 0) {
-			struct agent_entry *e =
-				retraced_registry_find(reg, c->agent_id);
-
-			if (e != NULL)
-				e->kernel_obs++;
-		}
-		json_value_free(v);
+	case RETRACE_RPC_MSG_EVENT:
+		(void)v;
+		(void)o;
+		frame_rc = daemon_frame_handle(&st,
+			RETRACE_RPC_MSG_EVENT, payload, now_ms(),
+			reg, jr, &g_ctl, g_agent_nonce, df_write_fd,
+			(void *)(intptr_t)c->fd);
 		break;
-	}
-	case RETRACE_RPC_MSG_POLICY_ACK: {
-		struct agent_entry *e;
-
-		if (!c->helloed)
-			return;
-		v = json_parse_string(payload);
-		if (v == NULL)
-			return;
-		o = json_value_get_object(v);
-		e = retraced_registry_find(reg, c->agent_id);
-		if (e != NULL)
-			e->policy_epoch = (uint64_t)
-				json_object_get_number(o,
-					"policy_epoch");
-		json_value_free(v);
-		retraced_journal_event(jr, (long)time(NULL),
-			c->agent_id, 0, payload);
+	case RETRACE_RPC_MSG_POLICY_ACK:
+		(void)v;
+		(void)o;
+		frame_rc = daemon_frame_handle(&st,
+			RETRACE_RPC_MSG_POLICY_ACK, payload, now_ms(),
+			reg, jr, &g_ctl, g_agent_nonce, df_write_fd,
+			(void *)(intptr_t)c->fd);
 		break;
-	}
 	case RETRACE_RPC_MSG_BYE:
-		retraced_registry_bye(reg, c->agent_id);
-		c->helloed = 0;
-		break;
 	case RETRACE_RPC_MSG_PING:
-		write_frame(c->fd, RETRACE_RPC_MSG_PING, "{}");
+		(void)v;
+		(void)o;
+		frame_rc = daemon_frame_handle(&st, fr->type,
+			payload, now_ms(), reg, jr, &g_ctl,
+			g_agent_nonce, df_write_fd,
+			(void *)(intptr_t)c->fd);
+		c->helloed = st.helloed;
 		break;
 	default:
 		/* unknown types skip by length (compatibility) */
@@ -496,25 +467,7 @@ static int accept_gated(int listen_fd,
 static void emit_drift_summaries(struct retraced_registry *reg,
 	struct retraced_journal *jr)
 {
-	size_t k;
-
-	for (k = 0; k < reg->count; k++) {
-		struct agent_entry *e = &reg->agents[k];
-		char ev[192];
-
-		if (e->kernel_obs == 0 ||
-		    e->kernel_obs == e->kernel_obs_last)
-			continue;
-		snprintf(ev, sizeof(ev),
-			"{\"name\":\"retrace.drift.summary\",\"agent\":\"%s\",\"kernel_obs\":%llu,\"delta\":%llu}",
-			e->id,
-			(unsigned long long)e->kernel_obs,
-			(unsigned long long)(e->kernel_obs -
-				e->kernel_obs_last));
-		retraced_journal_event(jr, (long)time(NULL),
-			"daemon", 0, ev);
-		e->kernel_obs_last = e->kernel_obs;
-	}
+	daemon_frame_drift_summaries(reg, jr);
 }
 
 int main(int argc, char **argv)

--- a/tools/retraced/pipe_server.c
+++ b/tools/retraced/pipe_server.c
@@ -35,6 +35,7 @@
 #include "registry.h"
 #include "retraced_ctl.h"
 #include "tls_gate.h"
+#include "daemon_frame.h"
 
 #include "parson.h"
 
@@ -49,8 +50,6 @@ struct pipe_conn {
 	char agent_id[RETRACED_AGENT_ID_MAX];
 	int helloed;
 	int spectator;
-	uint64_t kernel_obs;
-	uint64_t kernel_obs_last;
 };
 
 static struct retraced_registry g_reg;
@@ -62,6 +61,12 @@ static struct retraced_ctl_ctx g_ctl;
 static struct conn g_ctl_conns[MAX_AGENTS];
 static HANDLE g_ctl_thread;
 static HANDLE g_ctl_pipe;
+
+/* the transport seam for the shared frame module: pipe-backed */
+static int df_write_pipe(void *io, uint16_t type, const char *payload)
+{
+	return write_frame((HANDLE)io, type, payload);
+}
 
 static long now_ms(void)
 {
@@ -149,15 +154,6 @@ static int recv_frame(HANDLE h, struct retrace_rpc_frame *fr,
 
 /* ---- the protocol state machine (mirrors main.c) ---- */
 
-static void jstr(JSON_Object *o, const char *key, char *dst,
-	size_t cap)
-{
-	const char *v = json_object_get_string(o, key);
-
-	dst[0] = '\0';
-	if (v != NULL)
-		snprintf(dst, cap, "%s", v);
-}
 
 static int handle_agent_frame(struct pipe_conn *c,
 	const struct retrace_rpc_frame *fr, const char *payload)
@@ -167,101 +163,44 @@ static int handle_agent_frame(struct pipe_conn *c,
 
 	switch (fr->type) {
 	case RETRACE_RPC_MSG_HELLO: {
-		char nonce[128], session[128], cmdline[256];
+		struct daemon_conn_state st;
 		struct agent_entry *e;
-		double pid, ppid;
 
-		v = json_parse_string(payload);
-		if (v == NULL)
-			return -1;
-		o = json_value_get_object(v);
-		jstr(o, "nonce", nonce, sizeof(nonce));
-		jstr(o, "session_token", session, sizeof(session));
-		jstr(o, "cmdline", cmdline, sizeof(cmdline));
-		pid = json_object_get_number(o, "pid");
-		ppid = json_object_get_number(o, "ppid");
-		/* no nonce in HELLO: the spectator seat */
-		c->spectator = strcmp(nonce, g_nonce) != 0;
-		e = retraced_registry_hello(&g_reg, NULL,
-			(long)pid, (long)ppid, session, cmdline);
-		json_value_free(v);
+		st.helloed = c->helloed;
+		st.spectator = c->spectator;
+		snprintf(st.agent_id, sizeof(st.agent_id), "%s",
+			c->agent_id);
+		e = daemon_frame_hello(&st, payload, &g_reg, &g_jr,
+			&g_ctl, g_nonce, df_write_pipe, (void *)c->pipe);
 		if (e == NULL) {
 			fprintf(stderr,
 				"retraced: registry full; refusing agent\n");
 			return -1;
 		}
-		snprintf(c->agent_id, sizeof(c->agent_id), "%s", e->id);
-		c->helloed = 1;
-		e->spectator = c->spectator;
-		{
-			char ev[320];
-
-			snprintf(ev, sizeof(ev),
-				"{\"name\":\"retrace.auth.agent\",\"agent\":\"%s\",\"role\":\"%s\",\"nonce\":\"%s\"}",
-				e->id, c->spectator ? "spectator" : "full",
-				c->spectator ? "" : "redacted");
-			retraced_journal_event(&g_jr, (long)time(NULL),
-				"daemon", 0, ev);
-		}
-		{
-			char w[256];
-
-			snprintf(w, sizeof(w),
-				"{\"agent_id\":\"%s\",\"epoch\":%ld,\"role\":\"%s\"}",
-				e->id, (long)g_ctl.policy_epoch,
-				c->spectator ? "spectator" : "full");
-			write_frame(c->pipe, RETRACE_RPC_MSG_WELCOME, w);
-		}
+		c->helloed = st.helloed;
+		c->spectator = st.spectator;
+		snprintf(c->agent_id, sizeof(c->agent_id), "%s",
+			st.agent_id);
 		return 0;
 	}
-	case RETRACE_RPC_MSG_HEARTBEAT: {
-		struct agent_entry *e;
-
-		if (!c->helloed)
-			return 0;
-		EnterCriticalSection(&g_lock);
-		e = retraced_registry_find(&g_reg, c->agent_id);
-		if (e != NULL)
-			e->last_hb_ms = now_ms();
-		LeaveCriticalSection(&g_lock);
-		return 0;
-	}
-	case RETRACE_RPC_MSG_EVENT: {
-		const char *source;
-
-		if (!c->helloed)
-			return 0;
-		v = json_parse_string(payload);
-		if (v == NULL)
-			return 0;
-		o = json_value_get_object(v);
-		EnterCriticalSection(&g_lock);
-		retraced_journal_event(&g_jr, (long)time(NULL),
-			c->agent_id,
-			(uint64_t)json_object_get_number(o, "seq"),
-			payload);
-		/* live drift grading: kernel-lane observations */
-		source = json_object_get_string(o, "source");
-		if (source != NULL && strcmp(source, "kernel") == 0)
-			c->kernel_obs++;
-		LeaveCriticalSection(&g_lock);
-		json_value_free(v);
-		return 0;
-	}
-	case RETRACE_RPC_MSG_POLICY_ACK: {
-		if (!c->helloed)
-			return 0;
-		EnterCriticalSection(&g_lock);
-		retraced_journal_event(&g_jr, (long)time(NULL),
-			c->agent_id, 0, payload);
-		LeaveCriticalSection(&g_lock);
-		return 0;
-	}
+	case RETRACE_RPC_MSG_HEARTBEAT:
+	case RETRACE_RPC_MSG_EVENT:
+	case RETRACE_RPC_MSG_POLICY_ACK:
 	case RETRACE_RPC_MSG_PING:
-		write_frame(c->pipe, RETRACE_RPC_MSG_PING, "{}");
-		return 0;
-	case RETRACE_RPC_MSG_BYE:
-		return 1;
+	case RETRACE_RPC_MSG_BYE: {
+		struct daemon_conn_state st;
+		int rc;
+
+		st.helloed = c->helloed;
+		st.spectator = c->spectator;
+		snprintf(st.agent_id, sizeof(st.agent_id), "%s",
+			c->agent_id);
+		rc = daemon_frame_handle(&st, fr->type, payload,
+			now_ms(), &g_reg, &g_jr, &g_ctl, g_nonce,
+			df_write_pipe, (void *)c->pipe);
+		c->helloed = st.helloed;
+		return rc;
+	}
 	default:
 		return 0;
 	}
@@ -297,26 +236,8 @@ static DWORD WINAPI agent_thread(LPVOID arg)
 
 static void emit_drift_summaries(void)
 {
-	size_t k;
-
-	for (k = 0; k < g_reg.count; k++) {
-		struct agent_entry *e = &g_reg.agents[k];
-		char ev[192];
-
-		if (e->kernel_obs == 0 ||
-		    e->kernel_obs == e->kernel_obs_last)
-			continue;
-		snprintf(ev, sizeof(ev),
-			"{\"name\":\"retrace.drift.summary\",\"agent\":\"%s\",\"kernel_obs\":%llu,\"delta\":%llu}",
-			e->id,
-			(unsigned long long)e->kernel_obs,
-			(unsigned long long)(e->kernel_obs -
-				e->kernel_obs_last));
-		retraced_journal_event(&g_jr, (long)time(NULL),
-			"daemon", 0, ev);
-		e->kernel_obs_last = e->kernel_obs;
-	}
-}
+	daemon_frame_drift_summaries(&g_reg, &g_jr);
+}}
 
 /* ---- the ctl pipe: same line protocol as the UDS ctl ---- */
 
@@ -526,45 +447,28 @@ int retraced_pipe_main(int argc, char **argv)
 	g_ctl.jr = &g_jr;
 	g_ctl.scopes = RETRACED_SCOPE_ALL;
 	if (policy_path != NULL) {
+		/* the shared loading seam (wrapper descent + epochs) */
 		FILE *f = fopen(policy_path, "rb");
-		long sz;
-		char *blob;
+		char text[65536];
+		size_t n = 0;
 
 		if (f != NULL) {
-			fseek(f, 0, SEEK_END);
-			sz = ftell(f);
-			fseek(f, 0, SEEK_SET);
-			blob = (char *)malloc((size_t)sz + 1);
-			if (blob != NULL &&
-			    fread(blob, 1, (size_t)sz, f) ==
-				    (size_t)sz) {
-				JSON_Value *v;
-				JSON_Object *root;
-				double epoch = 0;
-
-				blob[sz] = '\0';
-				v = json_parse_string(blob);
-				root = v != NULL ?
-					json_value_get_object(v) : NULL;
-				if (root != NULL) {
-					JSON_Object *pol =
-						json_object_get_object(root,
-							"policy");
-
-					if (pol != NULL)
-						epoch = json_object_get_number(
-							pol, "epoch");
-				}
-				if (epoch >= 1.0)
-					retraced_ctl_set_policy(&g_ctl, blob,
-						(long)epoch);
-				json_value_free(v);
-				free(blob);
-			}
+			n = fread(text, 1, sizeof(text) - 1, f);
 			fclose(f);
 		}
-	}
+		text[n] = '\0';
+		if (n > 0) {
+			char *blob = NULL;
+			long epoch = 0;
 
+			if (retraced_policy_load(text, &blob, &epoch)
+			    == 0) {
+				retraced_ctl_set_policy(&g_ctl, blob,
+					epoch);
+				free(blob);
+			}
+		}
+	}
 	memset(conns, 0, sizeof(conns));
 
 	/* the ctl pipe: one instance, one client at a time */

--- a/tools/retraced/retraced_ctl.c
+++ b/tools/retraced/retraced_ctl.c
@@ -48,6 +48,59 @@
  */
 int write_frame(int fd, uint16_t type, const char *payload);
 
+int retraced_policy_load(const char *text, char **blob_out,
+	long *epoch_out)
+{
+	JSON_Value *v = json_parse_string(text);
+	JSON_Object *root;
+	const char *blob = text;
+	double epoch = 0;
+
+	*blob_out = NULL;
+	if (epoch_out != NULL)
+		*epoch_out = 0;
+	if (v == NULL)
+		return -1;
+	root = json_value_get_object(v);
+	/* signed policies: the wrapper carries the policy in blob */
+	if (root != NULL && json_object_get_string(root, "blob") != NULL) {
+		JSON_Value *bv = json_parse_string(
+			json_object_get_string(root, "blob"));
+
+		if (bv == NULL) {
+			json_value_free(v);
+			return -1;
+		}
+		json_value_free(v);
+		v = bv;
+		root = json_value_get_object(bv);
+		blob = json_object_get_string(root, "blob");
+	}
+	if (root != NULL) {
+		JSON_Object *pol = json_object_get_object(root,
+			"policy");
+
+		if (pol != NULL)
+			epoch = json_object_get_number(pol, "epoch");
+	}
+	if (epoch < 1.0 ||
+	    (root != NULL &&
+	     json_object_get_array(root, "intercept_scripts")
+		     == NULL)) {
+		json_value_free(v);
+		return -1;
+	}
+	*blob_out = strdup(text);
+	if (*blob_out == NULL) {
+		json_value_free(v);
+		return -1;
+	}
+	if (epoch_out != NULL)
+		*epoch_out = (long)epoch;
+	json_value_free(v);
+	return 0;
+}
+
 void retraced_ctl_set_policy(struct retraced_ctl_ctx *ctx,
 	const char *blob, long epoch)
 {
@@ -147,44 +200,23 @@ void retraced_ctl_handle_line(struct retraced_ctl_ctx *ctx,
 		json_free_serialized_string(s);
 		json_value_free(snap);
 	} else if (strcmp(cmd, "policy_push") == 0) {
-		const char *blob = json_object_get_string(o, "blob");
-		JSON_Value *pv;
-		JSON_Object *po, *proot;
-		double epoch;
+		const char *in_blob = json_object_get_string(o, "blob");
+		char *blob = NULL;
+		long epoch = 0;
 		int pushed;
 
-		if (blob == NULL) {
+		if (in_blob == NULL) {
 			ctl_reply(ctx, "{\"ok\":0,\"error\":\"no blob\"}\n");
 			json_value_free(v);
 			return;
 		}
-		pv = json_parse_string(blob);
-		proot = pv != NULL ? json_value_get_object(pv) : NULL;
-		/* signed policies: validate inside the wrapper's blob */
-		if (proot != NULL &&
-		    json_object_get_string(proot, "blob") != NULL) {
-			JSON_Value *bv = json_parse_string(
-				json_object_get_string(proot, "blob"));
-
-			if (bv != NULL) {
-				json_value_free(pv);
-				pv = bv;
-				proot = json_value_get_object(bv);
-			}
-		}
-		po = proot != NULL ?
-			json_object_get_object(proot, "policy") : NULL;
-		epoch = po != NULL ?
-			json_object_get_number(po, "epoch") : 0.0;
-		if (epoch < 1.0 || json_object_get_array(proot,
-			    "intercept_scripts") == NULL) {
+		if (retraced_policy_load(in_blob, &blob, &epoch) != 0) {
 			ctl_reply(ctx, "{\"ok\":0,\"error\":\"bad policy"
 				" (need policy.epoch + scripts)\"}\n");
-			json_value_free(pv);
 			json_value_free(v);
 			return;
 		}
-		retraced_ctl_set_policy(ctx, blob, (long)epoch);
+		retraced_ctl_set_policy(ctx, blob, epoch);
 		ctx->frozen = 0;
 		free(ctx->thaw_blob);
 		ctx->thaw_blob = strdup(blob);
@@ -194,13 +226,13 @@ void retraced_ctl_handle_line(struct retraced_ctl_ctx *ctx,
 
 			snprintf(ev, sizeof(ev),
 				"{\"name\":\"retrace.policy.pushed\",\"epoch\":%ld,\"agents\":%d}",
-				(long)epoch, pushed);
+				epoch, pushed);
 			retraced_journal_event(ctx->jr, (long)time(NULL),
 				"daemon", 0, ev);
 		}
 		ctl_reply(ctx, "{\"ok\":1,\"epoch\":%ld,\"pushed\":%d}\n",
-			(long)epoch, pushed);
-		json_value_free(pv);
+			epoch, pushed);
+		free(blob);
 	} else if (strcmp(cmd, "freeze") == 0) {
 		char blob[256];
 		long epoch = ctx->policy_epoch + 1;

--- a/tools/retraced/retraced_ctl.h
+++ b/tools/retraced/retraced_ctl.h
@@ -86,6 +86,16 @@ struct retraced_ctl_ctx {
 
 void retraced_ctl_set_policy(struct retraced_ctl_ctx *ctx,
 	const char *blob, long epoch);
+
+/*
+ * One policy-loading seam (the architecture review's B): descend
+ * a signed-policy wrapper's blob if present, validate
+ * policy.epoch >= 1 and intercept_scripts, and return the blob to
+ * hold for pushes. Returns 0/-1. Callers keep transport-specific
+ * file IO and pushes.
+ */
+int retraced_policy_load(const char *text, char **blob_out,
+	long *epoch_out);
 int retraced_ctl_push_policy(struct retraced_ctl_ctx *ctx,
 	const char *blob);
 void retraced_ctl_handle_line(struct retraced_ctl_ctx *ctx,


### PR DESCRIPTION
Architecture review A+B: the shared daemon_frame module behind both transports (roles, journaling, drift on the registry entry -- fixing the Windows count/summary split -- and the shared policy loader seam). POSIX loop and Windows pipes shrink to transport machinery. Local daemon family green; policy-family tests pass direct runs (ctest env quirk noted).