### PR TITLE
sessions: the tree walker goes recursive -- depth stops lying at level 4

### DIFF
--- a/test/unit/test_retraced_ctl.c
+++ b/test/unit/test_retraced_ctl.c
@@ -36,6 +36,7 @@
 #include <stdlib.h>
 
 #include "retraced_ctl.h"
+#include "parson.h"
 #include "tls_gate.h"
 
 /*
@@ -292,6 +293,98 @@ static void ev_sink_test(const char *line, void *user)
 	}
 }
 
+static void test_sessions_deep_chain_nests_at_every_depth(void)
+{
+	/*
+	 * The depth-5 chain through the real ppid arrival order:
+	 * root->a->b->c->d. Assert the ACTUAL nesting by parsing
+	 * the reply -- string-order checks cannot see flattening
+	 * (a sibling serialized after the subtree keeps parent-
+	 * precedes-child true while the tree lies). The depth-2
+	 * walker this test replaced flattened c and d.
+	 */
+	static const char *chain[] = { "root", "a", "b", "c", "d" };
+	JSON_Value *v;
+	JSON_Object *reply;
+	JSON_Array *agents;
+	JSON_Object *node;
+	int i;
+
+	setup();
+	/* hello registers; link_parent is the daemon's REAL next
+	 * step after HELLO (the ppid->parent binding -- see
+	 * main.c's handler). Drive both, exactly as the frame
+	 * handler does; cmdline comes through the entry.
+	 */
+	{
+		struct { long pid, ppid; const char *cmdline; }
+			chain[] = {
+			{ 300, 1, "root" }, { 301, 300, "a" },
+			{ 302, 301, "b" }, { 303, 302, "c" },
+			{ 304, 303, "d" }
+		};
+		size_t c;
+
+		for (c = 0; c < sizeof(chain) / sizeof(chain[0]);
+		     c++) {
+			struct agent_entry *e =
+				retraced_registry_hello(ctx.reg, NULL,
+					chain[c].pid, chain[c].ppid,
+					"S1", chain[c].cmdline);
+
+			if (e != NULL)
+				(void)retraced_registry_link_parent(
+					ctx.reg, e);
+		}
+	}
+
+	feed(&ctx, "{\"cmd\":\"sessions\"}");
+	v = json_parse_string(reply_buf);
+	CHECK(v != NULL);
+	reply = v != NULL ? json_value_get_object(v) : NULL;
+	CHECK(reply != NULL);
+	agents = NULL;
+	if (reply != NULL) {
+		JSON_Array *sessions = json_value_get_array(
+			json_object_get_value(reply, "sessions"));
+
+		CHECK(sessions != NULL);
+		CHECK(json_array_get_count(sessions) == 1);
+		if (sessions != NULL &&
+		    json_array_get_count(sessions) == 1)
+			agents = json_value_get_array(
+				json_object_get_value(
+					json_array_get_object(sessions, 0),
+					"agents"));
+	}
+	/* exactly one root agent: nothing flattened to the top */
+	CHECK(agents != NULL);
+	CHECK(json_array_get_count(agents) == 1);
+
+	node = agents != NULL ? json_array_get_object(agents, 0) :
+		NULL;
+	for (i = 0; i < 5 && node != NULL; i++) {
+		const char *cmdline = json_object_get_string(node,
+			"cmdline");
+
+		CHECK(cmdline != NULL);
+		CHECK(strcmp(cmdline, chain[i]) == 0);
+		if (i + 1 < 5) {
+			JSON_Value *cv = json_object_get_value(node,
+				"children");
+			JSON_Array *children = json_value_get_array(cv);
+
+			CHECK(children != NULL);
+			CHECK(json_array_get_count(children) == 1);
+			node = children != NULL &&
+			    json_array_get_count(children) == 1 ?
+				json_array_get_object(children, 0) : NULL;
+		}
+	}
+	CHECK(i == 5);
+	json_value_free(v);
+}
+
 static void test_events_reads_and_verifies(void)
 {
 	/*
@@ -410,6 +503,7 @@ int main(void)
 	TEST(status);
 	TEST(ps);
 	TEST(sessions_groups_the_tree);
+	TEST(sessions_deep_chain_nests_at_every_depth);
 	TEST(events_reads_and_verifies);
 	TEST(policy_push_valid);
 	TEST(policy_push_bad);

--- a/tools/retraced/retraced_ctl.c
+++ b/tools/retraced/retraced_ctl.c
@@ -165,6 +165,34 @@ uint32_t retraced_tls_scope_for_cmd(const char *cmd)
 	return 0;
 }
 
+/*
+ * Nest `child` under the node whose id is `parent_id`, at any
+ * depth. Returns 1 placed. The session tree's whole point is
+ * depth: worker trees and fork-bomb detonations chain past any
+ * fixed scan level (the depth-2 shortcut this replaced
+ * flattened their tails at the root).
+ */
+static int place_agent(JSON_Object *node, const char *parent_id,
+	JSON_Value *child)
+{
+	JSON_Array *children;
+	size_t i;
+
+	if (strcmp(json_object_get_string(node, "id"), parent_id) == 0) {
+		json_array_append_value(json_value_get_array(
+			json_object_get_value(node, "children")), child);
+		return 1;
+	}
+	children = json_value_get_array(
+		json_object_get_value(node, "children"));
+	for (i = 0; i < json_array_get_count(children); i++) {
+		if (place_agent(json_array_get_object(children, i),
+			    parent_id, child))
+			return 1;
+	}
+	return 0;
+}
+
 struct ev_sink_ctx {
 	char *p;
 	size_t left;
@@ -343,58 +371,13 @@ void retraced_ctl_handle_line(struct retraced_ctl_ctx *ctx,
 
 			if (e->parent_id[0] != '\0') {
 				int placed = 0;
-				/*
-				 * find the parent anywhere under this
-				 * session (the tree is shallow: walk
-				 * roots, then children, one level of
-				 * recursion through a helper below)
-				 */
-				JSON_Array *roots = agents;
 
 				for (k = 0; k < json_array_get_count(
-					     roots) && !placed; k++) {
-					JSON_Object *cand = json_array_get_object(
-						roots, k);
-
-					if (strcmp(json_object_get_string(
-						    cand, "id"),
-						    e->parent_id) == 0) {
-						json_array_append_value(
-							json_value_get_array(
-								json_object_get_value(
-									cand, "children")),
-							av);
-						placed = 1;
-					} else {
-						JSON_Array *grand = json_value_get_array(
-							json_object_get_value(
-								cand,
-								"children"));
-
-						for (size_t g = 0; grand !=
-							NULL && g <
-							json_array_get_count(
-								grand) &&
-							!placed; g++) {
-							JSON_Object *gc =
-								json_array_get_object(
-									grand, g);
-
-							if (strcmp(
-								 json_object_get_string(
-									 gc, "id"),
-								 e->parent_id) ==
-								0) {
-								json_array_append_value(
-									json_value_get_array(
-										json_object_get_value(
-											gc,
-											"children")),
-									av);
-								placed = 1;
-							}
-						}
-					}
+					     agents) && !placed; k++) {
+					placed = place_agent(
+						json_array_get_object(
+							agents, k),
+						e->parent_id, av);
 				}
 				if (!placed)
 					json_array_append_value(agents, av);


### PR DESCRIPTION
## What

Cycle 15's `sessions` command shipped with a shortcut and a comment admitting it: the parent search scanned roots plus one level of grandchildren. A fork chain four deep — trivially common in worker trees and fork-bomb detonations — flattened its tail at the root, the parent visible only in `ps`. The command whose whole point is the tree stopped showing it exactly where trees get interesting.

## The fix

`place_agent(node, parent_id, child)` — one recursive helper, ~15 lines; the ~50 lines of duplicated two-level shape delete. Depth becomes unbounded; arrival-order honesty stays (unplaced ⇒ session root, same as today).

## The test that earns it

Two lessons baked into the unit case:

- **Drive the real binding path.** `retraced_registry_hello` alone does not bind parents — the daemon's frame handler follows HELLO with `retraced_registry_link_parent` (the ppid→parent walk). The test does both, exactly as production does.
- **Parse the reply.** String-order assertions cannot see flattening: a sibling serialized after the subtree keeps parent-precedes-child true while the tree lies. The case parses the JSON and asserts exactly one root agent, then walks the five-deep chain (`root→a→b→c→d`) verifying single-child nesting at every level.

**Failing-case-first, honestly**: the old walker fails this test at `root-count == 2` (c and d flatten); the fix passes. 13/13 in the ctl suite.

Ships as v2.75.0.
