### PR TITLE
v2.64.0 version bump

### DIFF
--- a/include/retrace/version.h
+++ b/include/retrace/version.h
@@ -37,10 +37,10 @@
 #define RETRACE_VERSION_H
 
 #define RETRACE_VERSION_MAJOR 2
-#define RETRACE_VERSION_MINOR 63
+#define RETRACE_VERSION_MINOR 64
 #define RETRACE_VERSION_PATCH 0
 
-#define RETRACE_VERSION_STRING "2.63.0"
+#define RETRACE_VERSION_STRING "2.64.0"
 
 #define RETRACE_VERSION_ATLEAST(maj, min, pat)                  \
 	(RETRACE_VERSION_MAJOR > (maj) ||                       \


### PR DESCRIPTION
Version bump for the release: one policy ladder — POLICY_SET validation shared by both agent halves in policy_sig.c, per-half installs, the Windows expiry-guard drift healed, six new ladder unit cases. Both version macros ride the bump.