### PR TITLE
v2.59.0 version bump

### DIFF
--- a/include/retrace/version.h
+++ b/include/retrace/version.h
@@ -37,10 +37,10 @@
 #define RETRACE_VERSION_H
 
 #define RETRACE_VERSION_MAJOR 2
-#define RETRACE_VERSION_MINOR 58
+#define RETRACE_VERSION_MINOR 59
 #define RETRACE_VERSION_PATCH 0
 
-#define RETRACE_VERSION_STRING "2.58.0"
+#define RETRACE_VERSION_STRING "2.59.0"
 
 #define RETRACE_VERSION_ATLEAST(maj, min, pat)                  \
 	(RETRACE_VERSION_MAJOR > (maj) ||                       \


### PR DESCRIPTION
Version bump to 2.59.0 for pipe-native agents + sign-policy on Windows (PR #748). Fields consistent (2.59.0 / "2.59.0").