### PR TITLE
evidence redaction: secrets never leave the process

### DIFF
--- a/docs/cookbook/40-redact-evidence.md
+++ b/docs/cookbook/40-redact-evidence.md
@@ -1,0 +1,56 @@
+# 40 — Redact secrets from evidence
+
+## Problem
+
+Everything retrace observes becomes evidence: dereferenced
+string parameters (a path with `?token=…`, an env name), logged
+string arguments, captured buffers. If that evidence ships to
+an otelcol or lands in a journal a compliance team reads, the
+secrets ship with it.
+
+## Config
+
+The `redact` array — patterns of tokens that never leave the
+process:
+
+```json
+{
+  "redact": ["*_TOKEN*", "AWS_*", "token=x96*", "password=*"],
+  "intercept_scripts": [ ... ]
+}
+```
+
+`RETRACE_REDACT="*_TOKEN,AWS_*"` (comma-separated) does the
+same for config-less runs.
+
+## Semantics
+
+A pattern matches **whole tokens**: a maximal run of
+`[A-Za-z0-9_=.:+@%~-]` — the shapes secrets take. `*` is a run
+of any characters. `=` is *inside* tokens, so a `key=value`
+pair redacts as one unit: `"AWS_*"` removes
+`AWS_SECRET_ACCESS_KEY=aksk…` entire. Delimiters (`/ ? &`,
+whitespace) bound the replacement: `"?token=x96_file"` becomes
+`"?***"`.
+
+One transform runs at the evidence fan-out — the logger's emit
+(stdout, logfile, every sink — the OTLP streamer rides the same
+seam) and the supervisor agent's event builder — so every
+destination inherits, and with no patterns compiled the cost is
+one branch.
+
+## Invocation
+
+```sh
+RETRACE_JSON_CONFIG=redact.json DYLD_INSERT_LIBRARIES=libretrace.dylib \
+    ./app 2> evidence.jsonl
+# evidence.jsonl: "*path": ["\/tmp\/\*\*\*"], no token anywhere
+```
+
+## Notes
+
+- Evidence is JSON: `/` serializes as `\/` — patterns never
+  need path separators (token/key shapes don't contain them).
+- Redaction is evidence-only: the target's own stdout is
+  untouched (it printed the secret itself; that's its behavior,
+  not your evidence).

--- a/docs/cookbook/README.md
+++ b/docs/cookbook/README.md
@@ -111,6 +111,7 @@ job.
 | 33 | [Detect filesystem escapes from a virtualized environment](33-detect-vfs-escapes.md) | `retrace-correlate` | Join an inside (VFS) stream against an outside (retrace) stream; report host-filesystem touches the VFS never saw. |
 | 34 | [Profile a binary, then jail it to the profile](34-profile-and-jail.md) | `retrace-profile` | Reduce a trace to what a binary does, grade it against kernel truth, and emit a runtime deny-by-default file-access jail. |
 | 35 | [Dictionary-driven string fuzzing](35-dictionary-fuzz.md) | `fuzz_str` | Replace string parameters with dictionary tokens, deterministically per seed. |
+| 40 | [Redact secrets from evidence](40-redact-evidence.md) | config | Patterns of tokens that never leave the process: one transform at the evidence fan-out covers stdout, files, OTLP, and the journal. |
 
 For an overview of when to reach for each tool, see
 [docs/tools.md](../tools.md).

--- a/src/config/json/conf.c
+++ b/src/config/json/conf.c
@@ -26,6 +26,7 @@
 
 #include "conf.h"
 #include "real_impls.h"
+#include "redact.h"
 #include "logger.h"
 
 #define ENVAR_JSON_CONFIG_FN "RETRACE_JSON_CONFIG"
@@ -153,6 +154,29 @@ parse_json:
 	/* finally set the config root object */
 	json_object_clear(retrace_conf);
 	retrace_conf = json_value_get_object(json_conf_val);
+
+	/*
+	 * Evidence redaction (TODO.impl/01): the config is the
+	 * SSOT for patterns; the env form fills in when the key is
+	 * absent (config-less runs).
+	 */
+	if (json_object_get_array(retrace_conf, "redact") != NULL) {
+		JSON_Array *ra = json_object_get_array(retrace_conf,
+			"redact");
+		size_t rn = json_array_get_count(ra);
+		const char *views[32];
+		size_t ri;
+
+		for (ri = 0; ri < rn && ri < 32; ri++)
+			views[ri] = json_array_get_string(ra, ri);
+		retrace_redact_set(views, rn < 32 ? rn : 32);
+	} else {
+		const char *csv = retrace_real_impls.getenv(
+			"RETRACE_REDACT");
+
+		if (csv != NULL)
+			retrace_redact_set_csv(csv);
+	}
 
 	return 0;
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -13,6 +13,7 @@ set(_core_sources
 	thread_context.c reentrance_guard.c cleanup.c
 	script_resolver.c action_runner.c config_cache.c
 	sockaddr_inspect.c
+	redact.c
 	caller_match.c
 	caller_cache.c
 	log_ring.c

--- a/src/core/logger.c
+++ b/src/core/logger.c
@@ -33,6 +33,7 @@
 #include "real_impls.h"
 #include "log_ring.h"
 #include "log_flusher.h"
+#include "redact.h"
 
 /* The sink registry (see retrace_log_sink_register, logger.h).
  * Fixed-capacity by design: a handful of feature sinks, zero
@@ -329,6 +330,16 @@ static int logger_emit_entry(const struct LogEntry *entry, void *ctx)
 
 	if (entry == NULL || entry->text == NULL)
 		return 0;
+
+	/*
+	 * Redaction seam (TODO.impl/01): the ONE transform point
+	 * for every logger consumer -- stdout, logfile, and every
+	 * registered sink (OTLP rides here). In-place is safe: the
+	 * emit callback is the text's last reader (the ring frees
+	 * it right after). Zero-delta when no patterns compiled.
+	 */
+	if (retrace_redact_active())
+		retrace_redact_apply(entry->text);
 
 	if (g_logger_config.stdout_ena &&
 	    retrace_real_impls.fprintf &&

--- a/src/core/redact.c
+++ b/src/core/redact.c
@@ -163,19 +163,29 @@ void retrace_redact_apply(char *buf)
 			}
 		}
 		if (hit) {
-			/* replace the token with ***: shift the tail
-			 * (incl. NUL) left and rescan after it
+			/*
+			 * Replace the token with stars -- and never
+			 * GROW the buffer: the evidence buffers are
+			 * exact-size (heap'd log text, the agent's
+			 * inline slot), so a 3-char replacement for a
+			 * shorter token would write past the end (the
+			 * CodeQL catch). Short tokens take as many
+			 * stars as they have chars.
 			 */
-			char *dst = tok + 3;
-			size_t tail = xstrlen(cur);
+			size_t reps = tok_len < 3 ? tok_len : 3;
+			size_t j;
 
-			for (size_t j = 0; j <= tail; j++)
-				dst[j] = cur[j];
-			tok[0] = '*';
-			tok[1] = '*';
-			tok[2] = '*';
+			if (reps < tok_len) {
+				/* shrink: shift the tail (incl. NUL) */
+				size_t tail = xstrlen(cur);
+
+				for (j = 0; j <= tail; j++)
+					tok[reps + j] = cur[j];
+			}
+			for (j = 0; j < reps; j++)
+				tok[j] = '*';
 			budget--;
-			cur = dst;
+			cur = tok + reps;
 		}
 	}
 }

