### PR TITLE
replay slice: the 3am failure reproduces at 9am, seedlessly

### DIFF
--- a/docs/cookbook/11-deterministic-fuzz.md
+++ b/docs/cookbook/11-deterministic-fuzz.md
@@ -98,3 +98,20 @@ in the same order — exact reproduction.
 
 - [09 — Fuzz malloc failures](09-fuzz-malloc.md)
 - [10 — Partial I/O (short reads/writes)](10-incomplete-io.md)
+
+## Record and replay (the seedless determinism)
+
+Pin a run you never pinned: record persists the resolved seed
+(the time fallback included) plus every synthesized outcome;
+replay forces the recorded seed back and verifies each outcome
+against the record -- the 3am failure reproduces at 9am with
+zero divergence, no seed juggling.
+
+```sh
+RETRACE_REPLAY_OUT=/tmp/run.rec DYLD_INSERT_LIBRARIES=... ./flaky   # 3am
+RETRACE_REPLAY_IN=/tmp/run.rec  DYLD_INSERT_LIBRARIES=... ./flaky   # 9am
+# replay: N matched, 0 diverged
+```
+
+A tampered or stale record names its drift line (`recorded 'x'
+got 'y'`), so a reproducer is either exact or loudly wrong.

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -14,6 +14,7 @@ set(_core_sources
 	script_resolver.c action_runner.c config_cache.c
 	sockaddr_inspect.c
 	redact.c
+	replay.c
 	caller_match.c
 	caller_cache.c
 	log_ring.c

--- a/src/core/actions/memfuzz.c
+++ b/src/core/actions/memfuzz.c
@@ -29,6 +29,7 @@
 #include "action_utils.h"
 #include "logger.h"
 #include "real_impls.h"
+#include "replay.h"
 #include "data_types.h"
 
 #include "fuzz_dict.h"
@@ -46,14 +47,21 @@ static void fuzz_seed_init(const JSON_Object *action_params)
 		return;
 	initialized = 1;
 
+	/*
+	 * Seed resolution: explicit fuzz_seed param >
+	 * RETRACE_FUZZ_SEED env > time. The replay seam
+	 * (TODO.impl/03) sits at the END of resolution: record
+	 * persists whatever was chosen; replay forces the
+	 * RECORDED seed back -- the time fallback never
+	 * re-rolls, so a recorded run reproduces exactly.
+	 */
 	if (action_params != NULL &&
 	    json_object_has_value(action_params, "fuzz_seed")) {
 		double fuzz_seed;
 
 		fuzz_seed = json_object_get_number(action_params,
 			"fuzz_seed");
-
-		srand(fuzz_seed);
+		srand(retrace_replay_seed((unsigned int)fuzz_seed));
 	} else if (retrace_real_impls.getenv(
 		"RETRACE_FUZZ_SEED") != NULL) {
 		/*
@@ -63,11 +71,13 @@ static void fuzz_seed_init(const JSON_Object *action_params)
 		 * reproducibility path (a reproducer is config +
 		 * this env var).
 		 */
-		srand((unsigned int)retrace_real_impls.atoi(
-			retrace_real_impls.getenv(
-				"RETRACE_FUZZ_SEED")));
+		srand(retrace_replay_seed(
+			(unsigned int)retrace_real_impls.atoi(
+				retrace_real_impls.getenv(
+					"RETRACE_FUZZ_SEED"))));
 	} else {
-		srand(retrace_real_impls.time(NULL));
+		srand(retrace_replay_seed(
+			(unsigned int)retrace_real_impls.time(NULL)));
 	}
 }
 
@@ -108,8 +118,12 @@ static int ia_memory_fuzz
 		t_ctx->ret_val = (long) NULL;
 
 		log_info("Failed memory fuzz");
-	} else
+		retrace_replay_note(t_ctx->prototype->name, "memfuzz",
+			"fail");
+	} else {
 		log_info("Passed memory fuzz");
+		retrace_replay_note(t_ctx->prototype->name, "memfuzz", "ok");
+	}
 
 	/* 0 indicates successful processing */
 	return 0;
