### PR TITLE
docs and site catch up to v2.67: the packaging story

### DIFF
--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -139,3 +139,35 @@ See [configuration.md](configuration.md) for the full reference
 and [cookbook/34](cookbook/34-profile-and-jail.md) for the
 recipe-level walkthrough; the runnable loop lives in
 `examples/trace-profile-quickstart/`.
+
+## Packages and release artifacts
+
+Since v2.67.0 the release artifacts are built by the packaging
+module (CPack over the install surface):
+
+- **Every tarball and zip carries `bin/`** — retraced, retrace-ctl,
+  retrace-enforce, the kernel-truth converters, and the profiler ship
+  with the library and headers. (Earlier releases carried `lib/` and
+  `include/` only.)
+- **`.deb` packages** (`retrace-<version>-linux-x86_64.deb`,
+  `-linux-aarch64.deb`) are built and validated on the Linux CI legs:
+
+  ```sh
+  sudo apt install ./retrace-2.67.0-linux-x86_64.deb
+  ```
+
+- **Checksums**: every asset ships a `.sha256` sidecar
+  (`sha256sum -c retrace-2.67.0-linux-x86_64.tar.gz.sha256`).
+- **RPM** is configured in `cmake/Packaging.cmake` for source builds
+  (`cd build && cpack -G RPM`); the hosted CI runners carry no
+  `rpmbuild`, so release-side rpm artifacts await a repository channel.
+- **Building your own** from a checkout:
+
+  ```sh
+  cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release
+  cmake --build build
+  (cd build && cpack -G "TGZ;DEB")
+  ```
+
+The OHOS cross-built artifact remains hand-staged by design: its
+notices carry the self-signing disclaimer OHOS operators need.

--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -68,7 +68,7 @@ const cols = [
     </div>
     <div class="footer-bottom">
       <span>BSD-2-Clause · built by Ribose</span>
-      <span>v2.62.0</span>
+      <span>v2.67.0</span>
     </div>
   </div>
 </footer>

--- a/website/src/components/WhatsNew.astro
+++ b/website/src/components/WhatsNew.astro
@@ -5,6 +5,24 @@
 
 const shipped = [
   {
+    title: "Packages, and artifacts that carry the tools",
+    detail: "CPack now rides the install surface: every tarball and zip carries bin/ -- retraced, the fleet CLI, enforcement, all the converters (they were missing from releases entirely before) -- and the Linux legs ship dpkg-validated .deb packages. RPM is configured for source builds.",
+    accent: "control",
+    tag: "v2.67.0",
+  },
+  {
+    title: "The agent's last twins, unified",
+    detail: "One frame codec (the Windows arm adopted the shared encoder and its payload cap, closing a silent oversized-event loss), one policy validation ladder in policy_sig.c (the Windows copy had lost the expiry guard), and one pure event ring with drop accounting on both halves.",
+    accent: "see",
+    tag: "v2.63-66",
+  },
+  {
+    title: "Policy crosses the pipe",
+    detail: "The fleet CLI's policy push now reaches Windows pipe agents for the first time -- the broadcast sends through an installed sink over transport-opaque handles, and the codebase's last extern-as-interface retired.",
+    accent: "control",
+    tag: "v2.63.0",
+  },
+  {
     title: "The Windows lane goes real",
     detail: "The named-pipe daemon, fleet CLI, and all four agents (libc, kernel-ETW, Python, JVM) now build, link, and pass their integration tests on Windows -- including the SCM service lane (sc create/start/stop with graceful journal flush) and a configure-time conformance guard over the everywhere-build set. Sixteen defects that had shipped dark were burned off in one activation arc.",
     accent: "control",
@@ -113,9 +131,9 @@ const roadmap = [
     accent: "control",
   },
   {
-    title: "Distro packaging",
-    detail: "Source builds and the Nix flake exist; system packages (deb, rpm, brew) so operators install retraced the way they install everything else.",
-    eta: "planned",
+    title: "Brew + rpm channels",
+    detail: "The .deb ships from the releases (dpkg-validated in CI) and cpack builds rpm from source; the remaining channels are a Homebrew tap and an rpm repository so package managers see updates.",
+    eta: "next",
     accent: "break",
   },
 ];
@@ -155,7 +173,7 @@ const stats = [
 
     <div class="shipped-block">
       <header class="block-head reveal">
-        <div class="block-tag accent-control">SHIPPED: v2.38 - v2.62</div>
+        <div class="block-tag accent-control">SHIPPED: v2.38 - v2.67</div>
         <h3>The arc that made retrace a supervised instrument: daemon, fleet control, enforcement, three observation lanes, and the Windows lane made real.</h3>
       </header>
       <div class="shipped-grid">


### PR DESCRIPTION
Five releases since the last catch-up: the WhatsNew feed gains them (packages lead), the badge reads v2.38-v2.67, the roadmap's packaging line flips to shipped (remaining channels: a Homebrew tap and an rpm repository), and docs/platforms.md gains the packaging section the new .deb artifacts need — install, contents (bin/ since v2.67), checksum verification, and cpack from source. Site builds clean. Site + docs only — deploys from main, no product release.