### PR TITLE
ctl feed: the byte layer joins its module -- the seam, cut through

### DIFF
--- a/test/unit/test_retraced_ctl.c
+++ b/test/unit/test_retraced_ctl.c
@@ -75,14 +75,26 @@ static int tests_fail;
 
 static char reply_buf[4096];
 static size_t reply_len;
+static char replies_all[4096];	/* every reply, concatenated */
+static int replies_count;
 
 static void sink(const char *line, void *user)
 {
 	(void)user;
-	reply_len = 0;
-	while (*line != '\0' && reply_len + 1 < sizeof(reply_buf))
-		reply_buf[reply_len++] = *line++;
-	reply_buf[reply_len] = '\0';
+	size_t o = 0;
+
+	while (*line != '\0' && o + 1 < sizeof(reply_buf))
+		reply_buf[o++] = *line++;
+	reply_buf[o] = '\0';
+	reply_len = o;
+	{
+		char *dst = replies_all;
+
+		while (*line != '\0' && replies_count < 128)
+			line++;	/* already consumed above */
+		(void)dst;
+		(void)line;
+	}
 }
 
 static void feed(struct retraced_ctl_ctx *ctx, const char *line)
@@ -93,6 +105,16 @@ static void feed(struct retraced_ctl_ctx *ctx, const char *line)
 	reply_buf[0] = '\0';
 	reply_len = 0;
 	retraced_ctl_handle_line(ctx, buf);
+}
+
+/* the byte layer: transport chunks in, one reply counter */
+static int feed_count;
+
+static void counting_sink(const char *line, void *user)
+{
+	(void)user;
+	feed_count++;
+	snprintf(reply_buf, sizeof(reply_buf), "%s", line);
 }
 
 static struct retraced_ctl_ctx ctx;
@@ -554,6 +576,80 @@ static void test_spawn_scope_denied(void)
 }
 
 /*
+ * The framing tests (the byte layer's own test class -- the
+ * reason feed exists): a line split across reads is ONE
+ * command; two commands in one chunk are TWO; a partial line
+ * stays silent until its newline arrives; a line that exceeds
+ * the buffer is refused for the transport to drop.
+ */
+static void test_feed_splits_lines_across_chunks(void)
+{
+	setup();
+	ctx.reply_sink = counting_sink;
+	feed_count = 0;
+	{
+		char a[16], b[8];
+
+		snprintf(a, sizeof(a), "{\"cmd\":\"sta");
+		snprintf(b, sizeof(b), "tus\"}\n");
+		CHECK(retraced_ctl_feed(&ctx, a, strlen(a)) == 0);
+		CHECK(feed_count == 0);
+		CHECK(retraced_ctl_feed(&ctx, b, strlen(b)) == 0);
+	}
+	CHECK(feed_count == 1);
+	CHECK(strstr(reply_buf, "\"ok\":1") != NULL);
+}
+
+static void test_feed_two_commands_one_chunk(void)
+{
+	setup();
+	ctx.reply_sink = counting_sink;
+	feed_count = 0;
+	{
+		char chunk[64];
+
+		snprintf(chunk, sizeof(chunk),
+			"{\"cmd\":\"status\"}\n{\"cmd\":\"ps\"}\n");
+		CHECK(retraced_ctl_feed(&ctx, chunk, strlen(chunk)) == 0);
+	}
+	CHECK(feed_count == 2);
+}
+
+static void test_feed_partial_without_newline_is_silent(void)
+{
+	setup();
+	ctx.reply_sink = counting_sink;
+	feed_count = 0;
+	{
+		char part[24], whole[24];
+
+		snprintf(part, sizeof(part), "{\"cmd\":\"status\"}");
+		snprintf(whole, sizeof(whole), "{\"cmd\":\"status\"}\n");
+		CHECK(retraced_ctl_feed(&ctx, part, strlen(part)) == 0);
+		CHECK(feed_count == 0);
+		retraced_ctl_conn_reset(&ctx);
+		CHECK(retraced_ctl_feed(&ctx, whole,
+			    strlen(whole)) == 0);
+	}
+	CHECK(feed_count == 1);
+}
+
+static void test_feed_oversized_line_refused(void)
+{
+	static char big[9000];
+
+	setup();
+	memset(big, 'A', sizeof(big));
+	CHECK(retraced_ctl_feed(&ctx, big, sizeof(big)) == -1);
+	/* after a drop the framing state is empty: a fresh
+	 * connection parses normally
+	 */
+	retraced_ctl_conn_reset(&ctx);
+	feed(&ctx, "{\"cmd\":\"status\"}");
+	CHECK(strstr(reply_buf, "\"ok\":1") != NULL);
+}
+
+/*
  * Table conformance: the SSOT list expanded here -- every verb
  * must carry a nonzero claim scope (a zero-scope row would
  * silently grant nothing to every cert) and must ANSWER (a
@@ -594,6 +690,10 @@ int main(void)
 	TEST(spawn_no_argv);
 	TEST(spawn_scope_denied);
 	TEST(verb_table_conformance);
+	TEST(feed_splits_lines_across_chunks);
+	TEST(feed_two_commands_one_chunk);
+	TEST(feed_partial_without_newline_is_silent);
+	TEST(feed_oversized_line_refused);
 
 	printf("%d tests: %d pass, %d fail\n", tests_run, tests_pass,
 		tests_fail);

--- a/tools/retraced/main.c
+++ b/tools/retraced/main.c
@@ -402,8 +402,6 @@ static int g_ctl_listen = -1;
 static int g_ctl_fd = -1;
 static int g_ctl_pfd_slot = -1;
 static int g_reap_pfd_slot = -1;
-static char g_ctl_buf[8192];
-static size_t g_ctl_fill;
 /* TLS fleet listener (TODO.supervisor/08 P1 / beyond-libc/05) */
 static int g_tls_listen = -1;
 static struct retraced_tls_ctx *g_tls_ctx;
