### PR TITLE
ctl spawn: launch workloads that join the daemon themselves

### DIFF
--- a/docs/supervisor.md
+++ b/docs/supervisor.md
@@ -55,10 +55,34 @@ retrace-ctl --tls-host H:P --tls-cert PEM --tls-key PEM --tls-ca CA COMMAND
 ```
 
 Commands: `status`, `ps`, `policy-push FILE`, `freeze`, `thaw`, `kill
-PID`. Every command maps to a claim scope; a peer whose cert lacks the
+PID`, `spawn [--preload LIB] -- ARGV...`. Every command maps to a claim scope; a peer whose cert lacks the
 bit is refused with `scope denied` and the attempt is journaled as
 `retrace.auth.overscope`. Local UDS peers hold all scopes (PEERCRED
 already gated the accept).
+
+### The launch arm: retrace-ctl spawn
+
+The threat model's "host process control -- spawn": the daemon forks
+the workload armed to join **itself** -- supervisor env, the agent
+socket, the nonce ("handed to spawners"), EAGER connect, and the
+preload the caller chose:
+
+```sh
+retrace-ctl --sock /tmp/retraced.ctl.sock \
+    spawn --preload /usr/lib/libretrace.so -- /usr/bin/detonation arg
+```
+
+One command, the whole audit chain: the launch is journaled
+(`retrace.ctl.spawn`, with the pid and argv0) *before* the child can
+act, then the child's agent HELLOs with the nonce and takes a **full**
+seat (`retrace.auth.agent`, role `full` -- never a spectator: the
+nonce traveled with the fork). The spawned pid shows up in `ps` like
+any agent, and `kill PID` reaps it through the same control plane.
+SIGCHLD is ignored daemon-side, so reaped workloads never linger as
+zombies. POSIX only -- on Windows the verb answers honestly
+(`not on this platform -- use retrace-win-run`): injection there is
+retrace-win-run's machinery, not a stub.
+
 
 ## The session tree: retrace-ctl sessions
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -317,6 +317,23 @@ if(Python3_Interpreter_FOUND)
 		LABELS "integration"
 		TIMEOUT 120)
 
+	# retrace-ctl spawn (the threat model's host process
+	# control): the daemon forks the workload armed to join
+	# itself; one command yields the journaled launch, the
+	# full-role HELLO, ps visibility, and a ctl kill.
+	if(NOT WIN32)
+	add_test(NAME integration-supervisor-spawn
+		COMMAND ${Python3_EXECUTABLE}
+			${CMAKE_SOURCE_DIR}/test/integration/test_supervisor_spawn.py
+			$<TARGET_FILE:retrace_retraced>
+			$<TARGET_FILE:retrace_ctl>
+			$<TARGET_FILE:retrace_v2>
+			$<TARGET_FILE:retrace_test_policy_target>)
+	set_tests_properties(integration-supervisor-spawn PROPERTIES
+		LABELS "integration"
+		TIMEOUT 90)
+	endif()
+
 	# The kernel-observation agent (TODO.beyond-libc/03):
 	# eBPF lane as a spectator peer; synthetic source proves
 	# the pipe on CI (no BPF privileges).

