### PR TITLE
CPack becomes the packaging module; the artifacts finally carry the tools

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,61 +133,168 @@ jobs:
 
       - name: Stage binary (Linux)
         if: matrix.os == 'linux'
-        env:
-          NOTICES: |
-            retrace third-party notices
-            ===========================
-
-            retrace is BSD-2-Clause licensed.
-
-            This build does NOT link against or include:
-              - MinHook (https://github.com/TsudaKageyu/minhook)
-              - Microsoft Detours (https://github.com/microsoft/Detours)
-
-            The Windows inline-hooking backends (src/backends/win_common/) are
-            implemented from scratch per ADR-0009. The JSON parser (parson) is
-            vendored under src/config/json/parson.{c,h} and retains its MIT
-            license header in those files.
         run: |
           VERSION="$(awk -F\" '/^#define RETRACE_VERSION_STRING/ {print $2}' include/retrace/version.h)"
-          STAGE="retrace-${VERSION}-${{ matrix.platform }}"
-          mkdir -p "$STAGE/lib" "$STAGE/include"
-          cp build/src/v2/libretrace.so* "$STAGE/lib/"
-          cp -r include/retrace/* "$STAGE/include/"
-          cp LICENSE.md README.adoc "$STAGE/"
-          printf '%s\n' "$NOTICES" > "$STAGE/THIRD_PARTY_NOTICES"
-          tar -czf "retrace-${VERSION}-${{ matrix.platform }}.tar.gz" "$STAGE"
-          sha256sum "retrace-${VERSION}-${{ matrix.platform }}.tar.gz" \
-            > "retrace-${VERSION}-${{ matrix.platform }}.tar.gz.sha256"
-          # Also produce a bare library for curl + LD_PRELOAD use case
+          PKG="retrace-${VERSION}-${{ matrix.platform }}"
+          # the packaging module rides the install surface: the
+          # tarball carries bin/ + lib/ + include/ (the hand-staged
+          # era shipped lib/include only -- every tool was missing)
+          (cd build && cpack -G TGZ -D CPACK_PACKAGE_FILE_NAME="$PKG" \
+            && cpack -G DEB -D CPACK_PACKAGE_FILE_NAME="$PKG")
+          mv "build/$PKG.tar.gz" "build/$PKG.tar.gz.sha256" .
+          mv "build/$PKG.deb" "build/$PKG.deb.sha256" . 2>/dev/null || true
+          # bare library for curl + LD_PRELOAD use case
           cp "$(ls build/src/v2/libretrace.so.*.*.* | head -1)" "libretrace-${{ matrix.platform }}.so"
           sha256sum "libretrace-${{ matrix.platform }}.so" \
             > "libretrace-${{ matrix.platform }}.so.sha256"
+          # a broken package is red at build time, not install time
+          dpkg-deb -I "$PKG.deb" >/dev/null && dpkg-deb -c "$PKG.deb" | grep -q libretrace
 
       - name: Stage binary (macOS)
         if: matrix.os == 'macos'
-        env:
-          NOTICES: |
-            retrace third-party notices
-            ===========================
-
-            retrace is BSD-2-Clause licensed.
-
-            The JSON parser (parson) is vendored under
-            src/config/json/parson.{c,h} and retains its MIT license
-            header in those files.
         run: |
           VERSION="$(awk -F\" '/^#define RETRACE_VERSION_STRING/ {print $2}' include/retrace/version.h)"
-          STAGE="retrace-${VERSION}-${{ matrix.platform }}"
-          mkdir -p "$STAGE/lib" "$STAGE/include"
-          cp build/src/v2/libretrace.*.dylib "$STAGE/lib/"
-          cp -r include/retrace/* "$STAGE/include/"
-          cp LICENSE.md README.adoc "$STAGE/"
-          printf '%s\n' "$NOTICES" > "$STAGE/THIRD_PARTY_NOTICES"
-          tar -czf "retrace-${VERSION}-${{ matrix.platform }}.tar.gz" "$STAGE"
-          shasum -a 256 "retrace-${VERSION}-${{ matrix.platform }}.tar.gz" \
-            > "retrace-${VERSION}-${{ matrix.platform }}.tar.gz.sha256"
-          # Bare library for curl + DYLD_INSERT use case
+          PKG="retrace-${VERSION}-${{ matrix.platform }}"
+          (cd build && cpack -G TGZ -D CPACK_PACKAGE_FILE_NAME="$PKG")
+          mv "build/$PKG.tar.gz" "build/$PKG.tar.gz.sha256" .
+          # bare library for curl + DYLD_INSERT use case
+          cp "$(ls build/src/v2/libretrace.*.*.*.dylib | head -1)" "libretrace-${{ matrix.platform }}.dylib"
+          shasum -a 256 "libretrace-${{ matrix.platform }}.dylib" \
+            > "libretrace-${{ matrix.platform }}.dylib.sha256"
+
+      # ----- Windows (MSVC) -----
+      - name: Set up vcpkg (Windows)
+        if: matrix.os == 'windows'
+        shell: pwsh
+        run: |
+          if ('${{ matrix.platform }}' -eq 'windows-arm64') {
+            $triplet = 'arm64-windows'
+          } else {
+            $triplet = 'x64-windows'
+          }
+          if (-not (Test-Path vcpkg)) {
+            git clone --depth 1 https://github.com/microsoft/vcpkg.git vcpkg
+          }
+          cd vcpkg
+          if (-not (Test-Path vcpkg.exe)) { .\bootstrap-vcpkg.bat -disableMetrics }
+          "VCPKG_TRIPLET=$triplet" | Out-File -Append $env:GITHUB_ENV
+
+      - name: Configure & build (Windows)
+        if: matrix.os == 'windows'
+        shell: pwsh
+        run: |
+          $toolchain = "${{ github.workspace }}\vcpkg\scripts\buildsystems\vcpkg.cmake"
+          cmake -B build "-DCMAKE_BUILD_TYPE=Release" `
+            "-DVCPKG_TARGET_TRIPLET=$env:VCPKG_TRIPLET" `
+            "-DCMAKE_TOOLCHAIN_FILE=$toolchain"
+          cmake --build build --config Release
+
+      - name: Stage binary (Windows)
+        if: matrix.os == 'windows'
+        shell: pwsh
+        run: |
+          $version = (Select-String -Path include/retrace/version.h `
+            -Pattern '#define RETRACE_VERSION_STRING "([^"]+)"').Matches.Groups[1].Value
+          $pkg = "retrace-$version-${{ matrix.platform }}"
+          Push-Location build
+          cpack -G ZIP -D CPACK_PACKAGE_FILE_NAME="$pkg"
+          Pop-Location
+          Move-Item "build/$pkg.zip", "build/$pkg.zip.sha256" .
+          # bare library for manual injection use cases
+          $dll = Get-ChildItem -Recurse -Filter retrace.dll |
+            Select-Object -First 1 -ExpandProperty FullName
+          if ($dll) {
+            Copy-Item $dll "retrace-${{ matrix.platform }}.dll"
+            $h = (Get-FileHash "retrace-${{ matrix.platform }}.dll" -Algorithm SHA256).Hash
+            "$h  retrace-${{ matrix.platform }}.dll" | Out-File -Encoding ascii "retrace-${{ matrix.platform }}.dll.sha256"
+          }
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: source-tarball
+          path: |
+            ${{ runner.temp }}/retrace-*.tar.gz
+            ${{ runner.temp }}/retrace-*.tar.gz.sha256
+
+  # ---------------------------------------------------------------
+  # Binary artifacts -- matrix across (OS, arch).
+  # ---------------------------------------------------------------
+  binary:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux-x86_64
+            runner: ubuntu-22.04
+            os: linux
+          - platform: linux-aarch64
+            runner: ubuntu-22.04-arm
+            os: linux
+          - platform: macos-arm64
+            runner: macos-14
+            os: macos
+          - platform: macos-x86_64
+            runner: macos-15-intel
+            os: macos
+          - platform: windows-x64
+            runner: windows-2022
+            os: windows
+          - platform: windows-arm64
+            runner: windows-11-arm
+            os: windows
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      # ----- POSIX (Linux, macOS) -----
+      - name: Install deps (Linux)
+        if: matrix.os == 'linux'
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq cmake ninja-build libssl-dev
+
+      - name: Install deps (macOS)
+        if: matrix.os == 'macos'
+        run: |
+          brew install cmake ninja openssl
+
+      - name: Configure & build (POSIX)
+        if: matrix.os != 'windows'
+        run: |
+          cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release
+          cmake --build build
+
+      - name: Stage binary (Linux)
+        if: matrix.os == 'linux'
+        run: |
+          VERSION="$(awk -F\" '/^#define RETRACE_VERSION_STRING/ {print $2}' include/retrace/version.h)"
+          PKG="retrace-${VERSION}-${{ matrix.platform }}"
+          # the packaging module rides the install surface: the
+          # tarball carries bin/ + lib/ + include/ (the hand-staged
+          # era shipped lib/include only -- every tool was missing)
+          (cd build && cpack -G TGZ -D CPACK_PACKAGE_FILE_NAME="$PKG" \
+            && cpack -G DEB -D CPACK_PACKAGE_FILE_NAME="$PKG")
+          mv "build/$PKG.tar.gz" "build/$PKG.tar.gz.sha256" .
+          mv "build/$PKG.deb" "build/$PKG.deb.sha256" . 2>/dev/null || true
+          # bare library for curl + LD_PRELOAD use case
+          cp "$(ls build/src/v2/libretrace.so.*.*.* | head -1)" "libretrace-${{ matrix.platform }}.so"
+          sha256sum "libretrace-${{ matrix.platform }}.so" \
+            > "libretrace-${{ matrix.platform }}.so.sha256"
+          # a broken package is red at build time, not install time
+          dpkg-deb -I "$PKG.deb" >/dev/null && dpkg-deb -c "$PKG.deb" | grep -q libretrace
+
+      - name: Stage binary (macOS)
+        if: matrix.os == 'macos'
+        run: |
+          VERSION="$(awk -F\" '/^#define RETRACE_VERSION_STRING/ {print $2}' include/retrace/version.h)"
+          PKG="retrace-${VERSION}-${{ matrix.platform }}"
+          (cd build && cpack -G TGZ -D CPACK_PACKAGE_FILE_NAME="$PKG")
+          mv "build/$PKG.tar.gz" "build/$PKG.tar.gz.sha256" .
+          # bare library for curl + DYLD_INSERT use case
           cp "$(ls build/src/v2/libretrace.*.*.*.dylib | head -1)" "libretrace-${{ matrix.platform }}.dylib"
           shasum -a 256 "libretrace-${{ matrix.platform }}.dylib" \
             > "libretrace-${{ matrix.platform }}.dylib.sha256"
@@ -259,10 +366,14 @@ jobs:
           path: |
             retrace-*.tar.gz
             retrace-*.tar.gz.sha256
+            retrace-*.deb
+            retrace-*.deb.sha256
             libretrace-*.so
             libretrace-*.so.sha256
             libretrace-*.dylib
             libretrace-*.dylib.sha256
+            libretrace-*.dll
+            libretrace-*.dll.sha256
             retrace-*.zip
             retrace-*.zip.sha256
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,6 +163,13 @@ if(RETRACE_PLATFORM_OHOS)
 	add_compile_definitions(RETRACE_PLATFORM_OHOS=1)
 endif()
 
+# the install-dirs SSOT: tools referenced BINDIR/DATADIR/DOCDIR
+# and CMAKEDIR needs LIBDIR -- only BINDIR was ever defined,
+# leaving the profiler's schema and the config installs writing
+# to /<name> (first exercised by the packaging module). Before
+# every consumer.
+include(GNUInstallDirs)
+
 set(RETRACE_INSTALL_CMAKEDIR
 	"${CMAKE_INSTALL_LIBDIR}/cmake/retrace-${PROJECT_VERSION}"
 	CACHE PATH "Install path for CMake package config files")
@@ -365,6 +372,7 @@ endif()
 # ---------------------------------------------------------------
 
 # Public headers are installed from include/.
+
 add_subdirectory(include/retrace)
 
 # otlp-c is the live-streaming dependency (TODO.trace-profile/31)
@@ -491,6 +499,9 @@ add_subdirectory(grafana-plugin)
 # Wasm playground (pure C source + HTML, compiled separately).
 add_subdirectory(wasm-playground)
 
+# the packaging module (CPack over the install surface)
+include(${CMAKE_SOURCE_DIR}/cmake/Packaging.cmake)
+
 # ---------------------------------------------------------------
 # Package config
 # ---------------------------------------------------------------
@@ -511,6 +522,9 @@ install(FILES
 	"${CMAKE_CURRENT_BINARY_DIR}/retrace-config.cmake"
 	"${CMAKE_CURRENT_BINARY_DIR}/retrace-config-version.cmake"
 	DESTINATION "${RETRACE_INSTALL_CMAKEDIR}")
+
+install(FILES ${CMAKE_SOURCE_DIR}/THIRD_PARTY_NOTICES
+	DESTINATION share/doc/retrace)
 
 # pkg-config module
 configure_file(

--- a/cmake/Packaging.cmake
+++ b/cmake/Packaging.cmake
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# The packaging module (the architecture review's G): CPack over
+# the install() surface -- the release workflow's hand-staged
+# tarballs shipped lib/ and include/ only, leaving every tool
+# out of the artifacts, and carried the notices as YAML
+# folklore. Identity comes from version.h (the SSOT -- no third
+# version source); the workflow selects generators and keeps the
+# artifact naming per platform via CPACK_PACKAGE_FILE_NAME.
+
+file(READ "${CMAKE_SOURCE_DIR}/include/retrace/version.h" _retrace_vh)
+string(REGEX MATCH "#define RETRACE_VERSION_STRING \"([0-9]+\\.[0-9]+\\.[0-9]+)\""
+	_retrace_v "${_retrace_vh}")
+if(NOT CMAKE_MATCH_1)
+	message(FATAL_ERROR "packaging: no RETRACE_VERSION_STRING in version.h")
+endif()
+
+set(CPACK_PACKAGE_NAME "retrace")
+set(CPACK_PACKAGE_VERSION "${CMAKE_MATCH_1}")
+set(CPACK_PACKAGE_VENDOR "Ribose")
+set(CPACK_PACKAGE_CONTACT "open.source@ribose.com")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY
+	"userspace libc-call interceptor, kernel-truth grader, and supervisor")
+set(CPACK_PACKAGE_DESCRIPTION_FILE "${CMAKE_SOURCE_DIR}/README.adoc")
+set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_SOURCE_DIR}/LICENSE.md")
+set(CPACK_RESOURCE_FILE_README "${CMAKE_SOURCE_DIR}/README.adoc")
+set(CPACK_STRIP_FILES OFF)
+set(CPACK_PACKAGE_CHECKSUM SHA256)
+
+# default file name: the workflow overrides per platform so the
+# release asset names stay byte-identical to the hand-staged era
+set(CPACK_PACKAGE_FILE_NAME
+	"retrace-${CPACK_PACKAGE_VERSION}")
+
+# system packages (the roadmap item): the Linux legs also build
+# these; dpkg-deb/rpm validate at package time, not install time
+set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Ribose <open.source@ribose.com>")
+set(CPACK_DEBIAN_PACKAGE_SECTION "devel")
+set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS OFF)
+set(CPACK_RPM_PACKAGE_LICENSE "BSD-2-Clause")
+set(CPACK_RPM_PACKAGE_GROUP "Development/Tools")
+
+include(CPack)


### PR DESCRIPTION
## What

The architecture review's candidate G (cycle 8): the build tree's 26 `install()` rules formed a complete install surface — and `release.yml` ignored all of it, hand-staging tarballs in three per-OS shell blocks with the notices text pasted twice into the YAML. The artifacts shipped `lib/` + `include/` only: **every tool the last five releases built — retraced, retrace-ctl, retrace-enforce, all the converters — was missing from the releases that described them.**

## The deepening

- **`cmake/Packaging.cmake`** — the one packaging module: identity from `version.h` (the SSOT), notices from the checked-in file, `CPACK_PACKAGE_CHECKSUM` sidecars. Generators: TGZ/ZIP everywhere, **DEB on the Linux legs** (`dpkg-deb -I`/`-c` validates at package time, not install time). The RPM generator is configured for local/source use — hosted runners carry no `rpmbuild`.
- The workflow's three staging blocks become `cpack -G …` calls; artifact names stay byte-identical via `CPACK_PACKAGE_FILE_NAME` per matrix platform. The YAML notices heredocs are gone.
- New artifacts: `retrace-<v>-linux-*.deb` (+ checksums); Windows gains a bare `retrace.dll` asset.

## Two latent bugs the install surface had never been run enough to find

`CMAKE_INSTALL_DATADIR` and the `LIBDIR` under `RETRACE_INSTALL_CMAKEDIR` were undefined without `GNUInstallDirs` — the profiler's schema install and the cmake-config installs wrote to `/<name>` for anyone who ran `cmake --install`. `GNUInstallDirs` now lands before its first consumer.

## Verification

- Local: full build + `cpack -G TGZ` produces a package whose `bin/` carries the entire tool fleet, with checksum sidecars; the tarball layout rides the install rules.
- The release cut for this cycle will exercise the DEB path end-to-end on the Linux legs.
