### PR TITLE
retrace-ctl on Windows: the fleet CLI over the ctl pipe

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -49,6 +49,19 @@ if(RETRACE_PLATFORM_WINDOWS)
 			TIMEOUT 180)
 	endif()
 
+	# retrace-ctl over the ctl pipe (the fleet CLI on Windows).
+	find_package(Python3 COMPONENTS Interpreter)
+	if(Python3_Interpreter_FOUND AND TARGET retrace_ctl)
+		add_test(NAME integration-ctl-win
+			COMMAND ${Python3_EXECUTABLE}
+				${CMAKE_SOURCE_DIR}/test/integration/test_ctl_win.py
+				$<TARGET_FILE:retrace_retraced>
+				$<TARGET_FILE:retrace_ctl>)
+		set_tests_properties(integration-ctl-win PROPERTIES
+			LABELS "integration"
+			TIMEOUT 120)
+	endif()
+
 	# The named-pipe daemon (TODO.supervisor/12 P0): the same
 	# protocol over \\.\pipe\; a python stub walks the full
 	# HELLO/WINDOW/EVENT/BYE exchange as a spectator.

--- a/test/integration/test_ctl_win.py
+++ b/test/integration/test_ctl_win.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""
+E2E: retrace-ctl on Windows (the fleet CLI over the ctl pipe).
+
+The CLI's whole command surface rides one seam: newline-JSON over
+the ctl named pipe. This test drives `status` against a live pipe
+daemon and asserts the reply; `ps` proves the JSON surface too.
+
+Usage: test_ctl_win.py <retraced> <retrace-ctl>
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+
+
+def main():
+    if len(sys.argv) != 3:
+        print("usage: test_ctl_win.py <retraced> <retrace-ctl>",
+              file=sys.stderr)
+        return 2
+    if os.name != "nt":
+        print("SKIP: ctl pipe exists only on Windows", file=sys.stderr)
+        return 0
+    daemon, ctl = (os.path.abspath(p) for p in sys.argv[1:3])
+
+    work = tempfile.mkdtemp(prefix="ctl-win-")
+    agent = "\\\\.\\pipe\\retrace-ctl-e2e-agent"
+    ctlpipe = "\\\\.\\pipe\\retrace-ctl-e2e"
+    journal = os.path.join(work, "journal.jsonl")
+
+    d = subprocess.Popen(
+        [daemon, "--sock", agent, "--ctl", ctlpipe,
+         "--journal", journal, "--exit-after", "120"],
+        stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
+    try:
+        up = None
+        end = time.time() + 10
+        while time.time() < end:
+            try:
+                up = open(ctlpipe, "r+b", buffering=0)
+                break
+            except OSError:
+                time.sleep(0.1)
+        if up is None:
+            print("FAIL: ctl pipe never appeared", file=sys.stderr)
+            return 1
+        up.close()
+
+        r = subprocess.run([ctl, "--sock", ctlpipe, "status"],
+                           capture_output=True, text=True, timeout=30)
+        if r.returncode != 0 or '"ok":1' not in r.stdout:
+            print(f"FAIL: status rc={r.returncode}: "
+                  f"{r.stdout[:200]} {r.stderr[:200]}", file=sys.stderr)
+            return 1
+        st = json.loads(r.stdout)
+        if "pid" not in st or "policy_epoch" not in st:
+            print(f"FAIL: status shape: {r.stdout[:200]}",
+                  file=sys.stderr)
+            return 1
+
+        r = subprocess.run([ctl, "--sock", ctlpipe, "ps"],
+                           capture_output=True, text=True, timeout=30)
+        if r.returncode != 0 or '"registry"' not in r.stdout:
+            print(f"FAIL: ps rc={r.returncode}: "
+                  f"{r.stdout[:200]}", file=sys.stderr)
+            return 1
+
+        print("ctl-win: status + ps over the pipe -- OK")
+        return 0
+    finally:
+        if d.poll() is None:
+            subprocess.run(["taskkill", "/F", "/T", "/PID",
+                            str(d.pid)], capture_output=True)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -21,11 +21,8 @@ add_subdirectory(ktrace2retrace)
 add_subdirectory(etw2retrace)
 add_subdirectory(fuzz-report)
 
-# retraced runs everywhere since plan 12 (the named-pipe
-# transport on Windows); retrace-ctl stays POSIX until its own
-# Windows port.
+# retraced and retrace-ctl run everywhere since plan 12 (the
+# named-pipe transports on Windows).
 add_subdirectory(retraced)
-if(NOT WIN32)
-	add_subdirectory(retrace-ctl)
-endif()
+add_subdirectory(retrace-ctl)
 add_subdirectory(profiler)

--- a/tools/retrace-ctl/CMakeLists.txt
+++ b/tools/retrace-ctl/CMakeLists.txt
@@ -4,16 +4,23 @@
 # like retraced until plan 12 (named pipes). TLS client path
 # (TODO.supervisor/08 P1) reuses tools/retraced/tls_gate.c.
 
-add_executable(retrace_ctl
-	main.c
-	${CMAKE_SOURCE_DIR}/tools/retraced/tls_gate.c)
+if(RETRACE_PLATFORM_WINDOWS)
+	# supervisor/12: the fleet CLI over the ctl named pipe. The
+	# TLS client and sign-policy ride the POSIX build for now
+	# (tls_gate.c pulls POSIX socket headers).
+	add_executable(retrace_ctl main.c)
+else()
+	add_executable(retrace_ctl
+		main.c
+		${CMAKE_SOURCE_DIR}/tools/retraced/tls_gate.c)
+endif()
 set_target_properties(retrace_ctl PROPERTIES
 	OUTPUT_NAME retrace-ctl)
 
 target_include_directories(retrace_ctl PRIVATE
 	${CMAKE_SOURCE_DIR}/tools/retraced)
 
-if(OpenSSL_FOUND)
+if(OpenSSL_FOUND AND NOT RETRACE_PLATFORM_WINDOWS)
 	target_compile_definitions(retrace_ctl PRIVATE
 		RETRACED_HAVE_OPENSSL=1
 		RETRACE_HAVE_OPENSSL=1)

--- a/tools/retrace-ctl/main.c
+++ b/tools/retrace-ctl/main.c
@@ -36,10 +36,16 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
+
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#else
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <netdb.h>
-#include <unistd.h>
+#endif
 
 #include "../retraced/tls_gate.h"
 
@@ -48,7 +54,11 @@
 #include <openssl/pem.h>
 #endif
 
+#ifdef _WIN32
+#define CTL_DEFAULT "\\\\.\\pipe\\retraced-ctl"
+#else
 #define CTL_DEFAULT "/tmp/retraced.ctl.sock"
+#endif
 
 /* JSON string escape (policy blobs are JSON-in-JSON); caller frees */
 static char *jesc(const char *s)
@@ -121,6 +131,44 @@ static int print_reply(const char *reply)
 		return 1;
 	return 0;
 }
