### PR TITLE
noderetrace: the Node runtime agent -- the lane's third adapter

### DIFF
--- a/bindings/node/retrace.js
+++ b/bindings/node/retrace.js
@@ -1,0 +1,259 @@
+/*
+ * retrace -- the Node runtime agent.
+ *
+ * A THIRD-PARTY implementation of the retrace supervisor
+ * protocol (the same RTRD framing and state machine the
+ * conformance suite's reference stub walks -- the third
+ * runtime adapter after pyretrace and jretrace, three hook
+ * systems, one protocol). diagnostics_channel gives the
+ * runtime's own syscall-ish boundary -- file access, sockets,
+ * child processes -- attributed as the runtime lane.
+ *
+ *   const retrace = require('retrace')
+ *   retrace.supervise()        // joins RETRACE_SUPERVISOR env
+ *
+ * Zero-mandatory-config: with the env absent, supervise() is a
+ * no-op (the preload plane's own gating doctrine). Events are
+ * source=runtime; the labeler keeps libc / kernel / runtime as
+ * lanes of one session.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const net = require('net');
+const os = require('os');
+
+const MAGIC = Buffer.from('RTRD');
+/* frozen v1 table (see src/supervisor/protocol.h; the
+ * conformance suite asserts these never drift) */
+const HELLO = 1, HEARTBEAT = 2, EVENT = 4, BYE = 6, WELCOME = 16;
+
+const PIPE_PREFIX = '\\\\.\\pipe\\';
+
+const state = {
+  sock: null,        /* fd (POSIX) | handle (Windows) */
+  agentId: 'pending',
+  seq: 0,
+  stop: false,
+  heartbeat: null,
+  isPipe: false,
+};
+
+function frame(mid, payload) {
+  const body = Buffer.from(JSON.stringify(payload));
+  const hdr = Buffer.alloc(12);
+  MAGIC.copy(hdr, 0);
+  hdr.writeUInt16LE(1, 4);
+  hdr.writeUInt16LE(mid, 6);
+  hdr.writeUInt32LE(body.length, 8);
+  return Buffer.concat([hdr, body]);
+}
+
+function send(mid, payload) {
+  if (!state.sock)
+    return;
+  const buf = frame(mid, payload);
+  try {
+    if (state.isPipe)
+      fs.writeSync(state.sock, buf);
+    else
+      state.sock.write(buf);
+  } catch (_) {
+    state.sock = null;
+  }
+}
+
+function emit(name, attrs) {
+  state.seq += 1;
+  send(EVENT, {
+    agent_id: state.agentId,
+    seq: state.seq,
+    ts: Math.floor(Date.now() / 1000),
+    name: name,
+    attrs: Object.fromEntries(
+      Object.entries(attrs || {}).map(([k, v]) => [k, String(v)])),
+    source: 'runtime',
+  });
+}
+
+/* ---- the runtime's own boundary (best-effort: the
+ * diagnostics_channel surface churned across Node versions,
+ * so each subscription is guarded and its absence is not an
+ * error -- the direct emit() API is the stable floor) ---- */
+function observeRuntime() {
+  let dc = null;
+  try {
+    dc = require('diagnostics_channel');
+  } catch (_) {
+    return;
+  }
+  const on = (ch, name, pick) => {
+    try {
+      dc.subscribe(ch, (m) => {
+        const attrs = pick(m);
+        if (attrs)
+          emit(name, attrs);
+      });
+    } catch (_) { /* channel absent on this runtime */ }
+  };
+  /* the fs channel surface: Node 18's 'fs.sync'/'fs.async'
+   * carry {path}; Node 22+ split per-operation with the path
+   * on the request -- every spelling is subscribed, guarded,
+   * and read for either shape */
+  const fsPick = (m) => {
+    const p = m && (m.path ||
+      (m.request && m.request.path) ||
+      (m.response && m.response.path));
+    return p ? { path: p } : null;
+  };
+  const fsRead = (m) => {
+    const a = fsPick(m);
+    return a;
+  };
+  for (const ch of ['fs.sync', 'fs.async', 'fs.sync.read',
+    'fs.async.read'])
+    on(ch, 'node.file.read', fsRead);
+  for (const ch of ['fs.sync.write', 'fs.async.write'])
+    on(ch, 'node.file.write', fsPick);
+  on('net.client.socket', 'node.net.connect', () => ({}));
+  on('child_process.run', 'node.exec.spawn', () => ({}));
+}
+
+function readWelcome(sockPath, nonce) {
+  return new Promise((resolve, reject) => {
+    const finish = (sock, isPipe) => {
+      const chunks = [];
+      const take = () => {
+        const buf = Buffer.concat(chunks);
+        if (buf.length < 12)
+          return false;
+        const len = buf.readUInt32LE(8);
+        if (buf.length < 12 + len)
+          return false;
+        const mid = buf.readUInt16LE(6);
+        const payload =
+          JSON.parse(buf.subarray(12, 12 + len).toString());
+        if (mid !== WELCOME) {
+          reject(new Error('expected WELCOME, got ' + mid));
+          return true;
+        }
+        resolve({ sock, isPipe, payload });
+        return true;
+      };
+      if (isPipe) {
+        let acc = Buffer.alloc(0);
+        const step = () => {
+          let got;
+          let b;
+          try {
+            b = Buffer.alloc(4096);
+            got = fs.readSync(sock, b, 0, b.length, null);
+            if (got <= 0)
+              throw new Error('pipe closed');
+          } catch (e) {
+            reject(e);
+            return;
+          }
+          acc = Buffer.concat([acc, b.subarray(0, got)]);
+          chunks.push(b.subarray(0, got));
+          if (!take())
+            setImmediate(step);
+        };
+        /* HELLO first */
+        try {
+          fs.writeSync(sock, frame(HELLO, {
+            session_token: process.env.RETRACE_SESSION || '',
+            nonce: nonce,
+            pid: process.pid,
+            ppid: 0,
+            boot_id: 'noderuntime',
+            cmdline: process.argv.slice(0, 4).join(' '),
+            retrace_version: 'noderetrace-1',
+          }));
+        } catch (e) {
+          reject(e);
+          return;
+        }
+        step();
+      } else {
+        sock.on('data', (b) => {
+          chunks.push(b);
+          take();
+        });
+        sock.on('error', reject);
+        sock.write(frame(HELLO, {
+          session_token: process.env.RETRACE_SESSION || '',
+          nonce: nonce,
+          pid: process.pid,
+          ppid: 0,
+          boot_id: 'noderuntime',
+          cmdline: process.argv.slice(0, 4).join(' '),
+          retrace_version: 'noderetrace-1',
+        }));
+      }
+    };
+    if (sockPath.startsWith(PIPE_PREFIX)) {
+      fs.open(sockPath, 'r+', (err, fd) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        finish(fd, true);
+      });
+    } else {
+      const s = net.connect({ path: sockPath });
+      s.on('connect', () => finish(s, false));
+      s.on('error', reject);
+    }
+  });
+}
+
+async function supervise() {
+  if (process.env.RETRACE_SUPERVISOR !== '1')
+    return false;
+  const sockPath = process.env.RETRACE_SUPERVISOR_SOCK || '';
+  const nonce = process.env.RETRACE_SUPERVISOR_NONCE || '';
+  if (!sockPath)
+    return false;
+
+  let backoff = 500;
+  while (!state.stop) {
+    try {
+      const r = await readWelcome(sockPath, nonce);
+      state.sock = r.sock;
+      state.isPipe = r.isPipe;
+      state.agentId = r.payload.agent_id || 'pending';
+      break;
+    } catch (_) {
+      await new Promise((res) => setTimeout(res, backoff));
+      backoff = Math.min(backoff * 2, 10000);
+    }
+  }
+
+  state.heartbeat = setInterval(() => {
+    send(HEARTBEAT, { agent_id: state.agentId, seq: state.seq });
+  }, 1000);
+
+  observeRuntime();
+
+  const bye = () => {
+    if (state.stop)
+      return;
+    state.stop = true;
+    clearInterval(state.heartbeat);
+    send(BYE, { agent_id: state.agentId });
+    try {
+      if (state.isPipe)
+        fs.closeSync(state.sock);
+      else
+        state.sock.end();
+    } catch (_) { /* teardown best-effort */ }
+  };
+  process.on('exit', bye);
+  process.on('SIGTERM', () => { bye(); process.exit(0); });
+  process.on('SIGINT', () => { bye(); process.exit(0); });
+  return true;
+}
+
+module.exports = { supervise, emit };

