### PR TITLE
the developer persona returns: the root trail, back on the map

### DIFF
--- a/website/src/pages/audiences.astro
+++ b/website/src/pages/audiences.astro
@@ -73,10 +73,27 @@ const audiences = [
       { label: "Docs: quickstart", href: "/retrace/docs/#quickstart" },
     ],
   },
+  {
+    id: "developer",
+    accent: "control",
+    verb: "Debug",
+    who: "Developers & reverse engineers",
+    why: "retrace's root persona: the bug is in the boundary between your code and libc. Step through every call with arguments and returns, diff two runs, and pin the fault that only fires at 3am.",
+    steps: [
+      { t: "Trace with arguments", c: "retrace trace open,malloc,getenv -- ./app", d: "Dereferenced strings, sizes, returns — JSON per call." },
+      { t: "Diff two runs", c: "retrace-diff run1.json run2.json --threshold 5", d: "Which calls appear, vanish, or slow down between builds." },
+      { t: "Pin the 3am fault", c: "RETRACE_REPLAY_OUT=run.rec ./flaky && RETRACE_REPLAY_IN=run.rec ./flaky", d: "The time-seeded run records; the replay reproduces it exactly — or names its drift." },
+    ],
+    trail: [
+      { label: "Cookbook: the debugging set", href: "https://github.com/riboseinc/retrace/blob/main/docs/cookbook/README.md" },
+      { label: "Recipe 27: replay a trace", href: "https://github.com/riboseinc/retrace/blob/main/docs/cookbook/27-replay-debug.md" },
+      { label: "Recipe 41: cross-arch samples", href: "https://github.com/riboseinc/retrace/blob/main/docs/cookbook/41-qemu-cross-arch.md" },
+    ],
+  },
 ];
 ---
 
-<Layout title="Audiences — who retrace is for" description="Four audiences, four trails: security research, fuzzing, audit, and operations.">
+<Layout title="Audiences — who retrace is for" description="Five audiences, five trails: security research, fuzzing, audit, operations, and debugging.">
   <Nav />
   <main id="top">
     <section class="hero">

--- a/website/src/pages/docs.astro
+++ b/website/src/pages/docs.astro
@@ -145,7 +145,8 @@ retrace-profile harden p.json -o strict.json     <span class="c"># 5. deny-by-de
       <div class="wrap">
         <h2>7 · Going deeper</h2>
         <ul class="links">
-          <li><a href="https://github.com/riboseinc/retrace/blob/main/docs/cookbook/README.md">The cookbook</a> — 36 recipes, each one workflow</li>
+          <li><a href="https://github.com/riboseinc/retrace/blob/main/docs/cookbook/README.md">The cookbook</a> — 41 recipes, each one workflow</li>
+          <li>The debugging set — recipes 27 (replay TUI), 25/26 (run diffing), 31 (VS Code viewer), 41 (cross-arch samples)</li>
           <li><a href="https://github.com/riboseinc/retrace/blob/main/docs/reports.md">Output shapes</a> — trace, profile, risk, drift, jail, OTLP schema</li>
           <li><a href="https://github.com/riboseinc/retrace/blob/main/docs/supervisor.md">The supervisor</a> — retraced, the fleet CLI (spawn/kill lifecycle, departures journaled), TLS claim scopes, kernel enforcement + signed audit</li>
           <li><a href="https://github.com/riboseinc/retrace/blob/main/docs/runtime-agents.md">Runtime agents</a> — write your own lane (Python + JVM references)</li>


### PR DESCRIPTION
TODO.impl/23 — the last Ready card. The site sold four audiences; the tool's **root** persona — debugging and reverse engineering — was absent, and the ergonomics that serve it (run diffing, the replay TUI, the replay slice, the VS Code viewer) never had a trail.

- **audiences.astro gains the fifth card: Debug** — trace with dereferenced arguments, diff two runs, pin the 3am fault with `RETRACE_REPLAY_OUT`/`IN` (the v2.86.0 slice). The trail links the debugging set.
- **docs.astro names the set explicitly** (27 replay TUI, 25/26 run diffing, 31 VS Code viewer, 41 cross-arch samples) and finally counts the cookbook honestly — 41 recipes, not 36.

Every recipe the trail lists works on today's release (each shipped through this board's rails); the three-click acceptance is the audiences page itself. Astro build verified — the card, the count, and the trail render in `dist/`. Checkpatch clean.
