### PR TITLE
the broadcast seam: policy crosses the pipe

### DIFF
--- a/test/unit/test_retraced_ctl.c
+++ b/test/unit/test_retraced_ctl.c
@@ -39,12 +39,13 @@
 #include "tls_gate.h"
 
 /*
- * the connection-plane writer, stubbed: pushes are COUNTED,
- * not sent
+ * the broadcast seam, faked: pushes are COUNTED, not sent --
+ * no socket, no daemon, no extern symbol
  */
-int write_frame(int fd, uint16_t type, const char *payload)
+static int fake_conn_send(void *io, uint16_t type,
+	const char *payload)
 {
-	(void)fd;
+	(void)io;
 	(void)type;
 	(void)payload;
 	return 0;
@@ -53,7 +54,6 @@ int write_frame(int fd, uint16_t type, const char *payload)
 static int tests_run;
 static int tests_pass;
 static int tests_fail;
-static int pushes;
 
 #define TEST(name) do { \
 	tests_run++; \
@@ -105,12 +105,12 @@ static void setup(void)
 	memset(conns, 0, sizeof(conns));
 	memset(&reg, 0, sizeof(reg));
 	memset(&jr, 0, sizeof(jr));
-	pushes = 0;
 	retraced_journal_open(&jr, "/dev/null");
 	ctx.conns = conns;
 	ctx.reg = &reg;
 	ctx.jr = &jr;
 	ctx.reply_sink = sink;
+	ctx.conn_send = fake_conn_send;
 	ctx.scopes = RETRACED_SCOPE_ALL; /* local-UDS peer default */
 }
 
@@ -165,6 +165,22 @@ static void test_policy_push_valid(void)
 	CHECK(ctx.policy_blob != NULL);
 	CHECK(ctx.frozen == 0);
 	CHECK(ctx.thaw_blob != NULL);
+
+	/* the broadcast through the seam: a full peer is pushed,
+	 * a spectator is not (evidence always, policy never)
+	 */
+	setup();
+	conns[0].io = (void *)0x1234;
+	conns[0].helloed = 1;
+	conns[0].spectator = 0;
+	conns[1].io = (void *)0x1234;
+	conns[1].helloed = 1;
+	conns[1].spectator = 1;
+	feed(&ctx, "{\"cmd\":\"policy_push\",\"blob\":"
+		   "\"{\\\"policy\\\":{\\\"epoch\\\":8},"
+		   "\\\"intercept_scripts\\\":[{\\\"func_name\\\":\\\"*\\\","
+		   "\\\"actions\\\":[{\\\"action_name\\\":\\\"log_params\\\"}]}]}\"}");
+	CHECK(strstr(reply_buf, "\"pushed\":1") != NULL);
 }
 
 static void test_policy_push_bad(void)

--- a/tools/retraced/main.c
+++ b/tools/retraced/main.c
@@ -156,6 +156,15 @@ static void on_signal(int sig)
 	g_stop = 1;
 }
 
+/* the ctl broadcast's fd adapter: same shape as the
+ * daemon_frame write seam, one int narrower
+ */
+static int ctl_conn_send_fd(void *io, uint16_t type,
+	const char *payload)
+{
+	return write_frame((int)(intptr_t)io, type, payload);
+}
+
 static long now_ms(void)
 {
 	struct timespec ts;
@@ -718,6 +727,7 @@ int main(int argc, char **argv)
 	g_ctl.reg = &reg;
 	g_ctl.jr = &jr;
 	g_ctl.conns = conns;
+	g_ctl.conn_send = ctl_conn_send_fd;
 	g_ctl.reply_sink = ctl_reply_fd;
 	g_ctl.reply_user = &g_ctl_fd;
 	g_ctl.scopes = RETRACED_SCOPE_ALL; /* local UDS default */
@@ -952,6 +962,7 @@ int main(int argc, char **argv)
 							    pfds[i].fd) {
 								close(conns[k].fd);
 								conns[k].fd = -1;
+							conns[k].io = NULL;
 								conns[k].helloed = 0;
 								break;
 							}
@@ -1062,6 +1073,8 @@ int main(int argc, char **argv)
 					 * peer actually sends.
 					 */
 					conns[slot].fd = fd;
+					conns[slot].io =
+						(void *)(intptr_t)fd;
 					conns[slot].fill = 0;
 					conns[slot].agent_id[0] = '\0';
 					conns[slot].helloed = 0;
