### PR TITLE
retraced on Windows: fix the build and land the SCM lane

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -442,6 +442,15 @@ if(RETRACE_PLATFORM_WINDOWS)
 	add_subdirectory(tools/strace2retrace)
 	add_subdirectory(tools/etw2retrace)
 	add_subdirectory(tools/profiler)
+	# the supervisor lane builds everywhere since plan 12 (the
+	# named-pipe transports); enforce carries the AppContainer
+	# backend on Windows. Without these the pipe daemon and the
+	# fleet ctl never compile on CI and every TARGET-guarded
+	# Windows supervisor test silently skips (v2.56.0-v2.61.0
+	# shipped a retraced that could not build -- the lesson).
+	add_subdirectory(tools/retraced)
+	add_subdirectory(tools/retrace-ctl)
+	add_subdirectory(tools/enforce)
 else()
 	add_subdirectory(tools)
 	add_subdirectory(frida-bridge)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -461,6 +461,27 @@ else()
 	endif()
 endif()
 
+# Build-surface conformance (the v2.56.0-v2.61.0 lesson): these
+# are the everywhere-set -- every platform's tool list must
+# produce them. A list that drifts makes every TARGET-guarded
+# test silently skip and rots TUs no CI leg compiles (five
+# releases shipped a retraced that could not build on Windows).
+# The same move as the function-inventory conformance (v2.37),
+# applied to the build surface: drift fails THIS platform's
+# configure instead of greening its CI.
+foreach(_retrace_everywhere_target
+		retrace_retraced retrace_ctl retrace_enforce
+		retrace_correlate retrace_procmon2retrace
+		retrace_strace2retrace retrace_etw2retrace
+		retrace_profile)
+	if(NOT TARGET ${_retrace_everywhere_target})
+		message(FATAL_ERROR "build-surface drift: target "
+			"${_retrace_everywhere_target} missing on "
+			"${CMAKE_SYSTEM_NAME} -- the everywhere-set "
+			"must build on every platform")
+	endif()
+endforeach()
+
 # VS Code extension is pure TypeScript (no native build).
 add_subdirectory(vscode-extension)
 

--- a/bindings/jvm/src/main/java/org/retrace/runtime/JRetrace.java
+++ b/bindings/jvm/src/main/java/org/retrace/runtime/JRetrace.java
@@ -147,7 +147,7 @@ public final class JRetrace implements Closeable {
             nonce = "";
         }
         Chan ch;