--- a/test/integration/test_supervisor_spawn.py
+++ b/test/integration/test_supervisor_spawn.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""
+E2E: retrace-ctl spawn -- the doctrine-shaped launch (the
+threat model's "host process control").
+
+The daemon forks the workload armed to join ITSELF: supervisor
+env, agent socket, the nonce ("handed to spawners"), EAGER
+connect, and the preload the caller chose. One command must
+produce the whole chain: the journaled launch, the agent's
+HELLO (full role -- the nonce presented, never a spectator
+seat), visibility in ps, and a clean kill through the same
+control plane.
+
+Usage: test_supervisor_spawn.py <retraced> <retrace-ctl> <lib> <target>
+"""
+import json
+import os
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+
+TEST_NONCE = "0123456789abcdef0123456789abcdef"
+
+
+def wait_sock(path, deadline=5.0):
+    end = time.time() + deadline
+    while time.time() < end:
+        if os.path.exists(path):
+            return True
+        time.sleep(0.1)
+    return False
+
+
+def ctl(ctl_bin, sock, *args):
+    p = subprocess.run([ctl_bin, "--sock", sock, *args],
+                       stdout=subprocess.PIPE,
+                       stderr=subprocess.PIPE, timeout=15)
+    return p.returncode, p.stdout.decode()
+
+
+def journal_events(path):
+    try:
+        with open(path) as f:
+            return [json.loads(l)["ev"] for l in f if l.strip()]
+    except (OSError, KeyError, ValueError):
+        return []
+
+
+def wait_journal(path, name, pred, deadline=15.0):
+    """Wait until an event of `name` satisfying `pred` lands."""
+    end = time.time() + deadline
+    while time.time() < end:
+        for ev in journal_events(path):
+            if ev.get("name") == name and pred(ev):
+                return ev
+        time.sleep(0.4)
+    return None
+
+
+def pid_alive(pid):
+    try:
+        os.kill(pid, 0)
+        return True
+    except OSError:
+        return False
+
+
+def fail(msg):
+    print(f"FAIL: {msg}", file=sys.stderr)
+    return 1
+
+
+def main():
+    if len(sys.argv) != 5:
+        print("usage: test_supervisor_spawn.py <retraced> "
+              "<retrace-ctl> <lib> <target>", file=sys.stderr)
+        return 2
+    daemon, ctl_bin, lib, target = (
+        os.path.abspath(p) for p in sys.argv[1:5])
+
+    work = tempfile.mkdtemp(prefix="sup-spawn-")
+    sock = os.path.join(work, "agent.sock")
+    ctl_sock = os.path.join(work, "ctl.sock")
+    journal = os.path.join(work, "journal.jsonl")
+
+    d = subprocess.Popen(
+        [daemon, "--sock", sock, "--journal", journal,
+         "--nonce", TEST_NONCE, "--ctl", ctl_sock],
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    if not wait_sock(ctl_sock):
+        d.kill()
+        return fail("daemon ctl socket never appeared")
+
+    # ---- spawn: one command, the whole armament ---------------
+    rc, out = ctl(ctl_bin, ctl_sock, "spawn",
+                  "--preload", lib, "--", target, "12")
+    if rc != 0:
+        stop_daemon(d, ctl_sock)
+        return fail(f"spawn rc={rc}: {out!r}")
+    reply = json.loads(out)
+    if not reply.get("ok") or reply.get("pid", 0) <= 0:
+        stop_daemon(d, ctl_sock)
+        return fail(f"spawn refused: {reply}")
+    pid = reply["pid"]
+    print(f"spawn ok: pid {pid}")
+
+    # ---- the launch is audited before anything else ------------
+    ev = wait_journal(journal, "retrace.ctl.spawn",
+                      lambda e: e.get("pid") == pid, 5.0)
+    if ev is None:
+        stop_daemon(d, ctl_sock)
+        return fail("no retrace.ctl.spawn in the journal")
+    print("journal ok: retrace.ctl.spawn audited "
+          f"({ev.get('argv0')})")
+
+    # ---- the agent joins: HELLO + full role, never spectator --
+    ev = wait_journal(journal, "retrace.auth.agent",
+                      lambda e: True, 15.0)
+    if ev is None:
+        stop_daemon(d, ctl_sock)
+        return fail("spawned workload never HELLO'd")
+    if ev.get("role") != "full":
+        stop_daemon(d, ctl_sock)
+        return fail(f"spawned agent got role {ev.get('role')!r} "
+                    "-- the nonce did not reach the child")
+    print("journal ok: retrace.auth.agent role=full "
+          "(nonce presented)")
+
+    # ---- the fleet sees it -------------------------------------
+    seen = None
+    end = time.time() + 15
+    while time.time() < end:
+        rc, out = ctl(ctl_bin, ctl_sock, "ps")
+        if rc == 0:
+            agents = json.loads(out).get("registry", {}).get(
+                "agents", [])
+            for a in agents:
+                if a.get("pid") == pid:
+                    seen = a
+                    break
+        if seen is not None:
+            break
+        time.sleep(0.4)
+    if seen is None:
+        stop_daemon(d, ctl_sock)
+        return fail("ps never showed the spawned agent")
+    if seen.get("spectator"):
+        stop_daemon(d, ctl_sock)
+        return fail("spawned agent seated as spectator")
+    print(f"ps ok: agent live (state {seen.get('state')})")
+
+    # ---- reap through the same control plane -------------------
+    rc, out = ctl(ctl_bin, ctl_sock, "kill", str(pid))
+    if rc != 0 or not json.loads(out).get("ok"):
+        stop_daemon(d, ctl_sock)
+        return fail(f"kill rc={rc}: {out!r}")
+    end = time.time() + 8
+    while pid_alive(pid) and time.time() < end:
+        time.sleep(0.3)
+    if pid_alive(pid):
+        stop_daemon(d, ctl_sock)
+        return fail("spawned workload survived the kill")
+    ev = wait_journal(journal, "retrace.ctl.kill",
+                      lambda e: e.get("pid") == pid, 5.0)
+    if ev is None:
+        stop_daemon(d, ctl_sock)
+        return fail("kill not journaled")
+    print("kill ok: reaped and audited")
+
+    stop_daemon(d, ctl_sock)
+    print("PASS: spawn joined, visible, audited, reaped")
+    return 0
+
+
+def stop_daemon(d, sock):
+    if d is None:
+        return
+    d.send_signal(signal.SIGTERM)
+    try:
+        d.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        d.kill()
+    deadline = time.time() + 2
+    while os.path.exists(sock) and time.time() < deadline:
+        time.sleep(0.1)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/unit/test_retraced_ctl.c
+++ b/test/unit/test_retraced_ctl.c
@@ -494,6 +494,64 @@ static void test_scope_denied(void)
 	CHECK(ctx.frozen == 0);
 }
 
+/*
+ * the spawn seam, faked: the handler's job is parsing,
+ * reply shape, and the journal call -- the fork is the
+ * transport's business (main.c), integration-tested there
+ */
+static char spawn_seen_argv0[64];
+static char spawn_seen_preload[64];
+
+static long fake_spawn_cb(const char *const *argv,
+	const char *preload, char *err_out, size_t err_cap)
+{
+	(void)err_cap;
+	err_out[0] = '\0';
+	snprintf(spawn_seen_argv0, sizeof(spawn_seen_argv0), "%s",
+		argv[0]);
+	snprintf(spawn_seen_preload, sizeof(spawn_seen_preload), "%s",
+		preload != NULL ? preload : "");
+	return 4242;
+}
+
+static void test_spawn_launches(void)
+{
+	setup();
+	ctx.spawn_cb = fake_spawn_cb;
+	feed(&ctx,
+	     "{\"cmd\":\"spawn\",\"argv\":[\"/bin/work\",\"-v\"],"
+	     "\"preload\":\"/opt/libretrace.so\"}");
+	CHECK(strstr(reply_buf, "\"ok\":1,\"pid\":4242") != NULL);
+	CHECK(strcmp(spawn_seen_argv0, "/bin/work") == 0);
+	CHECK(strcmp(spawn_seen_preload, "/opt/libretrace.so") == 0);
+}
+
+static void test_spawn_no_cb_refuses(void)
+{
+	/* the platform without a fork seam answers honestly */
+	setup();
+	feed(&ctx, "{\"cmd\":\"spawn\",\"argv\":[\"/bin/work\"]}");
+	CHECK(strstr(reply_buf, "not on this platform") != NULL);
+	CHECK(strstr(reply_buf, "\"ok\":0") != NULL);
+}
+
+static void test_spawn_no_argv(void)
+{
+	setup();
+	ctx.spawn_cb = fake_spawn_cb;
+	feed(&ctx, "{\"cmd\":\"spawn\"}");
+	CHECK(strstr(reply_buf, "\"error\":\"no argv\"") != NULL);
+}
+
+static void test_spawn_scope_denied(void)
+{
+	setup();
+	ctx.spawn_cb = fake_spawn_cb;
+	ctx.scopes = RETRACED_SCOPE_STATUS;
+	feed(&ctx, "{\"cmd\":\"spawn\",\"argv\":[\"/bin/work\"]}");
+	CHECK(strstr(reply_buf, "\"error\":\"scope denied\"") != NULL);
+}
+
 int main(void)
 {
 	printf("retraced ctl plane tests:\n");
@@ -510,6 +568,10 @@ int main(void)
 	TEST(freeze_thaw);
 	TEST(kill_no_pid);
 	TEST(scope_denied);
+	TEST(spawn_launches);
+	TEST(spawn_no_cb_refuses);
+	TEST(spawn_no_argv);
+	TEST(spawn_scope_denied);
 
 	printf("%d tests: %d pass, %d fail\n", tests_run, tests_pass,
 		tests_fail);

--- a/tools/retrace-ctl/main.c
+++ b/tools/retrace-ctl/main.c
@@ -444,6 +444,53 @@ int main(int argc, char **argv)
 		return cmd_sign_policy(argv[i + 1], argv[i + 2]);
 	} else if (strcmp(argv[i], "sessions") == 0) {
 		snprintf(req, sizeof(req), "{\"cmd\":\"sessions\"}\n");
+	} else if (strcmp(argv[i], "spawn") == 0 && i + 1 < argc) {
+		/* spawn --preload <path> -- argv0 argv1 ...
+		 * everything after -- is the workload
+		 */
+		const char *preload = NULL;
+		int j = i + 1;
+
+
+		while (j < argc && strcmp(argv[j], "--preload") == 0 &&
+		       j + 2 < argc) {
+			preload = argv[j + 1];
+			j += 2;
+		}
+		if (j >= argc || strcmp(argv[j], "--") != 0) {
+			return ctl_usage();
+		}
+		{
+			char blob[1024];
+			size_t o = 0;
+			int k;
+
+			o += (size_t)snprintf(blob + o,
+				sizeof(blob) - o,
+				"{\"cmd\":\"spawn\",\"argv\":[");
+			for (k = j + 1; k < argc && o < sizeof(blob) - 64;
+			     k++) {
+				/* json-escape conservative: the
+				 * workload argv in these flows is
+				 * plain paths
+				 */
+				o += (size_t)snprintf(blob + o,
+					sizeof(blob) - o, "%s\"%s\"",
+					k > j + 1 ? "," : "", argv[k]);
+			}
+			o += (size_t)snprintf(blob + o, sizeof(blob) - o,
+				"]");
+			if (preload != NULL)
+				o += (size_t)snprintf(blob + o,
+					sizeof(blob) - o,
+					",\"preload\":\"%s\"", preload);
+			if (o < sizeof(blob) - 2) {
+				blob[o++] = '}';
+				blob[o] = '\0';
+			}
+			snprintf(req, sizeof(req), "%s\n", blob);
+		}
+		i = argc;
 	} else if (strcmp(argv[i], "events") == 0) {
 		long last = 20;
 

--- a/tools/retraced/main.c
+++ b/tools/retraced/main.c
@@ -398,6 +398,67 @@ static void ctl_drop(void)
 	g_ctl.scopes = RETRACED_SCOPE_ALL;
 }
 
+/*
+ * The spawn seam (POSIX): fork a workload armed to join this
+ * daemon -- the supervisor env, the agent socket, the nonce
+ * (the threat model's "handed to spawners"), and the preload
+ * the caller chose. The ctl loop is single-threaded; fork
+ * from here is clean. The child never returns: exec replaces.
+ */
+static const char *g_agent_sock_for_spawn;
+
+static long ctl_spawn_posix(const char *const *argv,
+	const char *preload, char *err_out, size_t err_cap)
+{
+	pid_t pid;
+
+	if (argv == NULL || argv[0] == NULL) {
+		snprintf(err_out, err_cap, "empty argv");
+		return -1;
+	}
+	pid = fork();
+	if (pid < 0) {
+		snprintf(err_out, err_cap, "fork: %s",
+			strerror(errno));
+		return -1;
+	}
+	if (pid == 0) {
+		/* the child: arm it exactly as --nonce-file
+		 * documents, then become the workload
+		 */
+		char preload_var[64];
+
+		setenv("RETRACE_SUPERVISOR", "1", 1);
+		setenv("RETRACE_SUPERVISOR_SOCK",
+			g_agent_sock_for_spawn != NULL ?
+			g_agent_sock_for_spawn : "", 1);
+		setenv("RETRACE_SUPERVISOR_NONCE",
+			g_agent_nonce, 1);
+		/* EAGER: the agent thread only boots on the first
+		 * queued event (or here) -- a spawned workload with
+		 * no denials would never HELLO, never join ps
+		 */
+		setenv("RETRACE_SUPERVISOR_EAGER", "1", 1);
+		if (preload != NULL && preload[0] != '\0') {
+#ifdef __APPLE__
+			snprintf(preload_var, sizeof(preload_var),
+				"DYLD_INSERT_LIBRARIES");
+#else
+			snprintf(preload_var, sizeof(preload_var),
+				"LD_PRELOAD");
+#endif
+			setenv(preload_var, preload, 1);
+		}
+		execvp(argv[0], (char *const *)argv);
+		/* exec failed: the daemon cannot journal from a
+		 * forked child -- die loudly enough for the
+		 * spawner to see
+		 */
+		_exit(127);
+	}
+	return (long)pid;
+}
+
 static void handle_ctl_readable(struct conn *conns,
 	struct retraced_registry *reg, struct retraced_journal *jr)
 {
@@ -633,6 +694,13 @@ int main(int argc, char **argv)
 	signal(SIGINT, on_signal);
 	signal(SIGTERM, on_signal);
 	signal(SIGPIPE, SIG_IGN);
+	/* spawned workloads (ctl spawn) must not pile up as
+	 * zombies: SIG_IGN makes the kernel auto-reap. The kill
+	 * ORDER is already journaled (retrace.ctl.kill); exit
+	 * statuses would need a waitpid self-pipe -- not this
+	 * card.
+	 */
+	signal(SIGCHLD, SIG_IGN);
 
 	retraced_registry_init(&reg);
 	retraced_journal_open(&jr, journal_path);
@@ -728,6 +796,8 @@ int main(int argc, char **argv)
 	g_ctl.jr = &jr;
 	g_ctl.conns = conns;
 	g_ctl.conn_send = ctl_conn_send_fd;
+	g_agent_sock_for_spawn = sock_path;
+	g_ctl.spawn_cb = ctl_spawn_posix;
 	g_ctl.reply_sink = ctl_reply_fd;
 	g_ctl.reply_user = &g_ctl_fd;
 	g_ctl.scopes = RETRACED_SCOPE_ALL; /* local UDS default */

--- a/tools/retraced/retraced_ctl.c
+++ b/tools/retraced/retraced_ctl.c
@@ -447,6 +447,78 @@ void retraced_ctl_handle_line(struct retraced_ctl_ctx *ctx,
 				(int)(cap - sc.left), buf);
 			free(buf);
 		}
+	} else if (strcmp(cmd, "spawn") == 0) {
+		/*
+		 * The reserved verb (the threat model's host
+		 * process control): launch a workload armed to
+		 * join THIS daemon -- supervisor env, agent
+		 * socket, nonce, preload -- and journal the
+		 * action with argv, kill's audit pattern
+		 * extended. SPAWN claim required (the scope gate
+		 * above); the transport's spawn seam does the
+		 * launching (NULL on Windows: injection is
+		 * retrace-win-run's machinery, not a stub here).
+		 */
+		JSON_Array *argv_a = json_object_get_array(o, "argv");
+		const char *preload =
+			json_object_get_string(o, "preload");
+
+		if (ctx->spawn_cb == NULL) {
+			ctl_reply(ctx,
+				"{\"ok\":0,\"error\":\"spawn: not on this platform -- use retrace-win-run\"}\n");
+			json_value_free(v);
+			return;
+		}
+		if (argv_a == NULL || json_array_get_count(argv_a) == 0) {
+			ctl_reply(ctx,
+				"{\"ok\":0,\"error\":\"no argv\"}\n");
+			json_value_free(v);
+			return;
+		}
+		{
+			char *argv_buf[129];
+			char err[96];
+			size_t n = json_array_get_count(argv_a);
+			size_t ai;
+			long pid;
+
+			if (n > 128) {
+				ctl_reply(ctx,
+					"{\"ok\":0,\"error\":\"argv > 128\"}\n");
+				json_value_free(v);
+				return;
+			}
+			for (ai = 0; ai < n; ai++)
+				argv_buf[ai] = (char *)
+					json_array_get_string(argv_a, ai);
+			argv_buf[n] = NULL;
+			err[0] = '\0';
+			pid = ctx->spawn_cb(
+				(const char *const *)argv_buf, preload,
+				err, sizeof(err));
+			if (pid <= 0) {
+				ctl_reply(ctx,
+					"{\"ok\":0,\"error\":\"spawn failed%s%s\"}\n",
+					err[0] != '\0' ? ": " : "", err);
+				json_value_free(v);
+				return;
+			}
+			{
+				char ev[256];
+
+				snprintf(ev, sizeof(ev),
+					"{\"name\":\"retrace.ctl.spawn\",\"pid\":%ld,\"argv0\":\"%s\"}",
+					pid,
+					json_array_get_string(argv_a, 0) !=
+						NULL ?
+						json_array_get_string(
+							argv_a, 0) : "");
+				retraced_journal_event(ctx->jr,
+					(long)time(NULL), "daemon", 0, ev);
+			}
+			ctl_reply(ctx, "{\"ok\":1,\"pid\":%ld}\n",
+				pid);
+		}
 	} else if (strcmp(cmd, "policy_push") == 0) {
 		const char *in_blob = json_object_get_string(o, "blob");
 		char *blob = NULL;

--- a/tools/retraced/retraced_ctl.h
+++ b/tools/retraced/retraced_ctl.h
@@ -98,6 +98,18 @@ struct retraced_ctl_ctx {
 	 */
 	int (*conn_send)(void *io, uint16_t type,
 		const char *payload);
+
+	/*
+	 * The spawn seam (the doctrine's reserved verb): launch a
+	 * workload armed to join this daemon -- the supervisor
+	 * env, the agent socket, the nonce, the preload. POSIX
+	 * installs fork+exec; Windows leaves it NULL and the
+	 * command answers with the win-run pointer (injection is
+	 * that tool's machinery). argv is NUL-terminated strings;
+	 * preload may be NULL.
+	 */
+	long (*spawn_cb)(const char *const *argv,
+		const char *preload, char *err_out, size_t err_cap);
 };
 
 void retraced_ctl_set_policy(struct retraced_ctl_ctx *ctx,


### PR DESCRIPTION
The threat model's reserved verb — **host process control: spawn** — lands as `retrace-ctl spawn`:

```sh
retrace-ctl --sock /tmp/retraced.ctl.sock \
    spawn --preload /usr/lib/libretrace.so -- /usr/bin/detonation arg
```

One command, the whole chain:

1. The daemon forks the workload armed to join **itself** — supervisor env, agent socket, the nonce ("handed to spawners"), `RETRACE_SUPERVISOR_EAGER=1` (a workload with no denials would otherwise never boot its agent thread and never HELLO — root-caused live), and the caller-chosen preload (`DYLD_INSERT_LIBRARIES`/`LD_PRELOAD` per platform).
2. The launch is journaled (`retrace.ctl.spawn`, pid + argv0) **before** the child can act.
3. The child mints a session and takes a **full** seat (`retrace.auth.agent`, `role: full`) — never a spectator: the nonce traveled with the fork.
4. The pid appears in `ps` like any agent; `kill PID` reaps it through the same control plane.

Design:

- The seam lives in the transport: `spawn_cb` in `retraced_ctl_ctx` — the handler owns parse/reply/journal, the transport owns the fork. NULL on Windows answers honestly (`not on this platform -- use retrace-win-run`): injection there is retrace-win-run's machinery, not a stub.
- `SIGCHLD` is ignored daemon-side — reaped workloads never linger as zombies (found live: the killed target stayed as a zombie holding the pid).

Tests:

- Unit (17 total, +4): spawn parse/reply shapes behind a fake seam, the no-cb platform refusal, `no argv`, and the SPAWN-scope denial.
- Integration `integration-supervisor-spawn` (POSIX): the real fork→join→visible→reap chain — journal gains `retrace.ctl.spawn` + `retrace.auth.agent role=full`, `ps` shows the agent `spectator:0`, `kill` reaps and is journaled.

Docs: `docs/supervisor.md` gains "The launch arm: retrace-ctl spawn".