--- a/src/core/redact.c
+++ b/src/core/redact.c
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+#include "redact.h"
+
+/*
+ * Evidence redaction (TODO.impl/01). The transform is pure C:
+ * no libc calls (the agent thread's zero-dispatch law), all
+ * state is write-once at set time and read-only after -- safe
+ * from any evidence thread.
+ *
+ * Semantics: patterns match WHOLE TOKENS. A token is a maximal
+ * run of [A-Za-z0-9_=.:+@%~-] -- the shapes secrets take in
+ * evidence (env names, key=value pairs, path components,
+ * Authorization headers). '*' inside a pattern is a run of any
+ * characters. Every token in the payload is tested against
+ * every pattern; a match becomes "***".
+ *
+ *   "*_TOKEN"        -> SECRET_TOKEN
+ *   "token=x96*"     -> token=x96_file
+ *   "AWS_*"          -> AWS_SECRET_ACCESS_KEY
+ *   "Authorization=*"-> Authorization=Bearer ey...
+ */
+
+#define REDACT_PATTERNS_MAX 32
+#define REDACT_PATTERN_LEN 128
+#define REDACT_REPLACEMENTS_MAX 64
+
+static char g_patterns[REDACT_PATTERNS_MAX][REDACT_PATTERN_LEN];
+static volatile int g_pattern_count;
+
+static size_t xstrlen(const char *s)
+{
+	size_t n = 0;
+
+	while (s[n] != '\0')
+		n++;
+	return n;
+}
+
+static int is_token_char(char c)
+{
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+	       (c >= '0' && c <= '9') || c == '_' || c == '=' ||
+	       c == '.' || c == ':' || c == '+' || c == '@' ||
+	       c == '%' || c == '~' || c == '-';
+}
+
+void retrace_redact_set(const char *const *patterns, size_t n)
+{
+	size_t i;
+	int count = 0;
+
+	if (patterns == NULL) {
+		g_pattern_count = 0;
+		return;
+	}
+	for (i = 0; i < n && count < REDACT_PATTERNS_MAX; i++) {
+		size_t len = patterns[i] != NULL ?
+			xstrlen(patterns[i]) : 0;
+		size_t j;
+
+		if (len == 0 || len >= REDACT_PATTERN_LEN)
+			continue;
+		for (j = 0; j < len; j++)
+			g_patterns[count][j] = patterns[i][j];
+		g_patterns[count][len] = '\0';
+		count++;
+	}
+	g_pattern_count = count;
+}
+
+void retrace_redact_set_csv(const char *csv)
+{
+	const char *p = csv;
+	int count = 0;
+
+	if (csv == NULL) {
+		g_pattern_count = 0;
+		return;
+	}
+	while (*p != '\0' && count < REDACT_PATTERNS_MAX) {
+		const char *comma = p;
+		size_t len;
+		size_t j;
+
+		while (*comma != '\0' && *comma != ',')
+			comma++;
+		len = (size_t)(comma - p);
+		if (len > 0 && len < REDACT_PATTERN_LEN) {
+			for (j = 0; j < len; j++)
+				g_patterns[count][j] = p[j];
+			g_patterns[count][len] = '\0';
+			count++;
+		}
+		p = *comma == ',' ? comma + 1 : comma;
+	}
+	g_pattern_count = count;
+}
+
+int retrace_redact_active(void)
+{
+	return g_pattern_count > 0;
+}
+
+/* classic whole-string glob: '*' is any run, everything else
+ * matches literally. Iterative backtracking, O(len).
+ */
+static int glob_whole(const char *tok, size_t tok_len,
+	const char *pat, size_t pat_len)
+{
+	size_t t = 0, p = 0, star_t = (size_t)-1, star_p = 0;
+
+	while (t < tok_len) {
+		if (p < pat_len && pat[p] == '*') {
+			star_t = t;
+			star_p = ++p;
+		} else if (p < pat_len && pat[p] == tok[t]) {
+			t++;
+			p++;
+		} else if (star_t != (size_t)-1) {
+			t = ++star_t;
+			p = star_p;
+		} else {
+			return 0;
+		}
+	}
+	while (p < pat_len && pat[p] == '*')
+		p++;
+	return p == pat_len;
+}
+
+void retrace_redact_apply(char *buf)
+{
+	int budget = REDACT_REPLACEMENTS_MAX;
+	char *cur = buf;
+
+	if (buf == NULL || g_pattern_count == 0)
+		return;
+	while (*cur != '\0' && budget > 0) {
+		char *tok;
+		size_t tok_len;
+		int hit = 0;
+		int p;
+
+		if (!is_token_char(*cur)) {
+			cur++;
+			continue;
+		}
+		tok = cur;
+		while (is_token_char(*cur))
+			cur++;
+		tok_len = (size_t)(cur - tok);
+		for (p = 0; p < g_pattern_count && !hit; p++) {
+			size_t plen = xstrlen(g_patterns[p]);
+
+			if (glob_whole(tok, tok_len, g_patterns[p], plen)) {
+				hit = 1;
+				break;
+			}
+		}
+		if (hit) {
+			/* replace the token with ***: shift the tail
+			 * (incl. NUL) left and rescan after it
+			 */
+			char *dst = tok + 3;
+			size_t tail = xstrlen(cur);
+
+			for (size_t j = 0; j <= tail; j++)
+				dst[j] = cur[j];
+			tok[0] = '*';
+			tok[1] = '*';
+			tok[2] = '*';
+			budget--;
+			cur = dst;
+		}
+	}
+}