@@ -1087,6 +1100,7 @@ int main(int argc, char **argv)
 				if (n <= 0) {
 					close(conns[i].fd);
 					conns[i].fd = -1;
+					conns[i].io = NULL;
 					/* connection-scoped
 					 * durability: a finished
 					 * conversation is on disk

--- a/tools/retraced/pipe_server.c
+++ b/tools/retraced/pipe_server.c
@@ -47,6 +47,7 @@
 
 struct pipe_conn {
 	HANDLE pipe;
+	struct conn *ctl;	/* the broadcast registration */
 	OVERLAPPED ov;
 	int live;
 	char agent_id[RETRACED_AGENT_ID_MAX];
@@ -67,6 +68,13 @@ static const char *g_ctl_name = "\\\\.\\pipe\\retraced-ctl";
 
 static int pipe_write_frame(HANDLE h, uint16_t type,
 	const char *payload);
+
+/* the ctl broadcast's pipe arm */
+static int ctl_conn_send_pipe(void *io, uint16_t type,
+	const char *payload)
+{
+	return pipe_write_frame((HANDLE)io, type, payload);
+}
 
 /* the transport seam for the shared frame module: pipe-backed */
 static int df_write_pipe(void *io, uint16_t type, const char *payload)
@@ -188,6 +196,13 @@ static int handle_agent_frame(struct pipe_conn *c,
 		c->spectator = st.spectator;
 		snprintf(c->agent_id, sizeof(c->agent_id), "%s",
 			st.agent_id);
+		if (c->ctl != NULL) {
+			c->ctl->helloed = c->helloed;
+			c->ctl->spectator = c->spectator;
+			snprintf(c->ctl->agent_id,
+				sizeof(c->ctl->agent_id), "%s",
+				c->agent_id);
+		}
 		return 0;
 	}
 	case RETRACE_RPC_MSG_HEARTBEAT:
@@ -206,6 +221,8 @@ static int handle_agent_frame(struct pipe_conn *c,
 			now_ms(), &g_reg, &g_jr, &g_ctl, g_nonce,
 			df_write_pipe, (void *)c->pipe);
 		c->helloed = st.helloed;
+		if (c->ctl != NULL)
+			c->ctl->helloed = c->helloed;
 		return rc;
 	}
 	default:
@@ -236,6 +253,14 @@ static DWORD WINAPI agent_thread(LPVOID arg)
 	CloseHandle(c->pipe);
 	c->pipe = NULL;
 	c->live = 0;
+	if (c->ctl != NULL) {
+		/* a concurrent push holds the same lock */
+		EnterCriticalSection(&g_lock);
+		c->ctl->io = NULL;
+		c->ctl->helloed = 0;
+		c->ctl = NULL;
+		LeaveCriticalSection(&g_lock);
+	}
 	/* connection-scoped durability (same as the POSIX conn
 	 * end): observations are buffered-class records, and a
 	 * force-killed daemon must not swallow a finished
@@ -600,6 +625,7 @@ int retraced_pipe_main(int argc, char **argv)
 	for (i = 0; i < MAX_AGENTS; i++)
 		g_ctl_conns[i].fd = -1;
 	g_ctl.conns = g_ctl_conns;
+	g_ctl.conn_send = ctl_conn_send_pipe;
 	g_ctl.reg = &g_reg;
 	g_ctl.jr = &g_jr;
 	g_ctl.scopes = RETRACED_SCOPE_ALL;
@@ -664,11 +690,30 @@ int retraced_pipe_main(int argc, char **argv)
 				}
 				if (slot >= 0) {
 					HANDLE th;
+					int cs;
 
 					conns[slot].pipe = h;
 					conns[slot].live = 1;
 					conns[slot].helloed = 0;
 					conns[slot].spectator = 0;
+					conns[slot].ctl = NULL;
+					/* the broadcast
+					 * registration: policy
+					 * reaches pipe agents
+					 */
+					EnterCriticalSection(&g_lock);
+					for (cs = 0; cs < MAX_AGENTS;
+					     cs++) {
+						if (g_ctl_conns[cs].io == NULL) {
+							g_ctl_conns[cs].io = (void *)h;
+							g_ctl_conns[cs].helloed = 0;
+							g_ctl_conns[cs].spectator = 0;
+							g_ctl_conns[cs].agent_id[0] = '\0';
+							conns[slot].ctl = &g_ctl_conns[cs];
+							break;
+						}
+					}
+					LeaveCriticalSection(&g_lock);
 					th = CreateThread(NULL, 0, agent_thread,
 						&conns[slot], 0, NULL);
 					if (th != NULL)
@@ -704,21 +749,6 @@ int retraced_pipe_main(int argc, char **argv)
 	LeaveCriticalSection(&g_lock);
 	retraced_journal_close(&g_jr);
 	DeleteCriticalSection(&g_lock);
