### PR TITLE
kernel-observation agents go pipe-native on Windows + sign-policy follows

### DIFF
--- a/ebpf-bridge/retrace-ebpf-agent
+++ b/ebpf-bridge/retrace-ebpf-agent
@@ -45,6 +45,34 @@ def frame(mid, payload):
     return MAGIC + struct.pack("<HHI", 1, mid, len(b)) + b
 
 
+class PipeFile:
+    """Named-pipe shim for the AF_UNIX socket surface the agent
+    uses (sendall/recv/settimeout/close). Windows Python has no
+    AF_UNIX; a byte-mode pipe opened as a raw file speaks the
+    same RTRD framing. Short reads are fine -- _recv_exact
+    loops. settimeout is a no-op: pipes block, and spectators
+    skip the optional POLICY_SET drain (the doctrine -- policy
+    never reaches observers anyway)."""
+
+    def __init__(self, path):
+        self.f = open(path, "r+b", buffering=0)
+
+    def sendall(self, b):
+        self.f.write(b)
+
+    def recv(self, n):
+        return self.f.read(n)
+
+    def settimeout(self, t):
+        pass
+
+    def close(self):
+        try:
+            self.f.close()
+        except OSError:
+            pass
+
+
 class Agent:
     def __init__(self, sock_path):
         self.sock_path = sock_path
@@ -52,10 +80,29 @@ class Agent:
         self.agent_id = "pending"
         self.seq = 0
         self.stop = False
-
     def connect(self):
+        if self.sock_path.startswith(r"\\.\pipe\\"):
+            self.s = PipeFile(self.sock_path)
+            self._hello(self.s)
+            return
         s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         s.connect(self.sock_path)
