### PR TITLE
v2.70.0 version bump

### DIFF
--- a/include/retrace/version.h
+++ b/include/retrace/version.h
@@ -37,10 +37,11 @@
 #define RETRACE_VERSION_H
 
 #define RETRACE_VERSION_MAJOR 2
-#define RETRACE_VERSION_MINOR 69
+#define RETRACE_VERSION_MAJOR 2
+#define RETRACE_VERSION_MINOR 70
 #define RETRACE_VERSION_PATCH 0
 
-#define RETRACE_VERSION_STRING "2.69.0"
+#define RETRACE_VERSION_STRING "2.70.0"
 
 #define RETRACE_VERSION_ATLEAST(maj, min, pat)                  \
 	(RETRACE_VERSION_MAJOR > (maj) ||                       \


### PR DESCRIPTION
Version bump for the release: noderetrace — the Node runtime agent (diagnostics_channel observation, both transports, guarded fs channels with the version dependence documented). Both version macros ride the bump.