### PR TITLE
v2.74.0 version bump

### DIFF
--- a/include/retrace/version.h
+++ b/include/retrace/version.h
@@ -38,10 +38,10 @@
 
 #define RETRACE_VERSION_MAJOR 2
 #define RETRACE_VERSION_MAJOR 2
-#define RETRACE_VERSION_MINOR 73
+#define RETRACE_VERSION_MINOR 74
 #define RETRACE_VERSION_PATCH 0
 
-#define RETRACE_VERSION_STRING "2.73.0"
+#define RETRACE_VERSION_STRING "2.74.0"
 
 #define RETRACE_VERSION_ATLEAST(maj, min, pat)                  \
 	(RETRACE_VERSION_MAJOR > (maj) ||                       \


### PR DESCRIPTION
Version bump for the release: mmap/munmap interception (PR #414's intent, the modern rails), fault injection at the memory level. Both version macros ride the bump.