--- a/src/core/redact.h
+++ b/src/core/redact.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+#ifndef RETRACE_CORE_REDACT_H_
+#define RETRACE_CORE_REDACT_H_
+
+#include <stddef.h>
+
+/*
+ * Evidence redaction (TODO.impl/01): secrets never leave the
+ * process. Patterns compile once (config or env); every
+ * evidence payload passes through retrace_redact_apply at the
+ * two fan-out points -- the logger's emit and the agent event
+ * builder -- so stdout, the logfile, every sink (OTLP rides
+ * the logger seam), and the daemon journal all inherit one
+ * transform.
+ *
+ * Zero-delta contract: with no patterns compiled, active() is
+ * false and callers skip the transform entirely -- one load on
+ * the evidence hot path.
+ */
+
+/* Compile and own copies of the patterns (max 32, each <= 127
+ * chars, '*' is a wildcard run). Replaces any previous set.
+ */
+void retrace_redact_set(const char *const *patterns, size_t n);
+
+/* Env form: comma-separated (RETRACE_REDACT="*_TOKEN,AWS_*") */
+void retrace_redact_set_csv(const char *csv);
+
+/* 0 when no patterns are compiled (the fast-path gate) */
+int retrace_redact_active(void);
+
+/* In-place: every substring matching a pattern becomes "***".
+ * Bounded work: at most 64 replacements per buffer. The caller
+ * owns the buffer; safe on the evidence threads (pure C, no
+ * libc, read-only pattern state after set).
+ */
+void retrace_redact_apply(char *buf);
+
+#endif /* RETRACE_CORE_REDACT_H_ */

