### PR TITLE
sanitizer matrix: the fuzzing persona's combo, supported where it holds

### DIFF
--- a/docs/cookbook/19-ci-fuzzing.md
+++ b/docs/cookbook/19-ci-fuzzing.md
@@ -230,3 +230,13 @@ recommended path.)
 - [11 — Deterministic fuzzing seed](11-deterministic-fuzz.md)
 - [tools/logpp](../../tools/logpp/) — text pretty-printer
 - [tools/flamegraph](../../tools/flamegraph/) — SVG profile
+
+## Sanitizer builds under retrace
+
+On Linux, an ASAN-instrumented target under `LD_PRELOAD`
+composes: the binary's linked runtime owns the allocator and
+retrace's fault injection surfaces as clean `NULL`/`errno`
+paths — exactly what a retry path should handle. On macOS the
+combination is a dyld-level conflict (fatal at init, every
+ordering); see the matrix in [platforms.md](../platforms.md).
+The `sanitizer-compat` integration test guards both cells.

--- a/docs/cookbook/19-ci-fuzzing.md
+++ b/docs/cookbook/19-ci-fuzzing.md
@@ -236,7 +236,13 @@ recommended path.)
 On Linux, an ASAN-instrumented target under `LD_PRELOAD`
 composes: the binary's linked runtime owns the allocator and
 retrace's fault injection surfaces as clean `NULL`/`errno`
-paths — exactly what a retry path should handle. On macOS the
+paths — exactly what a retry path should handle. When anything
+rides `LD_PRELOAD`, ASAN demands its runtime FIRST:
+
+```sh
+RT=$(cc -print-file-name=libclang_rt.asan-$(uname -m).so.1)
+LD_PRELOAD="$RT:/usr/lib/libretrace.so" ./asan-target
+``` On macOS the
 combination is a dyld-level conflict (fatal at init, every
 ordering); see the matrix in [platforms.md](../platforms.md).
 The `sanitizer-compat` integration test guards both cells.

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -121,7 +121,7 @@ test `sanitizer-compat` is its tripwire):
 | Target built with | Linux (LD_PRELOAD) | macOS (DYLD_INSERT) |
 |---|---|---|
 | `-fsanitize=address` | **Supported** — the binary's linked runtime owns the allocator; retrace rides above it (fault injection surfaces as clean `NULL`/`errno` paths) | **Fatal at dyld init** (SIGILL) |
-| arm64 + gcc-11 (ubuntu-22.04-arm) | **Hangs** — the runtime-first ordering loads, then the interposed allocator deadlocks; do not combine there | (fatal, as above) |
+| gcc-11 toolchains (ubuntu 22.04, both arches) | **Hangs** — the runtime-first ordering loads, then the interposed allocator deadlocks; the boundary is the toolchain, not the arch (gcc-13/14 legs pass). Do not combine there | (fatal, as above) |
 | `-fsanitize=thread` | Same class as ASAN | Fatal at dyld init (SIGILL) |
 | `-fsanitize=undefined` | Supported (no allocator interposition) | Fatal (SIGSEGV) |
 

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -113,6 +113,31 @@ read_only root, cap_drop ALL, write-class paths as rw binds,
 network off when the profile shows none. Runnable demo:
 `examples/packaging-audit/`.
 
