### PR TITLE
fail_first: the transient-fault action -- the retry-path primitive

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -356,6 +356,33 @@ Counts are per-function-name across the process. The first
 `call_count_limit` action to fire for a given function claims that
 function's counter.
 
+#### `fail_first`
+
+Fails the first N invocations with a chosen return value, then lets
+every later call through untouched — the transient-fault mirror of
+`call_count_limit` (which fails *after* N). This is the retry-path
+primitive: prove a library survives two `EAGAIN`s, or expose the
+untested infinite retry loop.
+
+```json
+{
+  "action_name": "fail_first",
+  "action_params": { "fails": 2, "retval_int": -11 }
+}
+```
+
+| Param        | Type   | Required | Notes                                              |
+|--------------|--------|----------|----------------------------------------------------|
+| `fails`      | number | yes      | How many leading invocations fail. `0` = inert.    |
+| `retval_int` | number | yes      | The return value the failing calls synthesize.     |
+
+Inside the failing window the action sets `ret_val` and aborts the
+script, so `call_real` never runs; after the window the script
+proceeds normally. Counts are per-function-name, first-to-fire
+claims the counter — same ownership rule as `call_count_limit`,
+and the two compose (transient fault on the way in, exhaustion
+eventually).
+
 #### `sandbox`
 
 File-access policy by path. Two modes:

--- a/docs/cookbook/12-fail-specific.md
+++ b/docs/cookbook/12-fail-specific.md
@@ -78,6 +78,38 @@ fd. The 6th+ calls: `modify_return_value_int` sets ret to `-2`,
 `call_count_limit` fires and aborts, `call_real` never runs.
 Effective: `-ENOENT`.
 