@@ -418,7 +416,7 @@ static void ctl_drop(void)
 		close(g_ctl_fd);
 		g_ctl_fd = -1;
 	}
-	g_ctl_fill = 0;
+	retraced_ctl_conn_reset(&g_ctl);
 	/* local UDS peers regain full scope on next accept */
 	g_ctl.scopes = RETRACED_SCOPE_ALL;
 }
@@ -484,39 +482,25 @@ static long ctl_spawn_posix(const char *const *argv,
 	return (long)pid;
 }
 
-static void handle_ctl_readable(struct conn *conns,
-	struct retraced_registry *reg, struct retraced_journal *jr)
+static void handle_ctl_readable(void)
 {
+	char buf[2048];
 	ssize_t n;
-	char *nl;
 
-	(void)conns;
-	(void)reg;
-	(void)jr;
 	if (g_ctl_ssl != NULL)
-		n = (ssize_t)retraced_tls_read(g_ctl_ssl,
-			g_ctl_buf + g_ctl_fill,
-			(int)(sizeof(g_ctl_buf) - 1 - g_ctl_fill));
+		n = (ssize_t)retraced_tls_read(g_ctl_ssl, buf,
+			(int)sizeof(buf));
 	else
-		n = read(g_ctl_fd, g_ctl_buf + g_ctl_fill,
-			sizeof(g_ctl_buf) - 1 - g_ctl_fill);
+		n = read(g_ctl_fd, buf, sizeof(buf));
 	if (n <= 0) {
 		ctl_drop();
 		return;
 	}
-	g_ctl_fill += (size_t)n;
-	g_ctl_buf[g_ctl_fill] = '\0';
-	while ((nl = strchr(g_ctl_buf, '\n')) != NULL) {
-		*nl = '\0';
-		retraced_ctl_handle_line(&g_ctl, g_ctl_buf);
-		memmove(g_ctl_buf, nl + 1,
-			g_ctl_fill - (size_t)(nl + 1 - g_ctl_buf));
-		g_ctl_fill -= (size_t)(nl + 1 - g_ctl_buf);
-	}
-	if (g_ctl_fill >= sizeof(g_ctl_buf) - 1) {
-		/* oversized line: drop the connection, not the daemon */
+	/* the module owns bytes->lines; a line that exceeds its
+	 * buffer drops the connection, not the daemon
+	 */
+	if (retraced_ctl_feed(&g_ctl, buf, (size_t)n) != 0)
 		ctl_drop();
-	}
 }
 
 /*
@@ -1162,7 +1146,7 @@ int main(int argc, char **argv)
 		    (pfds[g_ctl_pfd_slot].revents & POLLIN) &&
 		    g_ctl_fd < 0) {
 			g_ctl_fd = accept_gated(g_ctl_listen, &jr);
-			g_ctl_fill = 0;
+			retraced_ctl_conn_reset(&g_ctl);
 			g_ctl_ssl = NULL;
 			g_ctl.scopes = RETRACED_SCOPE_ALL;
 		}
@@ -1188,7 +1172,7 @@ int main(int argc, char **argv)
 				} else {
 					g_ctl_fd = tfd;
 					g_ctl_ssl = ssl;
-					g_ctl_fill = 0;
+					retraced_ctl_conn_reset(&g_ctl);
 					g_ctl.scopes = peer.scopes;
 					snprintf(ev, sizeof(ev),
 						"{\"name\":\"retrace.auth.tls\",\"cn\":\"%s\",\"scopes\":%u}",
@@ -1212,7 +1196,7 @@ int main(int argc, char **argv)
 			}
 			if (cfd != NULL &&
 			    (cfd->revents & (POLLIN | POLLHUP)))
-				handle_ctl_readable(conns, &reg, &jr);
+				handle_ctl_readable();
 		}
 
 

--- a/tools/retraced/retraced_ctl.c
+++ b/tools/retraced/retraced_ctl.c
@@ -703,3 +703,46 @@ static void verb_kill(struct retraced_ctl_ctx *ctx,
 	ctl_reply(ctx, "{\"ok\":1,\"pid\":%ld}\n", pid);
 }
 
+
+/*
+ * The byte layer (the seam, cut through): a transport chunk in,
+ * whole lines out. The partial-line state lives in the ctx --
+ * bytes, lines, and verbs are one module's pipeline, and the
+ * transport owns transport things (fds, TLS reads, poll).
+ * Returns 0 fed; -1 when a line exceeds the buffer -- the
+ * caller drops the connection, never the daemon.
+ */
+int retraced_ctl_feed(struct retraced_ctl_ctx *ctx,
+	const char *data, size_t n)
+{
+	if (data == NULL)
+		return 0;
+	while (n > 0) {
+		size_t room = sizeof(ctx->rbuf) - 1 - ctx->rfill;
+		char *nl;
+
+		if (room == 0)
+			return -1;	/* line exceeds the buffer */
+		if (n < room)
+			room = n;
+		memcpy(ctx->rbuf + ctx->rfill, data, room);
+		ctx->rfill += room;
+		ctx->rbuf[ctx->rfill] = '\0';
+		data += room;
+		n -= room;
+		while ((nl = strchr(ctx->rbuf, '\n')) != NULL) {
+			*nl = '\0';
+			retraced_ctl_handle_line(ctx, ctx->rbuf);
+			memmove(ctx->rbuf, nl + 1,
+				ctx->rfill -
+					(size_t)(nl + 1 - ctx->rbuf));
+			ctx->rfill -= (size_t)(nl + 1 - ctx->rbuf);
+		}
+	}
+	return 0;
+}
+
+void retraced_ctl_conn_reset(struct retraced_ctl_ctx *ctx)
+{
+	ctx->rfill = 0;
+}

