### PR TITLE
release: the publish globs carry the packaging module's new artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -424,7 +424,11 @@ jobs:
             artifacts/retrace-*.tar.gz.sha256
             artifacts/retrace-*.zip
             artifacts/retrace-*.zip.sha256
+            artifacts/retrace-*.deb
+            artifacts/retrace-*.deb.sha256
             artifacts/libretrace-*.so
             artifacts/libretrace-*.so.sha256
             artifacts/libretrace-*.dylib
             artifacts/libretrace-*.dylib.sha256
+            artifacts/libretrace-*.dll
+            artifacts/libretrace-*.dll.sha256


### PR DESCRIPTION
The Linux legs built and validated the debs in the v2.67.0 cut; the publish step's globs still carried the hand-staged era's file set, so they stopped at the artifact store. Adds retrace-*.deb(.sha256) and libretrace-*.dll(.sha256) to the release upload. Then I'll re-run the v2.67.0 release so the debs land on the tag.