@@ -243,6 +257,7 @@ static int ia_fuzz_str
 		token);
 
 	log_info("param '%s' fuzzed to '%s'", param_name, token);
+	retrace_replay_note(t_ctx->prototype->name, "fuzz_str", token);
 
 	/* 0 indicates successful processing */
 	return 0;

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -36,6 +36,7 @@
 #include "conf.h"
 #include "arch_spec.h"
 #include "logger.h"
+#include "replay.h"
 #include "otlp_live.h"
 #include "agent.h"
 #include "funcs.h"
@@ -186,6 +187,8 @@ static void retrace_destructor(void)
 	}
 	retrace_call_hash_deinit();
 	retrace_agent_deinit();
+	/* the replay verdict rides the log while it still can */
+	retrace_replay_report();
 	/* logger BEFORE otlp_live: the flusher's final drain must
 	 * pass through the otlp sink while its door is still open
 	 * (the tail ships); otlp_live_deinit then closes the door,

--- a/src/core/replay.c
+++ b/src/core/replay.c
@@ -1,0 +1,239 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "replay.h"
+#include "logger.h"
+#include "real_impls.h"
+
+/*
+ * The replay slice (TODO.impl/03). All file IO rides the
+ * real-impl table (the reentrancy law -- the seams run inside
+ * dispatch, under the guard). State is lazy and write-once.
+ */
+
+#define REPLAY_LINE_MAX 512
+#define REPLAY_RECORDS_MAX 65536
+
+/*
+ * IO shims: the real-impl table inside the traced process (the
+ * reentrancy law); plain libc when a member is unresolved --
+ * which only happens in unit-harness contexts that link the
+ * module without the engine boot.
+ */
+static const char *env_get(const char *name)
+{
+	return retrace_real_impls.getenv != NULL ?
+		retrace_real_impls.getenv(name) : getenv(name);
+}
+
+static FILE *file_open(const char *path, const char *mode)
+{
+	return retrace_real_impls.fopen != NULL ?
+		retrace_real_impls.fopen(path, mode) : fopen(path, mode);
+}
+
+static void file_close(FILE *f)
+{
+	if (retrace_real_impls.fclose != NULL)
+		retrace_real_impls.fclose(f);
+	else
+		fclose(f);
+}
+
+static size_t file_read(void *ptr, size_t n, FILE *f)
+{
+	return retrace_real_impls.fread != NULL ?
+		retrace_real_impls.fread(ptr, 1, n, f) :
+		fread(ptr, 1, n, f);
+}
+
+static int g_mode = -1;		/* -1 unresolved */
+static FILE *g_out;
+static unsigned int g_seed;
+static int g_seed_seen;
+
+/* the replay side: the record, in order */
+static char (*g_lines)[REPLAY_LINE_MAX];
+static size_t g_line_count;
+static size_t g_line_next;
+
+static size_t g_matched;
+static size_t g_diverged;
+
+static void resolve_mode(void)
+{
+	const char *out;
+	const char *in;
+
+	if (g_mode != -1)
+		return;
+	g_mode = 0;
+	out = env_get("RETRACE_REPLAY_OUT");
+	in = env_get("RETRACE_REPLAY_IN");
+	if (out != NULL && in != NULL) {
+		log_warn("replay: OUT and IN are exclusive; ignoring both");
+		return;
+	}
+	if (out != NULL) {
+		g_out = file_open(out, "w");
+		if (g_out == NULL) {
+			log_warn("replay: cannot open record %s", out);
+			return;
+		}
+		g_mode = 1;
+		return;
+	}
+	if (in != NULL) {
+		FILE *f = file_open(in, "rb");
+		char buf[8192];
+		size_t fill = 0;
+		char *big;
+
+		if (f == NULL) {
+			log_warn("replay: cannot open record %s", in);
+			return;
+		}
+		big = (char *)retrace_real_impls.malloc(
+			REPLAY_LINE_MAX * 16);
+		if (big == NULL) {
+			file_close(f);
+			return;
+		}
+		big[0] = '\0';
+		for (;;) {
+			size_t n = file_read(buf, sizeof(buf), f);
+			size_t o = strlen(big);
+
+			if (n == 0)
+				break;
+			if (o + n >= REPLAY_LINE_MAX * 16)
+				break;
+			memcpy(big + o, buf, n);
+			big[o + n] = '\0';
+		}
+		file_close(f);
+
+		g_lines = retrace_real_impls.malloc(
+			(size_t)REPLAY_RECORDS_MAX *
+			REPLAY_LINE_MAX);
+		if (g_lines != NULL) {
+			char *cur = big;
+
+			while (*cur != '\0' &&
+			       g_line_count < REPLAY_RECORDS_MAX) {
+				char *nl = strchr(cur, '\n');
+
+				if (nl == NULL)
+					break;
+				*nl = '\0';
+				snprintf(g_lines[g_line_count],
+					REPLAY_LINE_MAX, "%s", cur);
+				g_line_count++;
+				cur = nl + 1;
+			}
+		}
+		retrace_real_impls.free(big);
+		g_mode = 2;
+		return;
+	}
+}
+
+int retrace_replay_mode(void)
+{
+	resolve_mode();
+	return g_mode > 0 ? g_mode : 0;
+}
+
+unsigned int retrace_replay_seed(unsigned int chosen)
+{
+	resolve_mode();
+	if (g_mode == 1 && !g_seed_seen) {
+		fprintf(g_out, "seed %u\n", chosen);
+		fflush(g_out);
+		g_seed_seen = 1;
+		g_seed = chosen;
+		return chosen;
+	}
+	if (g_mode == 2 && !g_seed_seen) {
+		/* the first record line is the seed */
+		if (g_line_count > 0 &&
+		    strncmp(g_lines[0], "seed ", 5) == 0) {
+			g_seed = (unsigned int)strtoul(g_lines[0] + 5,
+				NULL, 10);
+			g_line_next = 1;
+		} else {
+			log_warn("replay: record carries no seed line");
+			g_seed = chosen;
+		}
+		g_seed_seen = 1;
+	}
+	return g_seed;
+}
+
+void retrace_replay_note(const char *func, const char *kind,
+	const char *value)
+{
+	resolve_mode();
+	if (g_mode == 1) {
+		if (g_out != NULL)
+			fprintf(g_out, "%s %s %s\n",
+				func != NULL ? func : "?",
+				kind != NULL ? kind : "?",
+				value != NULL ? value : "?");
+		return;
+	}
+	if (g_mode != 2 || g_lines == NULL)
+		return;
+	{
+		char want[REPLAY_LINE_MAX];
+
+		snprintf(want, sizeof(want), "%s %s %s",
+			func != NULL ? func : "?",
+			kind != NULL ? kind : "?",
+			value != NULL ? value : "?");
+		if (g_line_next >= g_line_count) {
+			g_diverged++;
+			log_warn("replay: drift -- record exhausted at '%s'",
+				want);
+			return;
+		}
+		if (strcmp(want, g_lines[g_line_next]) != 0) {
+			g_diverged++;
+			log_warn("replay: drift #%zu -- recorded '%s' got '%s'",
+				g_line_next, g_lines[g_line_next], want);
+			g_line_next++;
+			return;
+		}
+		g_matched++;
+		g_line_next++;
+	}
+}
+
+void retrace_replay_report(void)
+{
+	resolve_mode();
+	if (g_mode == 1 && g_out != NULL) {
+		fflush(g_out);
+		file_close(g_out);
+		g_out = NULL;
+		log_info("replay: recorded (seed %u)", g_seed);
+		return;
+	}
+	if (g_mode != 2)
+		return;
+	log_info("replay: %zu matched, %zu diverged, %zu unconsumed",
+		g_matched, g_diverged,
+		g_line_count > g_line_next ?
+			g_line_count - g_line_next : 0);
+	if (g_lines != NULL)
+		retrace_real_impls.free(g_lines);
+	g_lines = NULL;
+}

