### PR TITLE
ctl drift: the two-layer verdict as a read verb

### DIFF
--- a/docs/supervisor.md
+++ b/docs/supervisor.md
@@ -54,7 +54,7 @@ retrace-ctl [--sock PATH] COMMAND
 retrace-ctl --tls-host H:P --tls-cert PEM --tls-key PEM --tls-ca CA COMMAND
 ```
 
-Commands: `status`, `ps`, `policy-push FILE`, `freeze`, `thaw`, `kill
+Commands: `status`, `ps`, `drift`, `policy-push FILE`, `freeze`, `thaw`, `kill
 PID`, `spawn [--preload LIB] -- ARGV...`. Every command maps to a claim scope; a peer whose cert lacks the
 bit is refused with `scope denied` and the attempt is journaled as
 `retrace.auth.overscope`. Local UDS peers hold all scopes (PEERCRED
@@ -114,6 +114,29 @@ Read-only, PS-scope: the same claim bit `ps` needs on a TLS
 fleet. Agents whose parent HELLO has not been seen nest at
 the session root with `parent_hole` marked -- the same
 honesty the journal carries.
+
+### The two-layer read arm: retrace-ctl drift
+
+Kernel-lane observers (eBPF/ETW spectators) feed the registry
+their observations; the daemon journals drift summaries on its
+sweeps. `drift` answers the same numbers over the control
+plane, rolled up per session: the libc-layer agents, the
+observers' seats, the kernel-observation totals, and the
+not-yet-summarized delta -- the operator's live window onto
+sub-libc escapes, no filesystem access to the daemon's host.
+
+```sh
+retrace-ctl --sock /tmp/retraced.ctl.sock drift
+```
+
+```json
+{ "ok": 1, "sessions_count": 1, "sessions": [
+  { "token": "S1", "libc": ["boot.97009.1"],
+    "spectators": 1, "kernel_obs": 42, "delta": 7 } ] }
+```
+
+Read-only, PS-scope: the same claim bit `ps` needs on a TLS
+fleet.
 
 ### The evidence read arm: retrace-ctl events
 

--- a/test/unit/test_retraced_ctl.c
+++ b/test/unit/test_retraced_ctl.c
@@ -576,6 +576,63 @@ static void test_spawn_scope_denied(void)
 }
 
 /*
+ * The two-layer read: a libc agent and a kernel observer on
+ * one session fold into ONE rollup -- observers' kernel_obs
+ * totals and live deltas, the libc seats listed -- and a
+ * second session stays separate.
+ */
+static void test_drift_rolls_sessions(void)
+{
+	struct agent_entry *a, *k1, *k2;
+
+	setup();
+	a = retraced_registry_hello(ctx.reg, "libc-a", 100, 1,
+		"S1", "detonation");
+	k1 = retraced_registry_hello(ctx.reg, "ebpf-1", 101, 1,
+		"S1", "ebpf");
+	k2 = retraced_registry_hello(ctx.reg, "ebpf-2", 102, 1,
+		"S2", "ebpf");
+	CHECK(a != NULL && k1 != NULL && k2 != NULL);
+	k1->spectator = 1;
+	k1->kernel_obs = 40;
+	k1->kernel_obs_last = 33;
+	k2->spectator = 1;
+	k2->kernel_obs = 5;
+	feed(&ctx, "{\"cmd\":\"drift\"}");
+	{
+		JSON_Value *v = json_parse_string(reply_buf);
+		JSON_Array *sess;
+		JSON_Object *s1 = NULL, *s2 = NULL;
+		size_t i;
+
+		CHECK(v != NULL);
+		sess = json_value_get_array(
+			json_object_get_value(json_value_get_object(v),
+				"sessions"));
+		CHECK(json_array_get_count(sess) == 2);
+		for (i = 0; i < 2; i++) {
+			JSON_Object *o = json_array_get_object(sess, i);
+
+			if (strcmp(json_object_get_string(o, "token"),
+				    "S1") == 0)
+				s1 = o;
+			else
+				s2 = o;
+		}
+		CHECK(s1 != NULL && s2 != NULL);
+		CHECK(json_object_get_number(s1, "kernel_obs") == 40);
+		CHECK(json_object_get_number(s1, "delta") == 7);
+		CHECK(json_object_get_number(s1, "spectators") == 1);
+		CHECK(json_array_get_count(
+			json_value_get_array(json_object_get_value(
+				s1, "libc"))) == 1);
+		CHECK(json_object_get_number(s2, "kernel_obs") == 5);
+		CHECK(json_object_get_number(s2, "delta") == 5);
+		json_value_free(v);
+	}
+}
+
+/*
  * The framing tests (the byte layer's own test class -- the
  * reason feed exists): a line split across reads is ONE
  * command; two commands in one chunk are TWO; a partial line
@@ -694,6 +751,7 @@ int main(void)
 	TEST(feed_two_commands_one_chunk);
 	TEST(feed_partial_without_newline_is_silent);
 	TEST(feed_oversized_line_refused);
+	TEST(drift_rolls_sessions);
 
 	printf("%d tests: %d pass, %d fail\n", tests_run, tests_pass,
 		tests_fail);

--- a/tools/retrace-ctl/main.c
+++ b/tools/retrace-ctl/main.c
@@ -496,6 +496,8 @@ int main(int argc, char **argv)
 			snprintf(req, sizeof(req), "%s\n", blob);
 		}
 		i = argc;
+	} else if (strcmp(argv[i], "drift") == 0) {
+		snprintf(req, sizeof(req), "{\"cmd\":\"drift\"}\n");
 	} else if (strcmp(argv[i], "events") == 0) {
 		long last = 20;
 

--- a/tools/retraced/ctl_verbs.h
+++ b/tools/retraced/ctl_verbs.h
@@ -27,7 +27,9 @@
 	X(sessions, sessions, PS, "",				      \
 	  "the session tree (nested JSON)")			      \
 	X(events, events, STATUS, "[--last N]",		      \
-	  "journal tail + chain verdict")			      \
+	  "journal tail + chain verdict")		      \
+	X(drift, drift, PS, "",				      \
+	  "kernel observations per session (two-layer)")			      \
 	X(policy_push, policy-push, POLICY, "FILE",		      \
 	  "push a policy to all agents")			      \
 	X(freeze, freeze, POLICY, "",				      \

--- a/tools/retraced/retraced_ctl.c
+++ b/tools/retraced/retraced_ctl.c
@@ -746,3 +746,99 @@ void retraced_ctl_conn_reset(struct retraced_ctl_ctx *ctx)
 {
 	ctx->rfill = 0;
 }
+
+/*
+ * The two-layer verdict, read live (TODO.beyond-libc/03 P1's
+ * operator window): per session, the libc-layer agents, the
+ * kernel observers' seat count, and the observers' kernel-
+ * observation totals plus the not-yet-summarized delta -- the
+ * same numbers retrace.drift.summary journals, answerable over
+ * the control plane with no filesystem access to the daemon's
+ * host. Read-only, PS-scoped.
+ */
+static void verb_drift(struct retraced_ctl_ctx *ctx,
+	JSON_Object *o)
+{
+	JSON_Value *root = json_value_init_object();
+	JSON_Object *root_o = json_value_get_object(root);
+	JSON_Value *sessions_val = json_value_init_array();
+	JSON_Array *sessions = json_value_get_array(sessions_val);
+	size_t i, k;
+
+	(void)o;
+	for (i = 0; i < ctx->reg->count; i++) {
+		const struct agent_entry *e = &ctx->reg->agents[i];
+		int seen = 0;
+
+		for (k = 0; k < json_array_get_count(sessions); k++) {
+			const char *tok = json_object_get_string(
+				json_array_get_object(sessions, k),
+				"token");
+
+			if (tok != NULL &&
+			    strcmp(tok, e->session) == 0) {
+				seen = 1;
+				break;
+			}
+		}
+		if (!seen) {
+			JSON_Value *sv = json_value_init_object();
+			JSON_Object *so = json_value_get_object(sv);
+
+			json_object_set_string(so, "token", e->session);
+			json_object_set_value(so, "libc",
+				json_value_init_array());
+			json_object_set_number(so, "spectators", 0);
+			json_object_set_number(so, "kernel_obs", 0);
+			json_object_set_number(so, "delta", 0);
+			json_array_append_value(sessions, sv);
+		}
+	}
+	for (i = 0; i < ctx->reg->count; i++) {
+		const struct agent_entry *e = &ctx->reg->agents[i];
+		JSON_Object *so = NULL;
+
+		for (k = 0; k < json_array_get_count(sessions); k++) {
+			JSON_Object *cand = json_array_get_object(
+				sessions, k);
+
+			if (strcmp(json_object_get_string(cand, "token"),
+				    e->session) == 0) {
+				so = cand;
+				break;
+			}
+		}
+		if (so == NULL)
+			continue;
+		if (e->spectator) {
+			json_object_set_number(so, "spectators",
+				json_object_get_number(so,
+					"spectators") + 1);
+			json_object_set_number(so, "kernel_obs",
+				json_object_get_number(so,
+					"kernel_obs") +
+				(double)e->kernel_obs);
+			json_object_set_number(so, "delta",
+				json_object_get_number(so, "delta") +
+				(double)(e->kernel_obs -
+					e->kernel_obs_last));
+		} else {
+			json_array_append_string(
+				json_value_get_array(
+					json_object_get_value(so,
+						"libc")),
+				e->id);
+		}
+	}
+	json_object_set_number(root_o, "ok", 1);
+	json_object_set_number(root_o, "sessions_count",
+		(double)json_array_get_count(sessions));
+	json_object_set_value(root_o, "sessions", sessions_val);
+	{
+		char *s = json_serialize_to_string(root);
+
+		ctl_reply(ctx, "%s\n", s != NULL ? s : "{}");
+		json_free_serialized_string(s);
+	}
+	json_value_free(root);
+}


### PR DESCRIPTION
The operator's read surface completes: `status`, `ps`, `sessions`, `events` — and now **`drift`**.

Kernel-lane observers (eBPF/ETW spectators) feed the registry their observations and the daemon journals drift summaries on its sweeps — but the only way an operator saw any of it mid-run was the journal file on the daemon's host, exactly the filesystem dependency the `events` verb abolished for evidence.

**`retrace-ctl drift`** answers the same numbers over the control plane, rolled up per session: the libc-layer agents, the observers' seats, the kernel-observation totals, and the not-yet-summarized delta. Read-only, PS-scoped like every other read.

Implementation is the verb table's leverage exercised end to end: **one X-macro row** — dispatch, scope gate, CLI usage, and the conformance probe all derive — plus the rollup handler and a unit test driving the registry directly (a libc agent and two observers across two sessions fold into per-session totals, deltas, and seats; 23/23). Verified live: empty fleet, one spawned session, and the derived usage line. Full local suite green, checkpatch clean.
