### PR TITLE
policy templates: the holds the playbooks reference, ready to push

### DIFF
--- a/docs/cookbook/37-detonation-farm.md
+++ b/docs/cookbook/37-detonation-farm.md
@@ -74,6 +74,12 @@ retrace-ctl --sock ctl.sock policy-push cut-net.json
 Epochs only move forward: a captured POLICY_SET replayed at a
 cell is refused.
 
+Common holds ship ready to push under `share/policy-templates/`
+— read-only-workload, no-network, env-fence, decoy-farm — each a
+complete policy-push artifact with the epoch ladder documented
+in its README. Start from a template and tighten from there
+instead of hand-writing the first fence.
+
 ## Where the events go
 
 Every denial, scrub, and policy ack lands in the daemon's

--- a/share/policy-templates/README.md
+++ b/share/policy-templates/README.md
@@ -1,0 +1,39 @@
+# Supervisor policy templates
+
+Ready-to-push policies for `retraced` (TODO.supervisor/09 P1).
+Each file is a complete `retrace-ctl policy-push` artifact: the
+daemon's loader validates it as-is. (These are supervisor
+policies — `intercept_scripts` — not the profiler's risk-scoring
+rulesets in `../policies/`.)
+
+| Template | What it holds |
+|----------|---------------|
+| `read-only-workload.json` | The detonation default: write-class calls denied outright (mode/flags derived), credential paths fenced (`/etc/shadow`, ssh keys) |
+| `no-network.json` | `socket`/`connect` synthesized −1 + the secret env names fenced |
+| `env-fence.json` | getenv on common token/key names returns NULL — credential exposure without touching the filesystem |
+| `decoy-farm.json` | Deny-by-default jail (`allow_paths`) with `decoy_dir`: out-of-fence READS get plausible fakes instead of denials, keeping the sample on its happy path (the deception is logged). Edit the paths to the detonation host first |
+
+## Pushing
+
+```sh
+retrace-ctl --sock /tmp/retraced.ctl.sock policy-push read-only-workload.json
+```
+
+**The epoch ladder:** agents only ever accept a strictly greater
+epoch, and every template ships at `epoch: 1` for a cold boot
+(`retraced --policy read-only-workload.json`). On a warmed
+daemon, bump the epoch in your copy before pushing — or sign
+your edited ladder:
+
+```sh
+retrace-ctl sign-policy my-edit.json ed25519.key > signed.json
+retrace-ctl --sock ... policy-push signed.json
+```
+
+## Kernel truth
+
+A `sandbox` denial is observable without reading retrace's
+output: the blocked call returns EACCES (or the synthesized
+value), and every denial lands in the daemon's hash-chained
+journal (`retrace.jail.denied`) and, when OTLP is configured,
+live in the collector.

--- a/share/policy-templates/decoy-farm.json
+++ b/share/policy-templates/decoy-farm.json
@@ -1,0 +1,25 @@
+{
+  "policy": { "epoch": 1 },
+  "intercept_scripts": [
+    {
+      "func_name": "*",
+      "actions": [
+        {
+          "action_name": "sandbox",
+          "action_params": {
+            "allow_paths": [
+              "/usr/lib/",
+              "/usr/share/",
+              "/lib/",
+              "/etc/ld.so.cache",
+              "/tmp/decoy/",
+              "/tmp/detonation/"
+            ],
+            "decoy_dir": "/tmp/decoy"
+          }
+        },
+        { "action_name": "call_real" }
+      ]
+    }
+  ]
+}

--- a/share/policy-templates/env-fence.json
+++ b/share/policy-templates/env-fence.json
@@ -1,0 +1,24 @@
+{
+  "policy": { "epoch": 1 },
+  "intercept_scripts": [
+    {
+      "func_name": "*",
+      "actions": [
+        {
+          "action_name": "sandbox",
+          "action_params": {
+            "deny_env": [
+              "AWS_SESSION_TOKEN",
+              "AWS_SECRET_ACCESS_KEY",
+              "GITHUB_TOKEN",
+              "GITLAB_TOKEN",
+              "OPENAI_API_KEY",
+              "SSH_AUTH_SOCK"
+            ]
+          }
+        },
+        { "action_name": "call_real" }
+      ]
+    }
+  ]
+}

