### PR TITLE
v2.57.0 version bump

### DIFF
--- a/include/retrace/version.h
+++ b/include/retrace/version.h
@@ -37,10 +37,10 @@
 #define RETRACE_VERSION_H
 
 #define RETRACE_VERSION_MAJOR 2
-#define RETRACE_VERSION_MINOR 56
+#define RETRACE_VERSION_MINOR 57
 #define RETRACE_VERSION_PATCH 0
 
-#define RETRACE_VERSION_STRING "2.56.0"
+#define RETRACE_VERSION_STRING "2.57.0"
 
 #define RETRACE_VERSION_ATLEAST(maj, min, pat)                  \
 	(RETRACE_VERSION_MAJOR > (maj) ||                       \


### PR DESCRIPTION
Version bump to 2.57.0 for key rotation + heap fallback (PR #744). Fields consistent (2.57.0 / "2.57.0").