-	return 0;
-}
-
-/*
- * write_frame normally lives in main.c's TU (the POSIX daemon);
- * on Windows that file is not linked, and policy broadcast is
- * P0-off (the agent-side pipe port delivers POLICY_SET).
- */
-int write_frame(int fd, uint16_t type, const char *payload);
-
-int write_frame(int fd, uint16_t type, const char *payload)
-{
-	(void)fd;
-	(void)type;
-	(void)payload;
 	return 0;
 }
 

--- a/tools/retraced/retraced_ctl.c
+++ b/tools/retraced/retraced_ctl.c
@@ -51,12 +51,6 @@
 #include "tls_gate.h"
 #include "parson.h"
 
-/*
- * write_frame lives in main.c's TU (the connection-plane
- * writer); declared here for the policy push
- */
-int write_frame(int fd, uint16_t type, const char *payload);
-
 int retraced_policy_load(const char *text, char **blob_out,
 	long *epoch_out)
 {
@@ -124,10 +118,11 @@ int retraced_ctl_push_policy(struct retraced_ctl_ctx *ctx,
 	int i, pushed = 0;
 
 	for (i = 0; i < MAX_AGENTS; i++) {
-		if (ctx->conns[i].fd >= 0 &&
+		if (ctx->conns[i].io != NULL &&
 		    ctx->conns[i].helloed &&
-		    !ctx->conns[i].spectator) {
-			write_frame(ctx->conns[i].fd,
+		    !ctx->conns[i].spectator &&
+		    ctx->conn_send != NULL) {
+			ctx->conn_send(ctx->conns[i].io,
 				RETRACE_RPC_MSG_POLICY_SET, blob);
 			pushed++;
 		}

--- a/tools/retraced/retraced_ctl.h
+++ b/tools/retraced/retraced_ctl.h
@@ -40,6 +40,13 @@
  */
 struct conn {
 	int fd;
+	/*
+	 * The transport's write target: the fd as (intptr_t) on
+	 * POSIX, the pipe HANDLE on Windows (an int cannot carry
+	 * one). The broadcast sends through ctx->conn_send with
+	 * this; fd stays for the POSIX poll loop's own machinery.
+	 */
+	void *io;
 	uint8_t buf[RETRACE_RPC_PAYLOAD_MAX + RETRACE_RPC_HEADER_SZ];
 	size_t fill;
 	char agent_id[RETRACED_AGENT_ID_MAX];
@@ -82,6 +89,15 @@ struct retraced_ctl_ctx {
 	/* the reply sink (one line per command) */
 	void (*reply_sink)(const char *line, void *user);
 	void *reply_user;
+
+	/*
+	 * The broadcast seam: send one frame to a registered
+	 * agent's io. Same shape as the daemon_frame write seam.
+	 * The transport installs it; the unit test installs a
+	 * fake and counts.
+	 */
+	int (*conn_send)(void *io, uint16_t type,
+		const char *payload);
 };
 
 void retraced_ctl_set_policy(struct retraced_ctl_ctx *ctx,


### PR DESCRIPTION
## What

The architecture review's candidate A (sequenced "after the release" last cycle): **`policy_push` on Windows reached zero agents while reporting success.** The ctl plane's broadcast walked `ctx->conns[]` filtering on `fd` and called an *extern* `write_frame` resolved from whichever transport TU linked; the Windows daemon allocated its conns array and never populated it, so the loop pushed to nobody.

## The deepening

`struct conn` gains a transport-opaque **`io`** (an `int fd` cannot carry a Windows `HANDLE`), and the ctx gains **`conn_send(io, type, payload)`** — deliberately the same signature as the `daemon_frame` write seam that already ships twice.

- **POSIX `main.c`**: installs an fd adapter; stamps `io` at accept/close.
- **`pipe_server.c`**: registers accepted pipes into the ctl conns under the shared lock, syncs `helloed`/`spectator`/`agent_id` at HELLO and every frame, clears the seat at disconnect (under the lock — a concurrent push holds it). **The Windows policy broadcast is real for the first time.**
- The extern-symbol stub in `pipe_server.c` retires with the seam it served — the codebase's last extern-as-interface is gone.
- **Unit test**: installs a fake sink and asserts the count — a full peer pushed, a spectator skipped (*evidence always, policy never*). The broadcast was previously testable only by defining the extern symbol in the test TU.

## Verification

- Full local build green; `ctest -R 'retraced-ctl|supervisor'` → 7/7 (the POSIX policy-push integration path runs over the new `io` keying).
- checkpatch clean.
- The Windows legs will exercise the real broadcast through `integration-supervised-win` (its POLICY_ACK assertion now has something true to check).
