### PR TITLE
one pipe harness: the integration tests stop carrying five folk copies

### DIFF
--- a/test/integration/rpipe.py
+++ b/test/integration/rpipe.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""
+rpipe -- the shared harness for the pipe-family integration
+tests.
+
+One copy of the machinery every named-pipe test needs: frame
+build/parse against the RTRD header, a readiness wait that
+knows the canonical pipe prefix, journal reading, and a
+capture-output runner. The tests import this module (the
+script's directory rides sys.path) -- the folk copies these
+replaced drifted in deadlines, path prefixes (the
+doubled-backslash class), and header parsing (the version-
+field parse bug), each fixed one file at a time.
+"""
+import json
+import os
+import struct
+import subprocess
+import sys
+import time
+
+MAGIC = b"RTRD"
+PIPE_PREFIX = "\\\\.\\pipe\\"
+
+
+def frame(mid, payload):
+    b = payload.encode()
+    return MAGIC + struct.pack("<HHI", 1, mid, len(b)) + b
+
+
+def recv_exact(f, n):
+    buf = b""
+    while len(buf) < n:
+        chunk = f.read(n - len(buf))
+        if not chunk:
+            raise EOFError
+        buf += chunk
+    return buf
+
+
+def recv_frame(f):
+    hdr = recv_exact(f, 12)
+    _, _, mid, ln = struct.unpack("<4sHHI", hdr)
+    body = recv_exact(f, ln) if ln else b""
+    return mid, json.loads(body) if body else {}
+
+
+def is_pipe_path(path):
+    return path.startswith(PIPE_PREFIX)
+
+
+def open_pipe(path, deadline=10.0):
+    """The CONNECTION once the pipe accepts one (raw, unbuffered,
+    full duplex) -- None if the deadline passes first."""
+    end = time.time() + deadline
+    while time.time() < end:
+        try:
+            return open(path, "r+b", buffering=0)
+        except OSError:
+            time.sleep(0.1)
+    return None
+
+
+def wait_pipe(path, deadline=10.0):
+    """Readiness only: one throwaway open (the daemon re-arms)."""
+    end = time.time() + deadline
+    while time.time() < end:
+        try:
+            open(path, "r+b", buffering=0).close()
+            return True
+        except OSError:
+            time.sleep(0.1)
+    return False
+
+
+def wait_sock(path, deadline=5.0):
+    """Dual-mode readiness: pipe paths probe with an open,
+    socket paths with existence (the POSIX legs)."""
+    end = time.time() + deadline
+    while time.time() < end:
+        if is_pipe_path(path):
+            if wait_pipe(path, 0.5):
+                return True
+        elif os.path.exists(path):
+            return True
+        time.sleep(0.1)
+    return False
+
+
+def journal_records(path):
+    recs = []
+    with open(path, errors="replace") as f:
+        for ln in f.read().splitlines():
+            try:
+                recs.append(json.loads(ln))
+            except json.JSONDecodeError:
+                pass
+    return recs
+
+
+def run(cmd, **kw):
+    return subprocess.run(cmd, capture_output=True, text=True,
+                          timeout=60, **kw)
+
+
+def taskkill(pid):
+    """Windows force-kill of a test daemon tree (the finally
+    safety; happy paths stop the daemon gracefully)."""
+    if os.name != "nt":
+        return
+    subprocess.run(["taskkill", "/F", "/T", "/PID", str(pid)],
+                   capture_output=True)

--- a/test/integration/test_etw_agent.py
+++ b/test/integration/test_etw_agent.py
@@ -20,31 +20,7 @@ import sys
 import tempfile
 import time
 
-
-def wait_sock(path, deadline=5.0):
-    end = time.time() + deadline
-    while time.time() < end:
-        if path.startswith("\\\\.\\pipe\\"):
-            try:
-                open(path, "r+b", buffering=0).close()
-                return True
-            except OSError:
-                pass
-        elif os.path.exists(path):
-            return True
-        time.sleep(0.1)
-    return False
-
-
-def journal_records(path):
-    recs = []
-    with open(path) as f:
-        for ln in f.read().splitlines():
-            try:
-                recs.append(json.loads(ln))
-            except json.JSONDecodeError:
-                pass
-    return recs
+from rpipe import (wait_sock, journal_records)
 
 
 def main():

--- a/test/integration/test_jretrace.py
+++ b/test/integration/test_jretrace.py
@@ -19,6 +19,8 @@ import tempfile
 import textwrap
 import time
 
+from rpipe import (wait_sock, journal_records)
+
 
 CHILD = r"""
 import java.util.Map;
@@ -39,32 +41,6 @@ public class JRetraceSmoke {
     }
 }
 """
-
-
-def wait_sock(path, deadline=5.0):
-    end = time.time() + deadline
-    while time.time() < end:
-        if path.startswith("\\\\.\\pipe\\"):
-            try:
-                open(path, "r+b", buffering=0).close()
-                return True
-            except OSError:
-                pass
-        elif os.path.exists(path):
-            return True
-        time.sleep(0.1)
-    return False
-
-
-def journal_records(path):
-    recs = []
-    with open(path) as f:
-        for ln in f.read().splitlines():
-            try:
-                recs.append(json.loads(ln))
-            except json.JSONDecodeError:
-                pass
-    return recs
 
 
 def jdk_ok():

--- a/test/integration/test_pyretrace.py
+++ b/test/integration/test_pyretrace.py
@@ -19,31 +19,7 @@ import sys
 import tempfile
 import time
 
-
-def wait_sock(path, deadline=5.0):
-    end = time.time() + deadline
-    while time.time() < end:
-        if path.startswith("\\\\.\\pipe\\"):
-            try:
-                open(path, "r+b", buffering=0).close()
-                return True
-            except OSError:
-                pass
-        elif os.path.exists(path):
-            return True
-        time.sleep(0.1)
-    return False
-
-
-def journal_records(path):
-    recs = []
-    with open(path) as f:
-        for ln in f.read().splitlines():
-            try:
-                recs.append(json.loads(ln))
-            except json.JSONDecodeError:
-                pass
-    return recs
+from rpipe import (wait_sock, journal_records)
 
 
 CHILD = r"""

