### PR TITLE
v2.65.0 version bump

### DIFF
--- a/include/retrace/version.h
+++ b/include/retrace/version.h
@@ -37,10 +37,10 @@
 #define RETRACE_VERSION_H
 
 #define RETRACE_VERSION_MAJOR 2
-#define RETRACE_VERSION_MINOR 64
+#define RETRACE_VERSION_MINOR 65
 #define RETRACE_VERSION_PATCH 0
 
-#define RETRACE_VERSION_STRING "2.64.0"
+#define RETRACE_VERSION_STRING "2.65.0"
 
 #define RETRACE_VERSION_ATLEAST(maj, min, pat)                  \
 	(RETRACE_VERSION_MAJOR > (maj) ||                       \


### PR DESCRIPTION
Version bump for the release: one frame codec — the Windows agent adopts the shared proto-module encoder/decoder with the POSIX 2048-byte cap, closing the silent oversized-event loss path. Both version macros ride the bump.