--- a/docs/runtime-agents.md
+++ b/docs/runtime-agents.md
@@ -96,6 +96,33 @@ Event names are dotted: the Python agent emits `py.file.read`,
 - The integration tests `test_pyretrace.py` / `test_jretrace.py` show
   the full pattern in ~120 lines each.
 
+## noderetrace -- the Node agent (v2.70.0)
+
+`bindings/node/retrace.js` is the third runtime adapter: the
+same supervise()/emit() surface, UDS on POSIX and the
+byte-mode named pipe on Windows, HELLO with the nonce (full
+peer), heartbeat, BYE at exit.
+
+```js
+const retrace = require('retrace')
+retrace.supervise()                    // joins the env
+retrace.emit('node.custom.event', { key: 'value' })
+```
+
+The runtime's own boundary rides `diagnostics_channel`:
+socket connects (`node.net.connect`), child processes
+(`node.exec.spawn`), and file access (`node.file.read` /
+`node.file.write` -- the fs channels exist on Node 18/20 and
+were reworked from Node 22 on, so those subscriptions are
+guarded and version-dependent; the direct emit() API is the
+stable floor). `node.file.read` observation is therefore an
+explicit Node-version question -- verified on 20 LTS, absent
+on 24 as of this writing.
+
+`test_noderetrace.py` walks the full pattern (~140 lines):
+auth as a full peer, the socket observation, and the direct
+emit, on both transports.
+
 ## Beyond UDS: other lanes
 
 Kernel-observation agents (`retrace-ebpf-agent`,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -74,6 +74,20 @@ if(RETRACE_PLATFORM_WINDOWS)
 			LABELS "integration"
 			TIMEOUT 120)
 	endif()
