### PR TITLE
pyretrace goes pipe-native + docs catch up to v2.59

### DIFF
--- a/bindings/python/pyretrace.py
+++ b/bindings/python/pyretrace.py
@@ -72,6 +72,30 @@ def _recv_exact(s, n, deadline):
 
 
 def _hello(sock_path, nonce):
+    """pipe paths speak the byte-mode named pipe (Windows Python
+    has no AF_UNIX); UDS paths keep the original path below"""
+    if sock_path.startswith(r"\\.\pipe\\"):
+        return _hello_pipe(sock_path, nonce)
+    return _hello_uds(sock_path, nonce)
+
+
+def _hello_pipe(sock_path, nonce):
+    s = _PipeFile(sock_path)
+    s.sendall(_frame(_HELLO, json.dumps({
+        "session_token": os.environ.get("RETRACE_SESSION", ""),
+        "nonce": nonce, "pid": os.getpid(), "ppid": 0,
+        "boot_id": "pyruntime", "cmdline": " ".join(sys.argv[:4]),
+        "retrace_version": "pyretrace-1"})))
+    hdr = _recv_exact(s, 12, time.time() + 5)
+    _, _, mid, ln = struct.unpack("<4sHHI", hdr)
+    body = _recv_exact(s, ln, time.time() + 5)
+    if mid != 16:  # WELCOME
+        s.close()
+        raise RuntimeError(f"expected WELCOME, got {mid}")
+    return s, json.loads(body)
+
+
+def _hello_uds(sock_path, nonce):
     s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     s.connect(sock_path)
     s.sendall(_frame(_HELLO, json.dumps({

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -342,6 +342,7 @@ retraced --sock /run/retraced/agent.sock --ctl /run/retraced/ctl.sock          -
 retrace-ctl status                     # local: PEERCRED-gated
 retrace-ctl --tls-host fleet.internal:9443 --tls-key k.pem             --tls-cert c.pem --tls-ca ca.pem freeze   # fleet: mTLS + scopes
 retrace-profile enforce app.json --inside inside.json --backend all -o spec.json
+retrace-ctl sign-policy policy.json ed25519_key.pem > signed.json
 retrace-enforce --audit trail.jsonl --audit-key ed.pem spec.json -- ./target
 retrace-enforce --verify-audit trail.jsonl --audit-pubkey ed.pub.pem
 ```

--- a/docs/supervisor.md
+++ b/docs/supervisor.md
@@ -38,6 +38,7 @@ retraced [--sock PATH] [--journal PATH] [--policy FILE] [--ctl PATH]
 | `--nonce` / `--nonce-file` | the agent channel nonce; spawners inject it into the target env. No nonce in HELLO ⇒ **spectator** (evidence, never policy) |
 | `--tls-*` | the fleet control plane: TLS 1.3 mutual auth only, all four flags together or none. Controller certs carry claim scopes in a URI SAN (`retrace:scope:status+ps+policy+kill`). No plaintext remote mode exists |
 | `--user` / `--group` | privilege drop after every socket is bound; a failed drop exits (never continues elevated) |
+| `--exit-after N` | self-terminate after N seconds — the harness guard: a daemon orphaned by its test/CI run can never outlive its purpose |
 | `--fd N` | socket activation: serve an already-bound listener (systemd's `LISTEN_FDS` convention maps here). Inherited sockets are never unlinked |
 
 The journal is append-only and hash-chained; control-plane records
@@ -68,7 +69,8 @@ One session, one journal, three lanes:
   kernel *saw*. Both join as spectators (nonceless HELLO on purpose)
   and emit `source: kernel` events. `--synthetic` proves the protocol
   on CI; `--loader` wraps the real bridge (`retrace-ebpf-loader`,
-  `etw2retrace`).
+  `etw2retrace`). On Windows both speak
+  the named pipe natively (pass `--sock \\.\pipe\...`).
 - **runtime** — `pyretrace` / `jretrace`: which module, which line.
   See [runtime agents](runtime-agents.md).
 
@@ -100,6 +102,12 @@ One declared-set, four enforcement planes, graded against each other:
 Fail-closed everywhere: a missing plane aborts the exec unless
 `--allow-missing` (dev only).
 
+### Windows service
+
+On Windows, `retraced` registers with the SCM when started as a
+service — stop requests take the graceful shutdown path. Run from a
+console, it behaves exactly as above.
+
 ### The audit trail
 
 `--audit TRAIL` binds every exec to `(timestamp, pid, spec digest,
@@ -108,6 +116,15 @@ to *which filter was in force when*. With `--audit-key` (Ed25519) each
 record is signed over the exact bytes the chain hash covers;
 `--verify-audit --audit-pubkey` requires a valid signature on every
 record. A tampered, torn, or unwritable trail refuses the exec.
+
+## Policy signing & rotation
+
+`retrace-ctl sign-policy FILE KEY` wraps a policy in an Ed25519
+signature over its exact bytes; the agent verifies against the key
+pinned in `RETRACE_SUPERVISOR_PUBKEY` and refuses invalid or partial
+wrappers fail-closed. For rotation, pin a LIST of PEMs (path
+separator `:` on POSIX, `;` on Windows) — old and new keys overlap,
+so agents verify throughout the transition without redeploying.
 
 ## Where to read next
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -49,6 +49,19 @@ if(RETRACE_PLATFORM_WINDOWS)
 			TIMEOUT 180)
 	endif()
 
+	# pyretrace over the pipe (the runtime lane's Windows leg).
+	find_package(Python3 COMPONENTS Interpreter)
+	if(Python3_Interpreter_FOUND AND TARGET retrace_retraced)
+		add_test(NAME integration-pyretrace-win
+			COMMAND ${Python3_EXECUTABLE}
+				${CMAKE_SOURCE_DIR}/test/integration/test_pyretrace.py
+				$<TARGET_FILE:retrace_retraced>
+				${CMAKE_SOURCE_DIR}/bindings/python)
+		set_tests_properties(integration-pyretrace-win PROPERTIES
+			LABELS "integration"
+			TIMEOUT 120)
+	endif()
+
 	# The kernel-observation agents speak the pipe natively on
 	# Windows (TODO.beyond-libc/03): synthetic ETW lane E2E.
 	find_package(Python3 COMPONENTS Interpreter)

--- a/test/integration/test_pyretrace.py
+++ b/test/integration/test_pyretrace.py
@@ -23,7 +23,13 @@ import time
 def wait_sock(path, deadline=5.0):
     end = time.time() + deadline
     while time.time() < end:
-        if os.path.exists(path):
+        if path.startswith(r"\\.\pipe\\"):
+            try:
+                open(path, "r+b", buffering=0).close()
+                return True
+            except OSError:
+                pass
+        elif os.path.exists(path):
             return True
         time.sleep(0.1)
     return False
@@ -69,7 +75,8 @@ def main():
     daemon, moddir = (os.path.abspath(p) for p in sys.argv[1:3])
 
     work = tempfile.mkdtemp(prefix="pyrt-")
-    sock = os.path.join(work, "agent.sock")
+    sock = (r"\\.\pipe\\retrace-py-e2e" if os.name == "nt"
+            else os.path.join(work, "agent.sock"))
     journal = os.path.join(work, "journal.jsonl")
     nonce_file = os.path.join(work, "nonce.txt")
     sentinel = os.path.join(work, "sentinel.txt")


### PR DESCRIPTION
PipeFile shim in pyretrace (UDS path unchanged, green); pyretrace E2E on the Windows legs; supervisor.md/cli.md document --exit-after, the SCM service, pipe-native agents, and sign-policy/rotation. Then v2.60.0.