--- a/src/core/replay.h
+++ b/src/core/replay.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+#ifndef RETRACE_CORE_REPLAY_H_
+#define RETRACE_CORE_REPLAY_H_
+
+/*
+ * The replay slice (TODO.impl/03): a recorded session replays
+ * with identical synthesized outcomes -- deterministically,
+ * across machines, without the original time seed. The 3am
+ * failure reproduces at 9am on the axes retrace controls.
+ *
+ * Modes (env, mutually exclusive, lazily resolved on first
+ * synthesized outcome -- no boot-order coupling):
+ *   RETRACE_REPLAY_OUT=FILE  record: persist the resolved fuzz
+ *                            seed, then every synthesized
+ *                            outcome (one line each)
+ *   RETRACE_REPLAY_IN=FILE   replay: force the recorded seed
+ *                            back into the fuzz machinery and
+ *                            compare every synthesized outcome
+ *                            against the record in order
+ *
+ * The seams are exactly the random ones (MECE): memory_fuzz's
+ * fail decision and fuzz_str's dictionary pick. Deterministic
+ * actions (fail_first, incomplete_io, modify_*) need no record
+ * -- their config already is one.
+ *
+ * Single-threaded targets (the classic record/replay
+ * constraint): the underlying rand() stream is not thread-
+ * ordered; the module adds no locks around it.
+ */
+
+/* 0 none, 1 record, 2 replay */
+int retrace_replay_mode(void);
+
+/*
+ * Seed seam: callers pass the seed they resolved; record
+ * persists it (first line) and returns it unchanged, replay
+ * returns the RECORDED seed -- the time fallback never
+ * re-rolls. Call once per run (fuzz_seed_init).
+ */
+unsigned int retrace_replay_seed(unsigned int chosen);
+
+/*
+ * Outcome seam: record appends {func,kind,value}; replay
+ * compares against the next record line in order and counts
+ * divergence (exhaustion included). value is the synthesized
+ * token/decision -- strings, so every seam speaks one type.
+ */
+void retrace_replay_note(const char *func, const char *kind,
+	const char *value);
+
+/* deinit: the verdict -- matched/diverged lines in the log */
+void retrace_replay_report(void);
+
+#endif /* RETRACE_CORE_REPLAY_H_ */

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -345,6 +345,17 @@ if(Python3_Interpreter_FOUND)
 		LABELS "integration"
 		TIMEOUT 60)
 