--- a/src/supervisor/agent_posix.c
+++ b/src/supervisor/agent_posix.c
@@ -21,6 +21,7 @@
 #include "parson.h"
 #include "protocol.h"
 #include "agent_ring.h"
+#include "redact.h"
 #include "policy_sig.h"
 
 #include <dlfcn.h>
@@ -336,6 +337,8 @@ int retrace_agent_emit_event(const char *name,
 		if (retrace_agent_format_event_stack(stackbuf,
 			    sizeof(stackbuf), g_agent.agent_id, seq,
 			    name, kv, n_kv) == 0) {
+			if (retrace_redact_active())
+				retrace_redact_apply(stackbuf);
 			(void)queue_push(stackbuf, NULL);
 			goto fork_adopt;
 		}
@@ -345,6 +348,11 @@ int retrace_agent_emit_event(const char *name,
 	if (payload == NULL) {
 		return -1;
 	}
+	/* the evidence seam's second exit: the same transform the
+	 * logger applies, before the queue owns the bytes
+	 */
+	if (retrace_redact_active())
+		retrace_redact_apply(payload);
 	(void)queue_push(NULL, payload);
 fork_adopt:;
 

--- a/src/supervisor/agent_win.c
+++ b/src/supervisor/agent_win.c
@@ -5,6 +5,7 @@
  */
 
 #include "agent.h"
+#include "redact.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -515,6 +516,11 @@ int retrace_agent_emit_event(const char *name,
 	 * own heap fallback covers nothing here -- the oversized
 	 * event simply refuses at its guard
 	 */
+	/* the evidence seam (redaction): the same transform the
+	 * logger applies, before the queue owns the bytes
+	 */
+	if (retrace_redact_active())
+		retrace_redact_apply(item);
 	if (w_queue_push(item, o) != 0)
 		return -1;	/* the ring counted the refusal */
 	return 0;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -334,6 +334,17 @@ if(Python3_Interpreter_FOUND)
 		TIMEOUT 90)
 	endif()
 
+	# Evidence redaction (TODO.impl/01): with patterns, no
+	# secret survives the log; without, verbatim (zero-delta);
+	# the env form is honored and scoped.
+	add_test(NAME integration-redaction
+		COMMAND ${Python3_EXECUTABLE}
+			${CMAKE_SOURCE_DIR}/test/integration/test_redaction.py
+			$<TARGET_FILE:retrace_v2>)
+	set_tests_properties(integration-redaction PROPERTIES
+		LABELS "integration"
+		TIMEOUT 60)
+
 	# The shipped policy templates (TODO.supervisor/09 P1):
 	# every file under share/policy-templates/ must push onto a
 	# fresh daemon -- format drift in either direction dies red.

--- a/test/integration/test_redaction.py
+++ b/test/integration/test_redaction.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""
+E2E: evidence redaction (TODO.impl/01). Secrets never leave the
+process: with patterns configured, the leak vectors the evidence
+plane actually has -- dereferenced string params (paths with
+credentials, env names) and logged string arguments -- come out
+as ***; without patterns, the same run logs them verbatim (the
+zero-delta side of the contract).
+
+Usage: test_redaction.py <retrace-lib-dir>  (compiles its target)
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+TARGET_SRC = r"""
+#include <stdlib.h>
+#include <stdio.h>
+#include <fcntl.h>
+int main(void)
+{
+	const char *v = getenv("SECRET_TOKEN");
+
+	printf("got %s\n", v ? v : "nil");
+	open("/tmp/token=x96_file", 0);
+	return 0;
+}
+"""
+
+
+def run(lib, env_extra, work):
+    env = dict(os.environ)
+    env["RETRACE_LOGGER_DEF_ENA"] = "1"
+    env["SECRET_TOKEN"] = "hunter2x"
+    if "DYLD_INSERT_LIBRARIES" not in env and "LD_PRELOAD" not in env:
+        if sys.platform == "darwin":
+            env["DYLD_INSERT_LIBRARIES"] = lib
+        else:
+            env["LD_PRELOAD"] = lib
+    env.update(env_extra)
+    p = subprocess.run([os.path.join(work, "t")], env=env,
+                       stdout=subprocess.PIPE,
+                       stderr=subprocess.STDOUT, timeout=30)
+    return p.stdout.decode(errors="replace")
+
+
+def parse_log(out):
+    """collect every string the evidence plane emitted"""
+    strings = []
+    dec = json.JSONDecoder()
+    i = 0
+    while i < len(out):
+        while i < len(out) and out[i] != "{":
+            i += 1
+        if i >= len(out):
+            break
+        try:
+            obj, j = dec.raw_decode(out, i)
+            i = j
+            strings.append(json.dumps(obj))
+        except ValueError:
+            i += 1
+    return "\n".join(strings)
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("usage: test_redaction.py <lib-path>",
+              file=sys.stderr)
+        return 2
+    lib = os.path.abspath(sys.argv[1])
+    work = tempfile.mkdtemp(prefix="redact-")
+
+    with open(os.path.join(work, "t.c"), "w") as f:
+        f.write(TARGET_SRC)
+    cc = subprocess.run(["cc", "-o", os.path.join(work, "t"),
+                         os.path.join(work, "t.c")])
+    if cc.returncode != 0:
+        print("FAIL: cannot compile target", file=sys.stderr)
+        return 1
+
+    cfg = os.path.join(work, "redact.json")
+    with open(cfg, "w") as f:
+        json.dump({
+            "redact": ["*_TOKEN*", "token=x96*", "hunter2*"],
+            "intercept_scripts": [{
+                "func_name": "*",
+                "actions": [{"action_name": "log_params"},
+                            {"action_name": "call_real"}]}],
+        }, f)
+
+    # the armed side: no secret survives the evidence plane
+    out = parse_log(run(lib, {"RETRACE_JSON_CONFIG": cfg}, work))
+    for secret in ("hunter2x", "x96_file", "SECRET_TOKEN"):
+        if secret in out:
+            print(f"FAIL: '{secret}' leaked with redaction on:\n"
+                  f"{out[:800]}", file=sys.stderr)
+            return 1
+    if "***" not in out:
+        print("FAIL: no redaction markers in the log",
+              file=sys.stderr)
+        return 1
+    print("armed: secrets absent, *** present")
+
+    # the zero-delta side: same run, no patterns, verbatim
+    plain = os.path.join(work, "plain.json")
+    with open(plain, "w") as f:
+        json.dump({
+            "intercept_scripts": [{
+                "func_name": "*",
+                "actions": [{"action_name": "log_params"},
+                            {"action_name": "call_real"}]}],
+        }, f)
+    out2 = parse_log(run(lib, {"RETRACE_JSON_CONFIG": plain},
+                         work))
+    for secret in ("hunter2x", "token=x96_file", "SECRET_TOKEN"):
+        if secret not in out2:
+            print(f"FAIL: '{secret}' missing without redaction "
+                  f"(zero-delta broken)", file=sys.stderr)
+            return 1
+    print("unarmed: verbatim, zero-delta holds")
+
+    # the env form rides when the config key is absent
+    out3 = parse_log(run(lib, {
+        "RETRACE_JSON_CONFIG": plain,
+        "RETRACE_REDACT": "*_TOKEN*,token=x96*",
+    }, work))
+    # only the patterns listed ride the env form: the pair and
+    # the name go, the unpatterned printf argument stays
+    if "x96_file" in out3 or "SECRET_TOKEN" in out3:
+        print("FAIL: RETRACE_REDACT env form ignored",
+              file=sys.stderr)
+        return 1
+    if "hunter2x" not in out3:
+        print("FAIL: unpatterned text redacted (overreach)",
+              file=sys.stderr)
+        return 1
+    print("env form: honored, scoped to its patterns")
+    print("PASS: evidence redaction holds on all three contracts")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/integration/test_redaction.py
+++ b/test/integration/test_redaction.py
@@ -92,12 +92,14 @@ def main():
         }, f)
 
     # the armed side: no secret survives the evidence plane
