### PR TITLE
one policy ladder: validation moves in with its verifier

### DIFF
--- a/src/supervisor/agent.c
+++ b/src/supervisor/agent.c
@@ -511,88 +511,22 @@ static void set_reason(char *dst, size_t cap, const char *msg)
 int retrace_agent_policy_apply(const char *payload_wrapped,
 	char *reason_out, size_t reason_cap)
 {
-	char payload_buf[8192];
-	const char *payload_json = payload_wrapped;
-	JSON_Value *v;
-	JSON_Object *root, *pol;
-	double epoch, expires;
+	struct json_object_t *root;
+	uint64_t epoch;
+	int rc = retrace_policy_validate(payload_wrapped,
+		reason_out, reason_cap, g_agent.policy_epoch,
+		&root, &epoch);
 
-	if (reason_out != NULL && reason_cap > 0)
-		reason_out[0] = '\0';
-	if (payload_wrapped == NULL) {
-		set_reason(reason_out, reason_cap, "null payload");
-		return -1;
-	}
-
-	/*
-	 * Signed policies (TODO.supervisor/05): a wrapper carries
-	 * the exact policy bytes + an Ed25519 signature; with a key
-	 * pinned (RETRACE_SUPERVISOR_PUBKEY) verification is
-	 * fail-closed. Bare policies pass through unchanged.
-	 */
-	(void)retrace_policy_sig_init();
-	{
-		int src = retrace_policy_sig_check(payload_wrapped,
-			payload_buf, sizeof(payload_buf), reason_out,
-			reason_cap);
-
-		if (src < 0)
-			return -1;
-		payload_json = payload_buf;
-	}
-
-	v = json_parse_string(payload_json);
-	if (v == NULL) {
-		set_reason(reason_out, reason_cap, "malformed json");
-		return -1;
-	}
-	root = json_value_get_object(v);
-	pol = root != NULL ? json_object_get_object(root, "policy") : NULL;
-	if (pol == NULL) {
-		json_value_free(v);
-		set_reason(reason_out, reason_cap, "no policy header");
-		return -1;
-	}
-
-	epoch = json_object_get_number(pol, "epoch");
-	expires = json_object_get_number(pol, "expires");
-	if (epoch < 1.0) {
-		json_value_free(v);
-		set_reason(reason_out, reason_cap, "policy.epoch missing");
-		return -1;
-	}
-	if ((uint64_t)epoch == g_agent.policy_epoch) {
-		/* re-delivery of the HELD epoch (daemon restart, fork
-		 * child re-registration): idempotent -- the policy
-		 * is already in force, the ACK says so
-		 */
-		json_value_free(v);
-		return 0;
-	}
-	if ((uint64_t)epoch < g_agent.policy_epoch) {
-		json_value_free(v);
-		set_reason(reason_out, reason_cap,
-			"epoch regression refused");
-		return -1;
-	}
-	if (expires > 0.0 && (time_t)expires <= time(NULL)) {
-		json_value_free(v);
-		set_reason(reason_out, reason_cap, "policy expired");
-		return -1;
-	}
-	if (json_object_get_array(root, "intercept_scripts") == NULL) {
-		json_value_free(v);
-		set_reason(reason_out, reason_cap, "no intercept_scripts");
-		return -1;
-	}
-
+	if (rc != 0)
+		return rc > 0 ? 0 : -1;	/* HELD: idempotent ACK */
 	if (retrace_config_cache_build(root) != 0) {
-		json_value_free(v);
-		set_reason(reason_out, reason_cap, "cache rebuild failed");
+		json_value_free(json_object_get_wrapping_value(root));
+		set_reason(reason_out, reason_cap,
+			"cache rebuild failed");
 		return -1;
 	}
 	retrace_conf = root;
-	g_agent.policy_epoch = (uint64_t)epoch;
+	g_agent.policy_epoch = epoch;
 	return 0;
 }
 
