### PR TITLE
quickstart rides the launch arm: every step a control-plane verb

### DIFF
--- a/examples/supervisor-quickstart/README.md
+++ b/examples/supervisor-quickstart/README.md
@@ -8,21 +8,25 @@ detonation from supervisor boot to evidence bundle.
 ./run-macos.sh /path/to/build     # macOS
 ```
 
-What you should see, step by step:
+Every step is a control-plane verb — no hand-armed env, no
+shell-side kills:
 
-1. `retraced` boots and publishes the agent nonce (`--nonce-file`).
-2. A small "detonation" runs under `RETRACE_SUPERVISOR=1` +
-   preload; every denied path read is a supervised security
-   event that lands in the daemon's hash-chained journal.
-3. `retrace-ctl ps` shows the registration (role `full`, one
-   session).
+1. `retraced` boots with `--policy`: the denial policy rides
+   the boot, pushed to every agent as it joins.
+2. `retrace-ctl spawn` launches the detonation — supervisor
+   env, nonce, and preload in one journaled command (the
+   launch arm). No exported environment at all.
+3. `ps` shows the join: role `full` (the nonce traveled with
+   the fork), policy epoch already applied.
 4. `retrace-ctl policy-push` tightens the policy MID-RUN —
    the live target picks it up without restart.
 5. `retrace-ctl freeze` holds every agent (the incident-
    response hold: fabricated returns, no real execution).
-6. The journal bundle names the whole story: session minted,
-   denial, policy push, freeze.
-7. The target is killed after the hold — evidence first.
+6. The journal names the story so far: launch, session minted,
+   seat taken, denials, policy push, freeze.
+7. `retrace-ctl kill` ends the hold — and the departure is
+   journaled too (`retrace.ctl.exit`, with how and code).
+8. The graceful close flushes the tail: the complete bundle.
 
 Cookbook recipes built on this flow: 37 (detonation farm),
 38 (continuous audit), 39 (incident response) under

--- a/examples/supervisor-quickstart/run-linux.sh
+++ b/examples/supervisor-quickstart/run-linux.sh
@@ -1,8 +1,11 @@
 #!/bin/sh
 # supervisor-quickstart: the farm loop in one script
-# (TODO.supervisor/09, cookbook recipe 37). Platform: Linux.
-#   retraced up -> supervise a detonation -> watch events land
-#   -> tighten policy mid-run -> freeze -> bundle the journal
+# (TODO.supervisor/09, cookbook recipe 37). Platform: macOS.
+#   retraced up (denial policy at boot) -> retrace-ctl spawns
+#   the specimen -> events land -> tighten mid-run -> freeze ->
+#   bundle the journal -> kill, with the departure recorded.
+# Every step is a control-plane verb: no hand-armed env, no
+# shell-side kills.
 # usage: run-linux.sh [path-to-build-dir]
 set -eu
 HERE=$(cd "$(dirname "$0")" && pwd)
@@ -10,46 +13,49 @@ BUILD=${1:-$HERE/../../build}
 case "$BUILD" in /*) ;; *) BUILD=$(cd "$BUILD" && pwd);; esac
 WORK=$(mktemp -d)
 cd "$WORK"
+CTL="$BUILD/tools/retrace-ctl/retrace-ctl"
+LIB="$BUILD/src/v2/libretrace.so"
+# the daemon's env rides the fork: silence the workload's
+# per-call trace logging (the journal is the story, not stdout)
+export RETRACE_LOGGER_DEF_ENA=0
 trap 'kill $DAEMON_PID 2>/dev/null || true' EXIT
 
-echo "=== 1. supervisor up (nonce published for the spawner)"
+echo "=== 1. supervisor up (the denial policy rides the boot)"
+cat > boot.json <<EOF
+{"policy":{"epoch":1},"intercept_scripts":[{"func_name":"open","actions":[
+ {"action_name":"sandbox","action_params":{"deny_paths":["/etc/hosts"]}},
+ {"action_name":"call_real"}]}]}
+EOF
 "$BUILD/tools/retraced/retraced" \
 	--sock agent.sock --journal journal.jsonl \
-	--ctl ctl.sock --nonce-file nonce.txt > daemon.log 2>&1 &
+	--ctl ctl.sock --policy boot.json > daemon.log 2>&1 &
 DAEMON_PID=$!
 i=0
 while [ ! -S ctl.sock ]; do
 	i=$((i + 1)); [ "$i" -gt 50 ] && { echo "daemon never listened"; exit 1; }
 	sleep 0.1
 done
-NONCE=$(cat nonce.txt)
 
-echo "=== 2. detonate under supervision (denials are events)"
+echo "=== 2. the launch arm: spawn (env, nonce, preload -- one journaled command)"
 cc -O1 -o app "$HERE/app.c"
-cat > boot.json <<EOF
-{"intercept_scripts":[{"func_name":"open","actions":[
- {"action_name":"sandbox","action_params":{"deny_paths":["/etc/hosts"]}},
- {"action_name":"call_real"}]}]}
-EOF
-RETRACE_JSON_CONFIG="$WORK/boot.json" \
-RETRACE_SUPERVISOR=1 RETRACE_SUPERVISOR_EAGER=1 \
-RETRACE_SUPERVISOR_SOCK="$WORK/agent.sock" \
-RETRACE_SUPERVISOR_NONCE="$NONCE" \
-RETRACE_LOGGER_DEF_ENA=0 \
-LD_PRELOAD="$BUILD/src/v2/libretrace.so" \
-	./app 8 > app.out 2>&1 &
-APP_PID=$!
+REPLY=$("$CTL" --sock ctl.sock spawn --preload "$LIB" -- "$WORK/app" 8)
+echo "$REPLY"
+APP_PID=$(echo "$REPLY" | sed -n 's/.*"pid":\([0-9]*\).*/\1/p')
+[ -n "$APP_PID" ] || { echo "spawn refused"; exit 1; }
 
-echo "=== 3. it registered (poll the registry)"
+echo "=== 3. it joined, and the boot policy bit (epoch >= 1)"
 i=0
 while :; do
-	N=$("$BUILD/tools/retrace-ctl/retrace-ctl" --sock ctl.sock ps | \
-		grep -o '"count":[0-9]*' | head -1 | tr -dc 0-9)
-	[ "${N:-0}" -ge 1 ] 2>/dev/null && break
-	i=$((i + 1)); [ "$i" -gt 100 ] && { echo "never registered"; exit 1; }
+	PS=$("$CTL" --sock ctl.sock ps)
+	N=$(echo "$PS" | grep -o '"count":[0-9]*' | head -1 | tr -dc 0-9)
+	E=$(echo "$PS" | grep -o '"policy_epoch":[0-9]*' | head -1 | tr -dc 0-9)
+	[ "${N:-0}" -ge 1 ] 2>/dev/null && [ "${E:-0}" -ge 1 ] 2>/dev/null && break
+	i=$((i + 1)); [ "$i" -gt 150 ] && { echo "never registered/policied"; exit 1; }
 	sleep 0.1
 done
-"$BUILD/tools/retrace-ctl/retrace-ctl" --sock ctl.sock ps | head -3
+"$CTL" --sock ctl.sock ps | head -3
+# two beats in the denied window before the story moves on
+sleep 2
 
 echo "=== 4. mid-run tightening (deny writes too)"
 cat > tight.json <<EOF
@@ -57,17 +63,26 @@ cat > tight.json <<EOF
  {"action_name":"sandbox","action_params":{"deny_paths":["/etc/hosts","$WORK"]}},
  {"action_name":"call_real"}]}]}
 EOF
-"$BUILD/tools/retrace-ctl/retrace-ctl" --sock ctl.sock policy-push tight.json
+"$CTL" --sock ctl.sock policy-push tight.json
 
 echo "=== 5. freeze (the incident-response hold)"
-"$BUILD/tools/retrace-ctl/retrace-ctl" --sock ctl.sock freeze
-"$BUILD/tools/retrace-ctl/retrace-ctl" --sock ctl.sock status
+"$CTL" --sock ctl.sock freeze
+"$CTL" --sock ctl.sock status
 
 echo "=== 6. the evidence bundle (hash-chained journal)"
 grep -o '"name":"retrace[^"]*"' journal.jsonl | sort | uniq -c | sort -rn | head -8
 
-echo "=== 7. kill --after-ring (end the hold)"
-kill $APP_PID 2>/dev/null || true
-wait $APP_PID 2>/dev/null || true
+echo "=== 7. kill (the departure is journaled too)"
+"$CTL" --sock ctl.sock kill "$APP_PID"
+i=0
+while kill -0 "$APP_PID" 2>/dev/null; do
+	i=$((i + 1)); [ "$i" -gt 40 ] && break
+	sleep 0.1
+done
+grep -o '"name":"retrace.ctl[^"]*"' journal.jsonl | tail -3
+
+echo "=== 8. the complete bundle (graceful close flushes the tail)"
 kill $DAEMON_PID 2>/dev/null || true
+wait $DAEMON_PID 2>/dev/null || true
+grep -o '"name":"retrace[^"]*"' journal.jsonl | sort | uniq -c | sort -rn | head -10
 echo "=== done: journal + registry under $WORK (bundle on freeze)"

--- a/examples/supervisor-quickstart/run-macos.sh
+++ b/examples/supervisor-quickstart/run-macos.sh
@@ -1,8 +1,11 @@
 #!/bin/sh
 # supervisor-quickstart: the farm loop in one script
 # (TODO.supervisor/09, cookbook recipe 37). Platform: macOS.
-#   retraced up -> supervise a detonation -> watch events land
-#   -> tighten policy mid-run -> freeze -> bundle the journal
+#   retraced up (denial policy at boot) -> retrace-ctl spawns
+#   the specimen -> events land -> tighten mid-run -> freeze ->
+#   bundle the journal -> kill, with the departure recorded.
+# Every step is a control-plane verb: no hand-armed env, no
+# shell-side kills.
 # usage: run-macos.sh [path-to-build-dir]
 set -eu
 HERE=$(cd "$(dirname "$0")" && pwd)
@@ -10,46 +13,49 @@ BUILD=${1:-$HERE/../../build}
 case "$BUILD" in /*) ;; *) BUILD=$(cd "$BUILD" && pwd);; esac
 WORK=$(mktemp -d)
 cd "$WORK"
+CTL="$BUILD/tools/retrace-ctl/retrace-ctl"
+LIB="$BUILD/src/v2/libretrace.dylib"
+# the daemon's env rides the fork: silence the workload's
+# per-call trace logging (the journal is the story, not stdout)
+export RETRACE_LOGGER_DEF_ENA=0
 trap 'kill $DAEMON_PID 2>/dev/null || true' EXIT
 
-echo "=== 1. supervisor up (nonce published for the spawner)"
+echo "=== 1. supervisor up (the denial policy rides the boot)"
+cat > boot.json <<EOF
+{"policy":{"epoch":1},"intercept_scripts":[{"func_name":"open","actions":[
+ {"action_name":"sandbox","action_params":{"deny_paths":["/etc/hosts"]}},
+ {"action_name":"call_real"}]}]}
+EOF
 "$BUILD/tools/retraced/retraced" \
 	--sock agent.sock --journal journal.jsonl \
-	--ctl ctl.sock --nonce-file nonce.txt > daemon.log 2>&1 &
+	--ctl ctl.sock --policy boot.json > daemon.log 2>&1 &
 DAEMON_PID=$!
 i=0
 while [ ! -S ctl.sock ]; do
 	i=$((i + 1)); [ "$i" -gt 50 ] && { echo "daemon never listened"; exit 1; }
 	sleep 0.1
 done
-NONCE=$(cat nonce.txt)
 
-echo "=== 2. detonate under supervision (denials are events)"
+echo "=== 2. the launch arm: spawn (env, nonce, preload -- one journaled command)"
 cc -O1 -o app "$HERE/app.c"
-cat > boot.json <<EOF
-{"intercept_scripts":[{"func_name":"open","actions":[
- {"action_name":"sandbox","action_params":{"deny_paths":["/etc/hosts"]}},
- {"action_name":"call_real"}]}]}
-EOF
-RETRACE_JSON_CONFIG="$WORK/boot.json" \
-RETRACE_SUPERVISOR=1 RETRACE_SUPERVISOR_EAGER=1 \
-RETRACE_SUPERVISOR_SOCK="$WORK/agent.sock" \
-RETRACE_SUPERVISOR_NONCE="$NONCE" \
-RETRACE_LOGGER_DEF_ENA=0 \
-DYLD_INSERT_LIBRARIES="$BUILD/src/v2/libretrace.dylib" \
-	./app 8 > app.out 2>&1 &
-APP_PID=$!
+REPLY=$("$CTL" --sock ctl.sock spawn --preload "$LIB" -- "$WORK/app" 8)
+echo "$REPLY"
+APP_PID=$(echo "$REPLY" | sed -n 's/.*"pid":\([0-9]*\).*/\1/p')
+[ -n "$APP_PID" ] || { echo "spawn refused"; exit 1; }
 
-echo "=== 3. it registered (poll the registry)"
+echo "=== 3. it joined, and the boot policy bit (epoch >= 1)"
 i=0
 while :; do
-	N=$("$BUILD/tools/retrace-ctl/retrace-ctl" --sock ctl.sock ps | \
-		grep -o '"count":[0-9]*' | head -1 | tr -dc 0-9)
-	[ "${N:-0}" -ge 1 ] 2>/dev/null && break
-	i=$((i + 1)); [ "$i" -gt 100 ] && { echo "never registered"; exit 1; }
+	PS=$("$CTL" --sock ctl.sock ps)
+	N=$(echo "$PS" | grep -o '"count":[0-9]*' | head -1 | tr -dc 0-9)
+	E=$(echo "$PS" | grep -o '"policy_epoch":[0-9]*' | head -1 | tr -dc 0-9)
+	[ "${N:-0}" -ge 1 ] 2>/dev/null && [ "${E:-0}" -ge 1 ] 2>/dev/null && break
+	i=$((i + 1)); [ "$i" -gt 150 ] && { echo "never registered/policied"; exit 1; }
 	sleep 0.1
 done
-"$BUILD/tools/retrace-ctl/retrace-ctl" --sock ctl.sock ps | head -3
+"$CTL" --sock ctl.sock ps | head -3
+# two beats in the denied window before the story moves on
+sleep 2
 
 echo "=== 4. mid-run tightening (deny writes too)"
 cat > tight.json <<EOF
@@ -57,17 +63,26 @@ cat > tight.json <<EOF
  {"action_name":"sandbox","action_params":{"deny_paths":["/etc/hosts","$WORK"]}},
  {"action_name":"call_real"}]}]}
 EOF
-"$BUILD/tools/retrace-ctl/retrace-ctl" --sock ctl.sock policy-push tight.json
+"$CTL" --sock ctl.sock policy-push tight.json
 
 echo "=== 5. freeze (the incident-response hold)"
-"$BUILD/tools/retrace-ctl/retrace-ctl" --sock ctl.sock freeze
-"$BUILD/tools/retrace-ctl/retrace-ctl" --sock ctl.sock status
+"$CTL" --sock ctl.sock freeze
+"$CTL" --sock ctl.sock status
 
 echo "=== 6. the evidence bundle (hash-chained journal)"
 grep -o '"name":"retrace[^"]*"' journal.jsonl | sort | uniq -c | sort -rn | head -8
 
-echo "=== 7. kill --after-ring (end the hold)"
-kill $APP_PID 2>/dev/null || true
-wait $APP_PID 2>/dev/null || true
+echo "=== 7. kill (the departure is journaled too)"
+"$CTL" --sock ctl.sock kill "$APP_PID"
+i=0
+while kill -0 "$APP_PID" 2>/dev/null; do
+	i=$((i + 1)); [ "$i" -gt 40 ] && break
+	sleep 0.1
+done
+grep -o '"name":"retrace.ctl[^"]*"' journal.jsonl | tail -3
+
+echo "=== 8. the complete bundle (graceful close flushes the tail)"
 kill $DAEMON_PID 2>/dev/null || true
+wait $DAEMON_PID 2>/dev/null || true
+grep -o '"name":"retrace[^"]*"' journal.jsonl | sort | uniq -c | sort -rn | head -10
 echo "=== done: journal + registry under $WORK (bundle on freeze)"


### PR DESCRIPTION
The canonical tour still taught the ceremony the launch arm (v2.76) abolished: six hand-set env vars plus a nonce file read to arm the specimen, and a shell `kill` to end it — silent, unjournaled.

**Every step is now a control-plane verb:**

1. The denial policy rides the daemon's boot (`--policy`, epoch 1, pushed to every agent as it joins) — the specimen's env carries nothing.
2. `retrace-ctl spawn` launches the detonation — supervisor env, nonce, and preload in **one journaled command**. Zero exported environment.
3. The join poll also waits for the policy epoch to bite (deterministic denied window — the old race left zero denial events).
4. `policy-push` tightens mid-run; `freeze` holds; the mid-run bundle names launch, minted, seat, denials, push, freeze.
5. `retrace-ctl kill` ends the hold — and the departure is journaled (`retrace.ctl.exit`, how + code; the reap doctrine, v2.78).
6. The graceful close flushes the tail: step 8 prints the complete bundle.

The two platform scripts converge to identical bodies — `spawn` hides the DYLD/LD split; only the library name differs. Verified live and through `integration-supervisor-quickstart` (its exit-nonzero wiring unchanged); checkpatch clean.
