### PR TITLE
v2.61.0 version bump

### DIFF
--- a/include/retrace/version.h
+++ b/include/retrace/version.h
@@ -37,10 +37,10 @@
 #define RETRACE_VERSION_H
 
 #define RETRACE_VERSION_MAJOR 2
-#define RETRACE_VERSION_MINOR 60
+#define RETRACE_VERSION_MINOR 61
 #define RETRACE_VERSION_PATCH 0
 
-#define RETRACE_VERSION_STRING "2.60.0"
+#define RETRACE_VERSION_STRING "2.61.0"
 
 #define RETRACE_VERSION_ATLEAST(maj, min, pat)                  \
 	(RETRACE_VERSION_MAJOR > (maj) ||                       \


### PR DESCRIPTION
Version bump to 2.61.0 for jretrace pipe-native + conformance gate (PR #752). Fields consistent (2.61.0 / "2.61.0").