@@ -1379,72 +1313,22 @@ static void w_drop_connection(void)
 int retrace_agent_policy_apply(const char *payload_wrapped,
 	char *reason_out, size_t reason_cap)
 {
-	char payload_buf[8192];
-	const char *payload_json = payload_wrapped;
-	JSON_Value *v;
-	JSON_Object *root, *pol;
-	double epoch;
+	struct json_object_t *root;
+	uint64_t epoch;
+	int rc = retrace_policy_validate(payload_wrapped,
+		reason_out, reason_cap, w_agent.policy_epoch,
+		&root, &epoch);
 
-	if (reason_out != NULL && reason_cap > 0)
-		reason_out[0] = '\0';
-	if (payload_wrapped == NULL) {
-		w_set_reason(reason_out, reason_cap, "null payload");
-		return -1;
-	}
-	(void)retrace_policy_sig_init();
-	{
-		int src = retrace_policy_sig_check(payload_wrapped,
-			payload_buf, sizeof(payload_buf), reason_out,
-			reason_cap);
-
-		if (src < 0)
-			return -1;
-		payload_json = payload_buf;
-	}
-	v = json_parse_string(payload_json);
-	if (v == NULL) {
-		w_set_reason(reason_out, reason_cap, "malformed json");
-		return -1;
-	}
-	root = json_value_get_object(v);
-	pol = root != NULL ? json_object_get_object(root, "policy")
-		: NULL;
-	if (pol == NULL) {
-		json_value_free(v);
-		w_set_reason(reason_out, reason_cap, "no policy header");
-		return -1;
-	}
-	epoch = json_object_get_number(pol, "epoch");
-	if (epoch < 1.0) {
-		json_value_free(v);
-		w_set_reason(reason_out, reason_cap,
-			"policy.epoch missing");
-		return -1;
-	}
-	if ((uint64_t)epoch == w_agent.policy_epoch) {
-		json_value_free(v);
-		return 0;	/* idempotent re-delivery */
-	}
-	if ((uint64_t)epoch < w_agent.policy_epoch) {
-		json_value_free(v);
-		w_set_reason(reason_out, reason_cap,
-			"epoch regression refused");
-		return -1;
-	}
-	if (json_object_get_array(root, "intercept_scripts") == NULL) {
-		json_value_free(v);
-		w_set_reason(reason_out, reason_cap,
-			"no intercept_scripts");
-		return -1;
-	}
+	if (rc != 0)
+		return rc > 0 ? 0 : -1;	/* HELD: idempotent ACK */
 	if (retrace_config_cache_build(root) != 0) {
-		json_value_free(v);
+		json_value_free(json_object_get_wrapping_value(root));
 		w_set_reason(reason_out, reason_cap,
 			"cache rebuild failed");
 		return -1;
 	}
 	retrace_conf = root;
-	w_agent.policy_epoch = (uint64_t)epoch;
+	w_agent.policy_epoch = epoch;
 	return 0;
 }
 

--- a/src/supervisor/policy_sig.c
+++ b/src/supervisor/policy_sig.c
@@ -257,3 +257,105 @@ out:
 	json_value_free(v);
 	return rc;
 }