--- a/tools/retraced/retraced_ctl.h
+++ b/tools/retraced/retraced_ctl.h
@@ -110,6 +110,15 @@ struct retraced_ctl_ctx {
 	 */
 	long (*spawn_cb)(const char *const *argv,
 		const char *preload, char *err_out, size_t err_cap);
+
+	/*
+	 * The connection's framing state: partial bytes a peer
+	 * left mid-line, carried across reads. The transport feeds
+	 * chunks (retraced_ctl_feed); bytes, lines, and verbs are
+	 * this module's pipeline.
+	 */
+	char rbuf[8192];
+	size_t rfill;
 };
 
 void retraced_ctl_set_policy(struct retraced_ctl_ctx *ctx,
@@ -134,5 +143,18 @@ uint32_t retraced_tls_scope_for_cmd(const char *cmd);
 
 void retraced_ctl_handle_line(struct retraced_ctl_ctx *ctx,
 	char *line);
+
+/*
+ * The byte layer: one transport chunk in, whole lines out.
+ * Feeds the framing buffer, splits on newlines, dispatches
+ * each complete line. Returns 0 fed; -1 when a line exceeds
+ * the buffer -- the transport drops the peer (a daemon must
+ * not die to an oversized line).
+ */
+int retraced_ctl_feed(struct retraced_ctl_ctx *ctx,
+	const char *data, size_t n);
+
+/* empty the framing state: a fresh accept or a dropped peer */
+void retraced_ctl_conn_reset(struct retraced_ctl_ctx *ctx);
 
 #endif /* RETRACE_TOOLS_RETRACED_CTL_H_ */


### PR DESCRIPTION
The seam candidate three reports running, cut through. The verb layer lived in its module while the byte layer that feeds it did not — partial-line buffering sat in main.c as a module-global pair (`g_ctl_buf[8192]/g_ctl_fill`) plus a hand-rolled split loop, and the connection's framing state was reset by `ctl_drop` in another file reaching back into those globals.

**The framing state moves into the connection's ctx:**

- `retraced_ctl_feed(ctx, data, n)` owns bytes→lines: append, split on newlines, dispatch per complete line, and return -1 when a line exceeds the buffer so the transport drops the peer — never the daemon.
- `retraced_ctl_conn_reset(ctx)` for a fresh accept or a dropped connection.
- main.c keeps exactly what a transport should: fd ownership, the TLS-or-plain read (into a stack buffer now), and the poll wiring. Two globals and the split loop are gone.

**This opens a test class the old interface could not state** (the reason the seam is worth cutting): a line split across reads is ONE command; two commands in one chunk are TWO; a partial line stays silent until its newline arrives; an oversized line is refused and the connection afterwards parses normally. Four new unit tests (22/22), all nine supervisor/retraced integration E2Es pass, full local suite green, checkpatch clean.
