### PR TITLE
v2.69.0 version bump

### DIFF
--- a/include/retrace/version.h
+++ b/include/retrace/version.h
@@ -37,10 +37,10 @@
 #define RETRACE_VERSION_H
 
 #define RETRACE_VERSION_MAJOR 2
-#define RETRACE_VERSION_MINOR 68
+#define RETRACE_VERSION_MINOR 69
 #define RETRACE_VERSION_PATCH 0
 
-#define RETRACE_VERSION_STRING "2.68.0"
+#define RETRACE_VERSION_STRING "2.69.0"
 
 #define RETRACE_VERSION_ATLEAST(maj, min, pat)                  \
 	(RETRACE_VERSION_MAJOR > (maj) ||                       \


### PR DESCRIPTION
Version bump for the release: agent.c split into agent_posix.c + agent_win.c, per-platform CMake selection, zero behavior change, native long types in the Windows half. Both version macros ride the bump.