### PR TITLE
website catches up to v2.73: the evidence plane leads

### DIFF
--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -68,7 +68,7 @@ const cols = [
     </div>
     <div class="footer-bottom">
       <span>BSD-2-Clause · built by Ribose</span>
-      <span>v2.67.0</span>
+      <span>v2.73.0</span>
     </div>
   </div>
 </footer>

--- a/website/src/components/WhatsNew.astro
+++ b/website/src/components/WhatsNew.astro
@@ -5,6 +5,30 @@
 
 const shipped = [
   {
+    title: "The evidence plane: retrace-ctl events",
+    detail: "The journal's tail over the control plane, with the hash-chain verdict riding the reply -- evidence pulled over a network carries its own integrity statement, and a tampered line names its own line number. STATUS-scoped by design: an auditor reads evidence without touching even the registry. The fleet CLI is now control AND evidence.",
+    accent: "control",
+    tag: "v2.73.0",
+  },
+  {
+    title: "Session trees, as trees",
+    detail: "retrace-ctl sessions prints the tree the registry always carried -- session tokens, fork parents, spectator seats -- nested instead of flat. Detonation-farm operators stop re-nesting forks by eye across JSON lines.",
+    accent: "see",
+    tag: "v2.72.0",
+  },
+  {
+    title: "fail_first: the retry-path primitive",
+    detail: "Fault injection could exhaust a resource but never recover from one. fail_first fails the first N calls with a chosen error (the real call never made), then lets every later call through -- a correct retry loop converges on call N+1, an untested one hangs where retrace can see it.",
+    accent: "break",
+    tag: "v2.71.0",
+  },
+  {
+    title: "noderetrace: the runtime trio completes",
+    detail: "The Node runtime agent -- diagnostics_channel for the runtime's own boundary, UDS and named-pipe transports, the same supervise/emit surface as its Python and JVM siblings. Three independent implementations, three hook systems, one protocol: the conformance claim's strongest evidence.",
+    accent: "see",
+    tag: "v2.70.0",
+  },
+  {
     title: "Packages, and artifacts that carry the tools",
     detail: "CPack now rides the install surface: every tarball and zip carries bin/ -- retraced, the fleet CLI, enforcement, all the converters (they were missing from releases entirely before) -- and the Linux legs ship dpkg-validated .deb packages. RPM is configured for source builds.",
     accent: "control",
@@ -52,12 +76,7 @@ const shipped = [
     accent: "break",
     tag: "v2.54-56",
   },
-  {
-    title: "The fleet CLI over TLS 1.3",
-    detail: "retrace-ctl speaks mutual TLS where every certificate carries its own claim scopes (status, ps, policy, kill) as a URI SAN -- an over-scoped controller is refused and journaled, not merely rejected.",
-    accent: "control",
-    tag: "v2.47-49",
-  },
+
   {
     title: "The supervisor daemon",
     detail: "retraced: per-host registry, hash-chained journal, formally-versioned control protocol, and the nonce doctrine -- nonceless HELLOs seat as spectators: evidence always, policy never.",
@@ -126,7 +145,7 @@ const roadmap = [
   },
   {
     title: "Cookbook growth",
-    detail: "The recipe set covers the classic and security-research flows; the gap is fleet-scale stories -- policy rollout, journal forensics, drift triage across hosts.",
+    detail: "The recipe set covers the classic, security-research, and resilience flows (fail_first's retry-path recipe landed with v2.71); what's missing is user-contributed war stories.",
     eta: "ongoing",
     accent: "control",
   },
@@ -173,7 +192,7 @@ const stats = [
 
     <div class="shipped-block">
       <header class="block-head reveal">
-        <div class="block-tag accent-control">SHIPPED: v2.38 - v2.67</div>
+        <div class="block-tag accent-control">SHIPPED: v2.38 - v2.73</div>
         <h3>The arc that made retrace a supervised instrument: daemon, fleet control, enforcement, three observation lanes, and the Windows lane made real.</h3>
       </header>
       <div class="shipped-grid">

--- a/website/src/pages/about.astro
+++ b/website/src/pages/about.astro
@@ -59,7 +59,10 @@ import Footer from "../components/Footer.astro";
             a fleet CLI over TLS 1.3 with certificate claim scopes — plus
             kernel enforcement on Linux (Landlock + seccomp), macOS
             (Seatbelt), and Windows (AppContainer), each exec bound to a
-            signed audit trail. On Windows the whole plane speaks
+            signed audit trail. The fleet CLI is control and
+            evidence in one seat: it pushes policy, shows the
+            session tree, and pulls the journal with the
+            hash-chain verdict riding the reply. On Windows the whole plane speaks
             named pipes natively — daemon, fleet CLI, and every
             agent — and the daemon installs as an SCM service
             with one binary, two launches.</p>


### PR DESCRIPTION
## What

Six releases since the site's last catch-up (v2.67). The docs rode every release; the website didn't. A visitor judging aliveness by the site sees a project that paused — while it shipped the evidence plane.

## The catch-up

- **Feed**: four new entries — `events` (the evidence plane) leads, then `sessions`, `fail_first`, `noderetrace`. Badge → `SHIPPED: v2.38 - v2.73`; footer → v2.73.0.
- **About**: the supervisor card gains the one sentence that matters — the fleet CLI is control *and* evidence in one seat.
- **Roadmap**: the fleet-scale gap line retires (policy rollout, journal forensics, drift triage across hosts — every word shipped); the cookbook line updates to name what actually remains (user-contributed war stories).

Site builds clean. Content-only: deploys from main via the website workflow, no retrace release.
