### PR TITLE
qemu cross-arch detonation: the arm64-on-x64-farm recipe, verified

### DIFF
--- a/docs/cookbook/41-qemu-cross-arch.md
+++ b/docs/cookbook/41-qemu-cross-arch.md
@@ -1,0 +1,81 @@
+# 41 — Cross-arch detonation: arm64 samples on an x64 farm
+
+## Problem
+
+The sample is arm64; your detonation farm is x64. Rebuilding
+the sample is exactly what you must not do (the binary IS the
+evidence), and the aarch64 library retrace already ships was
+never documented for this flow.
+
+## Config
+
+Cross-build the guest-arch library once on the farm host:
+
+```sh
+apt-get install -y gcc-aarch64-linux-gnu qemu-user-static cmake ninja-build
+
+cat > xtool.cmake <<'EOF'
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR aarch64)
+set(CMAKE_C_COMPILER aarch64-linux-gnu-gcc)
+set(CMAKE_CXX_COMPILER aarch64-linux-gnu-g++)
+EOF
+
+cmake -S retrace -B build-arm64 -G Ninja \
+  -DCMAKE_TOOLCHAIN_FILE=$PWD/xtool.cmake \
+  -DRETRACE_BUILD_TESTS=OFF -DRETRACE_BUILD_EXAMPLES=OFF
+cmake --build build-arm64 --target retrace_v2
+# build-arm64/src/v2/libretrace.so  (aarch64 ELF)
+```
+
+## Invocation
+
+The farm shape: x86_64 host, qemu-user, arm64 guest. Env
+inherits normally — `LD_PRELOAD` points at the **arm64**
+library; `-L` names the guest sysroot the cross toolchain
+installed (without it qemu cannot find the guest loader):
+
+```sh
+LD_PRELOAD=$PWD/build-arm64/src/v2/libretrace.so \
+RETRACE_JSON_CONFIG=trace-open.json \
+qemu-aarch64-static -L /usr/aarch64-linux-gnu ./arm64-sample
+```
+
+`trace-open.json`:
+
+```json
+{
+  "intercept_scripts": [
+    { "func_name": "open",
+      "actions": [ { "action_name": "log_params" },
+                   { "action_name": "call_real" } ] }
+  ]
+}
+```
+
+Verified output (x86_64 host, Rosetta container, arm64 sample):
+
+```json
+{ "func": "open", "*path": ["/etc/hostname"], ... }
+```
+
+## Caveats (honest ones)
+
+- **qemu's own syscalls are not the guest's**: the kernel lane
+  (`retrace-ebpf-agent`) sees QEMU's process making x86_64
+  syscalls — the libc-layer evidence above is the truth for
+  guest behavior; grade kernel drift accordingly (or skip the
+  kernel lane for emulated runs).
+- Fault injection (`memory_fuzz`, `fail_first`), replay
+  (`RETRACE_REPLAY_OUT`/`IN`), and redaction all work — they
+  live in the guest's libc layer, which the preload owns.
+- The sample must be dynamically linked (a static arm64 binary
+  has no interposable libc — the ptrace lane is that story).
+- musl-based samples want the alpine cross toolchain's sysroot
+  at `-L` instead (the CI's alpine legs build exactly that).
+
+## Notes
+
+Under Docker: run the x86_64 container with `--platform
+linux/amd64` (Rosetta) — everything above works unchanged,
+which is how this recipe was verified.

--- a/docs/cookbook/README.md
+++ b/docs/cookbook/README.md
@@ -112,6 +112,7 @@ job.
 | 34 | [Profile a binary, then jail it to the profile](34-profile-and-jail.md) | `retrace-profile` | Reduce a trace to what a binary does, grade it against kernel truth, and emit a runtime deny-by-default file-access jail. |
 | 35 | [Dictionary-driven string fuzzing](35-dictionary-fuzz.md) | `fuzz_str` | Replace string parameters with dictionary tokens, deterministically per seed. |
 | 40 | [Redact secrets from evidence](40-redact-evidence.md) | config | Patterns of tokens that never leave the process: one transform at the evidence fan-out covers stdout, files, OTLP, and the journal. |
+| 41 | [Cross-arch detonation: arm64 samples on an x64 farm](41-qemu-cross-arch.md) | `qemu-aarch64-static` | The sample's arch is evidence: qemu-user + the aarch64 preload, with the kernel-lane caveat spelled out. |
 
 For an overview of when to reach for each tool, see
 [docs/tools.md](../tools.md).


### PR DESCRIPTION
TODO.impl/04 (P1) — we ship aarch64 libraries; nobody documented detonating arm64 samples on x64 farms, and the sample's arch IS evidence you must not rebuild.

**Cookbook 41 carries the verified flow:**

1. Cross-build the guest-arch library once per farm host (the three-line `xtool.cmake` + `gcc-aarch64-linux-gnu`).
2. `qemu-aarch64-static -L /usr/aarch64-linux-gnu ./arm64-sample` with plain env inheritance — the arm64 `LD_PRELOAD` rides straight through; `-L` names the guest sysroot the cross toolchain installed (without it qemu cannot find the guest loader — the one hard requirement the recipe exists to record).

**Verified live** in an x86_64 container (Rosetta): freshly cross-built arm64 sample + arm64 libretrace.so → opens captured with decoded paths; fault injection, replay, and redaction all ride the guest libc layer, which the preload owns.

**The honest caveats ride along:** the kernel lane (eBPF) sees *QEMU's* syscalls, not the guest's — libc evidence is the truth for emulated runs; static arm64 samples have no interposable libc (the ptrace lane is that story); musl samples want the alpine cross sysroot (exactly what the CI's alpine legs build).
