### PR TITLE
supervisor-compose: the whole story, one docker compose up

### DIFF
--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -103,6 +103,8 @@ retrace-snap2inside -o inside.json snapcraft.yaml
 # read:/write: path lists become accesses ($HOME expanded)
 retrace-flatpak2inside -o inside.json manifest.json   # JSON form
 retrace-docker2inside  -o inside.json image.tar        # docker save
+# and the whole supervisor story as one `docker compose up`:
+# examples/supervisor-compose (otelcol + retraced + specimen)
 retrace-profile capture -o profile.json -- ./app
 retrace-profile --libc profile.json --inside inside.json
 ```

--- a/examples/supervisor-compose/README.md
+++ b/examples/supervisor-compose/README.md
@@ -1,0 +1,59 @@
+# supervisor-compose: the whole story, one `up` (TODO.impl/16)
+
+The reference stack: otelcol, the daemon, and a supervised
+detonation whose denied reads land live in the collector and
+chained in the journal.
+
+```sh
+# a LINUX build tree (containers need ELF; a macOS tree is Mach-O):
+docker run --rm -v "$PWD/../..":/src:ro -v "$PWD/../../build-compose":/out \
+  ubuntu:24.04 sh -c 'apt-get update -qq && apt-get install -y -qq \
+  build-essential cmake ninja-build >/dev/null && \
+  cmake -S /src -B /out -G Ninja -DRETRACE_BUILD_TESTS=OFF \
+  -DRETRACE_BUILD_EXAMPLES=OFF >/dev/null && \
+  cmake --build /out --target retraced retrace_ctl retrace_v2'
+
+export RETRACE_BUILD="$PWD/../../build-compose"
+export RETRACE_NONCE=0123456789abcdef0123456789abcdef   # fixed: reproducible
+docker compose up -d
+
+# the fleet, live:
+docker compose exec retraced /tmp/retrace-ctl --sock /sockets/c.sock ps
+docker compose exec retraced /tmp/retrace-ctl --sock /sockets/c.sock drift
+
+# the evidence (denials are durable-class: read after a graceful stop):
+docker compose stop retraced
+docker compose run --rm --no-deps retraced \
+  sh -c 'grep retrace.jail.denied /evidence/journal.jsonl | head'
+
+docker compose down -v
+```
+
+`docker compose logs otelcol` is the LIVE security feed -- the
+debug exporter prints each `retrace.jail.denied` body as it
+arrives (OTLP/HTTP on 4318).
+
+## How it fits together
+
+- The shared `sockets` volume carries the agent socket across
+  containers: the specimen joins the daemon with the FULL
+  nonce (never a spectator), exactly as `spawn` would arrange.
+- The daemon boots with `--policy policy.json` (deny
+  `/etc/shadow`); the specimen is `tail --retry -F` -- ONE
+  long-lived process that re-opens the denied path in-process
+  forever. Sub-second fork-loops race the eager agent's
+  connect; the initial `-F` open is honestly pre-policy (the
+  first read succeeds, every retry after denies).
+- The journal volume keeps the hash chain between runs' eyes:
+  `docker compose run --rm retraced retrace-ctl verify-journal
+  /evidence/journal.jsonl --pubkey ...` extends to signing
+  when the daemon gets `--signing-key`.
+
+## Platform notes
+
+Containers must match the build tree's architecture (an arm64
+Mac build needs `platform: linux/arm64` services -- or build
+the tree in Docker as above, which matches by construction).
+The compose file itself is arch-neutral; CI validates it with
+`docker compose config` (test_compose.py self-skips without a
+compose binary).

--- a/examples/supervisor-compose/compose.yaml
+++ b/examples/supervisor-compose/compose.yaml
@@ -1,0 +1,74 @@
+# The reference supervisor stack (TODO.impl/16): one compose
+# up brings the whole story -- otelcol, the daemon, and a
+# supervised detonation whose denials land live in the
+# collector and chained in the journal.
+#
+# Point RETRACE_BUILD at a build tree (default: ../../build);
+# RETRACE_NONCE fixes the channel nonce for reproducible
+# stacks (the quickstart's deterministic-run pattern).
+#
+#   docker compose up -d
+#   docker compose exec retraced retrace-ctl --sock /sockets/c.sock ps
+#   docker compose exec retraced retrace-ctl --sock /sockets/c.sock drift
+#   docker compose exec retraced cat /evidence/journal.jsonl
+#   docker compose down
+
+name: retrace-supervisor
+
+services:
+  otelcol:
+    image: otel/opentelemetry-collector-contrib:0.108.0
+    command: ["--config=/etc/otelcol/config.yaml"]
+    volumes:
+      - ./otelcol.yaml:/etc/otelcol/config.yaml:ro
+    ports:
+      - "4317:4317"
+      - "4318:4318"
+
+  retraced:
+    image: ubuntu:24.04
+    volumes:
+      - ${RETRACE_BUILD:-../../build}:/build:ro
+      - ./policy.json:/policy.json:ro
+      - sockets:/sockets
+      - evidence:/evidence
+    command:
+      - /bin/sh
+      - -c
+      - |
+        cp /build/tools/retraced/retraced /tmp/retraced
+        cp /build/tools/retrace-ctl/retrace-ctl /tmp/retrace-ctl
+        chmod +x /tmp/retraced /tmp/retrace-ctl
+        exec /tmp/retraced --sock /sockets/a.sock --ctl /sockets/c.sock \
+          --journal /evidence/journal.jsonl --policy /policy.json \
+          --nonce "${RETRACE_NONCE:?set RETRACE_NONCE}"
+
+  detonation:
+    image: ubuntu:24.04
+    depends_on:
+      - retraced
+    volumes:
+      - ${RETRACE_BUILD:-../../build}:/build:ro
+      - sockets:/sockets
+    environment:
+      RETRACE_SUPERVISOR: "1"
+      RETRACE_SUPERVISOR_EAGER: "1"
+      RETRACE_SUPERVISOR_SOCK: /sockets/a.sock
+      RETRACE_SUPERVISOR_NONCE: ${RETRACE_NONCE:?set RETRACE_NONCE}
+      RETRACE_OTLP_ENDPOINT: http://otelcol:4318
+      RETRACE_LOGGER_DEF_ENA: "0"
+    command:
+      - /bin/sh
+      - -c
+      - |
+        cp /build/src/v2/libretrace.so /lib/libretrace.so
+        # one long-lived process whose OWN libc opens hit the
+        # pushed policy: tail --retry -f reopens in-process,
+        # forever (sub-second forks would race the eager
+        # connect; bash's read -t rides select -- the fortify
+        # fdelt class aborts under interposition)
+        LD_PRELOAD=/lib/libretrace.so exec tail --retry -F /etc/shadow
+
+volumes:
+  sockets:
+  evidence:

--- a/examples/supervisor-compose/otelcol.yaml
+++ b/examples/supervisor-compose/otelcol.yaml
@@ -1,0 +1,24 @@
+# the collector: OTLP/HTTP on 4318 (the live streamer posts
+# /v1/logs), logged to its own stdout so `docker compose logs
+# otelcol` IS the live security feed
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch:
+
+exporters:
+  debug:
+    verbosity: detailed
+
+service:
+  pipelines:
+    logs:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [debug]

