### PR TITLE
policy_sig: time.h for the ladder's expiry guard

### DIFF
--- a/src/supervisor/policy_sig.c
+++ b/src/supervisor/policy_sig.c
@@ -9,6 +9,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 
 #include "parson.h"
 


### PR DESCRIPTION
The validate ladder compares policy.expires against time(NULL) but policy_sig.c never included time.h — toolchains that do not leak time_t through other headers (the OHOS cross) refuse the build. One include; main's OHOS legs are red until this lands.