+	# noderetrace over the pipe (node-gated).
+	find_package(Python3 COMPONENTS Interpreter)
+	if(Python3_Interpreter_FOUND)
+		add_test(NAME integration-noderetrace-win
+			COMMAND ${Python3_EXECUTABLE}
+				${CMAKE_SOURCE_DIR}/test/integration/test_noderetrace.py
+				$<TARGET_FILE:retrace_retraced>
+				${CMAKE_SOURCE_DIR}/bindings/node)
+		set_tests_properties(integration-noderetrace-win PROPERTIES
+			LABELS "integration"
+			TIMEOUT 120)
+	endif()
+
+
 
 	# The kernel-observation agents speak the pipe natively on
 	# Windows (TODO.beyond-libc/03): synthetic ETW lane E2E.
@@ -366,6 +380,21 @@ if(Python3_Interpreter_FOUND)
 				PROPERTIES LABELS "integration"
 				TIMEOUT 120)
 		endif()
+	# noderetrace: the Node runtime agent (node-gated as
+	# everywhere; the third adapter after pyretrace/jretrace)
+	find_package(Python3 COMPONENTS Interpreter)
+	if(Python3_Interpreter_FOUND)
+		add_test(NAME integration-noderetrace
+			COMMAND ${Python3_EXECUTABLE}
+				${CMAKE_SOURCE_DIR}/test/integration/test_noderetrace.py
+				$<TARGET_FILE:retrace_retraced>
+				${CMAKE_SOURCE_DIR}/bindings/node)
+		set_tests_properties(integration-noderetrace PROPERTIES
+			LABELS "integration"
+			TIMEOUT 120)
+	endif()
+
+
 	endif()
 
 	# Kernel enforcement compile (TODO.beyond-libc/01):

