### PR TITLE
ctl verbs: the X-macro table -- one list, every surface derives

### DIFF
--- a/test/unit/test_retraced_ctl.c
+++ b/test/unit/test_retraced_ctl.c
@@ -36,6 +36,7 @@
 #include <stdlib.h>
 
 #include "retraced_ctl.h"
+#include "ctl_verbs.h"
 #include "parson.h"
 #include "tls_gate.h"
 
@@ -552,6 +553,26 @@ static void test_spawn_scope_denied(void)
 	CHECK(strstr(reply_buf, "\"error\":\"scope denied\"") != NULL);
 }
 
+/*
+ * Table conformance: the SSOT list expanded here -- every verb
+ * must carry a nonzero claim scope (a zero-scope row would
+ * silently grant nothing to every cert) and must ANSWER (a
+ * verb that falls through to "unknown cmd" is a list/handler
+ * drift; the handler-less row is a compile error, this catches
+ * the rest)
+ */
+static void test_verb_table_conformance(void)
+{
+#define VERB_PROBE(n, c, s, a, h)					      \
+	setup();							      \
+	feed(&ctx, "{\"cmd\":\"" #n "\"}");				      \
+	CHECK(strstr(reply_buf, "unknown cmd") == NULL);		      \
+	CHECK(retraced_tls_scope_for_cmd(#n) != 0);
+
+	RETRACED_CTL_VERBS(VERB_PROBE)
+#undef VERB_PROBE
+}
+
 int main(void)
 {
 	printf("retraced ctl plane tests:\n");
@@ -572,6 +593,7 @@ int main(void)
 	TEST(spawn_no_cb_refuses);
 	TEST(spawn_no_argv);
 	TEST(spawn_scope_denied);
+	TEST(verb_table_conformance);
 
 	printf("%d tests: %d pass, %d fail\n", tests_run, tests_pass,
 		tests_fail);

--- a/tools/retrace-ctl/main.c
+++ b/tools/retrace-ctl/main.c
@@ -48,6 +48,7 @@
 #endif
 
 #include "../retraced/tls_gate.h"
+#include "../retraced/ctl_verbs.h"
 
 #ifdef RETRACE_HAVE_OPENSSL
 #include <openssl/evp.h>
@@ -356,16 +357,20 @@ static int cmd_sign_policy(const char *file, const char *key_path)
 
 static int ctl_usage(void)
 {
+	/* the verb lines derive from the same SSOT list the
+	 * daemon dispatches on (ctl_verbs.h) -- the usage can no
+	 * longer drift behind the verb surface
+	 */
+#define USAGE_LINE(n, c, s, a, h)					      \
+	fprintf(stderr, "  %-14s%-26s%s\n", #c, a, h);
+
 	fprintf(stderr,
 		"usage: retrace-ctl [--sock PATH] COMMAND\n"
 		"       retrace-ctl --tls-host H:P --tls-cert C --tls-key K\n"
-		"                   --tls-ca CA COMMAND\n"
-		"  status                 daemon info, agent count\n"
-		"  ps                     registry table (JSON)\n"
-		"  policy-push FILE       push a policy to all agents\n"
-		"  freeze                 hold every agent (wildcard freeze)\n"
-		"  thaw                   restore the pre-freeze policy\n"
-		"  kill PID               SIGTERM one target\n"
+		"                   --tls-ca CA COMMAND\n");
+	RETRACED_CTL_VERBS(USAGE_LINE)
+#undef USAGE_LINE
+	fprintf(stderr,
 		"  sign-policy FILE KEY   emit a signed wrapper to stdout\n"
 		"  --tls-*: fleet mTLS (all four required together)\n");
 	return 2;

--- a/tools/retraced/ctl_verbs.h
+++ b/tools/retraced/ctl_verbs.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+#ifndef RETRACE_TOOLS_CTL_VERBS_H_
+#define RETRACE_TOOLS_CTL_VERBS_H_
+
+/*
+ * The control-plane verb list -- the SSOT every surface derives
+ * from (the X-macro idiom the protocol table set): the daemon's
+ * dispatch table and scope gate expand this list, and the CLI
+ * prints its usage from the same rows. A verb is one line here
+ * plus one handler function; nothing else enumerates names.
+ *
+ * Fields: (wire name, CLI name, scope suffix, args, help).
+ * The scope suffix concatenates with RETRACED_SCOPE_ (tls_gate.h).
+ * CLI-only commands (sign-policy) that never round-trip the
+ * daemon stay off this list.
+ */
+#define RETRACED_CTL_VERBS(X)					      \
+	X(status, status, STATUS, "",				      \
+	  "daemon info, agent count")				      \
+	X(ps, ps, PS, "",					      \
+	  "registry table (JSON)")				      \
+	X(sessions, sessions, PS, "",				      \
+	  "the session tree (nested JSON)")			      \
+	X(events, events, STATUS, "[--last N]",		      \
+	  "journal tail + chain verdict")			      \
+	X(policy_push, policy-push, POLICY, "FILE",		      \
+	  "push a policy to all agents")			      \
+	X(freeze, freeze, POLICY, "",				      \
+	  "hold every agent (wildcard freeze)")		      \
+	X(thaw, thaw, POLICY, "",				      \
+	  "restore the pre-freeze policy")			      \
+	X(kill, kill, KILL, "PID",				      \
+	  "SIGTERM one target")				      \
+	X(spawn, spawn, SPAWN, "--preload LIB -- ARGV...",	      \
+	  "launch a workload that joins this daemon")
+
+#endif /* RETRACE_TOOLS_CTL_VERBS_H_ */

--- a/tools/retraced/retraced_ctl.c
+++ b/tools/retraced/retraced_ctl.c
@@ -48,6 +48,7 @@
 #endif
 
 #include "retraced_ctl.h"
+#include "ctl_verbs.h"
 #include "tls_gate.h"
 #include "parson.h"
 
@@ -144,25 +145,49 @@ static void ctl_reply(struct retraced_ctl_ctx *ctx,
 		ctx->reply_sink(out, ctx->reply_user);
 }
 
+/*
+ * The verb table: the SSOT list (ctl_verbs.h) expands to name,
+ * scope, and handler -- dispatch, the scope gate, and the CLI
+ * usage all derive from the same rows (the X-macro idiom the
+ * protocol table set). A verb is one list line plus one
+ * handler; nothing else enumerates names.
+ */
+struct retraced_ctl_verb {
+	const char *name;
+	uint32_t scope;
+	void (*fn)(struct retraced_ctl_ctx *ctx, JSON_Object *o);
+};
+
+#define VERB_FWD(n, c, s, a, h)					      \
+	static void verb_##n(struct retraced_ctl_ctx *ctx,	      \
+		JSON_Object *o);
+RETRACED_CTL_VERBS(VERB_FWD)
+
+#define VERB_ROW(n, c, s, a, h)					      \
+	{ #n, RETRACED_SCOPE_##s, verb_##n },
+static const struct retraced_ctl_verb ctl_verbs[] = {
+	RETRACED_CTL_VERBS(VERB_ROW)
+};
+
+static const struct retraced_ctl_verb *ctl_verb_find(
+	const char *name)
+{
+	size_t i;
+
+	for (i = 0; i < sizeof(ctl_verbs) / sizeof(ctl_verbs[0]);
+	     i++) {
+		if (strcmp(ctl_verbs[i].name, name) == 0)
+			return &ctl_verbs[i];
+	}
+	return NULL;
+}
+
 uint32_t retraced_tls_scope_for_cmd(const char *cmd)
 {
-	if (cmd == NULL)
-		return 0;
-	if (strcmp(cmd, "status") == 0)
-		return RETRACED_SCOPE_STATUS;
-	if (strcmp(cmd, "status") == 0 || strcmp(cmd, "events") == 0)
-		return RETRACED_SCOPE_STATUS;
-	if (strcmp(cmd, "ps") == 0 || strcmp(cmd, "sessions") == 0)
-		return RETRACED_SCOPE_PS;
-	if (strcmp(cmd, "policy_push") == 0 ||
-	    strcmp(cmd, "freeze") == 0 ||
-	    strcmp(cmd, "thaw") == 0)
-		return RETRACED_SCOPE_POLICY;
-	if (strcmp(cmd, "kill") == 0)
-		return RETRACED_SCOPE_KILL;
-	if (strcmp(cmd, "spawn") == 0)
-		return RETRACED_SCOPE_SPAWN;
-	return 0;
+	const struct retraced_ctl_verb *vb = cmd != NULL ?
+		ctl_verb_find(cmd) : NULL;
+
+	return vb != NULL ? vb->scope : 0;
 }
 
 /*
@@ -223,6 +248,7 @@ void retraced_ctl_handle_line(struct retraced_ctl_ctx *ctx,
 	JSON_Value *v = json_parse_string(line);
 	JSON_Object *o;
 	const char *cmd;
+	const struct retraced_ctl_verb *vb;
 
 	if (v == NULL) {
 		ctl_reply(ctx, "{\"ok\":0,\"error\":\"malformed json\"}\n");
@@ -235,424 +261,445 @@ void retraced_ctl_handle_line(struct retraced_ctl_ctx *ctx,
 		json_value_free(v);
 		return;
 	}
+	vb = ctl_verb_find(cmd);
+	if (vb == NULL) {
+		ctl_reply(ctx, "{\"ok\":0,\"error\":\"unknown cmd\"}\n");
+		json_value_free(v);
+		return;
+	}
 	/*
-	 * Scope gate (TODO.supervisor/08 P1): every command maps
-	 * to a claim bit; a TLS peer whose cert URI SAN does not
-	 * carry it is refused + journaled. Local UDS peers hold
+	 * Scope gate (TODO.supervisor/08 P1): the table carries
+	 * each verb's claim bit; a peer whose cert lacks it is
+	 * refused + journaled. Local UDS peers hold
 	 * RETRACED_SCOPE_ALL (set at accept).
 	 */
-	{
-		uint32_t need = retraced_tls_scope_for_cmd(cmd);
+	if ((ctx->scopes & vb->scope) != vb->scope) {
+		char ev[160];
 
-		if (need == 0) {
-			ctl_reply(ctx, "{\"ok\":0,\"error\":\"unknown cmd\"}\n");
-			json_value_free(v);
-			return;
-		}
-		if ((ctx->scopes & need) != need) {
-			char ev[160];
-
-			snprintf(ev, sizeof(ev),
-				"{\"name\":\"retrace.auth.overscope\",\"cmd\":\"%s\",\"have\":%u,\"need\":%u}",
-				cmd, (unsigned int)ctx->scopes, (unsigned int)need);
-			retraced_journal_event(ctx->jr, (long)time(NULL),
-				"daemon", 0, ev);
-			ctl_reply(ctx,
-				"{\"ok\":0,\"error\":\"scope denied\"}\n");
-			json_value_free(v);
-			return;
-		}
+		snprintf(ev, sizeof(ev),
+			"{\"name\":\"retrace.auth.overscope\",\"cmd\":\"%s\",\"have\":%u,\"need\":%u}",
+			cmd, (unsigned int)ctx->scopes,
+			(unsigned int)vb->scope);
+		retraced_journal_event(ctx->jr, (long)time(NULL),
+			"daemon", 0, ev);
+		ctl_reply(ctx, "{\"ok\":0,\"error\":\"scope denied\"}\n");
+		json_value_free(v);
+		return;
 	}
-	if (strcmp(cmd, "status") == 0) {
-		ctl_reply(ctx, "{\"ok\":1,\"pid\":%ld,\"agents\":%zu,"
-			"\"policy_epoch\":%ld,\"frozen\":%d}\n",
-			(long)getpid(), ctx->reg->count, ctx->policy_epoch,
-			ctx->frozen);
-	} else if (strcmp(cmd, "ps") == 0) {
-		JSON_Value *snap = retraced_registry_to_json(ctx->reg);
-		char *s = json_serialize_to_string(snap);
-
-		ctl_reply(ctx, "{\"ok\":1,\"registry\":%s}\n",
-			s != NULL ? s : "null");
-		json_free_serialized_string(s);
-		json_value_free(snap);
-	} else if (strcmp(cmd, "sessions") == 0) {
-		/*
-		 * The session tree: the registry already carries
-		 * it (session token, parent agent id, spectator
-		 * seats) -- ps prints it flat and the operator
-		 * re-nests by eye. Group once, here: per session
-		 * token, agents nested by parent, spectators and
-		 * parent-holes marked. Pure transform of the same
-		 * data ps serializes.
-		 */
-		JSON_Value *root = json_value_init_object();
-		JSON_Object *root_o = json_value_get_object(root);
-		JSON_Value *sessions_val = json_value_init_array();
-		JSON_Array *sessions =
-			json_value_get_array(sessions_val);
-		size_t i, k;
-
-		/* one pass: collect the distinct session tokens */
-		for (i = 0; i < ctx->reg->count; i++) {
-			const struct agent_entry *e =
-				&ctx->reg->agents[i];
-			int seen = 0;
-
-			for (k = 0; k < json_array_get_count(sessions);
-			     k++) {
-				const char *tok = json_object_get_string(
-					json_array_get_object(sessions, k),
-					"token");
-
-				if (tok != NULL &&
-				    strcmp(tok, e->session) == 0) {
-					seen = 1;
-					break;
-				}
-			}
-			if (!seen) {
-				JSON_Value *sv = json_value_init_object();
-
-				json_object_set_string(
-					json_value_get_object(sv),
-					"token", e->session);
-				json_object_set_value(
-					json_value_get_object(sv),
-					"agents", json_value_init_array());
-				json_array_append_value(sessions, sv);
-			}
-		}
-
-		/*
-		 * nest each agent under its session, parents first
-		 * (the registry appends in arrival order; a parent
-		 * HELLOs before its fork children in practice, and a
-		 * child whose parent is not yet present nests at the
-		 * root with parent_hole marked -- the same honesty
-		 * the journal carries)
-		 */
-		for (i = 0; i < ctx->reg->count; i++) {
-			struct agent_entry *e = &ctx->reg->agents[i];
-			JSON_Object *sess = NULL;
-			JSON_Array *agents = NULL;
-			JSON_Value *av = json_value_init_object();
-			JSON_Object *ao = json_value_get_object(av);
-
-			for (k = 0; k < json_array_get_count(sessions);
-			     k++) {
-				JSON_Object *cand = json_array_get_object(
-					sessions, k);
-
-				if (strcmp(json_object_get_string(cand,
-					    "token"), e->session) == 0) {
-					sess = cand;
-					break;
-				}
-			}
-			if (sess == NULL) {
-				json_value_free(av);
-				continue;
-			}
-			agents = json_value_get_array(
-				json_object_get_value(sess, "agents"));
-
-			json_object_set_string(ao, "id", e->id);
-			json_object_set_string(ao, "cmdline",
-				e->cmdline);
-			json_object_set_number(ao, "pid", (double)e->pid);
-			json_object_set_number(ao, "spectator",
-				(double)e->spectator);
-			if (e->parent_hole)
-				json_object_set_number(ao,
-					"parent_hole", 1);
-			json_object_set_value(ao, "children",
-				json_value_init_array());
-
-			if (e->parent_id[0] != '\0') {
-				int placed = 0;
-
-				for (k = 0; k < json_array_get_count(
-					     agents) && !placed; k++) {
-					placed = place_agent(
-						json_array_get_object(
-							agents, k),
-						e->parent_id, av);
-				}
-				if (!placed)
-					json_array_append_value(agents, av);
-			} else {
-				json_array_append_value(agents, av);
-			}
-		}
-
-		json_object_set_number(root_o, "ok", 1);
-		json_object_set_number(root_o, "sessions_count",
-			(double)json_array_get_count(sessions));
-		json_object_set_value(root_o, "sessions", sessions_val);
-		{
-			char *s = json_serialize_to_string(root);
-
-			ctl_reply(ctx, "%s\n", s != NULL ? s : "{}");
-			json_free_serialized_string(s);
-		}
-		json_value_free(root);
-	} else if (strcmp(cmd, "events") == 0) {
-		/*
-		 * The evidence read arm: the journal's last records,
-		 * chain verdict riding the reply -- evidence pulled
-		 * over a network carries its own integrity statement.
-		 * last is bounded (<=128, default 20). Observe-only:
-		 * the STATUS claim, the least-privilege scope an
-		 * auditor's certificate needs.
-		 */
-		double last_d = json_object_get_number(o, "last");
-		size_t last_n = last_d > 0 ? (size_t)last_d : 20;
-		long chain = 0;
-		int emitted = 0;
-
-		if (last_n > 128) {
-			ctl_reply(ctx,
-				"{\"ok\":0,\"error\":\"last > 128\"}\n");
-			json_value_free(v);
-			return;
-		}
-		{
-			char *buf;
-			size_t cap = (size_t)emitted * 2100 + 64;
-			struct ev_sink_ctx {
-				char *p;
-				size_t left;
-				int first;
-			} sc;
-			int n;
-
-			buf = (char *)malloc(cap);
-			if (buf == NULL) {
-				ctl_reply(ctx,
-					"{\"ok\":0,\"error\":\"oom\"}\n");
-				json_value_free(v);
-				return;
-			}
-			sc.p = buf;
-			sc.left = cap;
-			sc.first = 1;
-			n = retraced_journal_tail(ctx->jr, last_n,
-				ev_sink_append, &sc, &chain);
-			(void)n;
-			ctl_reply(ctx,
-				"{\"ok\":1,\"chain\":\"%s\",\"broken_at\":%ld,\"events\":[%.*s]}\n",
-				chain == 0 ? "verified" : "broken",
-				chain,
-				(int)(cap - sc.left), buf);
-			free(buf);
-		}
-	} else if (strcmp(cmd, "spawn") == 0) {
-		/*
-		 * The reserved verb (the threat model's host
-		 * process control): launch a workload armed to
-		 * join THIS daemon -- supervisor env, agent
-		 * socket, nonce, preload -- and journal the
-		 * action with argv, kill's audit pattern
-		 * extended. SPAWN claim required (the scope gate
-		 * above); the transport's spawn seam does the
-		 * launching (NULL on Windows: injection is
-		 * retrace-win-run's machinery, not a stub here).
-		 */
-		JSON_Array *argv_a = json_object_get_array(o, "argv");
-		const char *preload =
-			json_object_get_string(o, "preload");
-
-		if (ctx->spawn_cb == NULL) {
-			ctl_reply(ctx,
-				"{\"ok\":0,\"error\":\"spawn: not on this platform -- use retrace-win-run\"}\n");
-			json_value_free(v);
-			return;
-		}
-		if (argv_a == NULL || json_array_get_count(argv_a) == 0) {
-			ctl_reply(ctx,
-				"{\"ok\":0,\"error\":\"no argv\"}\n");
-			json_value_free(v);
-			return;
-		}
-		{
-			char *argv_buf[129];
-			char err[96];
-			size_t n = json_array_get_count(argv_a);
-			size_t ai;
-			long pid;
-
-			if (n > 128) {
-				ctl_reply(ctx,
-					"{\"ok\":0,\"error\":\"argv > 128\"}\n");
-				json_value_free(v);
-				return;
-			}
-			for (ai = 0; ai < n; ai++)
-				argv_buf[ai] = (char *)
-					json_array_get_string(argv_a, ai);
-			argv_buf[n] = NULL;
-			err[0] = '\0';
-			pid = ctx->spawn_cb(
-				(const char *const *)argv_buf, preload,
-				err, sizeof(err));
-			if (pid <= 0) {
-				ctl_reply(ctx,
-					"{\"ok\":0,\"error\":\"spawn failed%s%s\"}\n",
-					err[0] != '\0' ? ": " : "", err);
-				json_value_free(v);
-				return;
-			}
-			{
-				char ev[256];
-
-				snprintf(ev, sizeof(ev),
-					"{\"name\":\"retrace.ctl.spawn\",\"pid\":%ld,\"argv0\":\"%s\"}",
-					pid,
-					json_array_get_string(argv_a, 0) !=
-						NULL ?
-						json_array_get_string(
-							argv_a, 0) : "");
-				retraced_journal_event(ctx->jr,
-					(long)time(NULL), "daemon", 0, ev);
-			}
-			ctl_reply(ctx, "{\"ok\":1,\"pid\":%ld}\n",
-				pid);
-		}
-	} else if (strcmp(cmd, "policy_push") == 0) {
-		const char *in_blob = json_object_get_string(o, "blob");
-		char *blob = NULL;
-		long epoch = 0;
-		int pushed;
-
-		if (in_blob == NULL) {
-			ctl_reply(ctx, "{\"ok\":0,\"error\":\"no blob\"}\n");
-			json_value_free(v);
-			return;
-		}
-		if (retraced_policy_load(in_blob, &blob, &epoch) != 0) {
-			ctl_reply(ctx, "{\"ok\":0,\"error\":\"bad policy"
-				" (need policy.epoch + scripts)\"}\n");
-			json_value_free(v);
-			return;
-		}
-		retraced_ctl_set_policy(ctx, blob, epoch);
-		ctx->frozen = 0;
-		free(ctx->thaw_blob);
-		ctx->thaw_blob = strdup(blob);
-		pushed = retraced_ctl_push_policy(ctx, blob);
-		{
-			char ev[160];
-
-			snprintf(ev, sizeof(ev),
-				"{\"name\":\"retrace.policy.pushed\",\"epoch\":%ld,\"agents\":%d}",
-				epoch, pushed);
-			retraced_journal_event(ctx->jr, (long)time(NULL),
-				"daemon", 0, ev);
-		}
-		ctl_reply(ctx, "{\"ok\":1,\"epoch\":%ld,\"pushed\":%d}\n",
-			epoch, pushed);
-		free(blob);
-	} else if (strcmp(cmd, "freeze") == 0) {
-		char blob[256];
-		long epoch = ctx->policy_epoch + 1;
-		int pushed;
-
-		snprintf(blob, sizeof(blob),
-			"{\"policy\":{\"epoch\":%ld},"
-			"\"intercept_scripts\":[{\"func_name\":\"*\","
-			"\"actions\":[{\"action_name\":\"freeze\"}]}]}",
-			epoch);
-		retraced_ctl_set_policy(ctx, blob, epoch);
-		ctx->frozen = 1;
-		pushed = retraced_ctl_push_policy(ctx, blob);
-		{
-			char ev[128];
-
-			snprintf(ev, sizeof(ev),
-				"{\"name\":\"retrace.policy.freeze\",\"epoch\":%ld,\"agents\":%d}",
-				epoch, pushed);
-			retraced_journal_event(ctx->jr, (long)time(NULL),
-				"daemon", 0, ev);
-		}
-		ctl_reply(ctx, "{\"ok\":1,\"epoch\":%ld,\"pushed\":%d}\n",
-			epoch, pushed);
-	} else if (strcmp(cmd, "thaw") == 0) {
-		long epoch = ctx->policy_epoch + 1;
-		char thawed[8192];
-		const char *src = ctx->thaw_blob != NULL ? ctx->thaw_blob :
-			"{\"policy\":{\"epoch\":1},\"intercept_scripts\":[]}";
-		JSON_Value *tv = json_parse_string(src);
-		int pushed;
-
-		/* re-stamp the saved policy at a fresh epoch: agents
-		 * only ever accept strictly-greater epochs
-		 */
-		if (tv != NULL) {
-			JSON_Object *troot = json_value_get_object(tv);
-			JSON_Object *tpo = json_object_get_object(troot,
-				"policy");
-
-			if (tpo != NULL)
-				json_object_set_number(tpo, "epoch",
-					(double)epoch);
-		}
-		{
-			char *s = json_serialize_to_string(tv);
-
-			snprintf(thawed, sizeof(thawed), "%s",
-				s != NULL ? s : src);
-			json_free_serialized_string(s);
-		}
-		json_value_free(tv);
-		retraced_ctl_set_policy(ctx, thawed, epoch);
-		ctx->frozen = 0;
-		pushed = retraced_ctl_push_policy(ctx, thawed);
-		{
-			char ev[128];
-
-			snprintf(ev, sizeof(ev),
-				"{\"name\":\"retrace.policy.thaw\",\"epoch\":%ld,\"agents\":%d}",
-				epoch, pushed);
-			retraced_journal_event(ctx->jr, (long)time(NULL),
-				"daemon", 0, ev);
-		}
-		ctl_reply(ctx, "{\"ok\":1,\"epoch\":%ld,\"pushed\":%d}\n",
-			epoch, pushed);
-	} else if (strcmp(cmd, "kill") == 0) {
-		long pid = (long)json_object_get_number(o, "pid");
-
-		if (pid <= 0) {
-			ctl_reply(ctx, "{\"ok\":0,\"error\":\"no pid\"}\n");
-			json_value_free(v);
-			return;
-		}
-#ifdef _WIN32
-		{
-			HANDLE h = OpenProcess(PROCESS_TERMINATE,
-				FALSE, (DWORD)pid);
-
-			if (h != NULL) {
-				TerminateProcess(h, 1);
-				CloseHandle(h);
-			}
-		}
-#else
-		kill((pid_t)pid, SIGTERM);
-#endif
-		{
-			char ev[128];
-
-			snprintf(ev, sizeof(ev),
-				"{\"name\":\"retrace.ctl.kill\",\"pid\":%ld}",
-				pid);
-			retraced_journal_event(ctx->jr, (long)time(NULL),
-				"daemon", 0, ev);
-		}
-		ctl_reply(ctx, "{\"ok\":1,\"pid\":%ld}\n", pid);
-	} else {
-		ctl_reply(ctx, "{\"ok\":0,\"error\":\"unknown cmd\"}\n");
-	}
+	/* the dispatcher owns the parse tree: handlers reply and
+	 * return; every path frees exactly once, here
+	 */
+	vb->fn(ctx, o);
 	json_value_free(v);
+}
+
+static void verb_status(struct retraced_ctl_ctx *ctx,
+	JSON_Object *o)
+{
+
+	ctl_reply(ctx, "{\"ok\":1,\"pid\":%ld,\"agents\":%zu,"
+		"\"policy_epoch\":%ld,\"frozen\":%d}\n",
+		(long)getpid(), ctx->reg->count, ctx->policy_epoch,
+		ctx->frozen);
+}
+
+static void verb_ps(struct retraced_ctl_ctx *ctx,
+	JSON_Object *o)
+{
+	JSON_Value *snap = retraced_registry_to_json(ctx->reg);
+	char *s = json_serialize_to_string(snap);
+
+	ctl_reply(ctx, "{\"ok\":1,\"registry\":%s}\n",
+		s != NULL ? s : "null");
+	json_free_serialized_string(s);
+	json_value_free(snap);
+}
+
+static void verb_sessions(struct retraced_ctl_ctx *ctx,
+	JSON_Object *o)
+{
+	/*
+	 * The session tree: the registry already carries
+	 * it (session token, parent agent id, spectator
+	 * seats) -- ps prints it flat and the operator
+	 * re-nests by eye. Group once, here: per session
+	 * token, agents nested by parent, spectators and
+	 * parent-holes marked. Pure transform of the same
+	 * data ps serializes.
+	 */
+	JSON_Value *root = json_value_init_object();
+	JSON_Object *root_o = json_value_get_object(root);
+	JSON_Value *sessions_val = json_value_init_array();
+	JSON_Array *sessions =
+		json_value_get_array(sessions_val);
+	size_t i, k;
+
+	/* one pass: collect the distinct session tokens */
+	for (i = 0; i < ctx->reg->count; i++) {
+		const struct agent_entry *e =
+			&ctx->reg->agents[i];
+		int seen = 0;
+
+		for (k = 0; k < json_array_get_count(sessions);
+		     k++) {
+			const char *tok = json_object_get_string(
+				json_array_get_object(sessions, k),
+				"token");
+
+			if (tok != NULL &&
+			    strcmp(tok, e->session) == 0) {
+				seen = 1;
+				break;
+			}
+		}
+		if (!seen) {
+			JSON_Value *sv = json_value_init_object();
+
+			json_object_set_string(
+				json_value_get_object(sv),
+				"token", e->session);
+			json_object_set_value(
+				json_value_get_object(sv),
+				"agents", json_value_init_array());
+			json_array_append_value(sessions, sv);
+		}
+	}
+
+	/*
+	 * nest each agent under its session, parents first
+	 * (the registry appends in arrival order; a parent
+	 * HELLOs before its fork children in practice, and a
+	 * child whose parent is not yet present nests at the
+	 * root with parent_hole marked -- the same honesty
+	 * the journal carries)
+	 */
+	for (i = 0; i < ctx->reg->count; i++) {
+		struct agent_entry *e = &ctx->reg->agents[i];
+		JSON_Object *sess = NULL;
+		JSON_Array *agents = NULL;
+		JSON_Value *av = json_value_init_object();
+		JSON_Object *ao = json_value_get_object(av);
+
+		for (k = 0; k < json_array_get_count(sessions);
+		     k++) {
+			JSON_Object *cand = json_array_get_object(
+				sessions, k);
+
+			if (strcmp(json_object_get_string(cand,
+				    "token"), e->session) == 0) {
+				sess = cand;
+				break;
+			}
+		}
+		if (sess == NULL) {
+			json_value_free(av);
+			continue;
+		}
+		agents = json_value_get_array(
+			json_object_get_value(sess, "agents"));
+
+		json_object_set_string(ao, "id", e->id);
+		json_object_set_string(ao, "cmdline",
+			e->cmdline);
+		json_object_set_number(ao, "pid", (double)e->pid);
+		json_object_set_number(ao, "spectator",
+			(double)e->spectator);
+		if (e->parent_hole)
+			json_object_set_number(ao,
+				"parent_hole", 1);
+		json_object_set_value(ao, "children",
+			json_value_init_array());
+
+		if (e->parent_id[0] != '\0') {
+			int placed = 0;
+
+			for (k = 0; k < json_array_get_count(
+				     agents) && !placed; k++) {
+				placed = place_agent(
+					json_array_get_object(
+						agents, k),
+					e->parent_id, av);
+			}
+			if (!placed)
+				json_array_append_value(agents, av);
+		} else {
+			json_array_append_value(agents, av);
+		}
+	}
+
+	json_object_set_number(root_o, "ok", 1);
+	json_object_set_number(root_o, "sessions_count",
+		(double)json_array_get_count(sessions));
+	json_object_set_value(root_o, "sessions", sessions_val);
+	{
+		char *s = json_serialize_to_string(root);
+
+		ctl_reply(ctx, "%s\n", s != NULL ? s : "{}");
+		json_free_serialized_string(s);
+	}
+	json_value_free(root);
+}
+
+static void verb_events(struct retraced_ctl_ctx *ctx,
+	JSON_Object *o)
+{
+	/*
+	 * The evidence read arm: the journal's last records,
+	 * chain verdict riding the reply -- evidence pulled
+	 * over a network carries its own integrity statement.
+	 * last is bounded (<=128, default 20). Observe-only:
+	 * the STATUS claim, the least-privilege scope an
+	 * auditor's certificate needs.
+	 */
+	double last_d = json_object_get_number(o, "last");
+	size_t last_n = last_d > 0 ? (size_t)last_d : 20;
+	long chain = 0;
+
+	if (last_n > 128) {
+		ctl_reply(ctx,
+			"{\"ok\":0,\"error\":\"last > 128\"}\n");
+		return;
+	}
+	{
+		char *buf;
+		size_t cap = last_n * 2100 + 64;
+		struct ev_sink_ctx sc;
+		int n;
+
+		buf = (char *)malloc(cap);
+		if (buf == NULL) {
+			ctl_reply(ctx,
+				"{\"ok\":0,\"error\":\"oom\"}\n");
+			return;
+		}
+		sc.p = buf;
+		sc.left = cap;
+		sc.first = 1;
+		n = retraced_journal_tail(ctx->jr, last_n,
+			ev_sink_append, &sc, &chain);
+		(void)n;
+		ctl_reply(ctx,
+			"{\"ok\":1,\"chain\":\"%s\",\"broken_at\":%ld,\"events\":[%.*s]}\n",
+			chain == 0 ? "verified" : "broken",
+			chain,
+			(int)(cap - sc.left), buf);
+		free(buf);
+	}
+}
+
+static void verb_spawn(struct retraced_ctl_ctx *ctx,
+	JSON_Object *o)
+{
+	/*
+	 * The reserved verb (the threat model's host
+	 * process control): launch a workload armed to
+	 * join THIS daemon -- supervisor env, agent
+	 * socket, nonce, preload -- and journal the
+	 * action with argv, kill's audit pattern
+	 * extended. SPAWN claim required (the scope gate
+	 * above); the transport's spawn seam does the
+	 * launching (NULL on Windows: injection is
+	 * retrace-win-run's machinery, not a stub here).
+	 */
+	JSON_Array *argv_a = json_object_get_array(o, "argv");
+	const char *preload =
+		json_object_get_string(o, "preload");
+
+	if (ctx->spawn_cb == NULL) {
+		ctl_reply(ctx,
+			"{\"ok\":0,\"error\":\"spawn: not on this platform -- use retrace-win-run\"}\n");
+		return;
+	}
+	if (argv_a == NULL || json_array_get_count(argv_a) == 0) {
+		ctl_reply(ctx,
+			"{\"ok\":0,\"error\":\"no argv\"}\n");
+		return;
+	}
+	{
+		char *argv_buf[129];
+		char err[96];
+		size_t n = json_array_get_count(argv_a);
+		size_t ai;
+		long pid;
+
+		if (n > 128) {
+			ctl_reply(ctx,
+				"{\"ok\":0,\"error\":\"argv > 128\"}\n");
+			return;
+		}
+		for (ai = 0; ai < n; ai++)
+			argv_buf[ai] = (char *)
+				json_array_get_string(argv_a, ai);
+		argv_buf[n] = NULL;
+		err[0] = '\0';
+		pid = ctx->spawn_cb(
+			(const char *const *)argv_buf, preload,
+			err, sizeof(err));
+		if (pid <= 0) {
+			ctl_reply(ctx,
+				"{\"ok\":0,\"error\":\"spawn failed%s%s\"}\n",
+				err[0] != '\0' ? ": " : "", err);
+			return;
+		}
+		{
+			char ev[256];
+
+			snprintf(ev, sizeof(ev),
+				"{\"name\":\"retrace.ctl.spawn\",\"pid\":%ld,\"argv0\":\"%s\"}",
+				pid,
+				json_array_get_string(argv_a, 0) !=
+					NULL ?
+					json_array_get_string(
+						argv_a, 0) : "");
+			retraced_journal_event(ctx->jr,
+				(long)time(NULL), "daemon", 0, ev);
+		}
+		ctl_reply(ctx, "{\"ok\":1,\"pid\":%ld}\n",
+			pid);
+	}
+}
+
+static void verb_policy_push(struct retraced_ctl_ctx *ctx,
+	JSON_Object *o)
+{
+	const char *in_blob = json_object_get_string(o, "blob");
+	char *blob = NULL;
+	long epoch = 0;
+	int pushed;
+
+	if (in_blob == NULL) {
+		ctl_reply(ctx, "{\"ok\":0,\"error\":\"no blob\"}\n");
+		return;
+	}
+	if (retraced_policy_load(in_blob, &blob, &epoch) != 0) {
+		ctl_reply(ctx, "{\"ok\":0,\"error\":\"bad policy"
+			" (need policy.epoch + scripts)\"}\n");
+		return;
+	}
+	retraced_ctl_set_policy(ctx, blob, epoch);
+	ctx->frozen = 0;
+	free(ctx->thaw_blob);
+	ctx->thaw_blob = strdup(blob);
+	pushed = retraced_ctl_push_policy(ctx, blob);
+	{
+		char ev[160];
+
+		snprintf(ev, sizeof(ev),
+			"{\"name\":\"retrace.policy.pushed\",\"epoch\":%ld,\"agents\":%d}",
+			epoch, pushed);
+		retraced_journal_event(ctx->jr, (long)time(NULL),
+			"daemon", 0, ev);
+	}
+	ctl_reply(ctx, "{\"ok\":1,\"epoch\":%ld,\"pushed\":%d}\n",
+		epoch, pushed);
+	free(blob);
+}
+
+static void verb_freeze(struct retraced_ctl_ctx *ctx,
+	JSON_Object *o)
+{
+	char blob[256];
+	long epoch = ctx->policy_epoch + 1;
+	int pushed;
+
+	snprintf(blob, sizeof(blob),
+		"{\"policy\":{\"epoch\":%ld},"
+		"\"intercept_scripts\":[{\"func_name\":\"*\","
+		"\"actions\":[{\"action_name\":\"freeze\"}]}]}",
+		epoch);
+	retraced_ctl_set_policy(ctx, blob, epoch);
+	ctx->frozen = 1;
+	pushed = retraced_ctl_push_policy(ctx, blob);
+	{
+		char ev[128];
+
+		snprintf(ev, sizeof(ev),
+			"{\"name\":\"retrace.policy.freeze\",\"epoch\":%ld,\"agents\":%d}",
+			epoch, pushed);
+		retraced_journal_event(ctx->jr, (long)time(NULL),
+			"daemon", 0, ev);
+	}
+	ctl_reply(ctx, "{\"ok\":1,\"epoch\":%ld,\"pushed\":%d}\n",
+		epoch, pushed);
+}
+
+static void verb_thaw(struct retraced_ctl_ctx *ctx,
+	JSON_Object *o)
+{
+	long epoch = ctx->policy_epoch + 1;
+	char thawed[8192];
+	const char *src = ctx->thaw_blob != NULL ? ctx->thaw_blob :
+		"{\"policy\":{\"epoch\":1},\"intercept_scripts\":[]}";
+	JSON_Value *tv = json_parse_string(src);
+	int pushed;
+
+	/* re-stamp the saved policy at a fresh epoch: agents
+	 * only ever accept strictly-greater epochs
+	 */
+	if (tv != NULL) {
+		JSON_Object *troot = json_value_get_object(tv);
+		JSON_Object *tpo = json_object_get_object(troot,
+			"policy");
+
+		if (tpo != NULL)
+			json_object_set_number(tpo, "epoch",
+				(double)epoch);
+	}
+	{
+		char *s = json_serialize_to_string(tv);
+
+		snprintf(thawed, sizeof(thawed), "%s",
+			s != NULL ? s : src);
+		json_free_serialized_string(s);
+	}
+	json_value_free(tv);
+	retraced_ctl_set_policy(ctx, thawed, epoch);
+	ctx->frozen = 0;
+	pushed = retraced_ctl_push_policy(ctx, thawed);
+	{
+		char ev[128];
+
+		snprintf(ev, sizeof(ev),
+			"{\"name\":\"retrace.policy.thaw\",\"epoch\":%ld,\"agents\":%d}",
+			epoch, pushed);
+		retraced_journal_event(ctx->jr, (long)time(NULL),
+			"daemon", 0, ev);
+	}
+	ctl_reply(ctx, "{\"ok\":1,\"epoch\":%ld,\"pushed\":%d}\n",
+		epoch, pushed);
+}
+
+static void verb_kill(struct retraced_ctl_ctx *ctx,
+	JSON_Object *o)
+{
+	long pid = (long)json_object_get_number(o, "pid");
+
+	if (pid <= 0) {
+		ctl_reply(ctx, "{\"ok\":0,\"error\":\"no pid\"}\n");
+		return;
+	}
+#ifdef _WIN32
+	{
+		HANDLE h = OpenProcess(PROCESS_TERMINATE,
+			FALSE, (DWORD)pid);
+
+		if (h != NULL) {
+			TerminateProcess(h, 1);
+			CloseHandle(h);
+		}
+	}
+#else
+	kill((pid_t)pid, SIGTERM);
+#endif
+	{
+		char ev[128];
+
+		snprintf(ev, sizeof(ev),
+			"{\"name\":\"retrace.ctl.kill\",\"pid\":%ld}",
+			pid);
+		retraced_journal_event(ctx->jr, (long)time(NULL),
+			"daemon", 0, ev);
+	}
+	ctl_reply(ctx, "{\"ok\":1,\"pid\":%ld}\n", pid);
 }
 


### PR DESCRIPTION
The control plane grew a verb every cycle (sessions → events → spawn), and each verb was **four hand-synced edits**: the daemon's dispatch chain, the scope gate's second strcmp list, the CLI's argv builder, and the CLI's usage text — which had already drifted: `sessions`, `events`, and `spawn` were missing from `retrace-ctl`'s usage output.

**The SSOT is now one X-macro list** — `tools/retraced/ctl_verbs.h`, the same idiom the protocol's frozen message table uses:

- the daemon expands it into the verb table `{name, scope, handler}`; dispatch walks it
- `retraced_tls_scope_for_cmd` walks the same rows (the hand-synced strcmp chain is gone)
- `retrace-ctl` prints its usage from the same list — the drift class is dead by construction
- a verb is now **one list line + one handler function**; a row without a handler is a compile error

Handlers were extracted verbatim; the dispatcher owns the parse tree, so every path frees exactly once (nine in-body frees deleted). New conformance unit test expands the same list and asserts every verb answers and carries a nonzero claim scope (18/18).

**Fixed in passing, found by the extraction:** the `events` reply buffer was sized from a dead variable (`emitted`, initialized 0, never assigned) — every `events` reply truncated at 64 bytes. The cap now derives from the requested tail.

Verified: 18/18 unit, full local ctest green, and a live smoke driving every verb through the table (status/ps/events/spawn-with-join/kill).