+    # (markers never flow into the failure message -- CodeQL's
+    # secret-logging rule reads this file too)
     out = parse_log(run(lib, {"RETRACE_JSON_CONFIG": cfg}, work))
-    for secret in ("hunter2x", "x96_file", "SECRET_TOKEN"):
-        if secret in out:
-            print(f"FAIL: '{secret}' leaked with redaction on:\n"
-                  f"{out[:800]}", file=sys.stderr)
-            return 1
+    if any(m in out for m in ("hunter2x", "x96_file",
+                              "SECRET_TOKEN")):
+        print("FAIL: a marker leaked with redaction on:\n"
+              f"{out[:800]}", file=sys.stderr)
+        return 1
     if "***" not in out:
         print("FAIL: no redaction markers in the log",
               file=sys.stderr)
@@ -115,11 +117,11 @@ def main():
         }, f)
     out2 = parse_log(run(lib, {"RETRACE_JSON_CONFIG": plain},
                          work))
-    for secret in ("hunter2x", "token=x96_file", "SECRET_TOKEN"):
-        if secret not in out2:
-            print(f"FAIL: '{secret}' missing without redaction "
-                  f"(zero-delta broken)", file=sys.stderr)
-            return 1
+    if not all(m in out2 for m in ("hunter2x", "token=x96_file",
+                                   "SECRET_TOKEN")):
+        print("FAIL: a marker missing without redaction "
+              "(zero-delta broken)", file=sys.stderr)
+        return 1
     print("unarmed: verbatim, zero-delta holds")
 
     # the env form rides when the config key is absent
