### PR TITLE
retraced: full spin guards + --exit-after (hang-incident hardening)

### DIFF
--- a/test/integration/test_retraced_fd.py
+++ b/test/integration/test_retraced_fd.py
@@ -130,7 +130,7 @@ def main():
     with open(d_out, "w") as df:
         d = subprocess.Popen(
             [daemon, "--sock", sock, "--journal", journal,
-             "--fd", str(fdnum)],
+             "--exit-after", "60", "--fd", str(fdnum)],
             stdin=subprocess.DEVNULL, stdout=df,
             stderr=subprocess.STDOUT,
             pass_fds=(fdnum,))
@@ -189,6 +189,7 @@ def main():
             d2 = subprocess.Popen(
                 [daemon, "--sock", os.path.join(work, "a2.sock"),
                  "--journal", os.path.join(work, "j2.jsonl"),
+                 "--exit-after", "60",
                  "--user", drop_user],
                 stdin=subprocess.DEVNULL, stdout=df,
                 stderr=subprocess.STDOUT)

--- a/tools/retraced/main.c
+++ b/tools/retraced/main.c
@@ -470,6 +470,32 @@ static void emit_drift_summaries(struct retraced_registry *reg,
 	daemon_frame_drift_summaries(reg, jr);
 }
 
+/*
+ * Loop guards (the spin-incident doctrine): any condition that
+ * could make poll() return instantly forever is FATAL, journaled
+ * first -- a daemon that cannot make progress must die loudly,
+ * never spin silently.
+ */
+static struct retraced_journal *g_jr_fatal;
+static volatile sig_atomic_t g_fatal_done;
+
+static void daemon_fatal(const char *why)
+{
+	char ev[192];
+
+	if (g_fatal_done)
+		_exit(2);
+	g_fatal_done = 1;
+	snprintf(ev, sizeof(ev),
+		"{\"name\":\"retrace.daemon.fatal\",\"why\":\"%s\"}",
+		why);
+	if (g_jr_fatal != NULL)
+		retraced_journal_event(g_jr_fatal, (long)time(NULL),
+			"daemon", 0, ev);
+	fprintf(stderr, "retraced: fatal: %s\n", why);
+	_exit(2);
+}
+
 int main(int argc, char **argv)
 {
 	const char *sock_path = "/tmp/retraced.agent.sock";
@@ -486,6 +512,7 @@ int main(int argc, char **argv)
 	const char *drop_group = NULL;
 	int inherit_fd = -1;
 	int unlink_sock = 1;
+	int exit_after_s = 0;
 	struct retraced_registry reg;
 	struct retraced_journal jr;
 	struct conn *conns;
@@ -540,6 +567,9 @@ int main(int argc, char **argv)
 		else if (strcmp(argv[i], "--fd") == 0 &&
 			 i + 1 < argc)
 			inherit_fd = atoi(argv[++i]);
+		else if (strcmp(argv[i], "--exit-after") == 0 &&
+			 i + 1 < argc)
+			exit_after_s = atoi(argv[++i]);
 		else {
 			fprintf(stderr,
 				"Usage: retraced [--sock <path>] [--journal <path>]\n"
@@ -548,6 +578,7 @@ int main(int argc, char **argv)
 				"                 [--tls-listen host:port --tls-cert c\n"
 				"                  --tls-key k --tls-ca ca]\n"
 				"                 [--user u] [--group g] [--fd N]\n"
+			"                 [--exit-after SECONDS]\n"
 				"  --policy: a policy file (header + full\n"
 				"    retrace config) pushed to every agent\n"
 				"    at registration; POLICY_ACKs are\n"
@@ -563,7 +594,10 @@ int main(int argc, char **argv)
 				"    drop exits, never continues elevated)\n"
 				"  --fd N: inherit an already-bound, listening\n"
 				"    agent socket on fd N (socket activation;\n"
-				"    --sock names it for clients only)\n");
+				"    --sock names it for clients only)\n"
+				"  --exit-after SECONDS: self-terminate (tests\n"
+				"    and CI -- an orphaned daemon must never\n"
+				"    outlive its purpose)\n");
 			return 2;
 		}
 	}
@@ -836,10 +870,15 @@ int main(int argc, char **argv)
 			(long)uid, (long)gid);
 	}
 
+	g_jr_fatal = &jr;
+	/* the harness guard: an orphaned test/CI daemon self-ends */
+	if (exit_after_s > 0)
+		alarm(exit_after_s);
 	last_sweep = now_ms();
 	while (!g_stop) {
 		int nfd = 0;
 		int r;
+		static int spin_hits;
 
 		pfds[nfd].fd = listen_fd;
 		pfds[nfd].events = POLLIN;
@@ -878,8 +917,67 @@ int main(int argc, char **argv)
 			}
 		}
 		r = poll(pfds, (nfds_t)nfd, 500);
