### PR TITLE
v2.91.0 version bump

### DIFF
--- a/include/retrace/version.h
+++ b/include/retrace/version.h
@@ -38,10 +38,10 @@
 
 #define RETRACE_VERSION_MAJOR 2
 #define RETRACE_VERSION_MAJOR 2
-#define RETRACE_VERSION_MINOR 90
+#define RETRACE_VERSION_MINOR 91
 #define RETRACE_VERSION_PATCH 0
 
-#define RETRACE_VERSION_STRING "2.90.0"
+#define RETRACE_VERSION_STRING "2.91.0"
 
 #define RETRACE_VERSION_ATLEAST(maj, min, pat)                  \
 	(RETRACE_VERSION_MAJOR > (maj) ||                       \


### PR DESCRIPTION
Version bump to 2.91.0.

Releases the developer persona trail (PR #823): the fifth
audience card on the site — debugging, the root persona — with
the replay pin flow, the cookbook's debugging set surfaced on
the docs page, and the recipe count stated honestly at 41.

- `RETRACE_VERSION_MINOR` 90 → 91
- `RETRACE_VERSION_STRING` "2.90.0" → "2.91.0"