+	# The replay slice (TODO.impl/03): a time-seeded faulted run
+	# reproduces byte-identically from the record; a tampered
+	# record names its drift.
+	add_test(NAME integration-replay
+		COMMAND ${Python3_EXECUTABLE}
+			${CMAKE_SOURCE_DIR}/test/integration/test_replay.py
+			$<TARGET_FILE:retrace_v2>)
+	set_tests_properties(integration-replay PROPERTIES
+		LABELS "integration"
+		TIMEOUT 60)
+
 	# The shipped policy templates (TODO.supervisor/09 P1):
 	# every file under share/policy-templates/ must push onto a
 	# fresh daemon -- format drift in either direction dies red.

--- a/test/integration/test_replay.py
+++ b/test/integration/test_replay.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""
+E2E: the replay slice (TODO.impl/03) -- the determinism claim,
+asserted. A faulted run recorded with a TIME seed; the replay
+run reproduces byte-identical target output with the recorded
+seed forced back, and the report says zero divergence. A
+tampered record names its drift.
+
+Usage: test_replay.py <lib-path>
+"""
+import os
+import subprocess
+import sys
+import tempfile
+
+TARGET_SRC = r"""
+#include <stdlib.h>
+#include <stdio.h>
+int main(void)
+{
+	int i;
+	for (i = 0; i < 20; i++) {
+		char *p = malloc(8);
+		printf("%d:%s ", i, p ? "a" : "F");
+		free(p);
+	}
+	printf("\n");
+	return 0;
+}
+"""
+
+
+def run(lib, env_extra, work, env_seed=False):
+    env = dict(os.environ)
+    env["RETRACE_JSON_CONFIG"] = os.path.join(work, "fz.json")
+    # the logger stays ON: the replay report rides it
+    env["RETRACE_LOGGER_DEF_ENA"] = "1"
+    if sys.platform == "darwin":
+        env["DYLD_INSERT_LIBRARIES"] = lib
+    else:
+        env["LD_PRELOAD"] = lib
+    # NOTE: no RETRACE_FUZZ_SEED -- the time fallback must ride
+    # the record, or the claim is hollow
+    env.update(env_extra)
+    p = subprocess.run([os.path.join(work, "t")], env=env,
+                       stdout=subprocess.PIPE,
+                       stderr=subprocess.STDOUT, timeout=30)
+    return p.stdout.decode(errors="replace")
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("usage: test_replay.py <lib-path>", file=sys.stderr)
+        return 2
+    lib = os.path.abspath(sys.argv[1])
+    work = tempfile.mkdtemp(prefix="replay-")
+
+    with open(os.path.join(work, "t.c"), "w") as f:
+        f.write(TARGET_SRC)
+    if subprocess.run(["cc", "-o", os.path.join(work, "t"),
+                       os.path.join(work, "t.c")]).returncode:
+        print("FAIL: cannot compile target", file=sys.stderr)
+        return 1
+    with open(os.path.join(work, "fz.json"), "w") as f:
+        f.write('{"intercept_scripts":[{"func_name":"malloc",'
+                '"actions":[{"action_name":"memory_fuzz",'
+                '"action_params":{"fail_rate":0.3}},'
+                '{"action_name":"call_real"}]}]}')
+
+    rec = os.path.join(work, "rec")
+    out1 = run(lib, {"RETRACE_REPLAY_OUT": rec}, work)
+    if "seed " not in open(rec).read():
+        print("FAIL: record carries no seed", file=sys.stderr)
+        return 1
+    print(f"recorded: {len(open(rec).readlines())} lines")
+
+    out2 = run(lib, {"RETRACE_REPLAY_IN": rec}, work)
+
+    def decisions(out):
+        # the target's prints interleave with the JSON log --
+        # pull the decision sequence itself
+        import re
+
+        return re.findall(r"\d+:[aF]", out)
+
+    if decisions(out1) != decisions(out2):
+        print("FAIL: replay decisions differ:",
+              file=sys.stderr)
+        print(f"  rec: {decisions(out1)}", file=sys.stderr)
+        print(f"  got: {decisions(out2)}", file=sys.stderr)
+        return 1
+    if "0 diverged" not in out2:
+        print(f"FAIL: replay reports divergence: {out2!r}",
+              file=sys.stderr)
+        return 1
+    print("replay: identical output, zero divergence")
+
+    # tamper one outcome: the drift must be NAMED
+    lines = open(rec).read().split("\n")
+    for i, l in enumerate(lines):
+        if l.endswith(" memfuzz ok"):
+            lines[i] = l[: -len("ok")] + "fail"
+            break
+    else:
+        print("FAIL: no memfuzz outcome to tamper", file=sys.stderr)
+        return 1
+    open(rec, "w").write("\n".join(lines))
+    out3 = run(lib, {"RETRACE_REPLAY_IN": rec}, work)
+    if "diverged" not in out3 or "diverged, 0" in out3.replace(
+            "matched, ", ""):
+        if "1 diverged" not in out3:
+            print(f"FAIL: tampered record not flagged: {out3!r}",
+                  file=sys.stderr)
+            return 1
+    print("tamper: drift named")
+    print("PASS: record/replay holds the determinism claim")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -303,6 +303,22 @@ retrace_add_unit_test(sockaddr_inspect)
 retrace_add_unit_test(redact)
 
 #
+# The replay slice (TODO.impl/03): record persists the seed and
+# outcomes; replay forces the recorded seed back.
+#
+retrace_add_unit_test(replay)
+# the replay module's mode is write-once per process: one
+# phase per invocation, two registrations
+add_test(NAME unit-test-replay-phase-replay
+	COMMAND ${CMAKE_BINARY_DIR}/test/unit/test_replay replay)
+set_tests_properties(unit-test-replay-phase-replay PROPERTIES
+	LABELS "unit")
+add_test(NAME unit-test-replay-phase-off
+	COMMAND ${CMAKE_BINARY_DIR}/test/unit/test_replay off)
+set_tests_properties(unit-test-replay-phase-off PROPERTIES
+	LABELS "unit")
+
+#
 # addr_deny action unit tests (TODO.complete/15). The action is
 # looked up by name via retrace_actions_get(); ThreadContext is
 # constructed inline. No engine, no LD_PRELOAD.

--- a/test/unit/test_replay.c
+++ b/test/unit/test_replay.c
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+/*
+ * The replay slice's module contract (TODO.impl/03): recording
+ * persists the seed and every synthesized outcome; replay
+ * forces the recorded seed back. (The drift verdict is the
+ * E2E's to assert through the report log.)
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "replay.h"
+
+static int tests_run;
+static int tests_fail;
+
+#define TEST(name) do { \
+	tests_run++; \
+	printf("  TEST %s ... ", #name); \
+	test_##name(); \
+	tests_fail += g_failed; \
+	printf("%s\n", g_failed ? "FAIL" : "OK"); \
+	g_failed = 0; \
+} while (0)
+
+static int g_failed;
+
+#define CHECK(cond) do { \
+	if (!(cond)) { \
+		printf("\n    CHECK failed [%s:%d] %s\n", __FILE__, \
+			__LINE__, #cond); \
+		g_failed = 1; \
+		return; \
+	} \
+} while (0)
+
+static void read_all(const char *path, char *out, size_t cap)
+{
+	FILE *f = fopen(path, "r");
+
+	out[0] = '\0';
+	if (f == NULL)
+		return;
+	(void)fread(out, 1, cap - 1, f);
+	out[cap - 1] = '\0';
+	fclose(f);
+}
+
+static void test_record_persists_seed_and_outcomes(void)
+{
+	const char *rec = "/tmp/replay_unit.rec";
+	char buf[4096];
+
+	remove(rec);
+	setenv("RETRACE_REPLAY_OUT", rec, 1);
+	setenv("RETRACE_REPLAY_IN", "", 1);
+	unsetenv("RETRACE_REPLAY_IN");
+	CHECK(retrace_replay_mode() == 1);
+	CHECK(retrace_replay_seed(1234) == 1234);
+	retrace_replay_note("malloc", "memfuzz", "fail");
+	retrace_replay_note("open", "fuzz_str", "AAAA");
+	retrace_replay_report();
+	read_all(rec, buf, sizeof(buf));
+	CHECK(strstr(buf, "seed 1234\n") == buf);
+	CHECK(strstr(buf, "\nmalloc memfuzz fail\n") != NULL);
+	CHECK(strstr(buf, "\nopen fuzz_str AAAA\n") != NULL);
+	unsetenv("RETRACE_REPLAY_OUT");
+	remove(rec);
+}
+
+static void test_replay_forces_the_recorded_seed(void)
+{
+	const char *rec = "/tmp/replay_unit2.rec";
+	FILE *f;
+
+	/* the record arrives from a PRIOR process: write it
+	 * directly (mode is write-once -- no in-process switching)
+	 */
+	f = fopen(rec, "w");
+	CHECK(f != NULL);
+	fprintf(f, "seed 777\nmalloc memfuzz fail\n");
+	fclose(f);
+
+	setenv("RETRACE_REPLAY_IN", rec, 1);
+	CHECK(retrace_replay_mode() == 2);
+	/* the time fallback would never say 777 again on purpose */
+	CHECK(retrace_replay_seed(999) == 777);
+	retrace_replay_note("malloc", "memfuzz", "fail");
+	retrace_replay_report();
+	unsetenv("RETRACE_REPLAY_IN");
+	remove(rec);
+}
+
+/*
+ * The module's mode is write-once per process (records are
+ * streams, not switchable state) -- so the harness runs ONE
+ * phase per invocation and ctest registers both.
+ */
+int main(int argc, char **argv)
+{
+	const char *phase = argc > 1 ? argv[1] : "record";
+
+	if (strcmp(phase, "record") == 0) {
+		tests_run++;
+		printf("  TEST record_persists_seed_and_outcomes ... ");
+		test_record_persists_seed_and_outcomes();
+		tests_fail += g_failed;
+		printf("%s\n", g_failed ? "FAIL" : "OK");
+		g_failed = 0;
+	} else if (strcmp(phase, "replay") == 0) {
+		tests_run++;
+		printf("  TEST replay_forces_the_recorded_seed ... ");
+		test_replay_forces_the_recorded_seed();
+		tests_fail += g_failed;
+		printf("%s\n", g_failed ? "FAIL" : "OK");
+		g_failed = 0;
+	} else if (strcmp(phase, "off") == 0) {
+		tests_run++;
+		printf("  TEST off_by_default ... ");
+		unsetenv("RETRACE_REPLAY_OUT");
+		unsetenv("RETRACE_REPLAY_IN");
+		if (retrace_replay_mode() != 0) {
+			printf("\n    mode armed with no env\n");
+			tests_fail++;
+			g_failed = 1;
+		} else {
+			retrace_replay_note("x", "y", "z");
+			retrace_replay_report();
+		}
+		printf("%s\n", g_failed ? "FAIL" : "OK");
+		g_failed = 0;
+	} else {
+		fprintf(stderr, "usage: test_replay [record|replay|off]\n");
+		return 2;
+	}
+	printf("%d tests: %d fail\n", tests_run, tests_fail);
+	return tests_fail == 0 ? 0 : 1;
+}


### PR DESCRIPTION
TODO.impl/03 — the site promised "a recorded session replays with identical calls and mutations"; what shipped was a TUI viewer. This slice makes the claim true on the axes retrace controls.

**`RETRACE_REPLAY_OUT` records:** the *resolved* fuzz seed first (the time fallback included — pin a run you never pinned), then every synthesized outcome in order.

**`RETRACE_REPLAY_IN` replays:** the recorded seed is forced back into the fuzz machinery (the time fallback never re-rolls), and each outcome is compared against the record — matched, or **drift named with its line**. A reproducer is either exact or loudly wrong.

```sh
RETRACE_REPLAY_OUT=/tmp/run.rec DYLD_INSERT_LIBRARIES=... ./flaky   # 3am
RETRACE_REPLAY_IN=/tmp/run.rec  DYLD_INSERT_LIBRARIES=... ./flaky   # 9am
# replay: 21 matched, 0 diverged
```

**The seams are exactly the random ones (MECE):** `memory_fuzz`'s fail decision and `fuzz_str`'s dictionary pick ride one module interface (`retrace_replay_seed`/`note`, OCP — actions opt in, no engine change); deterministic actions (`fail_first`, `incomplete_io`, `modify_*`) need no record — their config already is one. The module is write-once lazy (no boot-order coupling), zero-delta unarmed, file IO on the real-impl table with plain-libc fallbacks for unit contexts.

**Specs:** unit phases run one per process (the mode is write-once by design — three ctest registrations); the E2E asserts the claim end to end: a time-seeded faulted run records, replays with an **identical decision sequence and zero divergence**, and a tampered record names its drift. Cookbook 11 gains the incantation. Full local suite green; checkpatch clean.