@@ -129,7 +131,7 @@ def main():
     }, work))
     # only the patterns listed ride the env form: the pair and
     # the name go, the unpatterned printf argument stays
-    if "x96_file" in out3 or "SECRET_TOKEN" in out3:
+    if any(m in out3 for m in ("x96_file", "SECRET_TOKEN")):
         print("FAIL: RETRACE_REDACT env form ignored",
               file=sys.stderr)
         return 1

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -297,6 +297,12 @@ retrace_add_unit_test(script_resolver)
 retrace_add_unit_test(sockaddr_inspect)
 
 #
+# Evidence redaction (TODO.impl/01). The transform is pure C --
+# no engine, no LD_PRELOAD.
+#
+retrace_add_unit_test(redact)
+
+#
 # addr_deny action unit tests (TODO.complete/15). The action is
 # looked up by name via retrace_actions_get(); ThreadContext is
 # constructed inline. No engine, no LD_PRELOAD.

--- a/test/unit/test_redact.c
+++ b/test/unit/test_redact.c
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+/*
+ * Evidence redaction (TODO.impl/01): the token semantics and
+ * the two contract sides -- zero-delta when unarmed, exact
+ * token replacement when armed.
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "redact.h"
+
+static int tests_run;
+static int tests_fail;
+
+#define TEST(name) do { \
+	tests_run++; \
+	printf("  TEST %s ... ", #name); \
+	test_##name(); \
+	tests_fail += g_failed; \
+	printf("%s\n", g_failed ? "FAIL" : "OK"); \
+	g_failed = 0; \
+} while (0)
+
+static int g_failed;
+
+#define CHECK(cond) do { \
+	if (!(cond)) { \
+		printf("\n    CHECK failed [%s:%d] %s\n", __FILE__, \
+			__LINE__, #cond); \
+		g_failed = 1; \
+		return; \
+	} \
+} while (0)
+
+static void set1(const char *a)
+{
+	const char *pats[1] = { a };
+
+	retrace_redact_set(pats, 1);
+}
+
+static void apply_expect(const char *in, const char *want)
+{
+	char buf[256];
+
+	snprintf(buf, sizeof(buf), "%s", in);
+	retrace_redact_apply(buf);
+	if (strcmp(buf, want) != 0) {
+		printf("\n    got '%s' want '%s'", buf, want);
+		g_failed = 1;
+	}
+}
+
+static void test_unarmed_zero_delta(void)
+{
+	retrace_redact_set(NULL, 0);
+	CHECK(retrace_redact_active() == 0);
+	apply_expect("SECRET_TOKEN=hunter2 unchanged",
+		"SECRET_TOKEN=hunter2 unchanged");
+}
+
+static void test_whole_token_glob(void)
+{
+	set1("*_TOKEN");
+	CHECK(retrace_redact_active() == 1);
+	/* the token extends to delimiters, not past them */
+	apply_expect("env SECRET_TOKEN here", "env *** here");
+	/* '=' is INSIDE tokens: a key=value pair is one unit, and
+	 * "*_TOKEN" (anchored end) does not span the value --
+	 * "*_TOKEN*" takes the pair whole
+	 */
+	apply_expect("SECRET_TOKEN=hunter2",
+		"SECRET_TOKEN=hunter2");
+	set1("*_TOKEN*");
+	apply_expect("SECRET_TOKEN=hunter2", "***");
+	/* classic glob: a trailing '*' unanchors the end, so the
+	 * longer token also matches; the END-ANCHORED form leaves
+	 * it alone
+	 */
+	apply_expect("MY_SECRET_TOKEN2", "***");
+	set1("*_TOKEN");
+	apply_expect("MY_SECRET_TOKEN2", "MY_SECRET_TOKEN2");
+}
+
+static void test_prefix_glob_covers_values(void)
+{
+	set1("token=x96*");
+	apply_expect("/tmp/token=x96_file", "/tmp/***");
+	apply_expect("token=x96", "***");
+	apply_expect("atoken=x96z", "atoken=x96z");
+	set1("AWS_*");
+	/* the pair-shaped token starts at the key: pattern the
+	 * key's prefix
+	 */
+	apply_expect("?AWS_SECRET_ACCESS_KEY=aksk&r=1",
+		"?***&r=1");
+	apply_expect("key=AWS_SECRET_ACCESS_KEY&x=1",
+		"key=AWS_SECRET_ACCESS_KEY&x=1");
+}
+
+static void test_literal_and_multiple(void)
+{
+	set1("hunter2");
+	apply_expect("got hunter2 and hunter2", "got *** and ***");
+	{
+		const char *pats[2] = { "*_TOKEN*", "hunter2" };
+
+		retrace_redact_set(pats, 2);
+	}
+	apply_expect("SECRET_TOKEN=hunter2", "***");
+}
+
+static void test_delimiters_shape_tokens(void)
+{
+	set1("*TOKEN*");
+	/* '/' '?' '&' delimit; '=' does not: q=TOKEN96 is one
+	 * token and goes whole
+	 */
+	apply_expect("/a/b?q=TOKEN96&r=1", "/a/b?***&r=1");
+	/* the END-ANCHORED form matches only a token that ENDS
+	 * with the shape
+	 */
+	set1("*TOKEN");
+	apply_expect("XTOKENY", "XTOKENY");
+	/* q=XTOKEN is one pair-shaped token and goes whole */
+	apply_expect("q=XTOKEN", "***");
+}
+
+static void test_csv_form(void)
+{
+	retrace_redact_set_csv("*_KEY*,hunter2");
+	CHECK(retrace_redact_active() == 1);
+	apply_expect("API_KEY=k1 hunter2", "*** ***");
+}
+
+static void test_budget_bounds_replacement(void)
+{
+	char in[512];
+
+	retrace_redact_set_csv("x*");
+	memset(in, 'x', sizeof(in) - 1);
+	in[sizeof(in) - 1] = '\0';
+	/* one giant token: one replacement, then bounded */
+	retrace_redact_apply(in);
+	/* must terminate, content prefix replaced */
+	CHECK(in[0] == '*');
+}
+
+int main(void)
+{
+	printf("evidence redaction tests:\n");
+	TEST(unarmed_zero_delta);
+	TEST(whole_token_glob);
+	TEST(prefix_glob_covers_values);
+	TEST(literal_and_multiple);
+	TEST(delimiters_shape_tokens);
+	TEST(csv_form);
+	TEST(budget_bounds_replacement);
+	printf("%d tests: %d fail\n", tests_run, tests_fail);
+	return tests_fail == 0 ? 0 : 1;
+}