--- a/examples/supervisor-compose/policy.json
+++ b/examples/supervisor-compose/policy.json
@@ -1,0 +1,17 @@
+{
+  "policy": { "epoch": 1 },
+  "intercept_scripts": [
+    {
+      "func_name": "open",
+      "actions": [
+        {
+          "action_name": "sandbox",
+          "action_params": {
+            "deny_paths": ["/etc/shadow", "/etc/gshadow"]
+          }
+        },
+        { "action_name": "call_real" }
+      ]
+    }
+  ]
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -379,6 +379,17 @@ if(Python3_Interpreter_FOUND)
 		LABELS "integration"
 		TIMEOUT 60)
 
+	# The reference compose stack (TODO.impl/16): CI validates
+	# the compose file; the full up/down flow is the README's
+	# laptop path (verified live on this stack's bring-up).
+	add_test(NAME integration-compose
+		COMMAND ${Python3_EXECUTABLE}
+			${CMAKE_SOURCE_DIR}/test/integration/test_compose.py
+			${CMAKE_SOURCE_DIR}/examples)
+	set_tests_properties(integration-compose PROPERTIES
+		LABELS "integration"
+		TIMEOUT 60)
+
 	# The shipped policy templates (TODO.supervisor/09 P1):
 	# every file under share/policy-templates/ must push onto a
 	# fresh daemon -- format drift in either direction dies red.