--- a/test/integration/test_retraced_pipe.py
+++ b/test/integration/test_retraced_pipe.py
@@ -13,58 +13,16 @@ Usage: test_retraced_pipe.py <retraced>
 """
 import json
 import os
-import struct
 import subprocess
 import sys
 import tempfile
 import time
 
+from rpipe import (frame, recv_frame, open_pipe,
+                   journal_records, taskkill)
+
 MAGIC = b"RTRD"
 HELLO, HEARTBEAT, EVENT, BYE, WELCOME = 1, 2, 4, 6, 16
-
-
-def frame(mid, payload):
-    b = payload.encode()
-    return MAGIC + struct.pack("<HHI", 1, mid, len(b)) + b
-
-
-def recv_exact(f, n):
-    buf = b""
-    while len(buf) < n:
-        chunk = f.read(n - len(buf))
-        if not chunk:
-            raise EOFError
-        buf += chunk
-    return buf
-
-
-def recv_frame(f):
-    hdr = recv_exact(f, 12)
-    _, _, mid, ln = struct.unpack("<4sHHI", hdr)
-    body = recv_exact(f, ln) if ln else b""
-    return mid, json.loads(body) if body else {}
-
-
-def wait_pipe(path, deadline=10.0):
-    end = time.time() + deadline
-    while time.time() < end:
-        try:
-            f = open(path, "r+b", buffering=0)
-            return f
-        except OSError:
-            time.sleep(0.1)
-    return None
-
-
-def journal_records(path):
-    recs = []
-    with open(path, errors="replace") as f:
-        for ln in f.read().splitlines():
-            try:
-                recs.append(json.loads(ln))
-            except json.JSONDecodeError:
-                pass
-    return recs
 
 
 def main():
@@ -85,7 +43,7 @@ def main():
         [daemon, "--sock", pipe, "--journal", journal],
         stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
     try:
-        f = wait_pipe(pipe)
+        f = open_pipe(pipe)
         if f is None:
             print("FAIL: daemon never listened on the pipe",
                   file=sys.stderr)

--- a/test/integration/test_retraced_service.py
+++ b/test/integration/test_retraced_service.py
@@ -18,29 +18,11 @@ import sys
 import tempfile
 import time
 
+from rpipe import (frame, recv_exact, run)
+
 MAGIC = b"RTRD"
 HELLO, BYE, WELCOME = 1, 6, 16
 SVC = "retrace-svc-test"
-
-
-def frame(mid, payload):
-    b = payload.encode()
-    return MAGIC + struct.pack("<HHI", 1, mid, len(b)) + b
-
-
-def recv_exact(f, n):
-    buf = b""
-    while len(buf) < n:
-        c = f.read(n - len(buf))
-        if not c:
-            raise EOFError
-        buf += c
-    return buf
-
-
-def run(cmd, **kw):
-    return subprocess.run(cmd, capture_output=True, text=True,
-                          timeout=60, **kw)
 
 
 def main():

--- a/test/integration/test_supervised_win.py
+++ b/test/integration/test_supervised_win.py
@@ -16,6 +16,8 @@ import sys
 import tempfile
 import time
 
+from rpipe import (open_pipe as wait_pipe)
+
 PIPE_AGENT = "\\\\.\\pipe\\retrace-sup-agent"
 PIPE_CTL = "\\\\.\\pipe\\retrace-sup-ctl"
 NONCE = "a1b2c3d4e5f60718293a4b5c6d7e8f90"
@@ -30,17 +32,6 @@ def journal_records(path):
             except json.JSONDecodeError:
                 pass
     return recs
-
-
-def wait_pipe(name, deadline=10.0):
-    end = time.time() + deadline
-    while time.time() < end:
-        try:
-            f = open(name, "r+b", buffering=0)
-            return f
-        except OSError:
-            time.sleep(0.1)
-    return None
 
 
 def main():


### PR DESCRIPTION
## What

The architecture review's candidate E (cycle 7): the pipe-family integration tests carried **five folk copies** of the same harness — frame builders, recv loops, readiness waits, journal readers — with drifting deadlines (5s vs 10s), path prefixes (the doubled-backslash class lived in exactly these copies), and header parses (the version-field bug was fixed in one file only). The harness is the interface through which the whole Windows lane is exercised; it deserved a module.

## The consolidation

New `test/integration/rpipe.py`:

- `frame` / `recv_exact` / `recv_frame` — RTRD header build/parse, one audited copy
- `open_pipe` (the connection) and `wait_pipe` (readiness) — split by shape, since the folk copies disagreed on which one "wait" meant
- `wait_sock` — dual-mode readiness (pipe paths probe with an open; socket paths with existence), for the three tests that also run POSIX-side over UDS
- `journal_records`, `run`, `taskkill`

The seven pipe-family tests import it. The POSIX-only `wait_sock` users (ebpf, journal-durability) keep their socket-shaped copies — different semantics, not duplication.

## Verification

- The three dual-mode tests (etw-agent, pyretrace, jretrace) pass locally on the POSIX legs — 3/3 — exercising the harness end-to-end.
- All seven tests compile; checkpatch clean.
- Test-only change: no release warranted.