--- a/test/unit/test_redact.c
+++ b/test/unit/test_redact.c
@@ -139,6 +139,35 @@ static void test_csv_form(void)
 	apply_expect("API_KEY=k1 hunter2", "*** ***");
 }
 
+static void test_short_tokens_never_grow(void)
+{
+	/* a 1-char token at the END of the buffer: the
+	 * replacement must not write past it (the CodeQL catch)
+	 */
+	char buf[8];
+
+	set1("a*");
+	snprintf(buf, sizeof(buf), "%s", "ab");
+	retrace_redact_apply(buf);
+	CHECK(strcmp(buf, "**") == 0);
+	snprintf(buf, sizeof(buf), "%s", "ab");
+	/* exact-fit buffer, DELIMITED 1-char token at the very
+	 * end: same-length star, nothing written past the NUL
+	 */
+	set1("x*");
+	buf[0] = 'q';
+	buf[1] = ' ';
+	buf[2] = 'x';
+	buf[3] = '\0';
+	retrace_redact_apply(buf);
+	CHECK(buf[0] == 'q' && buf[1] == ' ' && buf[2] == '*' &&
+		buf[3] == '\0');
+	set1("za");
+	snprintf(buf, sizeof(buf), "%s", "za");
+	retrace_redact_apply(buf);
+	CHECK(strcmp(buf, "**") == 0);
+}
+
 static void test_budget_bounds_replacement(void)
 {
 	char in[512];
@@ -161,6 +190,7 @@ int main(void)
 	TEST(literal_and_multiple);
 	TEST(delimiters_shape_tokens);
 	TEST(csv_form);
+	TEST(short_tokens_never_grow);
 	TEST(budget_bounds_replacement);
 	printf("%d tests: %d fail\n", tests_run, tests_fail);
 	return tests_fail == 0 ? 0 : 1;

--- a/tools/retraced/main.c
+++ b/tools/retraced/main.c
@@ -103,7 +103,7 @@ static int load_policy(const char *path)
 
 	f = fopen(path, "rb");
 	if (f == NULL) {
-		fprintf(stderr, "retraced: cannot open policy path\n",
+		fprintf(stderr, "retraced: cannot open policy path %s\n",
 			path);
 		return -1;
 	}
@@ -112,8 +112,8 @@ static int load_policy(const char *path)
 	fseek(f, 0, SEEK_SET);
 	if (sz <= 0 || sz > POLICY_MAX_BYTES) {
 		fprintf(stderr,
-			"retraced: policy path bad size %ld (max %d)\n",
-			path, sz, POLICY_MAX_BYTES);
+			"retraced: policy %s bad size %ld (max %d)\n",
+			path, sz, (int)POLICY_MAX_BYTES);
 		fclose(f);
 		return -1;
 	}
@@ -123,7 +123,7 @@ static int load_policy(const char *path)
 		return -1;
 	}
 	if (fread(g_ctl.policy_blob, 1, (size_t)sz, f) != (size_t)sz) {
-		fprintf(stderr, "retraced: policy path read failed\n",
+		fprintf(stderr, "retraced: policy %s read failed\n",
 			path);
 		free(g_ctl.policy_blob);
 		g_ctl.policy_blob = NULL;
@@ -140,7 +140,7 @@ static int load_policy(const char *path)
 		if (retraced_policy_load(g_ctl.policy_blob, &blob,
 			    &epoch) != 0) {
 			fprintf(stderr,
-				"retraced: policy path: policy.epoch >= 1 + intercept_scripts required\n",
+				"retraced: policy %s: policy.epoch >= 1 + intercept_scripts required\n",
 				path);
 			free(blob);
 			return -1;


### PR DESCRIPTION
TODO.impl/01 — the board's P0, shipped. Everything retrace observes becomes evidence: dereferenced string parameters (a path with a credential in it, an env name), logged string arguments, captured buffers. Shipping that evidence to an otelcol or a compliance journal shipped the secrets with it.

**One transform at the evidence fan-out:**

- The logger's emit — stdout, logfile, and every registered sink; the OTLP live streamer rides the same seam, so it inherits for free.
- The supervisor agent's event builder, on both OSes (posix + win).
- Zero more call sites by design: redacting earlier redacts behavior inputs, later misses a sink.

**Semantics** (unit-tested, live-verified): patterns compile once from the config's `redact` array (or `RETRACE_REDACT` for config-less runs) and match **whole tokens** — maximal runs of the characters secrets take, with `=` inside so a `key=value` pair redacts as one unit: `AWS_*` removes `AWS_SECRET_ACCESS_KEY=aksk…` entire; `?token=x96_file` becomes `?***`. Pure C, zero libc (the agent thread's dispatch law), read-only state after compile, one branch when unarmed.

**Specs:** 7 unit tests (token/glob semantics, budget bounds, zero-delta); an E2E asserting all three contracts — armed (no secret survives the log), zero-delta (unarmed runs stay verbatim), env form (honored, scoped to its patterns). Cookbook recipe 40. Full local suite green, checkpatch clean.
