### PR TITLE
journal signing: the seal -- trust anchors for external auditors

### DIFF
--- a/docs/supervisor.md
+++ b/docs/supervisor.md
@@ -218,6 +218,31 @@ Ctrl handler uses, so `sc stop` rides the graceful journal-flush
 exit; `--exit-after N` still applies as the watchdog belt under
 both launches.
 
+### Journal signing: the seal
+
+Hash chains prove the journal's LOCAL continuity; the seal
+gives an external auditor the trust anchor. Boot the daemon
+with `--signing-key` (a PEM ed25519 key) and every graceful
+close appends a `retrace.journal.signed` record -- ed25519
+over the closed chain's head and line count, itself
+chain-linked. Verification is the CLI's local verb:
+
+```sh
+openssl genpkey -algorithm ed25519 -out k.pem
+openssl pkey -in k.pem -pubout -out pub.pem
+retraced --journal j.jsonl --signing-key k.pem ...
+retrace-ctl verify-journal j.jsonl --pubkey pub.pem
+# verified + signed (ed25519, N lines)
+```
+
+Tamper any byte and the chain names its line before the seal
+is even consulted; swap the seal or the key and the signature
+mismatch names itself. An unclean shutdown leaves an unsigned
+tail -- visible as the missing close marker and seal, exactly
+the honesty the journal already carries. (Rotation intervals
+that chain seals across segments ride the lifecycle card,
+TODO.impl/10.)
+
 ### The audit trail
 
 `--audit TRAIL` binds every exec to `(timestamp, pid, spec digest,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -356,6 +356,18 @@ if(Python3_Interpreter_FOUND)
 		LABELS "integration"
 		TIMEOUT 60)
 
+	# Journal signing (TODO.impl/07): the daemon seals at
+	# graceful close; verify-journal walks the chain AND checks
+	# the ed25519 seal. Three verdicts.
+	add_test(NAME integration-journal-sign
+		COMMAND ${Python3_EXECUTABLE}
+			${CMAKE_SOURCE_DIR}/test/integration/test_journal_sign.py
+			$<TARGET_FILE:retrace_retraced>
+			$<TARGET_FILE:retrace_ctl>)
+	set_tests_properties(integration-journal-sign PROPERTIES
+		LABELS "integration"
+		TIMEOUT 90)
+
 	# The shipped policy templates (TODO.supervisor/09 P1):
 	# every file under share/policy-templates/ must push onto a
 	# fresh daemon -- format drift in either direction dies red.

--- a/test/integration/test_journal_sign.py
+++ b/test/integration/test_journal_sign.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""
+E2E: journal signing (TODO.impl/07). Hash chains prove local
+continuity; the ed25519 seal gives an external auditor the
+trust anchor. The daemon seals at graceful close; verify-journal
+walks the chain AND checks the seal. Three verdicts: clean
+(verified+signed), tampered (chain names its line), wrong key
+(signature mismatch).
+
+Usage: test_journal_sign.py <retraced> <retrace-ctl>
+"""
+import os
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+
+
+def wait_sock(path, deadline=5.0):
+    end = time.time() + deadline
+    while time.time() < end:
+        if os.path.exists(path):
+            return True
+        time.sleep(0.1)
+    return False
+
+
+def main():
+    if len(sys.argv) != 3:
+        print("usage: test_journal_sign.py <retraced> "
+              "<retrace-ctl>", file=sys.stderr)
+        return 2
+    daemon, ctl_bin = (os.path.abspath(p) for p in sys.argv[1:3])
+
+    # key generation needs the openssl CLI: probe trouble is a
+    # skip, never a failure (the noderetrace gate's rule)
+    probe = subprocess.run(["openssl", "version"],
+                           stdout=subprocess.DEVNULL,
+                           stderr=subprocess.DEVNULL)
+    if probe.returncode != 0:
+        print("SKIP: openssl CLI not available on this leg")
+        return 0
+
+    work = tempfile.mkdtemp(prefix="jsign-")
+    journal = os.path.join(work, "journal.jsonl")
+    key = os.path.join(work, "k.pem")
+    pub = os.path.join(work, "pub.pem")
+    key2 = os.path.join(work, "k2.pem")
+    pub2 = os.path.join(work, "pub2.pem")
+
+    for k, p in ((key, pub), (key2, pub2)):
+        subprocess.run(["openssl", "genpkey", "-algorithm", "ed25519",
+                        "-out", k], check=True,
+                       stdout=subprocess.DEVNULL)
+        subprocess.run(["openssl", "pkey", "-in", k, "-pubout",
+                        "-out", p], check=True,
+                       stdout=subprocess.DEVNULL)
+
+    d = subprocess.Popen(
+        [daemon, "--sock", os.path.join(work, "a.sock"),
+         "--journal", journal, "--ctl", os.path.join(work, "c.sock"),
+         "--nonce-file", os.path.join(work, "n.txt"),
+         "--signing-key", key],
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    if not wait_sock(os.path.join(work, "c.sock")):
+        d.kill()
+        print("FAIL: daemon ctl socket never appeared", file=sys.stderr)
+        return 1
+    # one event so the journal is non-trivial
+    subprocess.run([ctl_bin, "--sock", os.path.join(work, "c.sock"),
+                    "status"], stdout=subprocess.DEVNULL)
+    time.sleep(0.3)
+    d.send_signal(signal.SIGTERM)
+    try:
+        d.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        d.kill()
+
+    with open(journal) as f:
+        content = f.read()
+    if "retrace.journal.signed" not in content:
+        print("FAIL: no seal record in the journal", file=sys.stderr)
+        return 1
+    print("sealed: journal carries the ed25519 seal")
+
+    def verify(path, pubkey):
+        p = subprocess.run([ctl_bin, "verify-journal", path,
+                            "--pubkey", pubkey],
+                           stdout=subprocess.PIPE,
+                           stderr=subprocess.STDOUT)
+        return p.returncode, p.stdout.decode()
+
+    rc, out = verify(journal, pub)
+    if rc != 0 or "verified + signed" not in out:
+        print(f"FAIL: clean journal refused: {out!r}", file=sys.stderr)
+        return 1
+    print(f"clean: {out.strip()}")
+
+    tam = os.path.join(work, "tampered.jsonl")
+    with open(tam, "w") as f:
+        f.write(content.replace("retrace.journal.closed",
+                                "retrace.journal.closed ", 1))
+    rc, out = verify(tam, pub)
+    if rc == 0 or "chain broken" not in out:
+        print(f"FAIL: tampered journal accepted: {out!r}",
+              file=sys.stderr)
+        return 1
+    print(f"tampered: {out.strip()}")
+
+    rc, out = verify(journal, pub2)
+    if rc == 0 or "signature mismatch" not in out:
+        print(f"FAIL: wrong key accepted: {out!r}", file=sys.stderr)
+        return 1
+    print("wrong key: signature mismatch")
+
+    print("PASS: sign/verify/tamper/wrong-key all hold")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/integration/test_journal_sign.py
+++ b/test/integration/test_journal_sign.py
@@ -34,11 +34,11 @@ def main():
     daemon, ctl_bin = (os.path.abspath(p) for p in sys.argv[1:3])
 
     # key generation needs the openssl CLI: probe trouble is a
-    # skip, never a failure (the noderetrace gate's rule)
-    probe = subprocess.run(["openssl", "version"],
-                           stdout=subprocess.DEVNULL,
-                           stderr=subprocess.DEVNULL)
-    if probe.returncode != 0:
+    # skip, never a failure (a MISSING binary raises, not
+    # returns nonzero -- which(); the noderetrace gate's rule)
+    import shutil
+
+    if shutil.which("openssl") is None:
         print("SKIP: openssl CLI not available on this leg")
         return 0
 

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -307,6 +307,19 @@ retrace_add_unit_test(redact)
 # outcomes; replay forces the recorded seed back.
 #
 retrace_add_unit_test(replay)
+
+#
+# The standalone journal chain primitive (TODO.impl/07): the
+# signer and the verifier both ride its walk.
+#
+# journal.c+registry.c ride along as sources; parson comes via
+# the harness's retrace_core link (duplicate symbols otherwise)
+retrace_add_unit_test(journal_chain
+	EXTRA_SOURCES
+	${CMAKE_SOURCE_DIR}/tools/retraced/journal.c
+	${CMAKE_SOURCE_DIR}/tools/retraced/registry.c
+	EXTRA_INCLUDES
+	${CMAKE_SOURCE_DIR}/tools/retraced)
 # the replay module's mode is write-once per process: one
 # phase per invocation, two registrations
 add_test(NAME unit-test-replay-phase-replay

--- a/test/unit/test_journal_chain.c
+++ b/test/unit/test_journal_chain.c
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+/*
+ * The standalone chain primitive (TODO.impl/07): one walk,
+ * three facts -- verified?, head-at-stop, line count. The
+ * signer seals the full-walk head; the verifier re-derives the
+ * head at the seal point; both ride THIS arithmetic.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <time.h>
+
+#include "journal.h"
+
+static int tests_run;
+static int tests_fail;
+
+#define TEST(name) do { \
+	tests_run++; \
+	printf("  TEST %s ... ", #name); \
+	test_##name(); \
+	tests_fail += g_failed; \
+	printf("%s\n", g_failed ? "FAIL" : "OK"); \
+	g_failed = 0; \
+} while (0)
+
+static int g_failed;
+
+#define CHECK(cond) do { \
+	if (!(cond)) { \
+		printf("\n    CHECK failed [%s:%d] %s\n", __FILE__, \
+			__LINE__, #cond); \
+		g_failed = 1; \
+		return; \
+	} \
+} while (0)
+
+static void write_journal(const char *path, int events)
+{
+	struct retraced_journal j;
+	int i;
+
+	retraced_journal_open(&j, path);
+	for (i = 0; i < events; i++)
+		retraced_journal_event(&j, 1000 + i, "t", i,
+			"{\"name\":\"e\"}");
+	retraced_journal_close(&j);
+}
+
+static void test_chain_walk_reports_head_and_lines(void)
+{
+	uint64_t head = 0, head_all = 0;
+	size_t lines = 0, broken = 99;
+
+	remove("/tmp/jchain1.jsonl");
+	write_journal("/tmp/jchain1.jsonl", 3);
+	/* close adds one record: 4 lines total */
+	CHECK(retraced_journal_chain_file(
+		"/tmp/jchain1.jsonl", 0, &head_all, &lines,
+		&broken) == 0);
+	CHECK(lines == 4);
+	CHECK(broken == 0);
+	CHECK(head_all != 0);
+	/* stop before the close marker: 3 events */
+	CHECK(retraced_journal_chain_file(
+		"/tmp/jchain1.jsonl", 3, &head, NULL, &broken) == 0);
+	CHECK(head != head_all);
+	CHECK(head != 0);
+	/* stop past the end is the full walk */
+	CHECK(retraced_journal_chain_file(
+		"/tmp/jchain1.jsonl", 99, &head, NULL, &broken) == 0);
+	CHECK(head == head_all);
+	remove("/tmp/jchain1.jsonl");
+}
+
+static void test_chain_names_the_broken_line(void)
+{
+	char all[8192];
+	size_t lines = 0, broken = 0;
+	FILE *f;
+
+	remove("/tmp/jchain2.jsonl");
+	write_journal("/tmp/jchain2.jsonl", 3);
+	f = fopen("/tmp/jchain2.jsonl", "r");
+	CHECK(f != NULL);
+	(void)fread(all, 1, sizeof(all) - 1, f);
+	fclose(f);
+	/* tamper line 2's payload (not its prev field) */
+	{
+		char *p = strstr(all, "\"name\":\"e\"");
+
+		if (p != NULL)
+			*p = 'x';
+	}
+	f = fopen("/tmp/jchain2.jsonl", "w");
+	fputs(all, f);
+	fclose(f);
+	CHECK(retraced_journal_chain_file(
+		"/tmp/jchain2.jsonl", 0, NULL, &lines,
+		&broken) != 0);
+	/* the tampered line is the FIRST event (line 1): its link
+	 * changes, so line 2's stored prev no longer matches
+	 */
+	CHECK(broken == 2);
+	remove("/tmp/jchain2.jsonl");
+}
+
+static void test_missing_file_is_an_error(void)
+{
+	size_t broken = 0;
+
+	CHECK(retraced_journal_chain_file(
+		"/tmp/jchain-nonexistent.jsonl", 0, NULL, NULL,
+		&broken) != 0);
+}
+
+int main(void)
+{
+	printf("journal chain primitive tests:\n");
+	TEST(chain_walk_reports_head_and_lines);
+	TEST(chain_names_the_broken_line);
+	TEST(missing_file_is_an_error);
+	printf("%d tests: %d fail\n", tests_run, tests_fail);
+	return tests_fail == 0 ? 0 : 1;
+}

--- a/tools/retrace-ctl/CMakeLists.txt
+++ b/tools/retrace-ctl/CMakeLists.txt
@@ -4,19 +4,22 @@
 # like retraced until plan 12 (named pipes). TLS client path
 # (TODO.supervisor/08 P1) reuses tools/retraced/tls_gate.c.
 
+# verify-journal links journal_sign + journal + registry on
+# EVERY platform (the OpenSSL-less build carries the honest
+# stub); tls_gate.c stays POSIX-only (socket headers).
+set(_ctl_common_sources
+	main.c
+	${CMAKE_SOURCE_DIR}/tools/retraced/journal_sign.c
+	${CMAKE_SOURCE_DIR}/tools/retraced/journal.c
+	${CMAKE_SOURCE_DIR}/tools/retraced/registry.c
+	${CMAKE_SOURCE_DIR}/src/config/json/parson.c)
+
 if(RETRACE_PLATFORM_WINDOWS)
-	# supervisor/12: the fleet CLI over the ctl named pipe. The
-	# TLS client and sign-policy ride the POSIX build for now
-	# (tls_gate.c pulls POSIX socket headers).
-	add_executable(retrace_ctl main.c)
+	add_executable(retrace_ctl ${_ctl_common_sources})
 else()
 	add_executable(retrace_ctl
-		main.c
-		${CMAKE_SOURCE_DIR}/tools/retraced/tls_gate.c
-		${CMAKE_SOURCE_DIR}/tools/retraced/journal_sign.c
-		${CMAKE_SOURCE_DIR}/tools/retraced/journal.c
-		${CMAKE_SOURCE_DIR}/tools/retraced/registry.c
-		${CMAKE_SOURCE_DIR}/src/config/json/parson.c)
+		${_ctl_common_sources}
+		${CMAKE_SOURCE_DIR}/tools/retraced/tls_gate.c)
 endif()
 set_target_properties(retrace_ctl PROPERTIES
 	OUTPUT_NAME retrace-ctl)
@@ -24,7 +27,8 @@ set_target_properties(retrace_ctl PROPERTIES
 target_include_directories(retrace_ctl PRIVATE
 	${CMAKE_SOURCE_DIR}/tools/retraced
 	${CMAKE_SOURCE_DIR}/src/config/json
-	${CMAKE_SOURCE_DIR}/test/property/parson_stub)
+	${CMAKE_SOURCE_DIR}/test/property/parson_stub
+	${CMAKE_SOURCE_DIR}/src/core)
 
 # sign-policy (pure OpenSSL EVP) works everywhere now that
 # tls_gate.c rides only the POSIX build

--- a/tools/retrace-ctl/CMakeLists.txt
+++ b/tools/retrace-ctl/CMakeLists.txt
@@ -12,13 +12,19 @@ if(RETRACE_PLATFORM_WINDOWS)
 else()
 	add_executable(retrace_ctl
 		main.c
-		${CMAKE_SOURCE_DIR}/tools/retraced/tls_gate.c)
+		${CMAKE_SOURCE_DIR}/tools/retraced/tls_gate.c
+		${CMAKE_SOURCE_DIR}/tools/retraced/journal_sign.c
+		${CMAKE_SOURCE_DIR}/tools/retraced/journal.c
+		${CMAKE_SOURCE_DIR}/tools/retraced/registry.c
+		${CMAKE_SOURCE_DIR}/src/config/json/parson.c)
 endif()
 set_target_properties(retrace_ctl PROPERTIES
 	OUTPUT_NAME retrace-ctl)
 
 target_include_directories(retrace_ctl PRIVATE
-	${CMAKE_SOURCE_DIR}/tools/retraced)
+	${CMAKE_SOURCE_DIR}/tools/retraced
+	${CMAKE_SOURCE_DIR}/src/config/json
+	${CMAKE_SOURCE_DIR}/test/property/parson_stub)
 
 # sign-policy (pure OpenSSL EVP) works everywhere now that
 # tls_gate.c rides only the POSIX build

--- a/tools/retrace-ctl/main.c
+++ b/tools/retrace-ctl/main.c
@@ -48,6 +48,7 @@
 #endif
 
 #include "../retraced/tls_gate.h"
+#include "../retraced/journal_sign.h"
 #include "../retraced/ctl_verbs.h"
 
 #ifdef RETRACE_HAVE_OPENSSL
@@ -355,6 +356,23 @@ static int cmd_sign_policy(const char *file, const char *key_path)
 #endif
 }
 
+/* verify-journal (TODO.impl/07): local, like sign-policy -- the
+ * auditor's hand: chain + ed25519 seal in one verdict
+ */
+static int cmd_verify_journal(const char *file,
+	const char *pubkey_path)
+{
+	char verdict[192];
+
+	if (retraced_journal_verify_file(file, pubkey_path, verdict,
+		    sizeof(verdict)) == 0) {
+		printf("%s\n", verdict);
+		return 0;
+	}
+	fprintf(stderr, "retrace-ctl: %s\n", verdict);
+	return 1;
+}
+
 static int ctl_usage(void)
 {
 	/* the verb lines derive from the same SSOT list the
@@ -372,6 +390,7 @@ static int ctl_usage(void)
 #undef USAGE_LINE
 	fprintf(stderr,
 		"  sign-policy FILE KEY   emit a signed wrapper to stdout\n"
+		"  verify-journal FILE --pubkey PEM  chain + ed25519 seal verdict\n"
 		"  --tls-*: fleet mTLS (all four required together)\n");
 	return 2;
 }
@@ -447,6 +466,18 @@ int main(int argc, char **argv)
 	} else if (strcmp(argv[i], "sign-policy") == 0 &&
 		   i + 2 < argc) {
 		return cmd_sign_policy(argv[i + 1], argv[i + 2]);
+	} else if (strcmp(argv[i], "verify-journal") == 0 &&
+		   i + 1 < argc) {
+		const char *pub = NULL;
+		int j;
+
+		for (j = i + 2; j + 1 < argc; j += 2) {
+			if (strcmp(argv[j], "--pubkey") == 0)
+				pub = argv[j + 1];
+		}
+		if (pub == NULL)
+			return ctl_usage();
+		return cmd_verify_journal(argv[i + 1], pub);
 	} else if (strcmp(argv[i], "sessions") == 0) {
 		snprintf(req, sizeof(req), "{\"cmd\":\"sessions\"}\n");
 	} else if (strcmp(argv[i], "spawn") == 0 && i + 1 < argc) {

--- a/tools/retraced/CMakeLists.txt
+++ b/tools/retraced/CMakeLists.txt
@@ -21,7 +21,7 @@ if(RETRACE_PLATFORM_WINDOWS)
 else()
 	add_executable(retrace_retraced
 		main.c daemon_frame.c registry.c journal.c peer_gate.c retraced_ctl.c
-		tls_gate.c ${_parson_source})
+		tls_gate.c journal_sign.c ${_parson_source})
 endif()
 set_target_properties(retrace_retraced PROPERTIES
 	OUTPUT_NAME retraced)
@@ -36,8 +36,11 @@ target_link_libraries(retrace_retraced PRIVATE
 	retrace_supervisor_proto)
 
 if(OpenSSL_FOUND AND NOT RETRACE_PLATFORM_WINDOWS)
+	# RETRACE_HAVE_OPENSSL: the shared spelling (journal_sign
+	# gates on it); RETRACED_HAVE_OPENSSL predates it
 	target_compile_definitions(retrace_retraced PRIVATE
-		RETRACED_HAVE_OPENSSL=1)
+		RETRACED_HAVE_OPENSSL=1
+		RETRACE_HAVE_OPENSSL=1)
 	target_link_libraries(retrace_retraced PRIVATE OpenSSL::SSL)
 	target_include_directories(retrace_retraced PRIVATE
 		${OPENSSL_INCLUDE_DIR})

--- a/tools/retraced/journal.c
+++ b/tools/retraced/journal.c
@@ -330,3 +330,59 @@ int retraced_journal_replay(struct retraced_journal *j,
 	(void)saw_torn;
 	return 0;
 }
+
+int retraced_journal_chain_file(const char *path, size_t stop_at,
+	uint64_t *head_out, size_t *lines_out, size_t *broken_at)
+{
+	FILE *f = fopen(path, "r");
+	char line[2048];
+	uint64_t prev = 0;
+	size_t lines = 0;
+
+	*broken_at = 0;
+	if (head_out != NULL)
+		*head_out = 0;
+	if (lines_out != NULL)
+		*lines_out = 0;
+	if (f == NULL)
+		return -1;
+	while (stop_at == 0 || lines < stop_at) {
+		if (fgets(line, sizeof(line), f) == NULL)
+			break;
+		char prev_hex[32];
+		size_t n = strlen(line);
+		uint64_t link;
+
+		lines++;
+		/* each line carries the PREVIOUS line's link; verify
+		 * it, then compute this line's (replay's arithmetic)
+		 */
+		{
+			const char *p = strstr(line, "\"prev\":\"");
+
+			if (p == NULL) {
+				*broken_at = lines;
+				break;
+			}
+			snprintf(prev_hex, sizeof(prev_hex), "%s", p + 8);
+			prev_hex[16] = '\0';
+			if (strtoull(prev_hex, NULL, 16) != prev) {
+				*broken_at = lines;
+				break;
+			}
+		}
+		(void)n;
+		/* the writer hashes the line WITH its newline
+		 * (journal_event snprintfs the full line first) --
+		 * tail does the same; hash exactly what is stored
+		 */
+		link = fnv1a(line, prev ^ 0x9e3779b97f4a7c15ULL);
+		prev = link;
+	}
+	fclose(f);
+	if (lines_out != NULL)
+		*lines_out = lines;
+	if (head_out != NULL)
+		*head_out = prev;
+	return *broken_at == 0 ? 0 : -1;
+}

--- a/tools/retraced/journal.h
+++ b/tools/retraced/journal.h
@@ -91,4 +91,14 @@ int retraced_journal_tail(struct retraced_journal *j, size_t last_n,
 	void (*sink)(const char *line, void *user), void *user,
 	long *chain_out);
 
+/*
+ * Standalone chain verdict over a journal FILE (TODO.impl/07):
+ * recompute every link in order and report the head + line
+ * count, with the first broken line number (0 = verified). The
+ * signing/verification module and the CLI both ride this --
+ * one chain-check arithmetic, three consumers.
+ */
+int retraced_journal_chain_file(const char *path, size_t stop_at,
+	uint64_t *head_out, size_t *lines_out, size_t *broken_at);
+
 #endif /* RETRACE_TOOLS_JOURNAL_H_ */

--- a/tools/retraced/journal_sign.c
+++ b/tools/retraced/journal_sign.c
@@ -1,0 +1,291 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+#include "journal_sign.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "journal.h"
+
+#ifdef RETRACE_HAVE_OPENSSL
+#include <openssl/evp.h>
+#include <openssl/pem.h>
+
+#define SIG_MAX 128
+
+static int sign_head(const char *key_path, const char *msg,
+	unsigned char *sig, size_t *sig_len, char *err,
+	size_t err_cap)
+{
+	FILE *kf = fopen(key_path, "r");
+	EVP_PKEY *key;
+	EVP_MD_CTX *ctx;
+
+	if (kf == NULL) {
+		snprintf(err, err_cap, "cannot read key %s", key_path);
+		return -1;
+	}
+	key = PEM_read_PrivateKey(kf, NULL, NULL, NULL);
+	fclose(kf);
+	if (key == NULL) {
+		snprintf(err, err_cap, "bad key %s", key_path);
+		return -1;
+	}
+	ctx = EVP_MD_CTX_new();
+	if (ctx == NULL ||
+	    EVP_DigestSignInit(ctx, NULL, NULL, NULL, key) != 1 ||
+	    EVP_DigestSign(ctx, sig, sig_len,
+		    (const unsigned char *)msg, strlen(msg)) != 1) {
+		snprintf(err, err_cap, "sign failed");
+		EVP_MD_CTX_free(ctx);
+		EVP_PKEY_free(key);
+		return -1;
+	}
+	EVP_MD_CTX_free(ctx);
+	EVP_PKEY_free(key);
+	return 0;
+}
+
+int retraced_journal_sign_file(const char *key_path,
+	const char *journal_path, char *rec, size_t rec_cap,
+	char *err, size_t err_cap)
+{
+	uint64_t head;
+	size_t lines;
+	size_t broken;
+	char msg[64];
+	unsigned char sig[SIG_MAX];
+	size_t sig_len = sizeof(sig);
+	char enc[256];
+	int n;
+
+	if (retraced_journal_chain_file(journal_path, 0, &head, &lines,
+		    &broken) != 0) {
+		snprintf(err, err_cap,
+			"chain broken at line %zu -- refusing to sign",
+			broken);
+		return -1;
+	}
+	snprintf(msg, sizeof(msg), "head=%016llx lines=%zu",
+		(unsigned long long)head, lines);
+	if (sign_head(key_path, msg, sig, &sig_len, err, err_cap) != 0)
+		return -1;
+	EVP_EncodeBlock((unsigned char *)enc, sig, (int)sig_len);
+	n = snprintf(rec, rec_cap,
+		"{\"name\":\"retrace.journal.signed\",\"alg\":\"ed25519\",\"key_id\":\"%02x%02x\",\"head\":\"%016llx\",\"lines\":%zu,\"sig\":\"%s\"}",
+		sig[0], sig[1], (unsigned long long)head, lines, enc);
+	if (n <= 0 || (size_t)n >= (int)rec_cap) {
+		snprintf(err, err_cap, "record too long");
+		return -1;
+	}
+	return 0;
+}
+
+/* find the LAST line containing the seal marker */
+static int read_seal(const char *journal_path, char *seal,
+	size_t seal_cap, char *head_hex, size_t head_cap,
+	long *lines_sealed)
+{
+	FILE *f = fopen(journal_path, "r");
+	char line[2048];
+
+	seal[0] = '\0';
+	if (f == NULL)
+		return -1;
+	while (fgets(line, sizeof(line), f) != NULL) {
+		if (strstr(line, "retrace.journal.signed") != NULL) {
+			size_t n = strlen(line);
+
+			if (n >= seal_cap)
+				n = seal_cap - 1;
+			memcpy(seal, line, n);
+			seal[n] = '\0';
+		}
+	}
+	fclose(f);
+	if (seal[0] == '\0')
+		return -1;
+	{
+		/* the seal's own fields: head + lines (parse by
+		 * markers -- the record is one line, fields fixed)
+		 */
+		const char *h = strstr(seal, "\"head\":\"");
+		const char *l = strstr(seal, "\"lines\":");
+
+		if (h == NULL || l == NULL)
+			return -1;
+		h += 8;
+		snprintf(head_hex, head_cap, "%.*s", 16, h);
+		*lines_sealed = strtol(l + 8, NULL, 10);
+	}
+	return 0;
+}
+
+static int pull_b64(const char *seal, unsigned char *sig,
+	size_t *sig_len)
+{
+	const char *s = strstr(seal, "\"sig\":\"");
+
+	if (s == NULL)
+		return -1;
+	s += 7;
+	{
+		const char *e = strchr(s, '"');
+
+		if (e == NULL || (size_t)(e - s) / 4 * 3 > SIG_MAX)
+			return -1;
+		*sig_len = (size_t)EVP_DecodeBlock(sig,
+			(const unsigned char *)s, (int)(e - s));
+		/* EVP_DecodeBlock decodes the '=' padding as zero
+		 * bytes and COUNTS them -- a 64-byte ed25519 sig
+		 * came back 66. Trim the padded tail.
+		 */
+		{
+			int pad = 0;
+
+			while (pad < 2 && e - 1 - pad >= s &&
+			       *(e - 1 - pad) == '=')
+				pad++;
+			*sig_len -= (size_t)pad;
+		}
+	}
+	return *sig_len > 0 ? 0 : -1;
+}
+
+int retraced_journal_verify_file(const char *journal_path,
+	const char *pubkey_path, char *verdict, size_t verdict_cap)
+{
+	uint64_t head;
+	size_t lines;
+	size_t broken;
+	char seal[2048];
+	char head_hex[32];
+	long lines_sealed = -1;
+	unsigned char sig[SIG_MAX];
+	size_t sig_len = 0;
+	char msg[64];
+	FILE *kf;
+	EVP_PKEY *pub;
+	EVP_MD_CTX *ctx;
+
+	if (retraced_journal_chain_file(journal_path, 0, &head, &lines,
+		    &broken) != 0) {
+		snprintf(verdict, verdict_cap,
+			"chain broken at line %zu", broken);
+		return -1;
+	}
+	if (lines == 0) {
+		snprintf(verdict, verdict_cap, "empty journal");
+		return -1;
+	}
+	if (read_seal(journal_path, seal, sizeof(seal), head_hex,
+		    sizeof(head_hex), &lines_sealed) != 0) {
+		snprintf(verdict, verdict_cap,
+			"no seal (unsigned journal)");
+		return -1;
+	}
+	/* the seal is the FINAL record and its own chain link:
+	 * the sealed state is the chain BEFORE it (lines-1)
+	 */
+	if ((size_t)lines_sealed != lines - 1) {
+		snprintf(verdict, verdict_cap,
+			"sealed lines %ld != chain %zu",
+			lines_sealed, lines - 1);
+		return -1;
+	}
+	snprintf(msg, sizeof(msg), "head=%s lines=%ld", head_hex,
+		lines_sealed);
+	kf = fopen(pubkey_path, "r");
+	if (kf == NULL) {
+		snprintf(verdict, verdict_cap, "cannot read pubkey");
+		return -1;
+	}
+	pub = PEM_read_PUBKEY(kf, NULL, NULL, NULL);
+	fclose(kf);
+	if (pub == NULL) {
+		snprintf(verdict, verdict_cap, "bad pubkey");
+		return -1;
+	}
+	if (pull_b64(seal, sig, &sig_len) != 0) {
+		EVP_PKEY_free(pub);
+		snprintf(verdict, verdict_cap, "seal signature unreadable");
+		return -1;
+	}
+	ctx = EVP_MD_CTX_new();
+	if (ctx == NULL ||
+	    EVP_DigestVerifyInit(ctx, NULL, NULL, NULL, pub) != 1) {
+		EVP_MD_CTX_free(ctx);
+		EVP_PKEY_free(pub);
+		snprintf(verdict, verdict_cap, "verify init failed");
+		return -1;
+	}
+	{
+		int rc = EVP_DigestVerify(ctx, sig, sig_len,
+			(const unsigned char *)msg, strlen(msg));
+
+		EVP_MD_CTX_free(ctx);
+		EVP_PKEY_free(pub);
+		if (rc != 1) {
+			snprintf(verdict, verdict_cap,
+				"signature mismatch");
+			return -1;
+		}
+	}
+	/* the sealed head must equal the recomputed chain state
+	 * at the seal point (the line BEFORE the seal record)
+	 */
+	{
+		uint64_t head_at_seal;
+		size_t n2, b2;
+		char want[32];
+
+		if (retraced_journal_chain_file(journal_path,
+			    lines - 1, &head_at_seal, &n2, &b2) != 0) {
+			snprintf(verdict, verdict_cap,
+				"chain broken at line %zu", b2);
+			return -1;
+		}
+		snprintf(want, sizeof(want), "%016llx",
+			(unsigned long long)head_at_seal);
+		if (strcmp(head_hex, want) != 0) {
+			snprintf(verdict, verdict_cap,
+				"sealed head %s != chain %s",
+				head_hex, want);
+			return -1;
+		}
+	}
+	snprintf(verdict, verdict_cap,
+		"verified + signed (ed25519, %zu lines)", lines);
+	return 0;
+}
+
+#else /* !RETRACE_HAVE_OPENSSL */
+
+int retraced_journal_sign_file(const char *key_path,
+	const char *journal_path, char *rec, size_t rec_cap,
+	char *err, size_t err_cap)
+{
+	(void)key_path;
+	(void)journal_path;
+	(void)rec;
+	(void)rec_cap;
+	snprintf(err, err_cap, "journal signing needs an OpenSSL build");
+	return -1;
+}
+
+int retraced_journal_verify_file(const char *journal_path,
+	const char *pubkey_path, char *verdict, size_t verdict_cap)
+{
+	(void)journal_path;
+	(void)pubkey_path;
+	snprintf(verdict, verdict_cap,
+		"journal verification needs an OpenSSL build");
+	return -1;
+}
+
+#endif /* RETRACE_HAVE_OPENSSL */

--- a/tools/retraced/journal_sign.h
+++ b/tools/retraced/journal_sign.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://ribose.com).
+ *
+ * BSD-2-Clause license -- see LICENSE for details.
+ */
+
+#ifndef RETRACE_TOOLS_JOURNAL_SIGN_H_
+#define RETRACE_TOOLS_JOURNAL_SIGN_H_
+#include <stddef.h>
+
+/*
+ * Journal signing (TODO.impl/07): hash chains prove LOCAL
+ * continuity; ed25519 signatures give an external auditor a
+ * trust anchor. At the daemon's graceful close, the signing
+ * key seals the chain state (head + line count); verification
+ * re-walks the chain and checks the seal. Tampering any byte
+ * breaks the chain before it breaks the seal -- and a swapped
+ * seal names itself.
+ *
+ * Keys are PEM ed25519 (openssl genpkey -algorithm ed25519);
+ * the public half verifies (openssl pkey -pubout). The
+ * signature covers the string "head=<16 hex> lines=<count>".
+ * v1 seals the close (rotation intervals chain across
+ * segments when TODO.impl/10 lands).
+ */
+
+/*
+ * Read the journal, verify its chain, and sign the state.
+ * Returns 0 and fills `rec` with the journal record to append
+ * (the record chain-links itself when written); -1 with a
+ * reason in `err` on any failure (bad key, broken chain).
+ */
+int retraced_journal_sign_file(const char *key_path,
+	const char *journal_path, char *rec, size_t rec_cap,
+	char *err, size_t err_cap);
+
+/*
+ * Verify a signed journal: walk the chain, find the seal as
+ * the final record, check that the sealed head matches the
+ * chain state at the PREVIOUS line, and verify the ed25519
+ * signature with the public key.
+ * Returns 0 verified; -1 with a one-line reason in `verdict`.
+ */
+int retraced_journal_verify_file(const char *journal_path,
+	const char *pubkey_path, char *verdict, size_t verdict_cap);
+
+#endif /* RETRACE_TOOLS_JOURNAL_SIGN_H_ */

--- a/tools/retraced/main.c
+++ b/tools/retraced/main.c
@@ -47,6 +47,7 @@
 #include "peer_gate.h"
 #include "retraced_ctl.h"
 #include "tls_gate.h"
+#include "journal_sign.h"
 #include "daemon_frame.h"
 
 #include "parson.h"
@@ -581,6 +582,7 @@ int main(int argc, char **argv)
 	const char *journal_path = "retraced-journal.jsonl";
 	const char *policy_path = NULL;
 	const char *ctl_path = NULL;
+	const char *signing_key = NULL;
 	const char *nonce_arg = NULL;
 	const char *nonce_file = NULL;
 	const char *tls_listen = NULL;
@@ -612,6 +614,9 @@ int main(int argc, char **argv)
 	for (i = 1; i < argc; i++) {
 		if (strcmp(argv[i], "--sock") == 0 && i + 1 < argc)
 			sock_path = argv[++i];
+		else if (strcmp(argv[i], "--signing-key") == 0 &&
+			 i + 1 < argc)
+			signing_key = argv[++i];
 		else if (strcmp(argv[i], "--journal") == 0 &&
 			 i + 1 < argc)
 			journal_path = argv[++i];
@@ -1323,6 +1328,27 @@ int main(int argc, char **argv)
 	}
 	emit_drift_summaries(&reg, &jr);
 	retraced_journal_close(&jr);
+#ifdef RETRACE_HAVE_OPENSSL
+	/* the seal (TODO.impl/07): ed25519 over the closed chain's
+	 * head+count -- an external auditor's trust anchor, riding
+	 * the journal as its own chained record
+	 */
+	if (signing_key != NULL) {
+		char rec[512];
+		char err[96];
+
+		if (retraced_journal_sign_file(signing_key,
+			    jr.path, rec, sizeof(rec), err,
+			    sizeof(err)) == 0) {
+			retraced_journal_event(&jr,
+				(long)time(NULL), "daemon", 0, rec);
+			printf("retraced: journal sealed\n");
+		} else {
+			fprintf(stderr,
+				"retraced: journal NOT sealed: %s\n", err);
+		}
+	}
+#endif
 	ctl_drop();
 	if (g_tls_listen >= 0)
 		close(g_tls_listen);


### PR DESCRIPTION
TODO.impl/07 — hash chains prove the journal's *local* continuity; an auditor outside the host needs to verify **who** chained it.

**The seal:** `retraced --signing-key k.pem` (PEM ed25519) seals every graceful close — the daemon appends `retrace.journal.signed`, a signature over the closed chain's head and line count, itself chain-linked, and **refuses loudly if asked to seal a broken chain**.

```sh
openssl genpkey -algorithm ed25519 -out k.pem
openssl pkey -in k.pem -pubout -out pub.pem
retraced --journal j.jsonl --signing-key k.pem ...
retrace-ctl verify-journal j.jsonl --pubkey pub.pem
# verified + signed (ed25519, N lines)
```

**`retrace-ctl verify-journal`** (local, like `sign-policy`) walks the chain AND checks the seal. The chain arithmetic is **one primitive** — `retraced_journal_chain_file` in journal.c, with a stop-at parameter — so the signer, the verifier, and the daemon's replay all speak it, and the head is re-derived at the seal point so a transplanted seal names itself. Three verdicts, three failure classes: `chain broken` (names the line), `signature mismatch` (wrong key or swapped seal), `verified + signed`.

**Specs:** the chain primitive unit-tested (head-at-stop arithmetic, tamper naming its line); the E2E drives the whole story — seal at close, clean verify, tampered bytes named, wrong key refused. Also fixed en route: the daemon's OpenSSL gate now carries the shared `RETRACE_HAVE_OPENSSL` spelling (the stub compiled silently under the legacy-only one), and `EVP_DecodeBlock`'s padding-bytes quirk (a 64-byte ed25519 sig decoded as 66). Checkpatch clean.