--- a/share/policy-templates/no-network.json
+++ b/share/policy-templates/no-network.json
@@ -1,0 +1,37 @@
+{
+  "policy": { "epoch": 1 },
+  "intercept_scripts": [
+    {
+      "func_name": "socket",
+      "actions": [
+        { "action_name": "modify_return_value_int",
+          "action_params": { "value": -1 } }
+      ]
+    },
+    {
+      "func_name": "connect",
+      "actions": [
+        { "action_name": "modify_return_value_int",
+          "action_params": { "value": -1 } }
+      ]
+    },
+    {
+      "func_name": "*",
+      "actions": [
+        {
+          "action_name": "sandbox",
+          "action_params": {
+            "deny_env": [
+              "AWS_SESSION_TOKEN",
+              "AWS_SECRET_ACCESS_KEY",
+              "GITHUB_TOKEN",
+              "GITLAB_TOKEN",
+              "OPENAI_API_KEY"
+            ]
+          }
+        },
+        { "action_name": "call_real" }
+      ]
+    }
+  ]
+}

--- a/share/policy-templates/read-only-workload.json
+++ b/share/policy-templates/read-only-workload.json
@@ -1,0 +1,23 @@
+{
+  "policy": { "epoch": 1 },
+  "intercept_scripts": [
+    {
+      "func_name": "*",
+      "actions": [
+        {
+          "action_name": "sandbox",
+          "action_params": {
+            "deny_classes": ["write"],
+            "deny_paths": [
+              "/etc/shadow",
+              "/etc/sudoers",
+              "/etc/ssh/",
+              "/root/.ssh/"
+            ]
+          }
+        },
+        { "action_name": "call_real" }
+      ]
+    }
+  ]
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -334,6 +334,20 @@ if(Python3_Interpreter_FOUND)
 		TIMEOUT 90)
 	endif()
 
+	# The shipped policy templates (TODO.supervisor/09 P1):
+	# every file under share/policy-templates/ must push onto a
+	# fresh daemon -- format drift in either direction dies red.
+	# Push-only (no spawn): runs on the Windows pipe too.
+	add_test(NAME integration-policy-templates
+		COMMAND ${Python3_EXECUTABLE}
+			${CMAKE_SOURCE_DIR}/test/integration/test_policy_templates.py
+			$<TARGET_FILE:retrace_retraced>
+			$<TARGET_FILE:retrace_ctl>
+			${CMAKE_SOURCE_DIR}/share/policy-templates)
+	set_tests_properties(integration-policy-templates PROPERTIES
+		LABELS "integration"
+		TIMEOUT 60)
+
 	# The kernel-observation agent (TODO.beyond-libc/03):
 	# eBPF lane as a spectator peer; synthetic source proves
 	# the pipe on CI (no BPF privileges).

