### PR TITLE
ctl exit statuses: the reap doctrine -- departures are journal records

### DIFF
--- a/docs/supervisor.md
+++ b/docs/supervisor.md
@@ -78,8 +78,12 @@ act, then the child's agent HELLOs with the nonce and takes a **full**
 seat (`retrace.auth.agent`, role `full` -- never a spectator: the
 nonce traveled with the fork). The spawned pid shows up in `ps` like
 any agent, and `kill PID` reaps it through the same control plane.
-SIGCHLD is ignored daemon-side, so reaped workloads never linger as
-zombies. POSIX only -- on Windows the verb answers honestly
+The **departure is journaled too**: a SIGCHLD self-pipe routes every
+child death to the daemon's poll loop, which reaps and records
+`retrace.ctl.exit {pid, how: exited|signaled, code}` -- a workload
+that crashes, is killed, or leaves on its own is never a silent gap,
+and reaped workloads never linger as zombies. POSIX only -- on
+Windows the verb answers honestly
 (`not on this platform -- use retrace-win-run`): injection there is
 retrace-win-run's machinery, not a stub.
 

--- a/test/integration/test_supervisor_spawn.py
+++ b/test/integration/test_supervisor_spawn.py
@@ -169,8 +169,38 @@ def main():
         return fail("kill not journaled")
     print("kill ok: reaped and audited")
 
+    # ---- the departure itself is an audit record -----------
+    ev = wait_journal(journal, "retrace.ctl.exit",
+                      lambda e: e.get("pid") == pid, 5.0)
+    if ev is None:
+        stop_daemon(d, ctl_sock)
+        return fail("no retrace.ctl.exit for the killed workload")
+    if ev.get("how") != "signaled":
+        stop_daemon(d, ctl_sock)
+        return fail(f"killed workload departed as {ev.get('how')!r}")
+    print(f"exit ok: departure journaled ({ev.get('how')}/"
+          f"{ev.get('code')})")
+
+    # ---- a workload that leaves ON ITS OWN is recorded too --
+    rc, out = ctl(ctl_bin, ctl_sock, "spawn",
+                  "--preload", lib, "--", target, "2")
+    if rc != 0 or not json.loads(out).get("ok"):
+        stop_daemon(d, ctl_sock)
+        return fail(f"self-exiting spawn refused: {out!r}")
+    pid2 = json.loads(out)["pid"]
+    ev = wait_journal(journal, "retrace.ctl.exit",
+                      lambda e: e.get("pid") == pid2, 15.0)
+    if ev is None:
+        stop_daemon(d, ctl_sock)
+        return fail("self-exiting workload never journaled its exit")
+    if ev.get("how") != "exited" or ev.get("code") != 0:
+        stop_daemon(d, ctl_sock)
+        return fail(f"natural exit recorded as {ev.get('how')!r}/"
+                    f"{ev.get('code')!r}")
+    print("exit ok: natural departure journaled (exited/0)")
+
     stop_daemon(d, ctl_sock)
-    print("PASS: spawn joined, visible, audited, reaped")
+    print("PASS: spawn joined, visible, audited, reaped, recorded")
     return 0
 
 

--- a/tools/retraced/journal.c
+++ b/tools/retraced/journal.c
@@ -42,6 +42,15 @@ static int payload_is_durable(const char *payload)
 		"\"name\":\"retrace.policy.",
 		"\"name\":\"retrace.session.",
 		"\"name\":\"retrace.journal.",
+		/* Control-plane audit (the reap cycle's lesson,
+		 * phase-3's shape): a journaled ORDER, LAUNCH, or
+		 * DEPARTURE is an audit decision -- a live auditor
+		 * must not wait for an unrelated flush. An exit
+		 * record rides NO traffic (the child is gone), so
+		 * without this it sat buffered forever on an idle
+		 * daemon.
+		 */
+		"\"name\":\"retrace.ctl.",
 		/* Live drift grading (03 P1): a kernel-obs delta is
 		 * the daemon's own heartbeat-grade of sub-libc
 		 * escapes -- audit-class, never buffered away.

--- a/tools/retraced/main.c
+++ b/tools/retraced/main.c
@@ -36,6 +36,9 @@
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <sys/stat.h>
+#ifndef _WIN32
+#include <sys/wait.h>
+#endif
 #include <time.h>
 #include <unistd.h>
 
@@ -155,6 +158,27 @@ static void on_signal(int sig)
 	(void)sig;
 	g_stop = 1;
 }
+
+/*
+ * The reap doctrine (the spawn verb's audit tail): a spawned
+ * workload's departure is a journal record, never silence.
+ * The handler is async-signal-safe by force -- one byte wakes
+ * the loop; the waitpids and the journal writes happen there.
+ */
+#ifndef _WIN32
+static int g_reap_pipe[2] = { -1, -1 };
+
+static void on_sigchld(int sig)
+{
+	ssize_t rc;
+
+	(void)sig;
+	if (g_reap_pipe[1] >= 0) {
+		rc = write(g_reap_pipe[1], "x", 1);
+		(void)rc;
+	}
+}
+#endif
 
 /* the ctl broadcast's fd adapter: same shape as the
  * daemon_frame write seam, one int narrower
@@ -377,6 +401,7 @@ static void handle_agent_frame(struct conn *c,
 static int g_ctl_listen = -1;
 static int g_ctl_fd = -1;
 static int g_ctl_pfd_slot = -1;
+static int g_reap_pfd_slot = -1;
 static char g_ctl_buf[8192];
 static size_t g_ctl_fill;
 /* TLS fleet listener (TODO.supervisor/08 P1 / beyond-libc/05) */