+### Fail the first N calls, then recover (retry paths)
+
+The inverse direction -- a *transient* fault -- is `fail_first`:
+the first N invocations return your chosen error with the real
+call never made; every call after runs for real. This is the
+primitive for testing retry logic deterministically:
+
+```json
+{
+  "intercept_scripts": [
+    {
+      "func_name": "open",
+      "actions": [
+        { "action_name": "fail_first",
+          "action_params": { "fails": 2, "retval_int": -11 } },
+        { "action_name": "call_real" },
+        { "action_name": "log_params" }
+      ]
+    }
+  ]
+}
+```
+
+The first two `open` calls see `EAGAIN` (-11) without touching
+the filesystem; the third and onward hit the real `open`. A
+correct retry loop converges on the third call; an untested one
+hangs or crashes -- retrace makes either visible in a single
+run. `fail_first` composes with `call_count_limit` on the same
+function: transient faults on the way in, exhaustion
+eventually.
+
+
 ### Fail network connects
 
 To make every outbound `connect()` fail with `ECONNREFUSED`

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -44,6 +44,7 @@ set(_core_action_sources
 	actions/basic.c actions/memfuzz.c
 	actions/incomplete_io.c actions/fuzzing_seed.c
 	actions/delay.c actions/call_count_limit.c
+	actions/fail_first.c
 	actions/sandbox.c actions/addr_deny.c
 	actions/filter.c actions/decode_http.c actions/decode_dns.c
 	actions/capture_buffer.c actions/fuzz_dict.c

--- a/src/core/actions/fail_first.c
+++ b/src/core/actions/fail_first.c
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+#include <stddef.h>
+
+#include "actions.h"
+#include "logger.h"
+#include "real_impls.h"
+
+/*
+ * fail_first -- fail the first N invocations with a chosen
+ * return value, then let every later call through untouched.
+ *
+ * The mirror of call_count_limit: that one simulates resource
+ * EXHAUSTION (calls 1..N pass, N+1.. fail); this one simulates
+ * the TRANSIENT fault (calls 1..N fail, the rest recover) --
+ * the retry-path primitive. A library that retries an EAGAIN
+ * can now be proven correct, not just broken: fail_first two
+ * EAGAINs and watch the third call succeed -- or watch the
+ * untested infinite retry loop hang.
+ *
+ * Counts are PER FUNCTION NAME across the whole process, first
+ * action_params to fire for a name claims its counter (same
+ * ownership rule as call_count_limit; the two share no state,
+ so a function may carry both -- transient fault on the way in,
+ exhaustion eventually).
+ *
+ * Run BEFORE call_real: inside the failing window the action
+ * sets ret_val and aborts the script, so the real libc call is
+ * never made (the engine already cancelled it when the script
+ * matched); outside the window it returns 0 and the script
+ * proceeds -- put call_real after it and the call recovers.
+ *
+ * action_params:
+ *   fails      - int. How many leading invocations fail.
+ *                Required. 0 = pass everything through (the
+ *                action is inert; useful for flipping a test
+ *                from fault to baseline without editing the
+ *                script shape).
+ *   retval_int - int. The return value the failing calls
+ *                synthesize (an errno-like int for the
+ *                libc-level contract). Required.
+ *
+ * Example JSON (open: two EAGAINs, then reality):
+ *   {
+ *     "func_name": "open",
+ *     "actions": [
+ *       { "action_name": "fail_first",
+ *         "action_params": { "fails": 2, "retval_int": -11 } },
+ *       { "action_name": "call_real" },
+ *       { "action_name": "log_params" }
+ *     ]
+ *   }
+ */
+
+#define MAX_TRACKED_FUNCS 64
+
+struct fail_entry {
+	char name[MAXLEN_FUNC_NAME + 1];
+	long count;
+	long fails;
+	long retval;
+};
+
+static struct fail_entry g_entries[MAX_TRACKED_FUNCS];
+
+static struct fail_entry *find_or_claim(const char *name,
+	long fails)
+{
+	int i;
+	int first_empty = -1;
+
+	for (i = 0; i < MAX_TRACKED_FUNCS; i++) {
+		if (g_entries[i].name[0] != '\0' &&
+			retrace_real_impls.strcmp(g_entries[i].name,
+				name) == 0) {
+			if (g_entries[i].fails != fails) {
+				log_warn(
+					"fail_first: '%s' already tracked with fails %ld; ignoring new %ld",
+					name, g_entries[i].fails, fails);
+			}
+			return &g_entries[i];
+		}
+		if (first_empty < 0 && g_entries[i].name[0] == '\0')
+			first_empty = i;
+	}
+
+	if (first_empty < 0) {
+		log_err("fail_first: tracking table full (%d entries)",
+			MAX_TRACKED_FUNCS);
+		return NULL;
+	}
+
+	/* same benign-claim race note as call_count_limit: worst
+	 * case the fault window silently doesn't apply for one
+	 * function -- acceptable for a fault-injection tool
+	 */
+	retrace_real_impls.strcpy(g_entries[first_empty].name, name);
+	g_entries[first_empty].count = 0;
+	g_entries[first_empty].fails = fails;
+	return &g_entries[first_empty];
+}
+
+static int ia_fail_first(struct ThreadContext *t_ctx,
+	const JSON_Object *action_params)
+{
+	double d;
+	long fails, retval;
+	struct fail_entry *entry;
+	const char *func_name;
+
+	if (action_params == NULL) {
+		log_err("action_params required for fail_first");
+		return -1;
+	}
+	if (!json_object_has_value(action_params, "fails") ||
+	    !json_object_has_value(action_params, "retval_int")) {
+		log_err("'fails' and 'retval_int' required for fail_first");
+		return -1;
+	}
+
+	d = json_object_get_number(action_params, "fails");
+	fails = (long)d;
+	d = json_object_get_number(action_params, "retval_int");
+	retval = (long)d;
+
+	if (t_ctx->prototype == NULL || t_ctx->prototype->name[0] == '\0') {
+		log_err("fail_first: no prototype name on thread ctx");
+		return -1;
+	}
+	func_name = t_ctx->prototype->name;
+
+	entry = find_or_claim(func_name, fails);
+	if (entry == NULL)
+		return 0;	/* table full; let the call through */
+
+	entry->count++;
+	entry->retval = retval;
+
+	if (entry->count <= entry->fails) {
+		t_ctx->ret_val = entry->retval;
+		log_info("fail_first: '%s' failing call %ld/%ld with %ld -- real not called",
+			func_name, entry->count, entry->fails,
+			entry->retval);
+		/* abort the script: call_real never runs, ret_val is
+		 * the transient fault the caller must retry through
+		 */
+		return -1;
+	}
+
+	log_dbg("fail_first: '%s' recovered at call %ld",
+		func_name, entry->count);
+	return 0;
+}
+
+retrace_actions_define_package(fail_first) = {
+	{
+		.name = "fail_first",
+		.action = ia_fail_first
+	}
+};

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -372,6 +372,10 @@ retrace_add_unit_test(freeze)
 #
 # call_count_limit action unit tests (TODO.complete/14).
 #
+retrace_add_unit_test(fail_first
+    EXTRA_SOURCES ${CMAKE_SOURCE_DIR}/src/core/actions/fail_first.c
+    EXTRA_INCLUDES ${CMAKE_SOURCE_DIR}/test/helpers)
+
 retrace_add_unit_test(call_count_limit
     EXTRA_INCLUDES ${CMAKE_SOURCE_DIR}/test/helpers)
 

--- a/test/unit/test_fail_first.c
+++ b/test/unit/test_fail_first.c
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+/*
+ * fail_first -- fail the first N invocations, then recover.
+ *
+ * Cases:
+ *   - The action registers under its name
+ *   - Missing params (null, no fails, no retval_int) -> -1
+ *   - Window edges: fails=2 -> calls 1,2 abort with the fault
+ *     ret_val set and real never called; call 3+ returns 0 and
+ *     leaves ret_val alone (the script's call_real owns it)
+ *   - fails=0 is inert (every call passes through)
+ *   - Independent functions tracked separately
+ *   - Re-claiming an existing name with different fails warns
+ *     but keeps the original window
+ */
+
+#include "test_utils.h"
+#include "parson.h"
+
+static JSON_Object *build_ff_params(double fails, double retval)
+{
+	JSON_Value *v = json_value_init_object();
+	JSON_Object *o = json_value_get_object(v);
+
+	json_object_set_number(o, "fails", fails);
+	json_object_set_number(o, "retval_int", retval);
+	return o;
+}
+
+/* two slots: tests that compare functions side by side need
+ * distinct contexts (the counter table keys on the prototype
+ * name, so aliasing one static ctx would alias the counters)
+ */
+static struct ThreadContext *build_ctx_for_func(int slot,
+	const char *func_name)
+{
+	static struct ThreadContext ctx[2];
+	static struct FuncPrototype proto[2];
+
+	memset(&ctx[slot], 0, sizeof(ctx[slot]));
+	memset(&proto[slot], 0, sizeof(proto[slot]));
+
+	strncpy(proto[slot].name, func_name,
+		sizeof(proto[slot].name) - 1);
+	proto[slot].name[sizeof(proto[slot].name) - 1] = '\0';
+	ctx[slot].prototype = &proto[slot];
+
+	return &ctx[slot];
+}
+
+DECLARE_TEST_STATE();
+
+static void test_action_lookup(void)
+{
+	retrace_actions_init();
+	CHECK(retrace_actions_get("fail_first") != NULL);
+}
+
+static void test_params_null(void)
+{
+	action_fn_t action = retrace_actions_get("fail_first");
+	struct ThreadContext *ctx = build_ctx_for_func(0, "ff_null_params");
+	int rc;
+
+	rc = action(ctx, NULL);
+	CHECK(rc == -1);
+}
+
+static void test_missing_params(void)
+{
+	action_fn_t action = retrace_actions_get("fail_first");
+	struct ThreadContext *ctx;
+	JSON_Value *root_val;
+	JSON_Object *root;
+	int rc;
+
+	ctx = build_ctx_for_func(0, "ff_missing_fails");
+	root_val = json_value_init_object();
+	root = json_value_get_object(root_val);
+	json_object_set_number(root, "retval_int", -11.0);
+	rc = action(ctx, root);
+	CHECK(rc == -1);
+	json_value_free(root_val);
+
+	ctx = build_ctx_for_func(0, "ff_missing_retval");
+	root_val = json_value_init_object();
+	root = json_value_get_object(root_val);
+	json_object_set_number(root, "fails", 2.0);
+	rc = action(ctx, root);
+	CHECK(rc == -1);
+	json_value_free(root_val);
+}
+
+static void test_window_edges(void)
+{
+	action_fn_t action = retrace_actions_get("fail_first");
+	struct ThreadContext *ctx = build_ctx_for_func(0, "ff_window");
+	JSON_Object *params;
+
+	params = build_ff_params(2.0, -11.0);
+
+	/* call 1: inside the window -- the fault is set, script
+	 * aborts (call_real never runs)
+	 */
+	ctx->ret_val = 0xdead;
+	CHECK(action(ctx, params) == -1);
+	CHECK(ctx->ret_val == -11);
+
+	/* call 2: still inside */
+	CHECK(action(ctx, params) == -1);
+	CHECK(ctx->ret_val == -11);
+
+	/* call 3: recovered -- the action passes (0) and does NOT
+	 * touch ret_val (the script's call_real owns it now)
+	 */
+	ctx->ret_val = 0xdead;
+	CHECK(action(ctx, params) == 0);
+	CHECK(ctx->ret_val == 0xdead);
+
+	/* call 4 and on: stays recovered */
+	CHECK(action(ctx, params) == 0);
+	CHECK(ctx->ret_val == 0xdead);
+
+	json_value_free(json_object_get_wrapping_value(params));
+}
+
+static void test_zero_fails_inert(void)
+{
+	action_fn_t action = retrace_actions_get("fail_first");
+	struct ThreadContext *ctx = build_ctx_for_func(0, "ff_zero");
+	JSON_Object *params;
+
+	params = build_ff_params(0.0, -1.0);
+	ctx->ret_val = 0xdead;
+	CHECK(action(ctx, params) == 0);
+	CHECK(ctx->ret_val == 0xdead);
+	CHECK(action(ctx, params) == 0);
+	CHECK(ctx->ret_val == 0xdead);
+
+	json_value_free(json_object_get_wrapping_value(params));
+}
+
+static void test_independent_functions(void)
+{
+	action_fn_t a = retrace_actions_get("fail_first");
+	struct ThreadContext *alpha = build_ctx_for_func(0, "ff_alpha");
+	struct ThreadContext *beta = build_ctx_for_func(1, "ff_beta");
+	JSON_Object *params;
+
+	params = build_ff_params(1.0, -22.0);
+
+	CHECK(a(alpha, params) == -1);
+	CHECK(alpha->ret_val == -22);
+	/* beta has its own window */
+	CHECK(a(beta, params) == -1);
+	CHECK(beta->ret_val == -22);
+	/* both recovered now */
+	CHECK(a(alpha, params) == 0);
+	CHECK(a(beta, params) == 0);
+
+	json_value_free(json_object_get_wrapping_value(params));
+}
+
+static void test_reclaim_keeps_original_window(void)
+{
+	action_fn_t a = retrace_actions_get("fail_first");
+	struct ThreadContext *ctx = build_ctx_for_func(0, "ff_reclaim");
+	JSON_Object *first;
+	JSON_Object *second;
+
+	first = build_ff_params(1.0, -1.0);
+	second = build_ff_params(5.0, -2.0);
+
+	CHECK(a(ctx, first) == -1);
+	/* the re-claim with fails=5 is ignored: the window was 1 */
+	CHECK(a(ctx, second) == 0);
+
+	json_value_free(json_object_get_wrapping_value(first));
+	json_value_free(json_object_get_wrapping_value(second));
+}
+
+DECLARE_TEST_STATE();
+
+int main(void)
+{
+	printf("  -- registration --\n");
+	TEST(action_lookup);
+	printf("  -- params --\n");
+	TEST(params_null);
+	TEST(missing_params);
+	printf("  -- the fault window --\n");
+	TEST(window_edges);
+	TEST(zero_fails_inert);
+	printf("  -- ownership --\n");
+	TEST(independent_functions);
+	TEST(reclaim_keeps_original_window);
+
+	return finish_tests(tests_run, tests_pass, tests_fail);
+}


### PR DESCRIPTION
## What

The cycle-14 report's card N — the fault-schedule gap at retrace's core: **fault injection could exhaust a resource (`call_count_limit`, fail after N) but never recover from one**, so the most common resilience pattern — the retry path — had no deterministic test primitive. A library retrying a transient `EAGAIN` could be broken by retrace; never verified.

## The action

`fail_first { fails: N, retval_int: R }` — the mirror:

- Inside the window (calls 1..N): sets `ret_val` and aborts the script before `call_real` — the caller sees the transient fault, the real libc call never happens.
- After the window: returns 0 and leaves `ret_val` alone — the script's `call_real` owns the call, and it recovers.
- Same per-function counter ownership as `call_count_limit`; the two compose (transient fault on the way in, exhaustion eventually). `fails: 0` is inert — flipping a test from fault to baseline without editing the script shape.
- No engine change — the action seam's design law holds.

## Verification

- Seven unit cases: registration, param guards, **window edges** (fault set + abort inside; ret_val untouched outside), inertness, independent functions, reclaim-keeps-original-window. 7/7.
- docs/configuration.md gains the action block; the fault-injection cookbook recipe gains the retry-path section.
- checkpatch clean.

Ships as v2.71.0.