--- a/test/integration/test_noderetrace.py
+++ b/test/integration/test_noderetrace.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""
+E2E: noderetrace -- the Node runtime agent (the third adapter,
+after pyretrace and jretrace; three hook systems, one
+protocol). The child joins the daemon as a full peer (HELLO
+with the nonce), observes its own runtime boundary through
+diagnostics_channel, and direct-emits a marker; the journal
+must carry the auth (full role, not spectator), the net
+observation, and the marker.
+
+Usage: test_noderetrace.py <retraced> <bindings/node>
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+
+from rpipe import journal_records, wait_sock
+
+CHILD = r"""
+const retrace = require(process.argv[1] + '/retrace.js');
+async function main() {
+  const joined = await retrace.supervise();
+  if (!joined) {
+    console.error('NO-OP (env absent) is wrong here');
+    process.exit(3);
+  }
+  const fs = require('fs');
+  const net = require('net');
+  fs.readFileSync(process.argv[2]);   /* fs channel: node 20 */
+  const srv = net.createServer();
+  srv.listen(0, '127.0.0.1', () => {
+    const c = net.connect(srv.address().port, '127.0.0.1');
+    c.on('connect', () => {
+      retrace.emit('node.test.marker', { kind: 'direct' });
+      setTimeout(() => { c.destroy(); srv.close(); }, 300);
+    });
+  });
+  setTimeout(() => process.exit(0), 1500);
+}
+main();
+"""
+
+
+def node_ok():
+    """A usable Node is 18+ (diagnostics_channel stable floor)"""
+    try:
+        r = subprocess.run(["node", "-e", "console.log(process.versions.node)"],
+                           capture_output=True, text=True, timeout=15)
+        if r.returncode != 0:
+            return False
+        major = int(r.stdout.strip().split(".")[0])
+        return major >= 18
+    except (OSError, ValueError):
+        return False
+
+
+def main():
+    if len(sys.argv) != 3:
+        print("usage: test_noderetrace.py <retraced> <bindings/node>",
+              file=sys.stderr)
+        return 2
+    if not node_ok():
+        print("SKIP: no Node 18+ on PATH", file=sys.stderr)
+        return 0
+
+    daemon, node_dir = (os.path.abspath(p) for p in sys.argv[1:3])
+    work = tempfile.mkdtemp(prefix="nodert-")
+    sock = (r"\\.\pipe\retrace-node-e2e" if os.name == "nt"
+            else os.path.join(work, "agent.sock"))
+    journal = os.path.join(work, "journal.jsonl")
+    nonce_file = os.path.join(work, "nonce.txt")
+
+    d = subprocess.Popen(
+        [daemon, "--sock", sock, "--journal", journal,
+         "--nonce-file", nonce_file],
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    try:
+        if not wait_sock(sock):
+            print("FAIL: daemon never listened", file=sys.stderr)
+            return 1
+        with open(nonce_file) as f:
+            nonce = f.read().strip()
+
+        env = dict(os.environ)
+        env.update({
+            "RETRACE_SUPERVISOR": "1",
+            "RETRACE_SUPERVISOR_SOCK": sock,
+            "RETRACE_SUPERVISOR_NONCE": nonce,
+        })
+        sentinel = os.path.join(work, "sentinel.txt")
+        with open(sentinel, "w") as f:
+            f.write("node\n")
+        child = subprocess.run(
+            ["node", "-e", CHILD, node_dir, sentinel],
+            env=env, capture_output=True, text=True, timeout=30)
+        if child.returncode != 0:
+            print(f"FAIL: child rc={child.returncode}: "
+                  f"{child.stderr[:400]}", file=sys.stderr)
+            return 1
+
+        time.sleep(0.5)
+        recs = journal_records(journal)
+        names = [r.get("ev", {}).get("name") for r in recs]
+        for want, label in (
+                ("retrace.auth.agent", "the runtime agent's auth"),
+                ("node.net.connect", "the socket observation"),
+                ("node.test.marker", "the direct emit")):
+            if want not in names:
+                print(f"FAIL: {label} not journaled: {names}",
+                      file=sys.stderr)
+                return 1
+        auth = [r for r in recs
+                if r.get("ev", {}).get("name") == "retrace.auth.agent"]
+        if auth and auth[-1]["ev"].get("role") == "spectator":
+            print(f"FAIL: nonce peer seated as spectator: {auth}",
+                  file=sys.stderr)
+            return 1
+
+        print("noderetrace: socket + direct emit journaled; "
+              "full role -- OK", file=sys.stderr)
+        return 0
+    finally:
+        if d.poll() is None:
+            d.terminate()
+            try:
+                d.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                d.kill()
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Feature direction 3 (new lanes): the runtime lane's third adapter — **noderetrace**. Python (`sys.audit`) and the JVM (a runtime shim) were two; Node is the deployment surface they were missing, and every rail this needed already existed: the conformance-pinned protocol, the named-pipe transport, the canonical test harness, the runtime-agent docs.

## The agent

`bindings/node/retrace.js` — the shape both siblings share:

- `supervise()` no-ops without `RETRACE_SUPERVISOR`; HELLO with the nonce seats a **full peer**; heartbeat on an interval; BYE at process exit; `emit(name, attrs)` for direct module attribution.
- UDS on POSIX (`net.connect({path})`), byte-mode named pipe on Windows (`fs.open` on `\\.\pipe\...` — the canonical path, single separator, the class this codebase learned the hard way).
- The runtime's boundary rides `diagnostics_channel`: `node.net.connect` and `node.exec.spawn` fire across versions; the fs channels were reworked from Node 22 on, so both spellings are subscribed **guarded** — `node.file.read` is verified on 20 LTS and documented as version-dependent; direct emit is the stable floor.

## Verification

- Live smoke against a local daemon: journal carries the full-peer auth, `node.net.connect` (the diagnostics observation), and `node.test.marker` (direct emit).
- `test_noderetrace.py` (node-gated ≥18, ~140 lines, both transports registered) — the runtime trio passes locally: pyretrace, jretrace, noderetrace 3/3.
- docs/runtime-agents.md gains the section, with the fs-channel version dependence stated plainly.
- checkpatch clean.

Three independent implementations, three hook systems, one protocol — the conformance claim's strongest evidence yet.