+
+#ifdef _WIN32
+/* one round trip over the ctl named pipe (supervisor/12): the
+ * same newline-JSON line protocol the UDS ctl speaks.
+ */
+static int ctl_roundtrip_pipe(const char *pipe_name,
+	const char *request)
+{
+	char reply[8192];
+	HANDLE h = CreateFileA(pipe_name, GENERIC_READ | GENERIC_WRITE,
+		0, NULL, OPEN_EXISTING, 0, NULL);
+	DWORD put = 0, got = 0;
+
+	if (h == INVALID_HANDLE_VALUE) {
+		fprintf(stderr, "retrace-ctl: cannot reach %s "
+			"(is retraced running with --ctl?)\n", pipe_name);
+		return 2;
+	}
+	if (!WriteFile(h, request, (DWORD)strlen(request), &put,
+		    NULL) || put == 0) {
+		CloseHandle(h);
+		return 2;
+	}
+	if (!ReadFile(h, reply, sizeof(reply) - 1, &got, NULL) ||
+	    got == 0) {
+		CloseHandle(h);
+		fprintf(stderr, "retrace-ctl: no reply\n");
+		return 2;
+	}
+	CloseHandle(h);
+	reply[got] = '\0';
+	fputs(reply, stdout);
+	if (strstr(reply, "\"ok\":1") == NULL &&
+	    strstr(reply, "\"ok\": true") == NULL)
+		return 1;
+	return 0;
+}
+#endif
 
 /* one round trip over local UDS */
 static int ctl_roundtrip_uds(const char *sock_path, const char *request)
@@ -402,8 +450,12 @@ int main(int argc, char **argv)
 	} else {
 		return ctl_usage();
 	}
+#ifdef _WIN32
+	return ctl_roundtrip_pipe(sock_path, req);
+#else
 	if (tls_host != NULL)
 		return ctl_roundtrip_tls(tls_host, tls_cert, tls_key,
 			tls_ca, req);
 	return ctl_roundtrip_uds(sock_path, req);
+#endif
 }


### PR DESCRIPTION
The roundtrip seam's second adapter: CreateFile + line I/O over the ctl named pipe; per-platform default sock; TLS client/sign-policy stay POSIX. Windows E2E (status + ps over the pipe); POSIX regressions green. Then v2.58.0.