--- a/test/integration/test_policy_templates.py
+++ b/test/integration/test_policy_templates.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""
+E2E: the shipped policy templates parse and push (TODO.
+supervisor/09 P1). Every file under share/policy-templates/ is
+pushed onto a fresh daemon and must be accepted -- a template
+that stops loading against the daemon's REAL validation is a
+red test, so format drift in either direction dies here.
+
+Usage: test_policy_templates.py <retraced> <retrace-ctl> <templates-dir>
+"""
+import glob
+import json
+import os
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+
+
+def wait_sock(path, deadline=5.0):
+    end = time.time() + deadline
+    while time.time() < end:
+        if os.path.exists(path):
+            return True
+        time.sleep(0.1)
+    return False
+
+
+def main():
+    if len(sys.argv) != 4:
+        print("usage: test_policy_templates.py <retraced> "
+              "<retrace-ctl> <templates-dir>", file=sys.stderr)
+        return 2
+    daemon, ctl_bin, tdir = (os.path.abspath(p)
+                             for p in sys.argv[1:4])
+
+    templates = sorted(glob.glob(os.path.join(tdir, "*.json")))
+    if not templates:
+        print("FAIL: no templates found", file=sys.stderr)
+        return 1
+    print(f"found {len(templates)} template(s)")
+
+    work = tempfile.mkdtemp(prefix="pol-tpl-")
+    sock = os.path.join(work, "agent.sock")
+    ctl_sock = os.path.join(work, "ctl.sock")
+    journal = os.path.join(work, "journal.jsonl")
+
+    dlog = os.path.join(work, "daemon.log")
+    log_f = open(dlog, "w")
+
+    def boot_daemon(journal_path):
+        return subprocess.Popen(
+            [daemon, "--sock", sock, "--journal", journal_path,
+             "--ctl", ctl_sock],
+            stdout=log_f, stderr=subprocess.STDOUT)
+
+    d = boot_daemon(journal)
+    if not wait_sock(ctl_sock):
+        d.kill()
+        print("FAIL: daemon ctl socket never appeared",
+              file=sys.stderr)
+        return 1
+
+    def stop_daemon(proc):
+        proc.send_signal(signal.SIGTERM)
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+        # the graceful close unlinks its sockets; a stale file
+        # would satisfy wait_sock instantly and the next CLI
+        # call would race the bind (rc=2, unreachable)
+        end = time.time() + 5
+        while time.time() < end and (os.path.exists(sock) or
+                                     os.path.exists(ctl_sock)):
+            time.sleep(0.1)
+
+    fails = 0
+    for tpl in templates:
+        # a fresh daemon per template: every template ships at
+        # epoch 1, and the ladder only climbs
+        if tpl != templates[0]:
+            stop_daemon(d)
+            d = boot_daemon(journal + ".n")
+            if not wait_sock(ctl_sock, 5.0):
+                d.kill()
+                print(f"FAIL: daemon never relistened for {tpl}",
+                      file=sys.stderr)
+                return 1
+        p = subprocess.run(
+            [ctl_bin, "--sock", ctl_sock, "policy-push", tpl],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            timeout=15)
+        out = p.stdout.decode()
+        name = os.path.basename(tpl)
+        if p.returncode != 0 or '"ok":1' not in out:
+            print(f"FAIL: {name}: rc={p.returncode} {out!r}",
+                  file=sys.stderr)
+            # the daemon's own words beat guessing at its state
+            d.poll()
+            with open(dlog) as f:
+                print(f"--- daemon.log (alive={d.poll() is None}):"
+                      f"\n{f.read()}", file=sys.stderr)
+            fails += 1
+        else:
+            print(f"push ok: {name}")
+
+    stop_daemon(d)
+    if fails:
+        return 1
+    print(f"PASS: all {len(templates)} templates push clean")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/retraced/main.c
+++ b/tools/retraced/main.c
@@ -1327,8 +1327,15 @@ int main(int argc, char **argv)
 	if (g_tls_listen >= 0)
 		close(g_tls_listen);
 	retraced_tls_free(g_tls_ctx);
-	if (unlink_sock)
+	if (unlink_sock) {
+		/* the ctl socket dies with the daemon: a stale file
+		 * connects a CLI to a dead inode -- and the next
+		 * boot's wait-for-socket lies
+		 */
 		unlink(sock_path);
+		if (ctl_path != NULL)
+			unlink(ctl_path);
+	}
 	free(conns);
 	return 0;
 }


### PR DESCRIPTION
The arc's last open card (**TODO.supervisor/09 P1**): every playbook and tour hand-wrote its policy JSON inline, and `share/policies/` was a false friend — the profiler's risk-scoring rulesets, not pushable supervisor policies.

**`share/policy-templates/` ships four complete `policy-push` artifacts:**

| Template | What it holds |
|----------|---------------|
| `read-only-workload.json` | The detonation default: wildcard sandbox, write-class denied outright (mode/flags derived), credential paths fenced |
| `no-network.json` | `socket`/`connect` synthesized −1 + the secret env names fenced |
| `env-fence.json` | getenv on common token/key names returns NULL |
| `decoy-farm.json` | Deny-by-default `allow_paths` with `decoy_dir` — out-of-fence reads get plausible fakes instead of denials (edit the paths first) |

The README covers the strictly-greater epoch ladder (templates ship at epoch 1 for `--policy` cold boots) and `sign-policy`; recipe 37 now points at the templates instead of hand-writing the first fence.

**Guard:** a push-smoke E2E (`integration-policy-templates`, push-only so it runs on the Windows pipe too) pushes every shipped template onto a fresh daemon and asserts `ok:1` — a template that stops loading against the daemon's real validation is a red test, so format drift in either direction dies. Verified: 4/4 push clean locally.