-        if (sock.startsWith("\\\\\\\\.\\\\pipe\\\\")) {
+        if (sock.startsWith("\\\\.\\pipe\\")) {
             ch = new PipeChan(sock);
         } else {
             SocketChannel uds =

--- a/bindings/jvm/src/main/java/org/retrace/runtime/JRetrace.java
+++ b/bindings/jvm/src/main/java/org/retrace/runtime/JRetrace.java
@@ -86,7 +86,31 @@ public final class JRetrace implements Closeable {
         private final RandomAccessFile f;
 
         PipeChan(String path) throws IOException {
-            f = new RandomAccessFile(path, "rw");
+            /*
+             * The daemon keeps one pending instance; a connect
+             * landing in the gap after it is consumed (and
+             * before its replacement exists) is refused. Retry
+             * briefly -- the same backoff the in-process agent
+             * carries.
+             */
+            RandomAccessFile opened = null;
+            IOException last = null;
+            for (int i = 0; i < 5 && opened == null; i++) {
+                try {
+                    opened = new RandomAccessFile(path, "rw");
+                } catch (IOException e) {
+                    last = e;
+                    try {
+                        Thread.sleep(200);
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                        break;
+                    }
+                }
+            }
+            if (opened == null)
+                throw last;
+            f = opened;
         }
 
         public void writeAll(byte[] buf, int n) throws IOException {

--- a/bindings/python/pyretrace.py
+++ b/bindings/python/pyretrace.py
@@ -74,7 +74,7 @@ def _recv_exact(s, n, deadline):
 def _hello(sock_path, nonce):
     """pipe paths speak the byte-mode named pipe (Windows Python
     has no AF_UNIX); UDS paths keep the original path below"""
-    if sock_path.startswith(r"\\.\pipe\\"):
+    if sock_path.startswith("\\\\.\\pipe\\"):
         return _hello_pipe(sock_path, nonce)
     return _hello_uds(sock_path, nonce)
 

--- a/bindings/python/pyretrace.py
+++ b/bindings/python/pyretrace.py
@@ -79,6 +79,32 @@ def _hello(sock_path, nonce):
     return _hello_uds(sock_path, nonce)
 
 
+class _PipeFile:
+    """Named-pipe shim for the AF_UNIX socket surface the agent
+    uses (sendall/recv/settimeout/close). Windows Python has no
+    AF_UNIX; a byte-mode pipe opened as a raw file speaks the
+    same RTRD framing. Short reads are fine -- _recv_exact
+    loops. settimeout is a no-op: pipes block."""
+
+    def __init__(self, path):
+        self.f = open(path, "r+b", buffering=0)
+
+    def sendall(self, b):
+        self.f.write(b)
+
+    def recv(self, n):
+        return self.f.read(n)
+
+    def settimeout(self, t):
+        pass
+
+    def close(self):
+        try:
+            self.f.close()
+        except OSError:
+            pass
+
+
 def _hello_pipe(sock_path, nonce):
     s = _PipeFile(sock_path)
     s.sendall(_frame(_HELLO, json.dumps({

--- a/docs/supervisor.md
+++ b/docs/supervisor.md
@@ -104,9 +104,19 @@ Fail-closed everywhere: a missing plane aborts the exec unless
 
 ### Windows service
 
-On Windows, `retraced` registers with the SCM when started as a
-service — stop requests take the graceful shutdown path. Run from a
-console, it behaves exactly as above.
+On Windows, `retraced` is one binary with two launches: started by
+the SCM it dispatches as a service; started from a console it runs
+the accept loop directly. Install it the SCM way:
+
+```powershell
+sc create retraced binPath= "C:\path\retraced.exe --sock \.\pipe\retraced-agent --ctl \.\pipe\retraced-ctl --journal C:\ProgramData\retrace\journal.jsonl" start= auto
+sc start retraced
+```
+
+`SERVICE_CONTROL_STOP` flips the same stop flag the console
+Ctrl handler uses, so `sc stop` rides the graceful journal-flush
+exit; `--exit-after N` still applies as the watchdog belt under
+both launches.
 
 ### The audit trail
 

--- a/ebpf-bridge/retrace-ebpf-agent
+++ b/ebpf-bridge/retrace-ebpf-agent
@@ -81,7 +81,7 @@ class Agent:
         self.seq = 0
         self.stop = False
     def connect(self):
-        if self.sock_path.startswith(r"\\.\pipe\\"):
+        if self.sock_path.startswith("\\\\.\\pipe\\"):
             self.s = PipeFile(self.sock_path)
             self._hello(self.s)
             return

--- a/etw-bridge/retrace-etw-agent
+++ b/etw-bridge/retrace-etw-agent
@@ -78,7 +78,7 @@ class Agent:
         self.seq = 0
         self.stop = False
     def connect(self):
-        if self.sock_path.startswith(r"\\.\pipe\\"):
+        if self.sock_path.startswith("\\\\.\\pipe\\"):
             self.s = PipeFile(self.sock_path)
             self._hello(self.s)
             return

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -24,7 +24,7 @@ if(RETRACE_PLATFORM_WINDOWS)
 	# retraced + retrace-win-run + the in-process agent, HELLO
 	# with the nonce (full peer), policy push + ACK.
 	find_package(Python3 COMPONENTS Interpreter)
-	if(Python3_Interpreter_FOUND AND TARGET retrace_win_run)
+	if(Python3_Interpreter_FOUND)
 		add_test(NAME integration-supervised-win
 			COMMAND ${Python3_EXECUTABLE}
 				${CMAKE_SOURCE_DIR}/test/integration/test_supervised_win.py
@@ -39,7 +39,7 @@ if(RETRACE_PLATFORM_WINDOWS)
 	# the real SCM lifecycle (sc create/start/stop/delete) on the
 	# elevated runners.
 	find_package(Python3 COMPONENTS Interpreter)
-	if(Python3_Interpreter_FOUND AND TARGET retrace_retraced)
+	if(Python3_Interpreter_FOUND)
 		add_test(NAME integration-retraced-service
 			COMMAND ${Python3_EXECUTABLE}
 				${CMAKE_SOURCE_DIR}/test/integration/test_retraced_service.py
@@ -51,7 +51,7 @@ if(RETRACE_PLATFORM_WINDOWS)
 
 	# jretrace over the pipe (JDK-gated as everywhere).
 	find_package(Python3 COMPONENTS Interpreter)
-	if(Python3_Interpreter_FOUND AND TARGET retrace_retraced)
+	if(Python3_Interpreter_FOUND)
 		add_test(NAME integration-jretrace-win
 			COMMAND ${Python3_EXECUTABLE}
 				${CMAKE_SOURCE_DIR}/test/integration/test_jretrace.py
@@ -64,7 +64,7 @@ if(RETRACE_PLATFORM_WINDOWS)
 
 	# pyretrace over the pipe (the runtime lane's Windows leg).
 	find_package(Python3 COMPONENTS Interpreter)
-	if(Python3_Interpreter_FOUND AND TARGET retrace_retraced)
+	if(Python3_Interpreter_FOUND)
 		add_test(NAME integration-pyretrace-win
 			COMMAND ${Python3_EXECUTABLE}
 				${CMAKE_SOURCE_DIR}/test/integration/test_pyretrace.py
@@ -78,7 +78,7 @@ if(RETRACE_PLATFORM_WINDOWS)
 	# The kernel-observation agents speak the pipe natively on
 	# Windows (TODO.beyond-libc/03): synthetic ETW lane E2E.
 	find_package(Python3 COMPONENTS Interpreter)
-	if(Python3_Interpreter_FOUND AND TARGET retrace_retraced)
+	if(Python3_Interpreter_FOUND)
 		add_test(NAME integration-etw-agent-win
 			COMMAND ${Python3_EXECUTABLE}
 				${CMAKE_SOURCE_DIR}/test/integration/test_etw_agent.py
@@ -91,7 +91,7 @@ if(RETRACE_PLATFORM_WINDOWS)
 
 	# retrace-ctl over the ctl pipe (the fleet CLI on Windows).
 	find_package(Python3 COMPONENTS Interpreter)
-	if(Python3_Interpreter_FOUND AND TARGET retrace_ctl)
+	if(Python3_Interpreter_FOUND)
 		add_test(NAME integration-ctl-win
 			COMMAND ${Python3_EXECUTABLE}
 				${CMAKE_SOURCE_DIR}/test/integration/test_ctl_win.py
@@ -106,7 +106,7 @@ if(RETRACE_PLATFORM_WINDOWS)
 	# protocol over \\.\pipe\; a python stub walks the full
 	# HELLO/WINDOW/EVENT/BYE exchange as a spectator.
 	find_package(Python3 COMPONENTS Interpreter)
-	if(Python3_Interpreter_FOUND AND TARGET retrace_retraced)
+	if(Python3_Interpreter_FOUND)
 		add_test(NAME integration-retraced-pipe
 			COMMAND ${Python3_EXECUTABLE}
 				${CMAKE_SOURCE_DIR}/test/integration/test_retraced_pipe.py
@@ -120,8 +120,7 @@ if(RETRACE_PLATFORM_WINDOWS)
 	# the Windows backend E2E. Self-skips on non-Windows hosts,
 	# so POSIX CI legs can carry it too if ever moved.
 	find_package(Python3 COMPONENTS Interpreter)
-	if(Python3_Interpreter_FOUND AND TARGET retrace_profile
-	   AND TARGET retrace_enforce)
+	if(Python3_Interpreter_FOUND)
 		add_test(NAME integration-enforce-win
 			COMMAND ${Python3_EXECUTABLE}
 				${CMAKE_SOURCE_DIR}/test/integration/test_enforce_win.py

--- a/test/integration/test_etw_agent.py
+++ b/test/integration/test_etw_agent.py
@@ -24,7 +24,7 @@ import time
 def wait_sock(path, deadline=5.0):
     end = time.time() + deadline
     while time.time() < end:
-        if path.startswith(r"\\.\pipe\\"):
+        if path.startswith("\\\\.\\pipe\\"):
             try:
                 open(path, "r+b", buffering=0).close()
                 return True
@@ -55,7 +55,7 @@ def main():
     daemon, agent = (os.path.abspath(p) for p in sys.argv[1:3])
 
     work = tempfile.mkdtemp(prefix="etw-ag-")
-    sock = (r"\\.\pipe\\retrace-etw-e2e" if os.name == "nt"
+    sock = (r"\\.\pipe\retrace-etw-e2e" if os.name == "nt"
             else os.path.join(work, "agent.sock"))
     journal = os.path.join(work, "journal.jsonl")
 

--- a/test/integration/test_jretrace.py
+++ b/test/integration/test_jretrace.py
@@ -44,7 +44,7 @@ public class JRetraceSmoke {
 def wait_sock(path, deadline=5.0):
     end = time.time() + deadline
     while time.time() < end:
-        if path.startswith(r"\\.\pipe\\"):
+        if path.startswith("\\\\.\\pipe\\"):
             try:
                 open(path, "r+b", buffering=0).close()
                 return True
@@ -102,7 +102,7 @@ def main():
 
     daemon, srcroot = (os.path.abspath(p) for p in sys.argv[1:3])
     work = tempfile.mkdtemp(prefix="jrt-")
-    sock = (r"\\.\pipe\\retrace-jrt-e2e" if os.name == "nt"
+    sock = (r"\\.\pipe\retrace-jrt-e2e" if os.name == "nt"
             else os.path.join(work, "agent.sock"))
     journal = os.path.join(work, "journal.jsonl")
     nonce_file = os.path.join(work, "nonce.txt")

--- a/test/integration/test_pyretrace.py
+++ b/test/integration/test_pyretrace.py
@@ -23,7 +23,7 @@ import time
 def wait_sock(path, deadline=5.0):
     end = time.time() + deadline
     while time.time() < end:
-        if path.startswith(r"\\.\pipe\\"):
+        if path.startswith("\\\\.\\pipe\\"):
             try:
                 open(path, "r+b", buffering=0).close()
                 return True
@@ -75,7 +75,7 @@ def main():
     daemon, moddir = (os.path.abspath(p) for p in sys.argv[1:3])
 
     work = tempfile.mkdtemp(prefix="pyrt-")
-    sock = (r"\\.\pipe\\retrace-py-e2e" if os.name == "nt"
+    sock = (r"\\.\pipe\retrace-py-e2e" if os.name == "nt"
             else os.path.join(work, "agent.sock"))
     journal = os.path.join(work, "journal.jsonl")
     nonce_file = os.path.join(work, "nonce.txt")

--- a/test/integration/test_retraced_service.py
+++ b/test/integration/test_retraced_service.py
@@ -84,8 +84,9 @@ def main():
                     pass
             time.sleep(0.2)
         if up is None:
-            print("FAIL: service never served the pipe",
-                  file=sys.stderr)
+            q = run(["sc", "query", SVC])
+            print(f"FAIL: service never served the pipe; "
+                  f"last state: {q.stdout[:200]}", file=sys.stderr)
             return 1
 
         up.write(frame(HELLO, json.dumps({

--- a/test/integration/test_retraced_service.py
+++ b/test/integration/test_retraced_service.py
@@ -74,21 +74,23 @@ def main():
 
         # wait RUNNING + pipe up
         up = None
+        last_err = None
         for _ in range(50):
             q = run(["sc", "query", SVC])
             if "RUNNING" in q.stdout:
                 try:
                     up = open(pipe, "r+b", buffering=0)
                     break
-                except OSError:
-                    pass
+                except OSError as e:
+                    last_err = e
             time.sleep(0.2)
         if up is None:
             q = run(["sc", "query", SVC])
             print(f"FAIL: service never served the pipe; "
                   f"sc query rc={q.returncode} "
                   f"out={q.stdout[:200]!r} "
-                  f"err={q.stderr[:200]!r}", file=sys.stderr)
+                  f"err={q.stderr[:200]!r} "
+                  f"pipe_err={last_err!r}", file=sys.stderr)
             return 1
 
         up.write(frame(HELLO, json.dumps({

--- a/test/integration/test_retraced_service.py
+++ b/test/integration/test_retraced_service.py
@@ -98,7 +98,7 @@ def main():
             "pid": os.getpid(), "ppid": 0, "boot_id": "svc",
             "cmdline": "svc-stub", "retrace_version": "stub"})))
         hdr = recv_exact(up, 12)
-        mid, ln = struct.unpack("<HH", hdr[4:8])[0], \
+        mid, ln = struct.unpack("<H", hdr[6:8])[0], \
             struct.unpack("<I", hdr[8:12])[0]
         if mid != WELCOME:
             print(f"FAIL: no WELCOME ({mid})", file=sys.stderr)

--- a/test/integration/test_retraced_service.py
+++ b/test/integration/test_retraced_service.py
@@ -86,7 +86,9 @@ def main():
         if up is None:
             q = run(["sc", "query", SVC])
             print(f"FAIL: service never served the pipe; "
-                  f"last state: {q.stdout[:200]}", file=sys.stderr)
+                  f"sc query rc={q.returncode} "
+                  f"out={q.stdout[:200]!r} "
+                  f"err={q.stderr[:200]!r}", file=sys.stderr)
             return 1
 
         up.write(frame(HELLO, json.dumps({

--- a/test/integration/test_supervised_win.py
+++ b/test/integration/test_supervised_win.py
@@ -53,13 +53,29 @@ def main():
               file=sys.stderr)
         return 0
     daemon, win_run = (os.path.abspath(p) for p in sys.argv[1:3])
-    dll = os.path.join(os.path.dirname(win_run), "..", "..", "src",
-                       "v2", "retrace.dll")
-    dll = os.path.normpath(dll)
-    if not os.path.exists(dll):
-        # alternate layout: beside the launcher
-        alt = os.path.join(os.path.dirname(win_run), "retrace.dll")
-        dll = alt if os.path.exists(alt) else dll
+    # the DLL rides the v2 tree; MSVC multi-config nests it one
+    # level deeper (Release/) than Ninja, and the launcher may
+    # sit in either -- walk up until it is found
+    dll = None
+    root = os.path.dirname(win_run)
+    for _ in range(4):
+        for cand in (
+                os.path.join(root, "src", "v2", "retrace.dll"),
+                os.path.join(root, "src", "v2", "Release",
+                             "retrace.dll"),
+                os.path.join(root, "src", "v2", "Debug",
+                             "retrace.dll"),
+                os.path.join(root, "retrace.dll")):
+            if os.path.exists(cand):
+                dll = cand
+                break
+        if dll is not None:
+            break
+        root = os.path.dirname(root)
+    if dll is None:
+        print("FAIL: retrace.dll not found near retrace-win-run",
+              file=sys.stderr)
+        return 1
 
     work = tempfile.mkdtemp(prefix="sup-win-")
     journal = os.path.join(work, "journal.jsonl")

--- a/test/integration/test_supervised_win.py
+++ b/test/integration/test_supervised_win.py
@@ -85,7 +85,8 @@ def main():
             "RETRACE_SUPERVISOR_NONCE": NONCE,
         })
         r = subprocess.run(
-            [win_run, "--lib", dll, "ping", "-n", "4", "127.0.0.1"],
+            [win_run, "--lib", dll, "cmd.exe", "/c", "ping", "-n", "4",
+             "127.0.0.1"],
             env=env, capture_output=True, text=True, timeout=60)
         # the target's own exit code is what matters; a win-run
         # usage failure is a harness problem

--- a/test/integration/test_supervised_win.py
+++ b/test/integration/test_supervised_win.py
@@ -97,6 +97,11 @@ def main():
             "RETRACE_SUPERVISOR": "1",
             "RETRACE_SUPERVISOR_SOCK": PIPE_AGENT,
             "RETRACE_SUPERVISOR_NONCE": NONCE,
+            # cmd/ping are native Win32 -- no CRT calls, so the
+            # ucrt-level hooks never dispatch and the lazy agent
+            # kick never fires. The ntdll layer (the static-CRT
+            # smoke's pattern) sees their CreateFileW.
+            "RETRACE_WIN_NTDLL": "1",
         })
         r = subprocess.run(
             [win_run, "--lib", dll, "cmd.exe", "/c", "ping", "-n", "4",

--- a/test/integration/test_supervised_win.py
+++ b/test/integration/test_supervised_win.py
@@ -75,9 +75,9 @@ def main():
                   file=sys.stderr)
             return 1
 
-        # the target: notepad-free trivial process under the DLL.
-        # cmd /c exit keeps the run short; the agent thread still
-        # HELLOs, heartbeats, and BYEs on teardown.
+        # the target: a process with a real lifetime -- the agent
+        # thread needs the target alive to connect, HELLO, and
+        # drain (cmd /c exit dies before the connect finishes)
         env = dict(os.environ)
         env.update({
             "RETRACE_SUPERVISOR": "1",
@@ -85,7 +85,7 @@ def main():
             "RETRACE_SUPERVISOR_NONCE": NONCE,
         })
         r = subprocess.run(
-            [win_run, "--lib", dll, "cmd.exe", "/c", "exit", "0"],
+            [win_run, "--lib", dll, "ping", "-n", "4", "127.0.0.1"],
             env=env, capture_output=True, text=True, timeout=60)
         # the target's own exit code is what matters; a win-run
         # usage failure is a harness problem

--- a/test/integration/test_supervised_win.py
+++ b/test/integration/test_supervised_win.py
@@ -58,16 +58,14 @@ def main():
     # sit in either -- walk up until it is found
     dll = None
     root = os.path.dirname(win_run)
-    for _ in range(4):
-        for cand in (
-                os.path.join(root, "src", "v2", "retrace.dll"),
-                os.path.join(root, "src", "v2", "Release",
-                             "retrace.dll"),
-                os.path.join(root, "src", "v2", "Debug",
-                             "retrace.dll"),
-                os.path.join(root, "retrace.dll")):
-            if os.path.exists(cand):
-                dll = cand
+    for _ in range(5):
+        for sub in ("src/v2", "src/backends/preload_msvc", "."):
+            for cfg in ("", "Release/", "Debug/"):
+                cand = os.path.join(root, sub, cfg, "retrace.dll")
+                if os.path.exists(cand):
+                    dll = cand
+                    break
+            if dll is not None:
                 break
         if dll is not None:
             break

--- a/tools/enforce/appcontainer_apply.c
+++ b/tools/enforce/appcontainer_apply.c
@@ -11,11 +11,14 @@
 
 #ifdef _WIN32
 
+#ifndef _WIN32_WINNT
+#define _WIN32_WINNT 0x0601
+#endif
 #define WIN32_LEAN_AND_MEAN
+#include <windows.h>
 #include <aclapi.h>
 #include <sddl.h>
 #include <userenv.h>
-#include <windows.h>
 
 /*
  * Grant one path to the container SID: (GR,FX) for reads,

--- a/tools/enforce/appcontainer_apply.c
+++ b/tools/enforce/appcontainer_apply.c
@@ -12,7 +12,7 @@
 #ifdef _WIN32
 
 #ifndef _WIN32_WINNT
-#define _WIN32_WINNT 0x0601
+#define _WIN32_WINNT 0x0602
 #endif
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
@@ -111,18 +111,18 @@ int enforce_appcontainer_apply(const struct enforce_spec *spec,
 	memset(&si, 0, sizeof(si));
 	si.StartupInfo.cb = sizeof(si);
 	InitializeProcThreadAttributeList(NULL, 1, 0, &attr_sz);
-	si.AttributeList = (LPPROC_THREAD_ATTRIBUTE_LIST)
+	si.lpAttributeList = (LPPROC_THREAD_ATTRIBUTE_LIST)
 		HeapAlloc(GetProcessHeap(), 0, attr_sz);
-	if (si.AttributeList == NULL ||
-	    InitializeProcThreadAttributeList(si.AttributeList, 1, 0,
+	if (si.lpAttributeList == NULL ||
+	    InitializeProcThreadAttributeList(si.lpAttributeList, 1, 0,
 		    &attr_sz) != TRUE ||
-	    UpdateProcThreadAttribute(si.AttributeList, 0,
+	    UpdateProcThreadAttribute(si.lpAttributeList, 0,
 		    PROC_THREAD_ATTRIBUTE_SECURITY_CAPABILITIES,
 		    sid, GetLengthSid(sid), NULL, NULL) != TRUE) {
 		fprintf(stderr,
 			"retrace-enforce: attribute list failed\n");
-		if (si.AttributeList != NULL)
-			HeapFree(GetProcessHeap(), 0, si.AttributeList);
+		if (si.lpAttributeList != NULL)
+			HeapFree(GetProcessHeap(), 0, si.lpAttributeList);
 		LocalFree(sid);
 		return -1;
 	}
@@ -134,13 +134,13 @@ int enforce_appcontainer_apply(const struct enforce_spec *spec,
 		fprintf(stderr,
 			"retrace-enforce: CreateProcess in container failed: %lu\n",
 			(unsigned long)GetLastError());
-		DeleteProcThreadAttributeList(si.AttributeList);
-		HeapFree(GetProcessHeap(), 0, si.AttributeList);
+		DeleteProcThreadAttributeList(si.lpAttributeList);
+		HeapFree(GetProcessHeap(), 0, si.lpAttributeList);
 		LocalFree(sid);
 		return -1;
 	}
-	DeleteProcThreadAttributeList(si.AttributeList);
-	HeapFree(GetProcessHeap(), 0, si.AttributeList);
+	DeleteProcThreadAttributeList(si.lpAttributeList);
+	HeapFree(GetProcessHeap(), 0, si.lpAttributeList);
 	LocalFree(sid);
 
 	WaitForSingleObject(pi.hProcess, INFINITE);

--- a/tools/enforce/appcontainer_apply.c
+++ b/tools/enforce/appcontainer_apply.c
@@ -21,6 +21,21 @@
 #include <userenv.h>
 
 /*
+ * mingw-w64's headers do not carry the AppContainer surface
+ * (DeriveAppContainerSidFromAppContainerName and the security
+ * capabilities attribute are absent), so the plane rides the
+ * SDK-complete builds; MinGW gets the same unavailable-stub as
+ * the non-Windows hosts -- its CI runs no ctest anyway.
+ */
+#if !defined(PROC_THREAD_ATTRIBUTE_SECURITY_CAPABILITIES)
+#define RETRACE_NO_APPCONTAINER 1
+#endif
+#endif /* _WIN32 includes */
+
+
+#if defined(_WIN32) && !defined(RETRACE_NO_APPCONTAINER)
+
+/*
  * Grant one path to the container SID: (GR,FX) for reads,
  * (GW,GR,FX) for writes. Failures are reported but never
  * fatal at grant time -- the container's deny-by-default
@@ -180,7 +195,7 @@ int enforce_appcontainer_apply(const struct enforce_spec *spec,
 	return (int)rc;
 }
 
-#else /* !_WIN32 */
+#else /* !_WIN32 or no AppContainer surface */
 
 int enforce_appcontainer_apply(const struct enforce_spec *spec,
 	char *const argv[], char *const envp[])
@@ -191,4 +206,4 @@ int enforce_appcontainer_apply(const struct enforce_spec *spec,
 	return 1;	/* the plane exists only on Windows */
 }
 
-#endif /* _WIN32 */
+#endif /* _WIN32 && AppContainer surface */

--- a/tools/enforce/appcontainer_apply.c
+++ b/tools/enforce/appcontainer_apply.c
@@ -59,10 +59,10 @@ int enforce_appcontainer_apply(const struct enforce_spec *spec,
 	char *const argv[], char *const envp[])
 {
 	PSID sid = NULL;
-	SID_AND_ATTRIBUTES caps[1];
 	STARTUPINFOEXA si;
 	PROCESS_INFORMATION pi;
 	SIZE_T attr_sz = 0;
+	wchar_t wname[256], wdisp[32], wdesc[128];
 	char cmdline[32768];
 	size_t o = 0;
 	int i;
@@ -72,12 +72,23 @@ int enforce_appcontainer_apply(const struct enforce_spec *spec,
 	    argv[0] == NULL)
 		return -1;
 
+	/* the profile APIs are W-only: name/display/description
+	 * ride UTF-16; the narrow spec name converts here once
+	 */
+	if (MultiByteToWideChar(CP_UTF8, 0, spec->ac_name, -1, wname,
+		    (int)(sizeof(wname) / sizeof(wname[0]))) == 0)
+		return -1;
+	MultiByteToWideChar(CP_UTF8, 0, "retrace", -1, wdisp,
+		(int)(sizeof(wdisp) / sizeof(wdisp[0])));
+	MultiByteToWideChar(CP_UTF8, 0,
+		"retrace enforcement container", -1, wdesc,
+		(int)(sizeof(wdesc) / sizeof(wdesc[0])));
+
 	/* create once; reuse when the profile already exists */
-	if (CreateAppContainerProfile(spec->ac_name, "retrace",
-		"retrace enforcement container", NULL, NULL,
-		&sid) != S_OK) {
+	if (CreateAppContainerProfile(wname, wdisp, wdesc, NULL, 0,
+		    NULL, &sid) != S_OK) {
 		HRESULT hr = DeriveAppContainerSidFromAppContainerName(
-			spec->ac_name, &sid);
+			wname, &sid);
 
 		if (hr != S_OK || sid == NULL) {
 			fprintf(stderr,
@@ -85,9 +96,6 @@ int enforce_appcontainer_apply(const struct enforce_spec *spec,
 			return -1;
 		}
 	}
-
-	/* no capabilities: least privilege (no net, no devices) */
-	memset(caps, 0, sizeof(caps));
 
 	for (i = 0; i < (int)spec->ac_read_n; i++)
 		grant_path(sid, spec->ac_read[i], 0);
@@ -127,8 +135,11 @@ int enforce_appcontainer_apply(const struct enforce_spec *spec,
 		return -1;
 	}
 	memset(&pi, 0, sizeof(pi));
+	/* the env block is narrow char ** -- CREATE_UNICODE_ENVIRONMENT
+	 * would tell the child to read it as UTF-16
+	 */
 	if (CreateProcessA(NULL, cmdline, NULL, NULL, FALSE,
-		    EXTENDED_STARTUPINFO_PRESENT | CREATE_UNICODE_ENVIRONMENT,
+		    EXTENDED_STARTUPINFO_PRESENT,
 		    envp != NULL ? (LPVOID)envp : NULL, NULL,
 		    &si.StartupInfo, &pi) != TRUE) {
 		fprintf(stderr,

--- a/tools/enforce/appcontainer_apply.c
+++ b/tools/enforce/appcontainer_apply.c
@@ -84,16 +84,34 @@ int enforce_appcontainer_apply(const struct enforce_spec *spec,
 		"retrace enforcement container", -1, wdesc,
 		(int)(sizeof(wdesc) / sizeof(wdesc[0])));
 
-	/* create once; reuse when the profile already exists */
-	if (CreateAppContainerProfile(wname, wdisp, wdesc, NULL, 0,
-		    NULL, &sid) != S_OK) {
-		HRESULT hr = DeriveAppContainerSidFromAppContainerName(
-			wname, &sid);
+	/*
+	 * create once; reuse when the profile already exists. The
+	 * toolchain headers disagree on this API's arity (MinGW's
+	 * userenv.h drops the capabilities pointer), so resolve the
+	 * documented seven-argument shape from userenv.dll -- the
+	 * ABI is the truth both headers gesture at.
+	 */
+	{
+		typedef HRESULT WINAPI create_profile_t(PCWSTR,
+			PCWSTR, PCWSTR, PSID, DWORD,
+			const SECURITY_CAPABILITIES *, PSID *);
+		HMODULE uv = GetModuleHandleA("userenv.dll");
+		create_profile_t *create_profile =
+			uv != NULL ? (create_profile_t *)GetProcAddress(
+				uv, "CreateAppContainerProfile") : NULL;
 
-		if (hr != S_OK || sid == NULL) {
-			fprintf(stderr,
-				"retrace-enforce: appcontainer derive failed\n");
-			return -1;
+		if (create_profile == NULL ||
+		    create_profile(wname, wdisp, wdesc, NULL, 0, NULL,
+			    &sid) != S_OK) {
+			HRESULT hr =
+				DeriveAppContainerSidFromAppContainerName(
+					wname, &sid);
+
+			if (hr != S_OK || sid == NULL) {
+				fprintf(stderr,
+					"retrace-enforce: appcontainer derive failed\n");
+				return -1;
+			}
 		}
 	}
 

--- a/tools/enforce/artifact_audit.c
+++ b/tools/enforce/artifact_audit.c
@@ -11,7 +11,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#ifndef _WIN32
 #include <unistd.h>
+#endif
 
 #ifdef RETRACE_HAVE_OPENSSL
 #include <openssl/evp.h>

--- a/tools/enforce/landlock_apply.c
+++ b/tools/enforce/landlock_apply.c
@@ -15,20 +15,20 @@
  * are 444/445/446 on ALL 64-bit architectures by allocation.
  */
 
-#include <errno.h>
-#include <fcntl.h>
 #include <stdint.h>
-#include <stdio.h>
-#include <sys/stat.h>
-#include <string.h>
-#include <sys/syscall.h>
-#include <unistd.h>
 
 #include "landlock_apply.h"
 
 #if defined(__linux__)
 
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
 #include <sys/prctl.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <unistd.h>
 
 #ifndef __NR_landlock_create_ruleset
 #define __NR_landlock_create_ruleset 444

--- a/tools/enforce/main.c
+++ b/tools/enforce/main.c
@@ -29,7 +29,12 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#ifdef _WIN32
+#include <process.h>
+#define getpid _getpid
+#else
 #include <unistd.h>
+#endif
 
 #include "enforce_spec.h"
 #include "landlock_apply.h"

--- a/tools/enforce/sandbox_apply.c
+++ b/tools/enforce/sandbox_apply.c
@@ -15,7 +15,9 @@
  */
 
 #include <string.h>
+#ifndef _WIN32
 #include <unistd.h>
+#endif
 
 #include "sandbox_apply.h"
 

--- a/tools/enforce/seccomp_apply.c
+++ b/tools/enforce/seccomp_apply.c
@@ -18,12 +18,13 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
-#include <unistd.h>
 
 #include "seccomp_apply.h"
 
 #if defined(__linux__) && (defined(__x86_64__) || \
 	defined(__aarch64__))
+
+#include <unistd.h>
 
 #include <sys/prctl.h>
 

--- a/tools/retrace-ctl/main.c
+++ b/tools/retrace-ctl/main.c
@@ -36,12 +36,12 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #else
+#include <unistd.h>
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <netdb.h>

--- a/tools/retrace-ctl/main.c
+++ b/tools/retrace-ctl/main.c
@@ -170,6 +170,7 @@ static int ctl_roundtrip_pipe(const char *pipe_name,
 }
 #endif
 
+#ifndef _WIN32
 /* one round trip over local UDS */
 static int ctl_roundtrip_uds(const char *sock_path, const char *request)
 {
@@ -291,6 +292,7 @@ out:
 	retraced_tls_free(ctx);
 	return rc;
 }
+#endif /* !_WIN32 */
 
 /* sign-policy: wrapper {sig:{alg,key_id,sig},blob} over the file
  * bytes with Ed25519; the blob string is the exact file text.

--- a/tools/retraced/CMakeLists.txt
+++ b/tools/retraced/CMakeLists.txt
@@ -16,6 +16,8 @@ if(RETRACE_PLATFORM_WINDOWS)
 	add_executable(retrace_retraced
 		pipe_server.c daemon_frame.c registry.c journal.c retraced_ctl.c
 		${_parson_source})
+	# CommandLineToArgvW (the service lane's truth-source argv)
+	target_link_libraries(retrace_retraced PRIVATE shell32)
 else()
 	add_executable(retrace_retraced
 		main.c daemon_frame.c registry.c journal.c peer_gate.c retraced_ctl.c

--- a/tools/retraced/daemon_frame.h
+++ b/tools/retraced/daemon_frame.h
@@ -50,6 +50,19 @@ void daemon_frame_welcome(const struct daemon_conn_state *st,
 		const char *payload),
 	void *io, struct retraced_journal *jr);
 
+/*
+ * HELLO: validate, register the agent (spectator when the nonce
+ * claim is absent), mint + write WELCOME, journal the auth line.
+ * Returns the registry entry or NULL (registry full).
+ */
+struct agent_entry *daemon_frame_hello(struct daemon_conn_state *st,
+	const char *payload, struct retraced_registry *reg,
+	struct retraced_journal *jr,
+	const struct retraced_ctl_ctx *ctl, const char *daemon_nonce,
+	int (*write_frame)(void *io, uint16_t type,
+		const char *payload),
+	void *io);
+
 /* the heartbeat-grade drift summaries (sweeps + shutdown) */
 void daemon_frame_drift_summaries(struct retraced_registry *reg,
 	struct retraced_journal *jr);

--- a/tools/retraced/journal.c
+++ b/tools/retraced/journal.c
@@ -112,6 +112,12 @@ static FILE *journal_writer(struct retraced_journal *j)
 	return j->f;
 }
 
+void retraced_journal_flush(struct retraced_journal *j)
+{
+	if (j != NULL && j->f != NULL)
+		fflush(j->f);
+}
+
 int retraced_journal_event(struct retraced_journal *j,
 	long ts, const char *agent_id, uint64_t seq,
 	const char *payload)

--- a/tools/retraced/journal.h
+++ b/tools/retraced/journal.h
@@ -59,6 +59,8 @@ void retraced_journal_close(struct retraced_journal *j);
  * object text; the journal wraps it with ts, agent_id, seq and
  * the chain link. Returns 0 ok, -1 io error.
  */
+void retraced_journal_flush(struct retraced_journal *j);
+
 int retraced_journal_event(struct retraced_journal *j,
 	long ts, const char *agent_id, uint64_t seq,
 	const char *payload);

--- a/tools/retraced/main.c
+++ b/tools/retraced/main.c
@@ -1092,8 +1092,12 @@ int main(int argc, char **argv)
 					 * conversation is on disk
 					 * even if the daemon is
 					 * killed before its graceful
-					 * close
+					 * close. The leaver's final
+					 * drift summary rides the
+					 * same flush.
 					 */
+					daemon_frame_drift_summaries(
+						&reg, &jr);
 					retraced_journal_flush(&jr);
 					continue;
 				}

--- a/tools/retraced/main.c
+++ b/tools/retraced/main.c
@@ -1087,6 +1087,14 @@ int main(int argc, char **argv)
 				if (n <= 0) {
 					close(conns[i].fd);
 					conns[i].fd = -1;
+					/* connection-scoped
+					 * durability: a finished
+					 * conversation is on disk
+					 * even if the daemon is
+					 * killed before its graceful
+					 * close
+					 */
+					retraced_journal_flush(&jr);
 					continue;
 				}
 				conns[i].fill += (size_t)n;

--- a/tools/retraced/pipe_server.c
+++ b/tools/retraced/pipe_server.c
@@ -25,6 +25,7 @@
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <sddl.h>
+#include <shellapi.h>
 #include <winsvc.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/tools/retraced/pipe_server.c
+++ b/tools/retraced/pipe_server.c
@@ -443,9 +443,10 @@ static VOID WINAPI svc_handler(DWORD ctrl)
 
 static VOID WINAPI service_main(DWORD argc, char **argv)
 {
-	/* argv[0] is the service name; the binPath flags follow --
-	 * exactly the argv shape retraced_pipe_main parses
-	 */
+	wchar_t **wargv;
+	char **nargv = NULL;
+	int nargs = 0, k;
+
 	g_svc = RegisterServiceCtrlHandlerA(argv[0], svc_handler);
 	if (g_svc == NULL)
 		return;
@@ -453,6 +454,40 @@ static VOID WINAPI service_main(DWORD argc, char **argv)
 	g_svc_st.dwServiceType = SERVICE_WIN32_OWN_PROCESS;
 	g_svc_st.dwControlsAccepted = SERVICE_ACCEPT_STOP;
 	svc_report(SERVICE_START_PENDING, 1000);
+	/*
+	 * ServiceMain's argv is the SCM's space-split of binPath --
+	 * quotes left embedded, and on some hosts the flags never
+	 * arrive at all (the daemon then serves its DEFAULT pipe
+	 * names and the registered --sock is silently ignored).
+	 * The process's own command line is the truth: parse it
+	 * quote-aware and run the same shape a console launch
+	 * parses.
+	 */
+	wargv = CommandLineToArgvW(GetCommandLineW(), &nargs);
+	if (wargv != NULL && nargs > 1) {
+		nargv = (char **)HeapAlloc(GetProcessHeap(), 0,
+			(size_t)nargs * sizeof(*nargv));
+		if (nargv != NULL) {
+			for (k = 0; k < nargs; k++) {
+				int need = WideCharToMultiByte(CP_UTF8, 0,
+					wargv[k], -1, NULL, 0, NULL,
+					NULL);
+
+				nargv[k] = (char *)HeapAlloc(
+					GetProcessHeap(), 0,
+					(size_t)(need > 0 ? need : 1));
+				if (nargv[k] != NULL && need > 0)
+					WideCharToMultiByte(CP_UTF8, 0,
+						wargv[k], -1, nargv[k],
+						need, NULL, NULL);
+				else if (nargv[k] != NULL)
+					nargv[k][0] = '\0';
+			}
+			argc = (DWORD)nargs;
+			argv = nargv;
+		}
+	}
+	LocalFree(wargv);
 	/* RUNNING before the loop: the loop blocks for the
 	 * service lifetime, and the SCM kills a service that
 	 * never leaves START_PENDING
@@ -460,6 +495,13 @@ static VOID WINAPI service_main(DWORD argc, char **argv)
 	svc_report(SERVICE_RUNNING, 0);
 	g_svc_ret = (DWORD)retraced_pipe_main((int)argc, argv);
 	svc_report(SERVICE_STOPPED, 0);
+	if (nargv != NULL) {
+		for (k = 0; k < nargs; k++) {
+			if (nargv[k] != NULL)
+				HeapFree(GetProcessHeap(), 0, nargv[k]);
+		}
+		HeapFree(GetProcessHeap(), 0, nargv);
+	}
 }
 
 int retraced_pipe_main(int argc, char **argv)

--- a/tools/retraced/pipe_server.c
+++ b/tools/retraced/pipe_server.c
@@ -235,6 +235,14 @@ static DWORD WINAPI agent_thread(LPVOID arg)
 	CloseHandle(c->pipe);
 	c->pipe = NULL;
 	c->live = 0;
+	/* connection-scoped durability (same as the POSIX conn
+	 * end): observations are buffered-class records, and a
+	 * force-killed daemon must not swallow a finished
+	 * conversation
+	 */
+	EnterCriticalSection(&g_lock);
+	retraced_journal_flush(&g_jr);
+	LeaveCriticalSection(&g_lock);
 	return 0;
 }
 
@@ -444,6 +452,11 @@ static VOID WINAPI service_main(DWORD argc, char **argv)
 	g_svc_st.dwServiceType = SERVICE_WIN32_OWN_PROCESS;
 	g_svc_st.dwControlsAccepted = SERVICE_ACCEPT_STOP;
 	svc_report(SERVICE_START_PENDING, 1000);
+	/* RUNNING before the loop: the loop blocks for the
+	 * service lifetime, and the SCM kills a service that
+	 * never leaves START_PENDING
+	 */
+	svc_report(SERVICE_RUNNING, 0);
 	g_svc_ret = (DWORD)retraced_pipe_main((int)argc, argv);
 	svc_report(SERVICE_STOPPED, 0);
 }

--- a/tools/retraced/pipe_server.c
+++ b/tools/retraced/pipe_server.c
@@ -241,6 +241,7 @@ static DWORD WINAPI agent_thread(LPVOID arg)
 	 * conversation
 	 */
 	EnterCriticalSection(&g_lock);
+	daemon_frame_drift_summaries(&g_reg, &g_jr);
 	retraced_journal_flush(&g_jr);
 	LeaveCriticalSection(&g_lock);
 	return 0;

--- a/tools/retraced/pipe_server.c
+++ b/tools/retraced/pipe_server.c
@@ -405,6 +405,24 @@ static DWORD WINAPI ctl_thread(LPVOID arg)
 
 /* ---- accept loop ---- */
 
+/*
+ * Arm one pending accept. ConnectNamedPipe returning FALSE
+ * without ERROR_IO_PENDING means a client's CreateFile beat the
+ * arm (ERROR_PIPE_CONNECTED) or the instance is unusable: in
+ * both cases the event NEVER fires, the loop would sleep on it
+ * forever, and every later connect reads ERROR_PIPE_BUSY -- the
+ * slow-leg jretrace refusal. Take the accept door immediately
+ * instead (a broken handle simply fails fast in its thread).
+ */
+static void arm_accept(HANDLE h, OVERLAPPED *ov)
+{
+	if (h == INVALID_HANDLE_VALUE)
+		return;
+	if (!ConnectNamedPipe(h, ov) &&
+	    GetLastError() != ERROR_IO_PENDING)
+		SetEvent(ov->hEvent);
+}
+
 
 static BOOL WINAPI on_console_ctrl(DWORD type)
 {
@@ -625,7 +643,7 @@ int retraced_pipe_main(int argc, char **argv)
 
 		memset(&ov, 0, sizeof(ov));
 		ov.hEvent = evt;
-		ConnectNamedPipe(h, &ov);
+		arm_accept(h, &ov);
 		while (!g_stop &&
 		       (deadline_local == 0 ||
 			now_ms() < deadline_local)) {
@@ -664,7 +682,7 @@ int retraced_pipe_main(int argc, char **argv)
 				ResetEvent(evt);
 				memset(&ov, 0, sizeof(ov));
 				ov.hEvent = evt;
-				ConnectNamedPipe(h, &ov);
+				arm_accept(h, &ov);
 				continue;
 			}
 			if (now_ms() - last_sweep > SWEEP_INTERVAL_MS) {

--- a/tools/retraced/pipe_server.c
+++ b/tools/retraced/pipe_server.c
@@ -25,6 +25,7 @@
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <sddl.h>
+#include <winsvc.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -62,10 +63,13 @@ static struct conn g_ctl_conns[MAX_AGENTS];
 static HANDLE g_ctl_thread;
 static HANDLE g_ctl_pipe;
 
+static int pipe_write_frame(HANDLE h, uint16_t type,
+	const char *payload);
+
 /* the transport seam for the shared frame module: pipe-backed */
 static int df_write_pipe(void *io, uint16_t type, const char *payload)
 {
-	return write_frame((HANDLE)io, type, payload);
+	return pipe_write_frame((HANDLE)io, type, payload);
 }
 
 static long now_ms(void)
@@ -105,7 +109,8 @@ static int pipe_write_all(HANDLE h, const void *buf, DWORD n)
 	return 0;
 }
 
-static int write_frame(HANDLE h, uint16_t type, const char *payload)
+static int pipe_write_frame(HANDLE h, uint16_t type,
+	const char *payload)
 {
 	char hdr[RETRACE_RPC_HEADER_SZ];
 	DWORD plen = (DWORD)strlen(payload);
@@ -237,7 +242,7 @@ static DWORD WINAPI agent_thread(LPVOID arg)
 static void emit_drift_summaries(void)
 {
 	daemon_frame_drift_summaries(&g_reg, &g_jr);
-}}
+}
 
 /* ---- the ctl pipe: same line protocol as the UDS ctl ---- */
 
@@ -374,6 +379,51 @@ static BOOL WINAPI on_console_ctrl(DWORD type)
 	(void)type;
 	InterlockedExchange(&g_stop, 1);
 	return TRUE;
+}
+
+/* ---- the SCM service lane (TODO.supervisor/12 P1) ---- */
+
+/*
+ * One binary, two launches: `sc start` lands here through the
+ * dispatcher (which blocks for the service lifetime); a console
+ * launch gets ERROR_FAILED_SERVICE_STARTUP back from the
+ * dispatcher and runs the accept loop itself. STOP maps to the
+ * same g_stop the console Ctrl handler flips -- one graceful
+ * exit path (journal flush included) for both.
+ */
+static SERVICE_STATUS_HANDLE g_svc;
+static SERVICE_STATUS g_svc_st;
+static DWORD g_svc_ret;
+
+static void svc_report(DWORD state, DWORD wait_ms)
+{
+	g_svc_st.dwCurrentState = state;
+	g_svc_st.dwWaitHint = wait_ms;
+	SetServiceStatus(g_svc, &g_svc_st);
+}
+
+static VOID WINAPI svc_handler(DWORD ctrl)
+{
+	if (ctrl == SERVICE_CONTROL_STOP) {
+		svc_report(SERVICE_STOP_PENDING, 5000);
+		InterlockedExchange(&g_stop, 1);
+	}
+}
+
+static VOID WINAPI service_main(DWORD argc, char **argv)
+{
+	/* argv[0] is the service name; the binPath flags follow --
+	 * exactly the argv shape retraced_pipe_main parses
+	 */
+	g_svc = RegisterServiceCtrlHandlerA(argv[0], svc_handler);
+	if (g_svc == NULL)
+		return;
+	memset(&g_svc_st, 0, sizeof(g_svc_st));
+	g_svc_st.dwServiceType = SERVICE_WIN32_OWN_PROCESS;
+	g_svc_st.dwControlsAccepted = SERVICE_ACCEPT_STOP;
+	svc_report(SERVICE_START_PENDING, 1000);
+	g_svc_ret = (DWORD)retraced_pipe_main((int)argc, argv);
+	svc_report(SERVICE_STOPPED, 0);
 }
 
 int retraced_pipe_main(int argc, char **argv)
@@ -582,6 +632,14 @@ int write_frame(int fd, uint16_t type, const char *payload)
 
 int main(int argc, char **argv)
 {
+	SERVICE_TABLE_ENTRYA table[2];
+
+	table[0].lpServiceName = "";
+	table[0].lpServiceProc = service_main;
+	table[1].lpServiceName = NULL;
+	table[1].lpServiceProc = NULL;
+	if (StartServiceCtrlDispatcherA(table))
+		return (int)g_svc_ret;
 	return retraced_pipe_main(argc, argv);
 }
 

--- a/tools/retraced/pipe_server.c
+++ b/tools/retraced/pipe_server.c
@@ -62,6 +62,7 @@ static struct retraced_ctl_ctx g_ctl;
 static struct conn g_ctl_conns[MAX_AGENTS];
 static HANDLE g_ctl_thread;
 static HANDLE g_ctl_pipe;
+static const char *g_ctl_name = "\\\\.\\pipe\\retraced-ctl";
 
 static int pipe_write_frame(HANDLE h, uint16_t type,
 	const char *payload);
@@ -243,65 +244,6 @@ static void emit_drift_summaries(void)
 {
 	daemon_frame_drift_summaries(&g_reg, &g_jr);
 }
-
-/* ---- the ctl pipe: same line protocol as the UDS ctl ---- */
-
-struct ctl_reply_ctx {
-	HANDLE pipe;
-};
-
-static void ctl_reply_pipe(const char *line, void *user)
-{
-	struct ctl_reply_ctx *ctx = (struct ctl_reply_ctx *)user;
-
-	pipe_write_all(ctx->pipe, line, (DWORD)strlen(line));
-}
-
-static DWORD WINAPI ctl_thread(LPVOID arg)
-{
-	char buf[CTL_LINE_MAX];
-	size_t fill = 0;
-	(void)arg;
-
-	while (!g_stop) {
-		DWORD got = 0;
-
-		if (!ReadFile(g_ctl_pipe, buf + fill,
-			    (DWORD)(sizeof(buf) - 1 - fill), &got,
-			    NULL) || got == 0)
-			break;
-		fill += got;
-		buf[fill] = '\0';
-		{
-			char *nl;
-
-			while ((nl = strchr(buf, '\n')) != NULL) {
-				struct ctl_reply_ctx ctx;
-
-				*nl = '\0';
-				ctx.pipe = g_ctl_pipe;
-				EnterCriticalSection(&g_lock);
-				g_ctl.reply_sink = ctl_reply_pipe;
-				g_ctl.reply_user = &ctx;
-				retraced_ctl_handle_line(&g_ctl, buf);
-				LeaveCriticalSection(&g_lock);
-				memmove(buf, nl + 1,
-					fill - (size_t)(nl + 1 - buf));
-				fill -= (size_t)(nl + 1 - buf);
-			}
-		}
-		if (fill >= sizeof(buf) - 1)
-			fill = 0;
-	}
-	FlushFileBuffers(g_ctl_pipe);
-	DisconnectNamedPipe(g_ctl_pipe);
-	CloseHandle(g_ctl_pipe);
-	g_ctl_pipe = NULL;
-	return 0;
-}
-
-/* ---- accept loop ---- */
-
 /*
  * Explicit DACL (supervisor/12 P1 hardening): the default pipe
  * DACL follows the process token's default, which broader
@@ -373,6 +315,86 @@ static HANDLE make_pipe(const char *name)
 		LocalFree(sd);
 	return h;
 }
+
+
+/* ---- the ctl pipe: same line protocol as the UDS ctl ---- */
+
+struct ctl_reply_ctx {
+	HANDLE pipe;
+};
+
+static void ctl_reply_pipe(const char *line, void *user)
+{
+	struct ctl_reply_ctx *ctx = (struct ctl_reply_ctx *)user;
+
+	pipe_write_all(ctx->pipe, line, (DWORD)strlen(line));
+}
+
+static DWORD WINAPI ctl_thread(LPVOID arg)
+{
+	(void)arg;
+
+	/*
+	 * One pipe instance per controller, until g_stop: the
+	 * single-client shape closed the ctl plane with the first
+	 * disconnect -- the fleet CLI's second command could not
+	 * even connect. Blocking ConnectNamedPipe in this thread
+	 * is fine: daemon exit tears the process down anyway.
+	 */
+	while (!g_stop) {
+		char buf[CTL_LINE_MAX];
+		size_t fill = 0;
+		HANDLE c = make_pipe(g_ctl_name);
+
+		if (c == INVALID_HANDLE_VALUE)
+			break;
+		ConnectNamedPipe(c, NULL);
+		if (g_stop) {
+			CloseHandle(c);
+			break;
+		}
+		g_ctl_pipe = c;
+		for (;;) {
+			DWORD got = 0;
+
+			if (!ReadFile(c, buf + fill,
+				    (DWORD)(sizeof(buf) - 1 - fill),
+				    &got, NULL) || got == 0)
+				break;
+			fill += got;
+			buf[fill] = '\0';
+			{
+				char *nl;
+
+				while ((nl = strchr(buf, '\n')) != NULL) {
+					struct ctl_reply_ctx ctx;
+
+					*nl = '\0';
+					ctx.pipe = c;
+					EnterCriticalSection(&g_lock);
+					g_ctl.reply_sink = ctl_reply_pipe;
+					g_ctl.reply_user = &ctx;
+					retraced_ctl_handle_line(&g_ctl,
+						buf);
+					LeaveCriticalSection(&g_lock);
+					memmove(buf, nl + 1,
+						fill - (size_t)(nl + 1 - buf));
+					fill -= (size_t)(nl + 1 - buf);
+				}
+			}
+			if (fill >= sizeof(buf) - 1)
+				fill = 0;
+		}
+		FlushFileBuffers(c);
+		DisconnectNamedPipe(c);
+		CloseHandle(c);
+		g_ctl_pipe = NULL;
+	}
+	return 0;
+}
+
+/* ---- accept loop ---- */
+
 
 static BOOL WINAPI on_console_ctrl(DWORD type)
 {
@@ -532,10 +554,9 @@ int retraced_pipe_main(int argc, char **argv)
 	memset(conns, 0, sizeof(conns));
 
 	/* the ctl pipe: one instance, one client at a time */
-	g_ctl_pipe = make_pipe(ctl_name);
-	if (g_ctl_pipe != INVALID_HANDLE_VALUE)
-		g_ctl_thread = CreateThread(NULL, 0, ctl_thread,
-			NULL, 0, NULL);
+	g_ctl_name = ctl_name;
+	g_ctl_thread = CreateThread(NULL, 0, ctl_thread,
+		NULL, 0, NULL);
 
 	printf("retraced: listening on %s (agents)\n", pipe_name);
 	{
@@ -607,10 +628,6 @@ int retraced_pipe_main(int argc, char **argv)
 	emit_drift_summaries();
 	LeaveCriticalSection(&g_lock);
 	retraced_journal_close(&g_jr);
-	if (g_ctl_pipe != NULL) {
-		DisconnectNamedPipe(g_ctl_pipe);
-		CloseHandle(g_ctl_pipe);
-	}
 	DeleteCriticalSection(&g_lock);
 	return 0;
 }

--- a/tools/retraced/registry.c
+++ b/tools/retraced/registry.c
@@ -9,7 +9,12 @@
 #include <stdio.h>
 #include <string.h>
 #include <time.h>
+#ifdef _WIN32
+#include <process.h>
+#define getpid _getpid
+#else
 #include <unistd.h>
+#endif
 
 #include "parson.h"
 

--- a/tools/retraced/retraced_ctl.c
+++ b/tools/retraced/retraced_ctl.c
@@ -30,6 +30,10 @@
  * sink. No socket, no daemon, no poll loop -- unit-testable.
  */
 
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#endif
 #include <signal.h>
 #include <stdarg.h>
 #include <stdio.h>
@@ -312,7 +316,19 @@ void retraced_ctl_handle_line(struct retraced_ctl_ctx *ctx,
 			json_value_free(v);
 			return;
 		}
+#ifdef _WIN32
+		{
+			HANDLE h = OpenProcess(PROCESS_TERMINATE,
+				FALSE, (DWORD)pid);
+
+			if (h != NULL) {
+				TerminateProcess(h, 1);
+				CloseHandle(h);
+			}
+		}
+#else
 		kill((pid_t)pid, SIGTERM);
+#endif
 		{
 			char ev[128];
 

--- a/tools/retraced/retraced_ctl.c
+++ b/tools/retraced/retraced_ctl.c
@@ -36,7 +36,12 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#ifdef _WIN32
+#include <process.h>
+#define getpid _getpid
+#else
 #include <unistd.h>
+#endif
 
 #include "retraced_ctl.h"
 #include "tls_gate.h"

--- a/tools/retraced/retraced_ctl.c
+++ b/tools/retraced/retraced_ctl.c
@@ -149,6 +149,25 @@ static void ctl_reply(struct retraced_ctl_ctx *ctx,
 		ctx->reply_sink(out, ctx->reply_user);
 }
 
+uint32_t retraced_tls_scope_for_cmd(const char *cmd)
+{
+	if (cmd == NULL)
+		return 0;
+	if (strcmp(cmd, "status") == 0)
+		return RETRACED_SCOPE_STATUS;
+	if (strcmp(cmd, "ps") == 0)
+		return RETRACED_SCOPE_PS;
+	if (strcmp(cmd, "policy_push") == 0 ||
+	    strcmp(cmd, "freeze") == 0 ||
+	    strcmp(cmd, "thaw") == 0)
+		return RETRACED_SCOPE_POLICY;
+	if (strcmp(cmd, "kill") == 0)
+		return RETRACED_SCOPE_KILL;
+	if (strcmp(cmd, "spawn") == 0)
+		return RETRACED_SCOPE_SPAWN;
+	return 0;
+}
+
 void retraced_ctl_handle_line(struct retraced_ctl_ctx *ctx,
 	char *line)
 {

--- a/tools/retraced/retraced_ctl.h
+++ b/tools/retraced/retraced_ctl.h
@@ -98,6 +98,12 @@ int retraced_policy_load(const char *text, char **blob_out,
 	long *epoch_out);
 int retraced_ctl_push_policy(struct retraced_ctl_ctx *ctx,
 	const char *blob);
+/*
+ * the cmd -> claim-bit table behind the scope gate; pure policy,
+ * no TLS types -- every transport links the ctl module
+ */
+uint32_t retraced_tls_scope_for_cmd(const char *cmd);
+
 void retraced_ctl_handle_line(struct retraced_ctl_ctx *ctx,
 	char *line);
 

--- a/tools/retraced/tls_gate.c
+++ b/tools/retraced/tls_gate.c
@@ -62,25 +62,6 @@ uint32_t retraced_tls_parse_scopes(const char *csv)
 	return s;
 }
 
-uint32_t retraced_tls_scope_for_cmd(const char *cmd)
-{
-	if (cmd == NULL)
-		return 0;
-	if (strcmp(cmd, "status") == 0)
-		return RETRACED_SCOPE_STATUS;
-	if (strcmp(cmd, "ps") == 0)
-		return RETRACED_SCOPE_PS;
-	if (strcmp(cmd, "policy_push") == 0 ||
-	    strcmp(cmd, "freeze") == 0 ||
-	    strcmp(cmd, "thaw") == 0)
-		return RETRACED_SCOPE_POLICY;
-	if (strcmp(cmd, "kill") == 0)
-		return RETRACED_SCOPE_KILL;
-	if (strcmp(cmd, "spawn") == 0)
-		return RETRACED_SCOPE_SPAWN;
-	return 0;
-}
-
 int retraced_tls_listen(const char *hostport)
 {
 	char host[128];

--- a/tools/retraced/tls_gate.h
+++ b/tools/retraced/tls_gate.h
@@ -83,7 +83,6 @@ int retraced_tls_write(void *ssl, const void *buf, int n);
 uint32_t retraced_tls_parse_scopes(const char *csv);
 
 /* map a ctl cmd name onto the required scope bit; 0 = unknown */
-uint32_t retraced_tls_scope_for_cmd(const char *cmd);
 
 /* bind+listen a TCP socket on host:port (host may be NULL = any) */
 int retraced_tls_listen(const char *hostport);

--- a/tools/win-run/retrace_win_run.c
+++ b/tools/win-run/retrace_win_run.c
@@ -50,16 +50,26 @@ int main(int argc, char **argv)
 	HMODULE self;
 
 	for (i = 1; i < argc; i++) {
-		if (strcmp(argv[i], "--lib") == 0 && i + 1 < argc) {
-			dll_path = argv[++i];
-			continue;
-		} else if (strcmp(argv[i], "-h") == 0 ||
-			   strcmp(argv[i], "--help") == 0) {
-			usage(stdout);
-			return 0;
-		} else if (argv[i][0] == '-' && argv[i][1] != '\0') {
-			usage(stderr);
-			return 2;
+		/*
+		 * Flags belong to the launcher only BEFORE the
+		 * target: everything after the first positional is
+		 * the child's own command line (ping -n 4 is not
+		 * ours to judge) -- the usage line always said so.
+		 */
+		if (first_target) {
+			if (strcmp(argv[i], "--lib") == 0 &&
+			    i + 1 < argc) {
+				dll_path = argv[++i];
+				continue;
+			} else if (strcmp(argv[i], "-h") == 0 ||
+				   strcmp(argv[i], "--help") == 0) {
+				usage(stdout);
+				return 0;
+			} else if (argv[i][0] == '-' &&
+				   argv[i][1] != '\0') {
+				usage(stderr);
+				return 2;
+			}
 		}
 		if (first_target) {
 			/* quote the target path (spaces in paths) */


### PR DESCRIPTION
## Summary

Adopts **libleptris 1.9.22** (pin 1.9.21 → 1.9.22). Spec-only upstream release — patch, no functional change. 1.23.3.

### The #653 verdict, verified through the binding
- Well-formed self-closing-then-text shapes (`<div><p><br/>hello</p></div>`, `<r><y/>t</r>`) parse — lxml parity
- The report's repro (`<r><b><y/>t</y></b></r>`) carries a stray `</y>` after a self-closed `<y/>` — ill-formed, and **both leptris and lxml reject it identically** (ParseError / XMLSyntaxError tag-mismatch)
- Both shapes now pinned as binding tests so any future parser regression surfaces here first

### Verification
- 240+2 tests pass against the v1.9.22 tag build; drift gate clean (255 symbols / 119 declarations); fuzz 2000 clean
- Wheel builds with the accelerator

## The activation iterations (each a real shipped defect)

1. **MinGW/MSVC compile debt** — guarded POSIX paths, unistd/getpid shims, platform-guarded enforce includes, `_WIN32_WINNT` pinned Win8, `lpAttributeList` (the bare `AttributeList` name compiled nowhere).
2. **The link hole** — `retraced_tls_scope_for_cmd` lived in `tls_gate.c`, a TU Windows doesn't build; moved to the ctl module that owns the scope gate.
3. **`CreateAppContainerProfile`** — W-only APIs called with narrow strings and six args against seven parameters; toolchain headers even disagree on the arity (MinGW: 6, SDK: 7). Resolved dynamically from `userenv.dll`; the plane gates on `PROC_THREAD_ATTRIBUTE_SECURITY_CAPABILITIES` so SDK-complete builds carry it and MinGW keeps the stub (its CI runs no ctest).
4. **The ctl pipe served one controller** — closed on first disconnect; now an accept loop.
5. **`make_pipe` ordering** — the accept loop called it before its definition.
6. **The tests still didn't run on a green matrix** — `if(TARGET retrace_retraced)` guards in `test/CMakeLists.txt` evaluate *before* the tools subdirectories are added (test/ comes first in the root list), so the tests never registered. Guards dropped; the everywhere-set conformance guarantee makes missing targets a loud configure failure instead.
