### PR TITLE
v2.55.0 version bump

### DIFF
--- a/include/retrace/version.h
+++ b/include/retrace/version.h
@@ -37,10 +37,10 @@
 #define RETRACE_VERSION_H
 
 #define RETRACE_VERSION_MAJOR 2
-#define RETRACE_VERSION_MINOR 54
+#define RETRACE_VERSION_MINOR 55
 #define RETRACE_VERSION_PATCH 0
 
-#define RETRACE_VERSION_STRING "2.54.0"
+#define RETRACE_VERSION_STRING "2.55.0"
 
 #define RETRACE_VERSION_ATLEAST(maj, min, pat)                  \
 	(RETRACE_VERSION_MAJOR > (maj) ||                       \


### PR DESCRIPTION
Version bump to 2.55.0 for the spin guards + --exit-after hardening (PR #740). Fields consistent (2.55.0 / "2.55.0").