### PR TITLE
ci: retry the checkpatch downloads -- a 429 is not a style verdict

### DIFF
--- a/ci/install_functions.sh
+++ b/ci/install_functions.sh
@@ -42,9 +42,13 @@ install_checkpatch() {
 	if [ ! -e "${CHECKPATCH_INSTALL}/checkpatch.pl" ]; then
 		mkdir -p "${CHECKPATCH_INSTALL}"
 		cd "${CHECKPATCH_INSTALL}"
-		wget https://raw.githubusercontent.com/torvalds/linux/master/scripts/checkpatch.pl
+		# raw.githubusercontent rate-limits (429) bursty CI
+		# merges -- a download flake must not fail a patch check
+		wget --tries=5 --retry-on-http-error=429 --waitretry=5 \
+			https://raw.githubusercontent.com/torvalds/linux/master/scripts/checkpatch.pl
 		chmod a+x checkpatch.pl
-		wget https://raw.githubusercontent.com/torvalds/linux/master/scripts/spelling.txt
+		wget --tries=5 --retry-on-http-error=429 --waitretry=5 \
+			https://raw.githubusercontent.com/torvalds/linux/master/scripts/spelling.txt
 		patch -p0 < "$SPWD"/checkpatch.pl.patch
 		echo "invalid.struct.name" > const_structs.checkpatch
 		printf '%s\n' "JSON_Object" "JSON_Array" "JSON_Value" \


### PR DESCRIPTION
PR #801 burned a full CI round to an HTTP 429 fetching checkpatch.pl from raw.githubusercontent.com (bursty merges get rate-limited). Both downloads now retry five times on 429 with a five-second backoff. Verified by forcing a fresh install: both files download, the patch applies, the config files stage.