### PR TITLE
one ring: the agent's twin queues become a pure module

### DIFF
--- a/src/supervisor/CMakeLists.txt
+++ b/src/supervisor/CMakeLists.txt
@@ -19,7 +19,7 @@ target_include_directories(retrace_supervisor_proto PUBLIC
 # protocol lib verbatim (DRY) and core's public surfaces
 # (logger, real_impls, reentrance_guard) resolved at final
 # link. POSIX body + WIN32 stubs in one file.
-add_library(retrace_supervisor_agent STATIC agent.c policy_sig.c)
+add_library(retrace_supervisor_agent STATIC agent.c agent_ring.c policy_sig.c)
 target_include_directories(retrace_supervisor_agent PUBLIC
 	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 target_link_libraries(retrace_supervisor_agent PUBLIC

--- a/src/supervisor/agent.c
+++ b/src/supervisor/agent.c
@@ -20,6 +20,7 @@
 #include "conf.h"
 #include "parson.h"
 #include "protocol.h"
+#include "agent_ring.h"
 #include "policy_sig.h"
 
 #ifndef _WIN32
@@ -55,21 +56,13 @@
  * path); the escaping fallback heap-points. heap == NULL means
  * inline.
  */
-struct queue_item {
-	char *heap;
-	char inline_buf[AGENT_EVENT_INLINE];
-};
-
 struct agent_state {
 	int armed;
 	char sock_path[108];
 	char agent_id[96];
 
 	pthread_mutex_t mu;
-	struct queue_item queue[AGENT_QUEUE_CAP];
-	size_t q_head;
-	size_t q_count;
-	uint64_t dropped;
+	struct agent_ring ring;
 	uint64_t drops_reported;
 
 	_Atomic uint64_t seq;
@@ -107,53 +100,16 @@ static void agent_atfork_child(void);
  */
 static int queue_push(const char *buf, char *heap_item)
 {
+	int rc;
+
 	pthread_mutex_lock(&g_agent.mu);
-	if (g_agent.q_count >= AGENT_QUEUE_CAP) {
-		g_agent.dropped++;
-		pthread_mutex_unlock(&g_agent.mu);
-		free(heap_item);
-		return -1;
-	}
-	{
-		struct queue_item *slot =
-			&g_agent.queue[(g_agent.q_head + g_agent.q_count) %
-				AGENT_QUEUE_CAP];
-
-		slot->heap = NULL;
-		if (buf != NULL)
-			memcpy(slot->inline_buf, buf,
-				AGENT_EVENT_INLINE);
-		else
-			slot->heap = heap_item;
-	}
-	g_agent.q_count++;
+	rc = buf != NULL ?
+		agent_ring_push_copy(&g_agent.ring, buf,
+			strlen(buf)) :
+		agent_ring_push_heap(&g_agent.ring, heap_item,
+			strlen(heap_item));
 	pthread_mutex_unlock(&g_agent.mu);
-	return 0;
-}
-
-/*
- * Pop the next event: *out views the slot's inline buffer or
- * the heap string; *heap_out is the pointer to free (NULL for
- * inline). Returns 0 popped, -1 empty.
- */
-static int queue_pop(const char **out, char **heap_out)
-{
-	struct queue_item *slot;
-
-	*out = NULL;
-	*heap_out = NULL;
-	pthread_mutex_lock(&g_agent.mu);
-	if (g_agent.q_count == 0) {
-		pthread_mutex_unlock(&g_agent.mu);
-		return -1;
-	}
-	slot = &g_agent.queue[g_agent.q_head];
-	g_agent.q_head = (g_agent.q_head + 1) % AGENT_QUEUE_CAP;
-	g_agent.q_count--;
-	*heap_out = slot->heap;
-	*out = slot->heap != NULL ? slot->heap : slot->inline_buf;
-	pthread_mutex_unlock(&g_agent.mu);
-	return 0;
+	return rc;
 }
 
 /*
@@ -416,7 +372,7 @@ fork_adopt:;
 		}
 		g_agent.connected = 0;
 		g_agent.rfill = 0;
-		g_agent.q_count = 0;
+		g_agent.ring.count = 0;
 		atomic_store(&g_agent.stop, 0);
 		memcpy(g_agent.agent_id, "pending",
 			sizeof("pending"));
@@ -730,16 +686,24 @@ static void drain_queue(void)
 {
 	for (;;) {
 		const char *item;
-		char *heap = NULL;
 
-		if (queue_pop(&item, &heap) != 0)
+		pthread_mutex_lock(&g_agent.mu);
+		item = agent_ring_peek(&g_agent.ring, NULL);
+		pthread_mutex_unlock(&g_agent.mu);
+		if (item == NULL)
 			break;
+		/* peek/pop split: the slot stays occupied for the
+		 * whole send -- a concurrent push cannot overwrite
+		 * the view under the sender (the old pop handed
+		 * the slot back first)
+		 */
 		if (send_frame(RETRACE_RPC_MSG_EVENT, item) != 0) {
 			drop_connection();
-			free(heap);
 			return;
 		}
-		free(heap);
+		pthread_mutex_lock(&g_agent.mu);
+		agent_ring_pop(&g_agent.ring);
+		pthread_mutex_unlock(&g_agent.mu);
 	}
 
 	/*
@@ -750,7 +714,7 @@ static void drain_queue(void)
 	 * drain make room for the marker itself.
 	 */
 	{
-		uint64_t now = g_agent.dropped;
+		uint64_t now = g_agent.ring.dropped;
 
 		if (now != g_agent.drops_reported) {
 			char marker[176];
@@ -967,7 +931,7 @@ static void agent_atfork_child(void)
 	 * (locks held by now-missing threads). Drop the pointers
 	 * and leak -- bounded, fork-children only.
 	 */
-	g_agent.q_count = 0;
+	g_agent.ring.count = 0;
 	atomic_store(&g_agent.thread_spawned, 0);
 	atomic_store(&g_agent.thread_done, 0);
 	atomic_store(&g_agent.stop, 0);
@@ -1101,9 +1065,9 @@ void retrace_agent_deinit(void)
 #else
 	retrace_real_impls.rc_thread_join(&g_agent.tid);
 #endif
-	if (g_agent.dropped > 0)
+	if (g_agent.ring.dropped > 0)
 		log_info("retrace_agent: dropped %llu events (full)",
-			(unsigned long long)g_agent.dropped);
+			(unsigned long long)g_agent.ring.dropped);
 }
 
 #else /* _WIN32: the named-pipe agent (TODO.supervisor/12 P0) */
@@ -1125,16 +1089,8 @@ void retrace_agent_deinit(void)
  * heap fallback can follow the POSIX shape when a target needs
  * it.
  */
-#define WIN_AGENT_QUEUE_CAP 256
-#define WIN_AGENT_ITEM_MAX 768
 #define WIN_AGENT_BACKOFF_MIN_MS 500
 #define WIN_AGENT_BACKOFF_MAX_MS 30000
-
-struct win_queue_item {
-	char *heap;		/* oversize events own their bytes */
-	char buf[WIN_AGENT_ITEM_MAX];
-	size_t len;
-};
 
 static struct {
 	int enabled;
@@ -1146,11 +1102,9 @@ static struct {
 	HANDLE pipe;
 	char agent_id[64];
 	volatile LONG64 seq;
-	volatile LONG64 dropped;
-	volatile LONG64 drops_reported;
+	uint64_t drops_reported;
 	uint64_t policy_epoch;
-	struct win_queue_item q[WIN_AGENT_QUEUE_CAP];
-	size_t q_head, q_tail, q_count;
+	struct agent_ring ring;
 	CRITICAL_SECTION mu;
 	CONDITION_VARIABLE cv;
 } w_agent;
@@ -1251,53 +1205,32 @@ static void w_drop_connection(void);
 
 static int w_queue_push(const char *item, size_t len)
 {
-	int rc = -1;
+	int rc;
 
 	EnterCriticalSection(&w_agent.mu);
-	if (w_agent.q_count < WIN_AGENT_QUEUE_CAP) {
-		struct win_queue_item *slot =
-			&w_agent.q[w_agent.q_tail];
-
-		slot->heap = NULL;
-		if (len > WIN_AGENT_ITEM_MAX - 1) {
-			/* heap fallback (the P0 honesty note,
-			 * retired): oversize events own their bytes
-			 */
-			slot->heap = (char *)malloc(len + 1);
-			if (slot->heap == NULL)
-				goto out;
-			memcpy(slot->heap, item, len);
-			slot->heap[len] = '\0';
-		} else {
-			memcpy(slot->buf, item, len);
-			slot->buf[len] = '\0';
-		}
-		slot->len = len;
-		w_agent.q_tail = (w_agent.q_tail + 1) %
-			WIN_AGENT_QUEUE_CAP;
-		w_agent.q_count++;
-		rc = 0;
-		WakeConditionVariable(&w_agent.cv);
-	}
-out:
+	rc = agent_ring_push_copy(&w_agent.ring, item, len);
 	LeaveCriticalSection(&w_agent.mu);
+	if (rc == 0)
+		WakeConditionVariable(&w_agent.cv);
 	return rc;
 }
 
 static void w_queue_send_one(void)
 {
-	struct win_queue_item *slot = &w_agent.q[w_agent.q_head];
-	const char *item = slot->heap != NULL ? slot->heap :
-		slot->buf;
+	const char *item;
 
+	EnterCriticalSection(&w_agent.mu);
+	item = agent_ring_peek(&w_agent.ring, NULL);
+	LeaveCriticalSection(&w_agent.mu);
+	if (item == NULL)
+		return;
 	if (w_send_frame(RETRACE_RPC_MSG_EVENT, item) != 0) {
 		w_drop_connection();
-	} else if (slot->heap != NULL) {
-		free(slot->heap);
-		slot->heap = NULL;
+		return;
 	}
-	w_agent.q_head = (w_agent.q_head + 1) % WIN_AGENT_QUEUE_CAP;
-	w_agent.q_count--;
+	EnterCriticalSection(&w_agent.mu);
+	agent_ring_pop(&w_agent.ring);
+	LeaveCriticalSection(&w_agent.mu);
 }
 
 static void w_drop_connection(void)
@@ -1435,10 +1368,12 @@ static int w_try_connect(void)
 static void w_drain_queue(void)
 {
 	for (;;) {
-		if (w_agent.q_count == 0)
-			break;
-		if (w_agent.q[w_agent.q_head].heap == NULL &&
-		    w_agent.q[w_agent.q_head].len == 0)
+		const char *item;
+
+		EnterCriticalSection(&w_agent.mu);
+		item = agent_ring_peek(&w_agent.ring, NULL);
+		LeaveCriticalSection(&w_agent.mu);
+		if (item == NULL)
 			break;
 		w_queue_send_one();
 		if (!w_agent.connected)
@@ -1446,20 +1381,24 @@ static void w_drain_queue(void)
 	}
 	/* loss signaling: report the counted delta, never silent */
 	{
-		LONG64 now = InterlockedAdd64(&w_agent.dropped, 0);
+		uint64_t now;
 
+		EnterCriticalSection(&w_agent.mu);
+		now = w_agent.ring.dropped;
+		LeaveCriticalSection(&w_agent.mu);
 		if (now != w_agent.drops_reported) {
 			char marker[256];
-			LONG64 delta = now - w_agent.drops_reported;
+			uint64_t delta = now - w_agent.drops_reported;
 
 			snprintf(marker, sizeof(marker),
 				"{\"agent_id\":\"%s\",\"seq\":0,"
 				"\"ts\":%ld,"
 				"\"name\":\"retrace.agent.dropped\","
-				"\"attrs\":{\"count\":\"%lld\","
-				"\"total\":\"%lld\"}}}",
+				"\"attrs\":{\"count\":\"%llu\","
+				"\"total\":\"%llu\"}}}",
 				w_agent.agent_id, (long)time(NULL),
-				delta, now);
+				(unsigned long long)delta,
+				(unsigned long long)now);
 			if (w_queue_push(marker, strlen(marker)) == 0)
 				w_agent.drops_reported = now;
 		}
@@ -1540,6 +1479,7 @@ int retrace_agent_init(void)
 	if (w_agent.inited)
 		return 0;
 	w_agent.inited = 1;
+	agent_ring_init(&w_agent.ring);
 	w_agent.pipe = INVALID_HANDLE_VALUE;
 	InitializeCriticalSection(&w_agent.mu);
 	InitializeConditionVariable(&w_agent.cv);
@@ -1587,7 +1527,7 @@ void retrace_agent_deinit(void)
 int retrace_agent_emit_event(const char *name,
 	const char *const *kv, size_t n_kv)
 {
-	char item[WIN_AGENT_ITEM_MAX];
+	char item[AGENT_RING_INLINE];
 	size_t o = 0;
 	size_t i;
 	int n;
@@ -1601,42 +1541,27 @@ int retrace_agent_emit_event(const char *name,
 		InterlockedIncrement64(&w_agent.seq),
 		(long)time(NULL), name);
 	if (n <= 0 || (size_t)n >= sizeof(item) - o)
-		goto drop;
+		return -1;
 	o += (size_t)n;
 	for (i = 0; i < n_kv; i++) {
 		n = snprintf(item + o, sizeof(item) - o,
 			"%s\"%s\":\"%s\"", i > 0 ? "," : "", kv[i * 2],
 			kv[i * 2 + 1]);
 		if (n <= 0 || (size_t)n >= sizeof(item) - o)
-			goto drop;
+			return -1;
 		o += (size_t)n;
 	}
 	n = snprintf(item + o, sizeof(item) - o, "},\"source\":\"libc\"}");
 	if (n <= 0 || (size_t)n >= sizeof(item) - o)
-		goto drop;
+		return -1;
 	o += (size_t)n;
-	{
-		size_t need = o;
-		char *big = need > sizeof(item) ?
-			(char *)malloc(need + 1) : NULL;
-
-		if (big != NULL) {
-			memcpy(big, item, o);
-			big[o] = '\0';
-			if (w_queue_push(big, o) == 0) {
-				free(big);
-				return 0;
-			}
-			free(big);
-			goto drop;
-		}
-	}
+	/* every write above is bounded by the slot, so the ring's
+	 * own heap fallback covers nothing here -- the oversized
+	 * event simply refuses at its guard
+	 */
 	if (w_queue_push(item, o) != 0)
-		goto drop;
+		return -1;	/* the ring counted the refusal */
 	return 0;
-drop:
-	InterlockedIncrement64(&w_agent.dropped);
-	return -1;
 }
 
 #endif

--- a/src/supervisor/agent_ring.c
+++ b/src/supervisor/agent_ring.c
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+#include "agent_ring.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+void agent_ring_init(struct agent_ring *ring)
+{
+	memset(ring, 0, sizeof(*ring));
+}
+
+static int ring_push(struct agent_ring *ring, char *heap_item,
+	const char *item, size_t len)
+{
+	struct agent_ring_slot *slot;
+
+	if (ring->count >= AGENT_RING_CAP) {
+		ring->dropped++;
+		free(heap_item);
+		return -1;
+	}
+	slot = &ring->slots[(ring->head + ring->count) %
+		AGENT_RING_CAP];
+	slot->heap = NULL;
+	if (heap_item != NULL) {
+		slot->heap = heap_item;
+	} else if (len > AGENT_RING_INLINE - 1) {
+		slot->heap = (char *)malloc(len + 1);
+		if (slot->heap == NULL) {
+			/* allocation failure is a refusal too --
+			 * counted, never silent
+			 */
+			ring->dropped++;
+			return -1;
+		}
+		memcpy(slot->heap, item, len);
+		slot->heap[len] = '\0';
+	} else {
+		memcpy(slot->buf, item, len);
+		slot->buf[len] = '\0';
+	}
+	slot->len = len;
+	ring->count++;
+	return 0;
+}
+
+int agent_ring_push_copy(struct agent_ring *ring, const char *item,
+	size_t len)
+{
+	return ring_push(ring, NULL, item, len);
+}
+
+int agent_ring_push_heap(struct agent_ring *ring, char *heap_item,
+	size_t len)
+{
+	return ring_push(ring, heap_item, heap_item, len);
+}
+
+const char *agent_ring_peek(const struct agent_ring *ring,
+	size_t *len_out)
+{
+	const struct agent_ring_slot *slot;
+
+	if (ring->count == 0)
+		return NULL;
+	slot = &ring->slots[ring->head];
+	if (len_out != NULL)
+		*len_out = slot->len;
+	return slot->heap != NULL ? slot->heap : slot->buf;
+}
+
+void agent_ring_pop(struct agent_ring *ring)
+{
+	struct agent_ring_slot *slot;
+
+	if (ring->count == 0)
+		return;
+	slot = &ring->slots[ring->head];
+	free(slot->heap);
+	slot->heap = NULL;
+	ring->head = (ring->head + 1) % AGENT_RING_CAP;
+	ring->count--;
+}

--- a/src/supervisor/agent_ring.h
+++ b/src/supervisor/agent_ring.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+#ifndef RETRACE_SUPERVISOR_AGENT_RING_H_
+#define RETRACE_SUPERVISOR_AGENT_RING_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+/*
+ * The agent's bounded event ring -- the ONE queue both platform
+ * halves drain (they each carried a copy; they drifted). PURE:
+ * the caller holds the transport's lock around every call, and
+ * condition-variable wakes stay with the caller -- the ring
+ * knows nothing of pthreads or critical sections.
+ *
+ * Storage policy, one rule: items up to AGENT_RING_INLINE copy
+ * into the slot; larger items heap-own their bytes (the heap
+ * fallback the Windows half retrofitted, now both halves').
+ * Every refusal is COUNTED in ring->dropped -- losses are
+ * reported, never silent; the doctrine lives here once.
+ *
+ * peek/pop split: the consumer sends the peeked view first and
+ * releases the slot after -- pop frees the heap when present.
+ */
+
+#define AGENT_RING_CAP 256
+#define AGENT_RING_INLINE 768
+
+struct agent_ring_slot {
+	char *heap;		/* oversize items own their bytes */
+	size_t len;
+	char buf[AGENT_RING_INLINE];
+};
+
+struct agent_ring {
+	struct agent_ring_slot slots[AGENT_RING_CAP];
+	size_t head;		/* next to release */
+	size_t count;
+	uint64_t dropped;
+};
+
+/* zero the ring (before first use; nothing allocated yet) */
+void agent_ring_init(struct agent_ring *ring);
+
+/* queue a copy of item (0 queued, -1 dropped+counted) */
+int agent_ring_push_copy(struct agent_ring *ring, const char *item,
+	size_t len);
+
+/*
+ * queue a heap string the ring owns on success (and frees on
+ * refusal -- the drop is still counted). len includes the
+ * terminating NUL the heap form carries.
+ */
+int agent_ring_push_heap(struct agent_ring *ring, char *heap_item,
+	size_t len);
+
+/* view the head (NULL when empty); *len_out optional */
+const char *agent_ring_peek(const struct agent_ring *ring,
+	size_t *len_out);
+
+/* release the head (frees the heap when present); no-op empty */
+void agent_ring_pop(struct agent_ring *ring);
+
+#endif /* RETRACE_SUPERVISOR_AGENT_RING_H_ */

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -321,6 +321,10 @@ retrace_add_unit_test(modify_return_value_int
 # signed POLICY_SET (TODO.supervisor/05): the wrapper format +
 # fail-closed pin (Ed25519 over the exact blob bytes).
 #
+retrace_add_unit_test(agent_ring
+    EXTRA_SOURCES ${CMAKE_SOURCE_DIR}/src/supervisor/agent_ring.c
+    EXTRA_INCLUDES ${CMAKE_SOURCE_DIR}/src/supervisor)
+
 retrace_add_unit_test(policy_sig
     EXTRA_SOURCES ${CMAKE_SOURCE_DIR}/src/supervisor/policy_sig.c
     EXTRA_INCLUDES ${CMAKE_SOURCE_DIR}/src/supervisor)

--- a/test/unit/test_agent_ring.c
+++ b/test/unit/test_agent_ring.c
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+/*
+ * The agent's bounded event ring -- the module both platform
+ * queues became. The contract that was drifting between the
+ * two copies is pinned here: inline copies, oversize owns its
+ * heap, every refusal is counted, order is kept, and the
+ * peek/pop split holds the slot through the consumer's send.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "agent_ring.h"
+
+static int tests_run;
+static int tests_pass;
+static int tests_fail;
+
+#define TEST(name) do { \
+	int before = tests_fail; \
+	tests_run++; \
+	printf("  TEST %s ... ", #name); \
+	name(); \
+	if (tests_fail == before) \
+		tests_pass++; \
+	printf("%s\n", tests_fail == before ? "ok" : ""); \
+} while (0)
+
+#define CHECK(cond) do { \
+	if (!(cond)) { \
+		printf("\n    FAIL %s:%d: %s\n", __func__, \
+			__LINE__, #cond); \
+		tests_fail++; \
+		return; \
+	} \
+} while (0)
+
+static void test_order_and_peek_pop_split(void);
+static void test_full_refusal_is_counted(void);
+static void test_heap_refusal_frees_and_counts(void);
+static void test_oversize_rides_the_heap(void);
+
+static void test_order_and_peek_pop_split(void)
+{
+	struct agent_ring r;
+	const char *v;
+	size_t len;
+
+	agent_ring_init(&r);
+	CHECK(agent_ring_push_copy(&r, "one", 3) == 0);
+	CHECK(agent_ring_push_copy(&r, "two", 3) == 0);
+	v = agent_ring_peek(&r, &len);
+	CHECK(v != NULL && strcmp(v, "one") == 0 && len == 3);
+	/* the peek holds: a push cannot overwrite the view */
+	CHECK(agent_ring_push_copy(&r, "three", 5) == 0);
+	v = agent_ring_peek(&r, NULL);
+	CHECK(v != NULL && strcmp(v, "one") == 0);
+	agent_ring_pop(&r);
+	v = agent_ring_peek(&r, NULL);
+	CHECK(v != NULL && strcmp(v, "two") == 0);
+	agent_ring_pop(&r);
+	v = agent_ring_peek(&r, NULL);
+	CHECK(v != NULL && strcmp(v, "three") == 0);
+	agent_ring_pop(&r);
+	CHECK(agent_ring_peek(&r, NULL) == NULL);
+	agent_ring_pop(&r);	/* no-op on empty */
+	CHECK(r.dropped == 0);
+}
+
+static void test_full_refusal_is_counted(void)
+{
+	struct agent_ring r;
+	size_t i;
+
+	agent_ring_init(&r);
+	for (i = 0; i < AGENT_RING_CAP; i++)
+		CHECK(agent_ring_push_copy(&r, "x", 1) == 0);
+	CHECK(agent_ring_push_copy(&r, "y", 1) == -1);
+	CHECK(r.dropped == 1);
+	CHECK(agent_ring_push_copy(&r, "y", 1) == -1);
+	CHECK(r.dropped == 2);
+}
+
+static void test_heap_refusal_frees_and_counts(void)
+{
+	struct agent_ring r;
+	char *big;
+
+	agent_ring_init(&r);
+	big = (char *)malloc(AGENT_RING_INLINE + 64);
+	CHECK(big != NULL);
+	memset(big, 'h', AGENT_RING_INLINE + 63);
+	big[AGENT_RING_INLINE + 63] = '\0';
+	/* fill, then hand the ring an oversize item it must
+	 * refuse: the heap is freed (the ring never leaks a
+	 * refused item) and the drop is counted
+	 */
+	{
+		size_t i;
+
+		for (i = 0; i < AGENT_RING_CAP; i++)
+			CHECK(agent_ring_push_copy(&r, "x", 1) == 0);
+	}
+	CHECK(agent_ring_push_heap(&r, big, strlen(big)) == -1);
+	CHECK(r.dropped == 1);
+}
+
+static void test_oversize_rides_the_heap(void)
+{
+	struct agent_ring r;
+	static char big[AGENT_RING_INLINE + 32];
+	const char *v;
+	size_t len;
+
+	agent_ring_init(&r);
+	memset(big, 'H', sizeof(big) - 1);
+	big[sizeof(big) - 1] = '\0';
+	CHECK(agent_ring_push_copy(&r, big, strlen(big)) == 0);
+	CHECK(r.dropped == 0);
+	v = agent_ring_peek(&r, &len);
+	CHECK(v != NULL && len == strlen(big));
+	CHECK(strlen(v) == strlen(big));
+	CHECK(strncmp(v, big, len) == 0);
+	agent_ring_pop(&r);
+}
+
+int main(void)
+{
+	printf("agent ring tests:\n");
+	TEST(test_order_and_peek_pop_split);
+	TEST(test_full_refusal_is_counted);
+	TEST(test_heap_refusal_frees_and_counts);
+	TEST(test_oversize_rides_the_heap);
+
+	printf("%d tests: %d pass, %d fail\n", tests_run, tests_pass,
+		tests_fail);
+	return tests_fail == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## What

The architecture review's candidate D (cycle 6): the agent's bounded event queue existed twice — one per platform half — and had drifted the way every twin in this file has:

- the Windows `w_queue_push` never counted its refusals (the *counted, never silent* loss doctrine lives at a different site there, and not on every path);
- it owned its own heap fallback where POSIX puts that choice on the caller;
- the ring indexing styles differed (`q_tail % cap` vs `(head+count) % cap`);
- the POSIX `queue_pop` handed the slot back **before the sender finished** — a concurrent push could overwrite the inline view mid-send.

## The deepening

New `src/supervisor/agent_ring.{c,h}` — a **pure** ring: caller-locked, no condition variables inside, one storage policy (inline copy up to the slot size, heap-owns-beyond, every refusal counted in `ring->dropped`). POSIX wraps it with its mutex; Windows with its critical section plus the wake — the only genuinely platform part left.

The **peek/pop split** holds the slot through the consumer's send, closing the overwrite race on both halves.

## Verification

- The queue's first unit surface: `test_agent_ring` pins the contract — order kept, peek holds across a push, full refusal counted, heap refusal freed-not-leaked, oversize rides the heap. 4/4.
- Full local build green; `agent|policy|supervis|ring` families pass (49s of integration included).
- checkpatch clean.