+
+/*
+ * The validation ladder (see policy_sig.h). Pure given the
+ * agent's held epoch; the install belongs to the caller.
+ */
+static void validate_reason(char *out, size_t cap,
+	const char *msg)
+{
+	if (out != NULL && cap > 0)
+		snprintf(out, cap, "%s", msg);
+}
+
+int retrace_policy_validate(const char *payload_wrapped,
+	char *reason_out, size_t reason_cap, uint64_t have_epoch,
+	struct json_object_t **root_out, uint64_t *epoch_out)
+{
+	char payload_buf[8192];
+	const char *payload_json = payload_wrapped;
+	JSON_Value *v;
+	JSON_Object *root, *pol;
+	double epoch, expires;
+
+	if (root_out != NULL)
+		*root_out = NULL;
+	if (epoch_out != NULL)
+		*epoch_out = 0;
+	if (reason_out != NULL && reason_cap > 0)
+		reason_out[0] = '\0';
+	if (payload_wrapped == NULL) {
+		validate_reason(reason_out, reason_cap,
+			"null payload");
+		return -1;
+	}
+
+	(void)retrace_policy_sig_init();
+	{
+		int src = retrace_policy_sig_check(payload_wrapped,
+			payload_buf, sizeof(payload_buf), reason_out,
+			reason_cap);
+
+		if (src < 0)
+			return -1;
+		payload_json = payload_buf;
+	}
+
+	v = json_parse_string(payload_json);
+	if (v == NULL) {
+		validate_reason(reason_out, reason_cap,
+			"malformed json");
+		return -1;
+	}
+	root = json_value_get_object(v);
+	pol = root != NULL ? json_object_get_object(root, "policy")
+		: NULL;
+	if (pol == NULL) {
+		json_value_free(v);
+		validate_reason(reason_out, reason_cap,
+			"no policy header");
+		return -1;
+	}
+
+	epoch = json_object_get_number(pol, "epoch");
+	expires = json_object_get_number(pol, "expires");
+	if (epoch < 1.0) {
+		json_value_free(v);
+		validate_reason(reason_out, reason_cap,
+			"policy.epoch missing");
+		return -1;
+	}
+	if ((uint64_t)epoch == have_epoch) {
+		/* re-delivery of the HELD epoch (daemon restart,
+		 * fork child re-registration): idempotent -- the
+		 * policy is already in force, the ACK says so
+		 */
+		json_value_free(v);
+		return 1;
+	}
+	if ((uint64_t)epoch < have_epoch) {
+		json_value_free(v);
+		validate_reason(reason_out, reason_cap,
+			"epoch regression refused");
+		return -1;
+	}
+	if (expires > 0.0 && (time_t)expires <= time(NULL)) {
+		json_value_free(v);
+		validate_reason(reason_out, reason_cap,
+			"policy expired");
+		return -1;
+	}
+	if (json_object_get_array(root, "intercept_scripts") == NULL) {
+		json_value_free(v);
+		validate_reason(reason_out, reason_cap,
+			"no intercept_scripts");
+		return -1;
+	}
+
+	if (root_out != NULL)
+		*root_out = root;	/* document: caller installs */
+	if (epoch_out != NULL)
+		*epoch_out = (uint64_t)epoch;
+	return 0;
+}

--- a/src/supervisor/policy_sig.h
+++ b/src/supervisor/policy_sig.h
@@ -43,4 +43,32 @@ int retrace_policy_sig_init(void);
 /* 1 when a key is pinned */
 int retrace_policy_sig_pinned(void);
 
+/*
+ * The POLICY_SET validation ladder -- shared by both agent
+ * halves (the POSIX UDS agent and the Windows pipe agent once
+ * carried a copy each; they drifted). Everything up to the
+ * install: wrapper verification, JSON parse, the policy
+ * header, epoch sanity against the agent's HELD epoch
+ * (idempotent re-delivery vs regression refusal), expiry, and
+ * the intercept_scripts presence. The INSTALL stays with the
+ * caller: it touches process state (config rebuild + the
+ * agent's epoch stamp).
+ *
+ * root_out receives the parsed document's OBJECT -- the shape
+ * installs consume (retrace_config_cache_build, retrace_conf);
+ * on OK the document's ownership passes to the caller's
+ * install, exactly as before the extraction. epoch_out
+ * receives the policy epoch.
+ *
+ * Returns 0 OK, 1 HELD (same epoch: idempotent, ACK and keep
+ * the policy in force), -1 ERR (reason_out filled).
+ */
+#include <stdint.h>
+
+struct json_object_t;
+
+int retrace_policy_validate(const char *payload_wrapped,
+	char *reason_out, size_t reason_cap, uint64_t have_epoch,
+	struct json_object_t **root_out, uint64_t *epoch_out);
+
 #endif /* RETRACE_SUPERVISOR_POLICY_SIG_H_ */

--- a/test/unit/test_policy_sig.c
+++ b/test/unit/test_policy_sig.c
@@ -17,6 +17,7 @@
 #include <unistd.h>
 
 #include "policy_sig.h"
