### PR TITLE
v2.92.0 version bump

### DIFF
--- a/include/retrace/version.h
+++ b/include/retrace/version.h
@@ -38,10 +38,10 @@
 
 #define RETRACE_VERSION_MAJOR 2
 #define RETRACE_VERSION_MAJOR 2
-#define RETRACE_VERSION_MINOR 91
+#define RETRACE_VERSION_MINOR 92
 #define RETRACE_VERSION_PATCH 0
 
-#define RETRACE_VERSION_STRING "2.91.0"
+#define RETRACE_VERSION_STRING "2.92.0"
 
 #define RETRACE_VERSION_ATLEAST(maj, min, pat)                  \
 	(RETRACE_VERSION_MAJOR > (maj) ||                       \


### PR DESCRIPTION
Version bump to 2.92.0.

Releases the syscall-lane actions (PR #825, ADR-0016): the arch-spec seam made polymorphic, and the ptrace lane gains its actions — a static detonation is contained, not merely watched.

- `sandbox` denies `open("/etc/shadow")` with `-EACCES` at the syscall stop, from the same JSON scripts the preload lanes run
- `call_real` = allow (the kernel IS the real implementation); modify-after-allow lands at the syscall-exit stop
- `log_params` reads paths out of the tracee via `process_vm_readv`
- The skip rides a benign getpid rewrite delivered at syscall-exit — immune to the container seccomp filters that turn invalid syscall numbers into ENOSYS
- Recipe 42, platforms.md, ADR-0016; standalone seam unit + live deny E2E on every Linux leg

- `RETRACE_VERSION_MINOR` 91 → 92
- `RETRACE_VERSION_STRING` "2.91.0" → "2.92.0"