-		if (r <= 0)
+		if (r <= 0) {
+			spin_hits = 0;	/* timed out: healthy */
 			continue;
+		}
+
+		/*
+		 * Poll-set hygiene (the spin-incident guards): a
+		 * POLLNVAL is a descriptor error poll reports
+		 * INSTANTLY and forever -- left in the set it is a
+		 * 100%-CPU spin. Listeners: fatal (configuration
+		 * error; the startup --fd check should have caught
+		 * it, this is the backstop). Connections: drop.
+		 * POLLERR|POLLHUP without POLLIN route through the
+		 * read path, whose EOF handling drops them.
+		 */
+		{
+			int acted = 0;
+
+			for (i = 0; i < nfd; i++) {
+				if (pfds[i].revents & POLLNVAL) {
+					if (pfds[i].fd == listen_fd ||
+					    pfds[i].fd == g_ctl_listen ||
+					    pfds[i].fd == g_tls_listen)
+						daemon_fatal(
+							"listener POLLNVAL (bad descriptor)");
+					/* connection: find + drop */
+					{
+						int k;
+
+						for (k = 0; k < MAX_AGENTS;
+						     k++) {
+							if (conns[k].fd ==
+							    pfds[i].fd) {
+								close(conns[k].fd);
+								conns[k].fd = -1;
+								conns[k].helloed = 0;
+								break;
+							}
+						}
+						if (pfds[i].fd ==
+						    g_ctl_fd)
+							ctl_drop();
+					}
+					acted = 1;
+				}
+				if (pfds[i].revents & (POLLIN | POLLHUP |
+						       POLLERR))
+					acted = 1;
+			}
+			if (acted)
+				spin_hits = 0;
+			else if (++spin_hits > 10000) {
+				/*
+				 * Backstop: poll reported activity but
+				 * nothing consumed it, ten thousand
+				 * times in a row -- every iteration
+				 * returned instantly. Die loudly.
+				 */
+				daemon_fatal("poll spin backstop");
+			}
+		}
 
 		if (g_ctl_pfd_slot >= 0 &&
 		    (pfds[g_ctl_pfd_slot].revents & POLLIN) &&

--- a/tools/retraced/pipe_server.c
+++ b/tools/retraced/pipe_server.c
@@ -384,6 +384,8 @@ int retraced_pipe_main(int argc, char **argv)
 	const char *policy_path = NULL;
 	const char *nonce_arg = NULL;
 	const char *nonce_file = NULL;
+	int exit_after_s = 0;
+	long deadline;
 	struct pipe_conn conns[PIPE_AGENTS_MAX];
 	int i;
 
@@ -401,6 +403,9 @@ int retraced_pipe_main(int argc, char **argv)
 		else if (strcmp(argv[i], "--nonce-file") == 0 &&
 			 i + 1 < argc)
 			nonce_file = argv[++i];
+		else if (strcmp(argv[i], "--exit-after") == 0 &&
+			 i + 1 < argc)
+			exit_after_s = atoi(argv[++i]);
 		else {
 			fprintf(stderr,
 				"Usage: retraced [--sock PIPE] [--journal PATH]\n"
@@ -414,6 +419,11 @@ int retraced_pipe_main(int argc, char **argv)
 
 	InitializeCriticalSection(&g_lock);
 	SetConsoleCtrlHandler(on_console_ctrl, TRUE);
+	/* the harness guard: an orphaned test/CI daemon self-ends
+	 * (deadline checked in the accept loop -- pump-free)
+	 */
+	deadline = exit_after_s > 0 ?
+		now_ms() + (long)exit_after_s * 1000 : 0;
 
 	retraced_registry_init(&g_reg);
 	retraced_journal_open(&g_jr, journal_path);
@@ -480,6 +490,7 @@ int retraced_pipe_main(int argc, char **argv)
 	printf("retraced: listening on %s (agents)\n", pipe_name);
 	{
 		long last_sweep = now_ms();
+		long deadline_local = deadline;
 		HANDLE evt = CreateEvent(NULL, TRUE, FALSE, NULL);
 		HANDLE h = make_pipe(pipe_name);
 		OVERLAPPED ov;
@@ -487,7 +498,9 @@ int retraced_pipe_main(int argc, char **argv)
 		memset(&ov, 0, sizeof(ov));
 		ov.hEvent = evt;
 		ConnectNamedPipe(h, &ov);
-		while (!g_stop) {
+		while (!g_stop &&
+		       (deadline_local == 0 ||
+			now_ms() < deadline_local)) {
 			/*
 			 * ONE pending accept at a time (classic pattern):
 			 * the event fires when a client lands; the 250ms


### PR DESCRIPTION
Four layered guards from the machine-hang incident: poll-set hygiene (listener POLLNVAL = journaled fatal, conn POLLNVAL = drop), a 10k-iteration spin backstop, --exit-after harness self-termination on both platforms, and the fd test (incident site) guarded. Verified: exit-after stops live daemons, bad fd exits 2, daemon family 5/5.