### PR TITLE
v2.72.0 version bump

### DIFF
--- a/include/retrace/version.h
+++ b/include/retrace/version.h
@@ -38,10 +38,10 @@
 
 #define RETRACE_VERSION_MAJOR 2
 #define RETRACE_VERSION_MAJOR 2
-#define RETRACE_VERSION_MINOR 71
+#define RETRACE_VERSION_MINOR 72
 #define RETRACE_VERSION_PATCH 0
 
-#define RETRACE_VERSION_STRING "2.71.0"
+#define RETRACE_VERSION_STRING "2.72.0"
 
 #define RETRACE_VERSION_ATLEAST(maj, min, pat)                  \
 	(RETRACE_VERSION_MAJOR > (maj) ||                       \


### PR DESCRIPTION
Version bump for the release: the retrace-ctl sessions command (the tree the registry always carried), the alpine-qemu perf-label exclusion, and the hardened noderetrace gate. Both version macros ride the bump.