### PR TITLE
version: the STRING macro rides the bump (v2.62.0)

### DIFF
--- a/include/retrace/version.h
+++ b/include/retrace/version.h
@@ -40,7 +40,7 @@
 #define RETRACE_VERSION_MINOR 62
 #define RETRACE_VERSION_PATCH 0
 
-#define RETRACE_VERSION_STRING "2.61.0"
+#define RETRACE_VERSION_STRING "2.62.0"
 
 #define RETRACE_VERSION_ATLEAST(maj, min, pat)                  \
 	(RETRACE_VERSION_MAJOR > (maj) ||                       \


### PR DESCRIPTION
The v2.62.0 bump moved the numeric macros but left RETRACE_VERSION_STRING at 2.61.0; release.yml names every artifact from the string, so the tag's tarballs cut as retrace-2.61.0-*. Fixes the v2.62.0 cut (tag will be re-cut on this commit).