### PR TITLE
v2.66.0 version bump

### DIFF
--- a/include/retrace/version.h
+++ b/include/retrace/version.h
@@ -37,10 +37,10 @@
 #define RETRACE_VERSION_H
 
 #define RETRACE_VERSION_MAJOR 2
-#define RETRACE_VERSION_MINOR 65
+#define RETRACE_VERSION_MINOR 66
 #define RETRACE_VERSION_PATCH 0
 
-#define RETRACE_VERSION_STRING "2.65.0"
+#define RETRACE_VERSION_STRING "2.66.0"
 
 #define RETRACE_VERSION_ATLEAST(maj, min, pat)                  \
 	(RETRACE_VERSION_MAJOR > (maj) ||                       \


### PR DESCRIPTION
Version bump for the release: one ring — the agent's twin event queues become a pure caller-locked module; the Windows drop-count drift heals, the POSIX peek-overwrite race closes, and the queue gains its first unit surface (4/4). Both version macros ride the bump.