@@ -694,13 +719,29 @@ int main(int argc, char **argv)
 	signal(SIGINT, on_signal);
 	signal(SIGTERM, on_signal);
 	signal(SIGPIPE, SIG_IGN);
-	/* spawned workloads (ctl spawn) must not pile up as
-	 * zombies: SIG_IGN makes the kernel auto-reap. The kill
-	 * ORDER is already journaled (retrace.ctl.kill); exit
-	 * statuses would need a waitpid self-pipe -- not this
-	 * card.
+#ifndef _WIN32
+	/* spawned workloads must never pile up as zombies, and
+	 * their exits must land in the journal: the self-pipe
+	 * routes every SIGCHLD to the poll loop, which reaps and
+	 * records (the daemon's only fork site is the spawn seam,
+	 * so every reaped child is a workload it launched)
 	 */
-	signal(SIGCHLD, SIG_IGN);
+	if (pipe(g_reap_pipe) == 0) {
+		int flags = fcntl(g_reap_pipe[0], F_GETFL, 0);
+
+		(void)fcntl(g_reap_pipe[0], F_SETFL,
+			flags | O_NONBLOCK);
+		(void)fcntl(g_reap_pipe[0], F_SETFD, FD_CLOEXEC);
+		(void)fcntl(g_reap_pipe[1], F_SETFD, FD_CLOEXEC);
+		signal(SIGCHLD, on_sigchld);
+	} else {
+		/* no pipe, no records: fall back to silent auto-reap
+		 * rather than leaking zombies
+		 */
+		g_reap_pipe[0] = g_reap_pipe[1] = -1;
+		signal(SIGCHLD, SIG_IGN);
+	}
+#endif
 
 	retraced_registry_init(&reg);
 	retraced_journal_open(&jr, journal_path);
@@ -984,6 +1025,16 @@ int main(int argc, char **argv)
 				pfds[nfd].events = POLLIN;
 				nfd++;
 			}
+#ifndef _WIN32
+			if (g_reap_pipe[0] >= 0) {
+				pfds[nfd].fd = g_reap_pipe[0];
+				pfds[nfd].events = POLLIN;
+				g_reap_pfd_slot = nfd;
+				nfd++;
+			} else {
+				g_reap_pfd_slot = -1;
+			}
+#endif
 			g_ctl_pfd_slot = ctl_idx;
 			g_tls_pfd_slot = tls_idx;
 		}
@@ -997,6 +1048,53 @@ int main(int argc, char **argv)
 			}
 		}
 		r = poll(pfds, (nfds_t)nfd, 500);
+#ifndef _WIN32
+		if (g_reap_pipe[0] >= 0) {
+			char flush[64];
+			ssize_t rn;
+
+			/* The sweep runs EVERY iteration, not just on
+			 * the pipe's POLLIN: Darwin can deliver the
+			 * SIGCHLD (and wake the pipe) a hair before
+			 * the child is waitable -- the first waitpid
+			 * then reports ECHILD and the byte is spent.
+			 * The 500ms poll timeout is the backstop that
+			 * guarantees the record; the byte only
+			 * accelerates it. The byte count is
+			 * irrelevant -- the waitpid pass reaps every
+			 * dead child.
+			 */
+			while ((rn = read(g_reap_pipe[0], flush,
+			    sizeof(flush))) > 0)
+				;
+			for (;;) {
+				int status;
+				pid_t pid = waitpid((pid_t)-1, &status,
+					WNOHANG);
+				if (pid <= 0)
+					break;
+				{
+					int signaled = WIFSIGNALED(status);
+					int code = signaled ?
+						WTERMSIG(status) :
+						WEXITSTATUS(status);
+					char ev[160];
+
+					snprintf(ev, sizeof(ev),
+						"{\"name\":\"retrace.ctl.exit\","
+						"\"pid\":%ld,\"how\":\"%s\",\"code\":%d}",
+						(long)pid,
+						signaled ? "signaled"
+							 : "exited",
+						code);
+					retraced_journal_event(&jr,
+						(long)time(NULL), "daemon",
+						0, ev);
+				}
+			}
+		}
+#endif
+
 		if (r <= 0) {
 			spin_hits = 0;	/* timed out: healthy */
 			continue;
@@ -1116,6 +1214,8 @@ int main(int argc, char **argv)
 			    (cfd->revents & (POLLIN | POLLHUP)))
 				handle_ctl_readable(conns, &reg, &jr);
 		}
+
+
 
 		if (pfds[0].revents & POLLIN) {
 			int fd = accept_gated(listen_fd, &jr);


### PR DESCRIPTION
The journal recorded a spawned workload's whole life except its ending — launch, session, seat, even the kill order — but the **departure itself was silence** (SIGCHLD was `SIG_IGN`; a workload that crashed, OOMed, or left on its own left no trace). The piece cycle 20's comment explicitly deferred, now closed with the self-pipe pattern on the existing poll loop:

- The SIGCHLD handler does nothing but `write()` one byte (async-signal-safe); the loop drains and `waitpid(-1, WNOHANG)`s, journaling `retrace.ctl.exit {pid, how: exited|signaled, code}` per reaped child. The daemon's only fork site is the spawn seam, so every reaped child is a workload it launched.
- **The sweep runs every loop iteration**, not only on the pipe's POLLIN — Darwin can deliver the SIGCHLD (and spend the byte) a hair before the child is waitable; the 500ms poll timeout is the backstop that guarantees the record.
- **`retrace.ctl.*` joined the journal's durable classes** — an exit record rides no subsequent traffic (the child is gone), so without the per-event flush it sat in the stdio buffer of an idle daemon. The phase-3 visibility lesson (`feedback` recorded then), applied one class late.

E2E grows both departure assertions: the killed workload (`signaled/15`) and a natural exit (`exited/0`). 115/115 local, checkpatch clean.