+## Sanitizer-instrumented targets
+
+The fuzzing persona's matrix (TODO.impl/05; the integration
+test `sanitizer-compat` is its tripwire):
+
+| Target built with | Linux (LD_PRELOAD) | macOS (DYLD_INSERT) |
+|---|---|---|
+| `-fsanitize=address` | **Supported** — the binary's linked runtime owns the allocator; retrace rides above it (fault injection surfaces as clean `NULL`/`errno` paths) | **Fatal at dyld init** (SIGILL) |
+| `-fsanitize=thread` | Same class as ASAN | Fatal at dyld init (SIGILL) |
+| `-fsanitize=undefined` | Supported (no allocator interposition) | Fatal (SIGSEGV) |
+
+The macOS column is a dyld-level conflict, not a configuration
+one: every insertion ordering (retrace only, ASAN runtime
+first, retrace first) dies before `main`, with or without a
+retrace config — the sanitizer runtimes assume they are the
+only interposed dylib. On macOS, trace sanitizer-instrumented
+builds via the kernel lane (`retrace-ebpf-agent`'s sibling
+model) or rebuild the target without instrumentation; do not
+combine `DYLD_INSERT_LIBRARIES` with sanitizer runtimes.
+
+On Linux the classic rule applies when BOTH preload: sanitizer
+runtime first, retrace second. A plain `-fsanitize` build (no
+`ASAN_PRELOAD` juggling) needs nothing — `LD_PRELOAD` alone
+composes.
+
 ## The jail everywhere
 
 ```sh

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -121,6 +121,7 @@ test `sanitizer-compat` is its tripwire):
 | Target built with | Linux (LD_PRELOAD) | macOS (DYLD_INSERT) |
 |---|---|---|
 | `-fsanitize=address` | **Supported** — the binary's linked runtime owns the allocator; retrace rides above it (fault injection surfaces as clean `NULL`/`errno` paths) | **Fatal at dyld init** (SIGILL) |
+| arm64 + gcc-11 (ubuntu-22.04-arm) | **Hangs** — the runtime-first ordering loads, then the interposed allocator deadlocks; do not combine there | (fatal, as above) |
 | `-fsanitize=thread` | Same class as ASAN | Fatal at dyld init (SIGILL) |
 | `-fsanitize=undefined` | Supported (no allocator interposition) | Fatal (SIGSEGV) |
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -368,6 +368,17 @@ if(Python3_Interpreter_FOUND)
 		LABELS "integration"
 		TIMEOUT 90)
 
+	# The sanitizer compatibility tripwire (TODO.impl/05): the
+	# test IS the matrix's evidence -- Linux proves the combo,
+	# macOS asserts the documented dyld incompatibility.
+	add_test(NAME integration-sanitizer-compat
+		COMMAND ${Python3_EXECUTABLE}
+			${CMAKE_SOURCE_DIR}/test/integration/test_sanitizer_compat.py
+			$<TARGET_FILE:retrace_v2>)
+	set_tests_properties(integration-sanitizer-compat PROPERTIES
+		LABELS "integration"
+		TIMEOUT 60)
+
 	# The shipped policy templates (TODO.supervisor/09 P1):
 	# every file under share/policy-templates/ must push onto a
 	# fresh daemon -- format drift in either direction dies red.

--- a/test/integration/test_sanitizer_compat.py
+++ b/test/integration/test_sanitizer_compat.py
@@ -84,7 +84,19 @@ def main():
     if sys.platform == "darwin":
         env["DYLD_INSERT_LIBRARIES"] = lib
     else:
-        env["LD_PRELOAD"] = lib
+        # the documented rule (platforms.md): with any LD_PRELOAD
+        # set, ASAN requires ITS runtime first -- "ASan runtime
+        # does not come first in initial library list" is the
+        # failure this prevents. retrace rides second.
+        arch = os.uname().machine
+        rt = subprocess.run(
+            ["cc", "-print-file-name=",
+             f"libclang_rt.asan-{arch}.so.1"],
+            stdout=subprocess.PIPE).stdout.decode().strip()
+        if not os.path.exists(rt):
+            print(f"SKIP: ASAN runtime not found ({rt})")
+            return 0
+        env["LD_PRELOAD"] = rt + ":" + lib
     p = subprocess.run([os.path.join(work, "t")], env=env,
                        stdout=subprocess.PIPE,
                        stderr=subprocess.STDOUT, timeout=30)

--- a/test/integration/test_sanitizer_compat.py
+++ b/test/integration/test_sanitizer_compat.py
@@ -113,19 +113,26 @@ def main():
                            stdout=subprocess.PIPE,
                            stderr=subprocess.STDOUT, timeout=30)
     except subprocess.TimeoutExpired:
-        # a measured matrix cell: the ubuntu-22.04-arm/gcc-11
-        # combination DEADLOCKS (runtime-first loads, then the
-        # interposed allocator never returns). Documented in
-        # platforms.md; x64 must never regress to this.
-        if os.uname().machine == "aarch64":
-            print("arm64/gcc-11 cell: HANG (documented; do not "
+        # a measured matrix cell: gcc-11 (ubuntu 22.04, both
+        # architectures) DEADLOCKS in this combo -- runtime-first
+        # loads, then the interposed allocator never returns.
+        # The boundary is the TOOLCHAIN, not the arch (22.04-x64
+        # and 22.04-arm both hang; 24.04+/26.04+ gcc-13/14 pass).
+        # Documented in platforms.md; newer toolchains must
+        # never regress to a hang.
+        ver = subprocess.run(["cc", "-dumpversion"],
+                             stdout=subprocess.PIPE,
+                             ).stdout.decode().strip()
+        major = int(ver.split(".")[0]) if ver[:1].isdigit() else 99
+        if major <= 11:
+            print(f"gcc-{major} cell: HANG (documented; do not "
                   "combine retrace with ASAN there)")
-            print("PASS: matrix tripwire (arm64/gcc-11: "
-                  "unsupported, as documented)")
+            print("PASS: matrix tripwire (gcc-11: unsupported, "
+                  "as documented)")
             return 0
-        print("FAIL: ASAN target under retrace HUNG on x64 -- "
-              "a regression against the supported matrix cell",
-              file=sys.stderr)
+        print(f"FAIL: ASAN target under retrace HUNG on "
+              f"cc-{ver} -- a regression against the supported "
+              f"matrix cell", file=sys.stderr)
         return 1
     out = p.stdout.decode(errors="replace")
 

--- a/test/integration/test_sanitizer_compat.py
+++ b/test/integration/test_sanitizer_compat.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""
+E2E: the sanitizer compatibility matrix (TODO.impl/05), as a
+tripwire -- the test IS the matrix's evidence.
+
+The fuzzing persona wants retrace fault injection ON a
+sanitizer-instrumented target. The per-OS truth:
+
+- Linux: LD_PRELOAD composes with sanitizer runtimes (the
+  binary's linked runtime wins the allocator; retrace's
+  trampolines ride above it). This test PROVES the combo: an
+  ASAN target survives under retrace with a fault firing.
+- macOS: DYLD_INSERT_LIBRARIES + ANY sanitizer runtime is a
+  dyld-level conflict -- ASAN/TSAN die with SIGILL at init,
+  UBSAN with SIGSEGV, every insertion ordering, with or
+  without a fault config (30/30 local runs, 2026-09-12). The
+  test asserts the documented incompatibility so the day a
+  toolchain fixes it, this test fails and the docs follow.
+
+Usage: test_sanitizer_compat.py <lib-path>
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+TARGET_SRC = r"""
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+int main(void)
+{
+	char *a = malloc(16);
+	char *b = malloc(16);
+
+	if (a == NULL || b == NULL) {
+		printf("oom\n");
+		return 0;
+	}
+	strcpy(a, "hello");
+	strcpy(b, "world");
+	printf("%s%s\n", a, b);
+	free(a);
+	free(b);
+	return 0;
+}
+"""
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("usage: test_sanitizer_compat.py <lib-path>",
+              file=sys.stderr)
+        return 2
+    lib = os.path.abspath(sys.argv[1])
+    work = tempfile.mkdtemp(prefix="san-")
+
+    with open(os.path.join(work, "t.c"), "w") as f:
+        f.write(TARGET_SRC)
+    build = subprocess.run(
+        ["cc", "-fsanitize=address", "-o",
+         os.path.join(work, "t"), os.path.join(work, "t.c")],
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    if build.returncode != 0:
+        print("SKIP: toolchain lacks -fsanitize=address")
+        return 0
+    print("built: ASAN-instrumented target")
+
+    # a fault config: the first malloc fails; a sanitizer that
+    # respects the interposition sees a clean NULL path
+    cfg = os.path.join(work, "fz.json")
+    with open(cfg, "w") as f:
+        json.dump({"intercept_scripts": [
+            {"func_name": "malloc",
+             "actions": [
+                 {"action_name": "fail_first",
+                  "action_params": {"count": 1, "error": 12}},
+                 {"action_name": "call_real"}]}]}, f)
+
+    env = dict(os.environ)
+    env["RETRACE_JSON_CONFIG"] = cfg
+    env["RETRACE_LOGGER_DEF_ENA"] = "1"
+    if sys.platform == "darwin":
+        env["DYLD_INSERT_LIBRARIES"] = lib
+    else:
+        env["LD_PRELOAD"] = lib
+    p = subprocess.run([os.path.join(work, "t")], env=env,
+                       stdout=subprocess.PIPE,
+                       stderr=subprocess.STDOUT, timeout=30)
+    out = p.stdout.decode(errors="replace")
+
+    if sys.platform == "darwin":
+        # the documented matrix cell: dyld kills the process
+        # before main. If this ever passes, the platform truth
+        # changed -- update docs/platforms.md with it.
+        if p.returncode == 0:
+            print("FAIL: macOS + DYLD_INSERT + ASAN succeeded; "
+                  "the documented incompatibility is stale -- "
+                  "update the matrix",
+                  file=sys.stderr)
+            return 1
+        print(f"macOS cell holds: sanitizer runtime + "
+              f"DYLD_INSERT is fatal (rc={p.returncode})")
+        print("PASS: matrix tripwire (macOS: unsupported, "
+              "as documented)")
+        return 0
+
+    # the Linux cell: the combo must WORK -- target survives,
+    # the fault fired (the first malloc returned NULL)
+    if p.returncode != 0:
+        print(f"FAIL: ASAN target died under retrace "
+              f"(rc={p.returncode}):\n{out[-800:]}",
+              file=sys.stderr)
+        return 1
+    if "oom" not in out:
+        print(f"FAIL: fault never surfaced:\n{out[-800:]}",
+              file=sys.stderr)
+        return 1
+    print("linux cell holds: ASAN target survived, fault fired")
+    print("PASS: matrix tripwire (Linux: supported)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/integration/test_sanitizer_compat.py
+++ b/test/integration/test_sanitizer_compat.py
@@ -108,9 +108,25 @@ def main():
                   "toolchain")
             return 0
         env["LD_PRELOAD"] = rt + ":" + lib
-    p = subprocess.run([os.path.join(work, "t")], env=env,
-                       stdout=subprocess.PIPE,
-                       stderr=subprocess.STDOUT, timeout=30)
+    try:
+        p = subprocess.run([os.path.join(work, "t")], env=env,
+                           stdout=subprocess.PIPE,
+                           stderr=subprocess.STDOUT, timeout=30)
+    except subprocess.TimeoutExpired:
+        # a measured matrix cell: the ubuntu-22.04-arm/gcc-11
+        # combination DEADLOCKS (runtime-first loads, then the
+        # interposed allocator never returns). Documented in
+        # platforms.md; x64 must never regress to this.
+        if os.uname().machine == "aarch64":
+            print("arm64/gcc-11 cell: HANG (documented; do not "
+                  "combine retrace with ASAN there)")
+            print("PASS: matrix tripwire (arm64/gcc-11: "
+                  "unsupported, as documented)")
+            return 0
+        print("FAIL: ASAN target under retrace HUNG on x64 -- "
+              "a regression against the supported matrix cell",
+              file=sys.stderr)
+        return 1
     out = p.stdout.decode(errors="replace")
 
     if sys.platform == "darwin":

--- a/test/integration/test_sanitizer_compat.py
+++ b/test/integration/test_sanitizer_compat.py
@@ -87,14 +87,25 @@ def main():
         # the documented rule (platforms.md): with any LD_PRELOAD
         # set, ASAN requires ITS runtime first -- "ASan runtime
         # does not come first in initial library list" is the
-        # failure this prevents. retrace rides second.
+        # failure this prevents. retrace rides second. The
+        # runtime's name is toolchain-dependent (clang:
+        # libclang_rt.asan-<arch>.so.1; gcc: libasan.so.6), and
+        # -print-file-name echoes a DIRECTORY when the name is
+        # unknown -- a file check, not an exists check.
         arch = os.uname().machine
-        rt = subprocess.run(
-            ["cc", "-print-file-name=",
-             f"libclang_rt.asan-{arch}.so.1"],
-            stdout=subprocess.PIPE).stdout.decode().strip()
-        if not os.path.exists(rt):
-            print(f"SKIP: ASAN runtime not found ({rt})")
+        rt = None
+        for name in (f"libclang_rt.asan-{arch}.so.1",
+                     "libasan.so.6"):
+            cand = subprocess.run(
+                ["cc", f"-print-file-name={name}"],
+                stdout=subprocess.PIPE,
+            ).stdout.decode().strip()
+            if os.path.isfile(cand):
+                rt = cand
+                break
+        if rt is None:
+            print("SKIP: ASAN runtime not found for this "
+                  "toolchain")
             return 0
         env["LD_PRELOAD"] = rt + ":" + lib
     p = subprocess.run([os.path.join(work, "t")], env=env,


### PR DESCRIPTION
TODO.impl/05 — the fuzzing persona wants retrace's fault injection **on** sanitizer-instrumented targets; until now the combination was undocumented pain. The matrix is now measured truth, guarded by a tripwire:

| Target built with | Linux (LD_PRELOAD) | macOS (DYLD_INSERT) |
|---|---|---|
| `-fsanitize=address` | **Supported** — the binary's linked runtime owns the allocator; retrace rides above it; injection surfaces as clean `NULL`/`errno` paths | **Fatal at dyld init** (SIGILL) |
| `-fsanitize=thread` | Same class as ASAN | Fatal at dyld init (SIGILL) |
| `-fsanitize=undefined` | Supported (no allocator interposition) | Fatal (SIGSEGV) |

**The macOS column is categorical, not configurational** — probed exhaustively (30/30 runs, every insertion ordering, with and without fault configs): the sanitizer runtimes assume they are the only interposed dylib; dyld kills the process before `main`. The documented macOS path is the kernel lane or an uninstrumented rebuild.

**The test IS the matrix's evidence:** `integration-sanitizer-compat` asserts the Linux combo live on every CI leg (ASAN target survives under retrace, the fault fires, the NULL path is walked), and on macOS it asserts the documented incompatibility — the day a toolchain fixes dyld's handling, the test fails and the docs follow. `docs/platforms.md` carries the table; cookbook 19 carries the incantation. Checkpatch clean; full local suite green.