+        self.s = s
+        self._hello(s)
+        # a POLICY_SET may follow (UDS); observers drop it
+        s.settimeout(0.2)
+        try:
+            hdr = s.recv(12)
+            if len(hdr) == 12:
+                _, _, m2, l2 = struct.unpack("<4sHHI", hdr)
+                while l2:
+                    b = s.recv(l2)
+                    l2 -= len(b)
+        except OSError:
+            pass
+        s.settimeout(None)
+
+    def _hello(self, s):
         # HELLO without a nonce: the spectator seat, on purpose
         s.sendall(frame(HELLO, json.dumps({
             "session_token": "", "nonce": "",
@@ -78,19 +125,6 @@ class Agent:
                 f"{self.welcome.get('role')}; the doctrine says "
                 "observers ride as spectators\n")
         self.agent_id = self.welcome.get("agent_id", "pending")
-        self.s = s
-        # a POLICY_SET may follow; observers drop it
-        s.settimeout(0.2)
-        try:
-            hdr = s.recv(12)
-            if len(hdr) == 12:
-                _, _, m2, l2 = struct.unpack("<4sHHI", hdr)
-                while l2:
-                    b = s.recv(l2)
-                    l2 -= len(b)
-        except OSError:
-            pass
-        s.settimeout(None)
 
     def emit(self, name, **attrs):
         self.seq += 1

--- a/etw-bridge/retrace-etw-agent
+++ b/etw-bridge/retrace-etw-agent
@@ -42,6 +42,34 @@ def frame(mid, payload):
     return MAGIC + struct.pack("<HHI", 1, mid, len(b)) + b
 
 
+class PipeFile:
+    """Named-pipe shim for the AF_UNIX socket surface the agent
+    uses (sendall/recv/settimeout/close). Windows Python has no
+    AF_UNIX; a byte-mode pipe opened as a raw file speaks the
+    same RTRD framing. Short reads are fine -- _recv_exact
+    loops. settimeout is a no-op: pipes block, and spectators
+    skip the optional POLICY_SET drain (the doctrine -- policy
+    never reaches observers anyway)."""
+
+    def __init__(self, path):
+        self.f = open(path, "r+b", buffering=0)
+
+    def sendall(self, b):
+        self.f.write(b)
+
+    def recv(self, n):
+        return self.f.read(n)
+
+    def settimeout(self, t):
+        pass
+
+    def close(self):
+        try:
+            self.f.close()
+        except OSError:
+            pass
+
+
 class Agent:
     def __init__(self, sock_path):
         self.sock_path = sock_path
@@ -49,10 +77,29 @@ class Agent:
         self.agent_id = "pending"
         self.seq = 0
         self.stop = False
-
     def connect(self):
+        if self.sock_path.startswith(r"\\.\pipe\\"):
+            self.s = PipeFile(self.sock_path)
+            self._hello(self.s)
+            return
         s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         s.connect(self.sock_path)
+        self.s = s
+        self._hello(s)
+        # a POLICY_SET may follow (UDS); observers drop it
+        s.settimeout(0.2)
+        try:
+            hdr = s.recv(12)
+            if len(hdr) == 12:
+                _, _, m2, l2 = struct.unpack("<4sHHI", hdr)
+                while l2:
+                    b = s.recv(l2)
+                    l2 -= len(b)
+        except OSError:
+            pass
+        s.settimeout(None)
+
+    def _hello(self, s):
         # HELLO without a nonce: the spectator seat, on purpose
         s.sendall(frame(HELLO, json.dumps({
             "session_token": "", "nonce": "",
@@ -75,19 +122,6 @@ class Agent:
                 f"{self.welcome.get('role')}; the doctrine says "
                 "observers ride as spectators\n")
         self.agent_id = self.welcome.get("agent_id", "pending")
-        self.s = s
-        # a POLICY_SET may follow; observers drop it
-        s.settimeout(0.2)
-        try:
-            hdr = s.recv(12)
-            if len(hdr) == 12:
-                _, _, m2, l2 = struct.unpack("<4sHHI", hdr)
-                while l2:
-                    b = s.recv(l2)
-                    l2 -= len(b)
-        except OSError:
-            pass
-        s.settimeout(None)
 
     def emit(self, name, **attrs):
         self.seq += 1

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -49,6 +49,20 @@ if(RETRACE_PLATFORM_WINDOWS)
 			TIMEOUT 180)
 	endif()
 
+	# The kernel-observation agents speak the pipe natively on
+	# Windows (TODO.beyond-libc/03): synthetic ETW lane E2E.
+	find_package(Python3 COMPONENTS Interpreter)
+	if(Python3_Interpreter_FOUND AND TARGET retrace_retraced)
+		add_test(NAME integration-etw-agent-win
+			COMMAND ${Python3_EXECUTABLE}
+				${CMAKE_SOURCE_DIR}/test/integration/test_etw_agent.py
+				$<TARGET_FILE:retrace_retraced>
+				${CMAKE_SOURCE_DIR}/etw-bridge/retrace-etw-agent)
+		set_tests_properties(integration-etw-agent-win PROPERTIES
+			LABELS "integration"
+			TIMEOUT 120)
+	endif()
+
 	# retrace-ctl over the ctl pipe (the fleet CLI on Windows).
 	find_package(Python3 COMPONENTS Interpreter)
 	if(Python3_Interpreter_FOUND AND TARGET retrace_ctl)

--- a/test/integration/test_etw_agent.py
+++ b/test/integration/test_etw_agent.py
@@ -24,7 +24,13 @@ import time
 def wait_sock(path, deadline=5.0):
     end = time.time() + deadline
     while time.time() < end:
-        if os.path.exists(path):
+        if path.startswith(r"\\.\pipe\\"):
+            try:
+                open(path, "r+b", buffering=0).close()
+                return True
+            except OSError:
+                pass
+        elif os.path.exists(path):
             return True
         time.sleep(0.1)
     return False
@@ -49,7 +55,8 @@ def main():
     daemon, agent = (os.path.abspath(p) for p in sys.argv[1:3])
 
     work = tempfile.mkdtemp(prefix="etw-ag-")
-    sock = os.path.join(work, "agent.sock")
+    sock = (r"\\.\pipe\\retrace-etw-e2e" if os.name == "nt"
+            else os.path.join(work, "agent.sock"))
     journal = os.path.join(work, "journal.jsonl")
 
     d = subprocess.Popen(

--- a/tools/retrace-ctl/CMakeLists.txt
+++ b/tools/retrace-ctl/CMakeLists.txt
@@ -20,7 +20,9 @@ set_target_properties(retrace_ctl PROPERTIES
 target_include_directories(retrace_ctl PRIVATE
 	${CMAKE_SOURCE_DIR}/tools/retraced)
 
-if(OpenSSL_FOUND AND NOT RETRACE_PLATFORM_WINDOWS)
+# sign-policy (pure OpenSSL EVP) works everywhere now that
+# tls_gate.c rides only the POSIX build
+if(OpenSSL_FOUND)
 	target_compile_definitions(retrace_ctl PRIVATE
 		RETRACED_HAVE_OPENSSL=1
 		RETRACE_HAVE_OPENSSL=1)


### PR DESCRIPTION
PipeFile shim in both agents (pipe path skips the spectator policy drain -- doctrine-correct); pipe-aware synthetic ETW E2E registered on Windows legs; OpenSSL exclusion lifted for the ctl so sign-policy works on Windows. UDS paths green locally (both agents + daemon family). Then v2.59.0.