+#include "parson.h"
 
 /* fixtures: the committed audit keypair (throwaway, tests only) */
 #define PRIV RETRACE_SOURCE_DIR "/test/fixtures/audit_ed25519_key.pem"
@@ -237,6 +238,61 @@ static void test_partial_wrapper_rejected(void)
 	CHECK(strstr(reason, "partial") != NULL);
 }
 
+static const char *VGOOD =
+	"{\"policy\":{\"epoch\":9},\"intercept_scripts\":["
+	"{\"func_name\":\"open\",\"actions\":["
+	"{\"action_name\":\"log_params\"}]}]}";
+
+static void test_ladder_held_is_idempotent(void)
+{
+	char reason[64];
+
+	CHECK(retrace_policy_validate(VGOOD, reason, sizeof(reason),
+		9, NULL, NULL) == 1);
+}
+
+static void test_ladder_regression_refused(void)
+{
+	char reason[64];
+
+	CHECK(retrace_policy_validate(VGOOD, reason, sizeof(reason),
+		10, NULL, NULL) == -1);
+	CHECK(strstr(reason, "regression") != NULL);
+}
+
+static void test_ladder_expired_refused(void)
+{
+	const char *old = "{\"policy\":{\"epoch\":99,"
+			  "\"expires\":1000},"
+			  "\"intercept_scripts\":[]}";
+	char reason[64];
+
+	CHECK(retrace_policy_validate(old, reason, sizeof(reason),
+		0, NULL, NULL) == -1);
+	CHECK(strstr(reason, "expired") != NULL);
+}
+
+static void test_ladder_no_scripts_refused(void)
+{
+	char reason[64];
+
+	CHECK(retrace_policy_validate(
+		"{\"policy\":{\"epoch\":9}}", reason,
+		sizeof(reason), 0, NULL, NULL) == -1);
+	CHECK(strstr(reason, "no intercept_scripts") != NULL);
+}
+
+static void test_ladder_ok_hands_root(void)
+{
+	struct json_object_t *root;
+	uint64_t epoch = 0;
+	char reason[64];
+
+	CHECK(retrace_policy_validate(VGOOD, reason, sizeof(reason),
+		0, &root, &epoch) == 0);
+	CHECK(root != NULL && epoch == 9);
+}
+
 int main(void)
 {
 	printf("policy signature tests:\n");
@@ -247,6 +303,11 @@ int main(void)
 	TEST(tampered_rejected);
 	TEST(partial_wrapper_rejected);
 	TEST(rotation_both_keys_verify);
+	TEST(ladder_held_is_idempotent);
+	TEST(ladder_regression_refused);
+	TEST(ladder_expired_refused);
+	TEST(ladder_no_scripts_refused);
+	TEST(ladder_ok_hands_root);
 
 	printf("%d tests: %d pass, %d fail\n", tests_run, tests_pass,
 		tests_fail);


### PR DESCRIPTION
## What

The architecture review's candidate B (cycle 4): `retrace_agent_policy_apply` was defined **twice in `agent.c`** — a POSIX copy at line 511 and a Windows copy at 1379 — the same POLICY_SET validation ladder, already drifting (the Windows copy had lost the `expires` guard).

## The deepening

The ladder moves to `policy_sig.c` — the module that already owns wrapper verification — as `retrace_policy_validate(payload, reason, cap, have_epoch, &root, &epoch)`: wrapper verification, JSON parse, policy header, epoch sanity against the agent's HELD epoch (idempotent re-delivery vs regression refusal), expiry, intercept_scripts presence. Returns OK / **HELD** / ERR.

The **install stays with each half** — config rebuild plus the agent's own epoch stamp — where the process state lives. `root_out` is the parsed document's *object*, the shape installs consume.

The drift heals as a side effect: **expired policies are now refused on Windows too.**

## Verification

- `agent.c` gives up ~170 lines toward the eventual two-TU split.
- Six ladder cases join the policy_sig unit test: held-is-idempotent, regression refused, expired refused, no-scripts refused, ok-hands-root. 11/11 pass.
- `unit-test-agent-policy` (the full apply gates) passes direct-run.
- Full build green; checkpatch clean.