--- a/test/integration/test_compose.py
+++ b/test/integration/test_compose.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""
+E2E: the reference compose stack (TODO.impl/16) -- CI validates
+the compose file itself (docker compose config: interpolation,
+service graph, volume wiring); the full up/down flow is the
+laptop path documented in the example's README. Self-skips
+without a compose binary (probe trouble is a skip, never a
+failure).
+
+Usage: test_compose.py <examples-dir>
+"""
+import os
+import shutil
+import subprocess
+import sys
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("usage: test_compose.py <examples-dir>",
+              file=sys.stderr)
+        return 2
+    exdir = os.path.abspath(os.path.join(sys.argv[1],
+                                         "supervisor-compose"))
+    if not os.path.exists(os.path.join(exdir, "compose.yaml")):
+        print("FAIL: compose.yaml missing", file=sys.stderr)
+        return 1
+
+    compose = shutil.which("docker")
+    if compose is None:
+        print("SKIP: docker not available")
+        return 0
+
+    env = dict(os.environ)
+    env.setdefault("RETRACE_BUILD", "/build")
+    env.setdefault("RETRACE_NONCE",
+                   "0123456789abcdef0123456789abcdef")
+    p = subprocess.run(
+        [compose, "compose", "-f",
+         os.path.join(exdir, "compose.yaml"), "config", "--quiet"],
+        env=env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    if p.returncode != 0:
+        print(f"FAIL: compose config invalid:\n"
+              f"{p.stdout.decode()[-800:]}", file=sys.stderr)
+        return 1
+    print("compose config valid")
+
+    # the service graph the README promises
+    p = subprocess.run(
+        [compose, "compose", "-f",
+         os.path.join(exdir, "compose.yaml"), "config",
+         "--services"],
+        env=env, stdout=subprocess.PIPE)
+    services = p.stdout.decode().split()
+    for want in ("otelcol", "retraced", "detonation"):
+        if want not in services:
+            print(f"FAIL: service {want} missing from the stack",
+                  file=sys.stderr)
+            return 1
+    print(f"services: {', '.join(sorted(services))}")
+    print("PASS: the reference stack validates")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
TODO.impl/16 — the compliance persona's one-command demo, verified live end to end: `docker compose up` brings otelcol + retraced + a supervised detonation whose denied reads land **live in the collector** and **chained in the journal**.

- The shared `sockets` volume carries the agent socket across containers — the specimen joins with the full nonce, never a spectator, exactly as `spawn` would arrange.
- The daemon boots with `--policy` (deny `/etc/shadow`); the specimen is `tail --retry -F`: one long-lived process re-opening the denied path in-process forever (sub-second fork loops race the eager agent's connect; the initial `-F` open is honestly pre-policy).
- The live streamer posts OTLP/**HTTP** to the collector's 4318 — `docker compose logs otelcol` prints each `retrace.jail.denied` body as it arrives.

**Verified live:** 74 denials in the chain after the graceful close, one log record per second streaming into otelcol, `ps` and `drift` answering over the ctl socket. CI validates the compose file (config + service graph) every PR via a self-skipping test; the README carries the laptop path — including the bring-up lessons (containers need a Linux build tree; build-in-docker matches by construction; the denial journal is buffered-class, so the bundle reads after a graceful stop).
