### PR TITLE
publish: the rpm glob (the artifacts/-prefixed set)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -428,6 +428,8 @@ jobs:
             artifacts/retrace-*.zip.sha256
             artifacts/retrace-*.deb
             artifacts/retrace-*.deb.sha256
+            artifacts/retrace-*.rpm
+            artifacts/retrace-*.rpm.sha256
             artifacts/libretrace-*.so
             artifacts/libretrace-*.so.sha256
             artifacts/libretrace-*.dylib


### PR DESCRIPTION
The v2.68.0 rpms built, validated, and reached the artifact store — the publish step's glob list carries the artifacts/ prefix and missed the rpm lines the upload set gained. Two lists, one shape in each. On merge I'll move the v2.68.0 tag and re-dispatch so the rpms land.