### PR TITLE
queries as config: the filter expression language (TODO.impl/08)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -316,6 +316,41 @@ value to half of what the real call returned.
 
 Actions that shape the run as a whole — gating, throttling, denying.
 
+#### `filter`
+
+Aborts the script (skipping subsequent actions) when the
+condition does not hold — the gate that turns "log everything"
+into "log what I'm hunting". Two forms.
+
+The expression form (`expr`): a small predicate language over
+the call — params by name, numbers, quoted strings, the
+builtins `func` / `ret` / `caller`, globs (`~`, `!~`), the
+comparisons (`==`, `!=`, `<`, `<=`, `>`, `>=`), and `and` /
+`or` / `not` with parentheses. See
+[cookbook recipe 43](cookbook/43-filter-expr.md) for the full
+grammar and semantics.
+
+```json
+{
+  "action_name": "filter",
+  "action_params": { "expr": "path ~ "*.log"" }
+}
+```
+
+The legacy form (`param_name` / `op` / `value`): one
+comparison on one named param.
+
+| Param        | Type   | Required        | Notes                              |
+|--------------|--------|-----------------|------------------------------------|
+| `expr`       | string | one of the two  | The expression form.               |
+| `param_name` | string | with `expr`     | Legacy single-comparison form.     |
+| `op`         | string | legacy form     | `==`, `!=`, `>`, `<`, `>=`, `<=`.  |
+| `value`      | number | legacy form     | The comparison value.              |
+
+A filter expression is compiled once and validated at config
+load: a bad expression REFUSES the whole config file at boot
+with a reason and character offset — never a silent no-match.
+
 #### `delay`
 
 Injects N milliseconds of latency before the call returns. Useful

--- a/docs/cookbook/43-filter-expr.md
+++ b/docs/cookbook/43-filter-expr.md
@@ -1,0 +1,79 @@
+# 43 — Log only what you're hunting: the filter expression
+
+## Problem
+
+The trace is enormous and 99% of it is noise. You want the
+opens of `*.log` — not every open on the box — and you want to
+say it in the config, not in a grep pipeline after the fact.
+
+## Config
+
+The `filter` action speaks a small expression language in its
+`expr` param:
+
+```json
+{
+  "intercept_scripts": [
+    { "func_name": "open",
+      "actions": [
+        { "action_name": "filter",
+          "action_params": { "expr": "path ~ \"*.log\"" } },
+        { "action_name": "log_params" },
+        { "action_name": "call_real" } ] }
+  ]
+}
+```
+
+Everything after a non-matching filter is skipped — no log, no
+actions — exactly like the single-comparison form (which still
+works: `param_name`/`op`/`value`).
+
+## The language
+
+```
+disj   := conj ("or" conj)*
+conj   := neg  ("and" neg)*
+neg    := "not" neg | primary
+primary:= "(" disj ")" | operand OP operand
+OP     := == != < <= > >= ~ !~
+```
+
+with `expr` = `disj` (the start production).
+
+Operands: any param by name (`path`, `flags`, `fd`, ...),
+numbers, quoted strings, and three builtins — `func` (the
+intercepted function), `ret` (the call's return value:
+meaningful in scripts that run after `call_real`), `caller`
+(the caller's symbol). `~` is a glob match (`*`, `?`,
+`[a-z]`); `!~` its negation.
+
+More shapes:
+
+```json
+"expr": "func ~ \"open*\" and not path ~ \"/proc/*\""
+"expr": "flags == 0 and path ~ \"*.conf\""
+"expr": "ret < 0"                                  (after call_real)
+```
+
+A string param compared with a relational operator (`s < 3`)
+evaluates FALSE at runtime — strings compare with `~`, `==`,
+`!=`. A param the call doesn't have is FALSE, never an error.
+**A bad expression is a config error**: the whole file is
+refused at boot with the reason and character offset, not
+silently matching nothing.
+
+## Verified
+
+`test/integration/test_filter_expr.py`: a target opens `.log`
+and `.txt` files; only `.log` opens reach the log, and an
+invalid expression refuses the config. The parser and
+evaluator are property-tested in `test/unit/test_filter_dsl.c`
+(seeded random expression trees, truth by construction).
+
+## Notes
+
+The predicate compiles once (a small arena-allocated tree) and
+caches on the expression string — per-call cost is the
+evaluation, not the parse. The glob matcher is retrace's own
+portable one (`retrace_filter_glob_match`) — the same matcher
+the caller-glob and future grammar family members share.

--- a/docs/cookbook/README.md
+++ b/docs/cookbook/README.md
@@ -114,6 +114,7 @@ job.
 | 40 | [Redact secrets from evidence](40-redact-evidence.md) | config | Patterns of tokens that never leave the process: one transform at the evidence fan-out covers stdout, files, OTLP, and the journal. |
 | 41 | [Cross-arch detonation: arm64 samples on an x64 farm](41-qemu-cross-arch.md) | `qemu-aarch64-static` | The sample's arch is evidence: qemu-user + the aarch64 preload, with the kernel-lane caveat spelled out. |
 | 42 | [Stop a static sample: policy on the syscall lane](42-static-lane-deny.md) | ptrace | `retrace attach` runs the same sandbox scripts at the syscall stop — a static detonation gets contained, not just watched. |
+| 43 | [Log only what you're hunting: the filter expression](43-filter-expr.md) | `filter` | `path ~ "*.log" and not ret < 0` — queries as config, compiled once, bad syntax refused at boot. |
 
 For an overview of when to reach for each tool, see
 [docs/tools.md](../tools.md).

--- a/src/config/json/conf.c
+++ b/src/config/json/conf.c
@@ -25,6 +25,8 @@
 #include <errno.h>
 
 #include "conf.h"
+
+#include "filter_dsl.h"
 #include "real_impls.h"
 #include "redact.h"
 #include "logger.h"
@@ -176,6 +178,71 @@ parse_json:
 
 		if (csv != NULL)
 			retrace_redact_set_csv(csv);
+	}
+
+	/*
+	 * Filter expressions (TODO.impl/08): a bad expression is a
+	 * CONFIG ERROR, not a silent no-match -- refuse the whole
+	 * file (the parse-failure contract) so the operator sees it
+	 * at boot.
+	 */
+	{
+		JSON_Array *scripts = json_object_get_array(retrace_conf,
+						  "intercept_scripts");
+		size_t si;
+
+		for (si = 0; scripts != NULL &&
+			    si < json_array_get_count(scripts); si++) {
+			JSON_Object *script = json_array_get_object(
+				scripts, si);
+			JSON_Array *acts = script != NULL ?
+				json_object_get_array(script, "actions") :
+				NULL;
+			size_t ai;
+
+			for (ai = 0; acts != NULL &&
+				    ai < json_array_get_count(acts);
+			     ai++) {
+				JSON_Object *act = json_array_get_object(
+					acts, ai);
+				const char *name = act != NULL ?
+					json_object_get_string(act,
+						"action_name") : NULL;
+				JSON_Object *params = act != NULL ?
+					json_object_get_object(act,
+						"action_params") : NULL;
+				const char *expr;
+
+				if (name == NULL || params == NULL ||
+				    retrace_real_impls.strcmp(name,
+						"filter") != 0)
+					continue;
+
+				expr = json_object_get_string(params,
+					"expr");
+				if (expr == NULL)
+					continue;
+
+				{
+					char err[128];
+					struct retrace_filter_ast *ast =
+						retrace_filter_compile(
+							expr, err,
+							sizeof(err));
+
+					if (ast == NULL) {
+						log_err("script for '%s': "
+							"filter expr '%s': %s",
+							json_object_get_string(
+								script,
+								"func_name"),
+							expr, err);
+						return -1;
+					}
+					retrace_filter_free(ast);
+				}
+			}
+		}
 	}
 
 	return 0;

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -17,6 +17,7 @@ set(_core_sources
 	replay.c
 	caller_match.c
 	caller_cache.c
+	filter_dsl.c
 	log_ring.c
 	log_flusher.c
 	otlp_allocator.c

--- a/src/core/actions/filter.c
+++ b/src/core/actions/filter.c
@@ -67,6 +67,80 @@
 #include "logger.h"
 #include "real_impls.h"
 #include "action_utils.h"
+#include "filter_dsl.h"
+
+/*
+ * Compiled-predicate cache (TODO.impl/08). The `expr` param is
+ * compiled ONCE and cached on the expr string's identity + a
+ * content guard -- the same revalidation lesson as sandbox's
+ * compiled set (a freed JSON tree's memory can be recycled
+ * into a new string at the same address).
+ */
+struct filter_expr_cache_el {
+	const char *expr_ptr;
+	size_t expr_len;
+	char first;
+	char last;
+	struct retrace_filter_ast *ast;
+};
+
+#define FILTER_EXPR_CACHE_MAX 16
+
+static struct filter_expr_cache_el expr_cache[FILTER_EXPR_CACHE_MAX];
+static size_t expr_cache_cnt;
+
+static struct retrace_filter_ast *expr_cache_get(const char *expr)
+{
+	size_t len = retrace_real_impls.strlen(expr);
+	size_t i;
+
+	for (i = 0; i < expr_cache_cnt; i++) {
+		struct filter_expr_cache_el *el = &expr_cache[i];
+
+		if (el->expr_ptr == expr && el->expr_len == len &&
+		    el->first == expr[0] && el->last == expr[len - 1])
+			return el->ast;
+	}
+	return NULL;
+}
+
+static struct retrace_filter_ast *expr_compile_cached(const char *expr)
+{
+	char err[128];
+	size_t len = retrace_real_impls.strlen(expr);
+	struct retrace_filter_ast *ast;
+	struct filter_expr_cache_el *el;
+
+	ast = retrace_filter_compile(expr, err, sizeof(err));
+	if (ast == NULL) {
+		/*
+		 * config validation should have caught this; a bad
+		 * expr reaching here fails CLOSED (never matches)
+		 */
+		log_err("filter: bad expr '%s': %s", expr, err);
+		return NULL;
+	}
+
+	if (expr_cache_cnt == FILTER_EXPR_CACHE_MAX) {
+		/* recycle the oldest slot */
+		el = &expr_cache[0];
+		retrace_filter_free(el->ast);
+		memmove(expr_cache, expr_cache + 1,
+			(FILTER_EXPR_CACHE_MAX - 1) * sizeof(expr_cache[0]));
+		el = &expr_cache[FILTER_EXPR_CACHE_MAX - 1];
+		expr_cache_cnt--;
+	} else {
+		el = &expr_cache[expr_cache_cnt];
+	}
+
+	el->expr_ptr = expr;
+	el->expr_len = len;
+	el->first = expr[0];
+	el->last = expr[len - 1];
+	el->ast = ast;
+	expr_cache_cnt++;
+	return ast;
+}
 
 static int eval_op(long actual, const char *op, long expected)
 {
@@ -101,6 +175,36 @@ static int ia_filter(struct ThreadContext *t_ctx,
 	if (action_params == NULL) {
 		log_err("filter: action_params required");
 		return -1;
+	}
+
+	/*
+	 * Expression form (TODO.impl/08): a small predicate
+	 * language over params, func, ret, and globs. Compiled
+	 * once, evaluated per call. No expr: the legacy
+	 * single-comparison triple below, unchanged.
+	 */
+	{
+		const char *expr = json_object_get_string(action_params,
+							  "expr");
+
+		if (expr != NULL) {
+			struct retrace_filter_ast *ast = expr_cache_get(expr);
+			const char *func = t_ctx->prototype != NULL ?
+				t_ctx->prototype->name : NULL;
+
+			if (ast == NULL) {
+				ast = expr_compile_cached(expr);
+				if (ast == NULL)
+					return -1;	/* fail closed */
+			}
+
+			if (retrace_filter_eval(ast, t_ctx, func)) {
+				log_dbg("filter: expr matched -- continuing");
+				return 0;
+			}
+			log_dbg("filter: expr not matched -- aborting script");
+			return -1;
+		}
 	}
 
 	param_name = json_object_get_string(action_params, "param_name");

--- a/src/core/filter_dsl.c
+++ b/src/core/filter_dsl.c
@@ -1,0 +1,913 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * The filter expression language (TODO.impl/08). See filter_dsl.h
+ * for the grammar and semantics. This module is deliberately
+ * self-contained: no logger, no JSON -- the parser walks plain
+ * memory and the tree evaluates against a ThreadContext. The
+ * `filter` action and the config validator are its only
+ * consumers; the standalone unit test its proof.
+ */
+
+#include "filter_dsl.h"
+
+#include <string.h>
+
+#include "engine.h"
+#include "real_impls.h"
+
+/* No libc classification/conversion calls here: the parser runs
+ * inside the engine (config validation at boot, first-action
+ * compile later), where direct libc would recurse through the
+ * trampolines. Tiny local helpers instead.
+ */
+static int is_digit(char c)
+{
+	return c >= '0' && c <= '9';
+}
+
+static int is_alpha(char c)
+{
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
+}
+
+static int is_ident_char(char c)
+{
+	return is_alpha(c) || is_digit(c) || c == '_';
+}
+
+#define STR_EQ(a, b) (retrace_real_impls.strcmp((a), (b)) == 0)
+#define STR_NCMP(a, b, n) (retrace_real_impls.strncmp((a), (b), (n)))
+/*
+ * parenthesized: fortified <string.h> macro-substitutes bare
+ * member-call syntax on macOS toolchains
+ */
+#define RI_MEMSET(s, c, n) (retrace_real_impls.memset)((s), (c), (n))
+#define RI_MEMCPY(d, s, n) (retrace_real_impls.memcpy)((d), (s), (n))
+
+/* ---- AST ----------------------------------------------------------------
+ *
+ * Nodes live in ONE arena block (malloc'd with the tree header):
+ * strings reference slices copied into the same arena. Nothing
+ * individual is freed -- one free() releases the compilation.
+ */
+
+enum fnode_kind {
+	FN_OR,		/* lhs | rhs (children in seq[]) */
+	FN_AND,		/* lhs & rhs */
+	FN_NOT,		/* !child */
+	FN_CMP,		/* operand OP operand */
+};
+
+enum fop_kind {
+	FO_EQ,
+	FO_NE,
+	FO_LT,
+	FO_LE,
+	FO_GT,
+	FO_GE,
+	FO_GLOB,
+	FO_NGLOB,
+};
+
+enum foperand_kind {
+	FO_NUM,		/* literal number */
+	FO_STR,		/* literal string */
+	FO_PARAM,	/* param name -> value at eval */
+	FO_FUNC,	/* builtin: function name */
+	FO_RET,		/* builtin: ret_val */
+	FO_CALLER,	/* builtin: caller symbol */
+};
+
+struct foperand {
+	enum foperand_kind kind;
+	long long num;
+	const char *str;	/* arena slice */
+	size_t str_len;
+};
+
+struct fnode {
+	enum fnode_kind kind;
+	union {
+		struct {
+			struct fnode *lhs;
+			struct fnode *rhs;
+		} bin;
+		struct fnode *child;
+		struct {
+			enum fop_kind op;
+			struct foperand lhs;
+			struct foperand rhs;
+		} cmp;
+	} u;
+};
+
+struct retrace_filter_ast {
+	char *arena;		/* the single allocation */
+	size_t arena_len;
+	struct fnode *root;
+	/* number of nodes (for the unit test's size assertions) */
+	size_t node_cnt;
+};
+
+/* ---- glob matcher ------------------------------------------------------ */
+
+int
+retrace_filter_glob_match(const char *pattern, const char *text)
+{
+	const char *p = pattern;
+	const char *t = text;
+	const char *star_p = NULL;
+	const char *star_t = NULL;
+
+	if (pattern == NULL || text == NULL)
+		return 0;
+
+	while (*t != '\0') {
+		if (*p == '?') {
+			p++;
+			t++;
+		} else if (*p == '\\' && p[1] != '\0') {
+			if (*t == p[1]) {
+				p += 2;
+				t++;
+			} else if (star_p != NULL) {
+				p = star_p + 1;
+				t = ++star_t;
+			} else {
+				return 0;
+			}
+		} else if (*p == '[') {
+			const char *q = p + 1;
+			int negate = 0;
+			int matched = 0;
+
+			if (*q == '!' || *q == '^') {
+				negate = 1;
+				q++;
+			}
+			/* ']' first = a literal ']' in the class */
+			if (*q == ']') {
+				if (*t == ']')
+					matched = 1;
+				q++;
+			}
+			while (*q != ']' && *q != '\0') {
+				if (q[1] == '-' && q[2] != ']' &&
+				    q[2] != '\0') {
+					if (*t >= q[0] && *t <= q[2])
+						matched = 1;
+					q += 3;
+				} else {
+					if (*t == *q)
+						matched = 1;
+					q++;
+				}
+			}
+			if (*q != ']') {
+				/* unterminated class: literal '[' */
+				if (*t == '[') {
+					p++;
+					t++;
+				} else if (star_p != NULL) {
+					p = star_p + 1;
+					t = ++star_t;
+				} else {
+					return 0;
+				}
+			} else if (matched != negate) {
+				p = q + 1;
+				t++;
+			} else if (star_p != NULL) {
+				p = star_p + 1;
+				t = ++star_t;
+			} else {
+				return 0;
+			}
+		} else if (*p == *t && *p != '\0') {
+			p++;
+			t++;
+		} else if (*p == '*') {
+			star_p = p;
+			star_t = t;
+			p++;
+		} else if (star_p != NULL) {
+			p = star_p + 1;
+			t = ++star_t;
+		} else {
+			return 0;
+		}
+	}
+
+	while (*p == '*')
+		p++;
+	return *p == '\0';
+}
+
+/* ---- parser ------------------------------------------------------------- */
+
+struct fparser {
+	const char *src;
+	size_t pos;
+	char *err;
+	size_t err_cap;
+	int failed;
+	/* arena building */
+	char *arena;
+	size_t arena_cap;
+	size_t arena_len;
+	struct fnode *nodes;
+	size_t node_cnt;
+	size_t node_cap;
+};
+
+static void
+perr(struct fparser *p, size_t at, const char *msg)
+{
+	if (p->failed)
+		return;
+	p->failed = 1;
+	if (p->err != NULL && p->err_cap > 0) {
+		size_t n = (size_t) retrace_real_impls.real_snprintf(
+			p->err, p->err_cap, "%s (at char %zu)", msg, at + 1);
+
+		(void) n;
+	}
+}
+
+static char *
+arena_push(struct fparser *p, size_t n)
+{
+	char *out;
+
+	if (p->arena_len + n > p->arena_cap) {
+		size_t want = (p->arena_cap * 2) + n + 64;
+		char *grown = (char *) retrace_real_impls.malloc(want);
+
+		if (grown == NULL) {
+			perr(p, p->pos, "out of memory");
+			return NULL;
+		}
+		RI_MEMCPY(grown, p->arena, p->arena_len);
+		retrace_real_impls.free(p->arena);
+		p->arena = grown;
+		p->arena_cap = want;
+	}
+	out = p->arena + p->arena_len;
+	p->arena_len += n;
+	return out;
+}
+
+static struct fnode *
+node_new(struct fparser *p)
+{
+	if (p->node_cnt == p->node_cap) {
+		size_t want = p->node_cap * 2 + 16;
+		struct fnode *grown = (struct fnode *)
+			retrace_real_impls.malloc(want * sizeof(*grown));
+
+		if (grown == NULL) {
+			perr(p, p->pos, "out of memory");
+			return NULL;
+		}
+		RI_MEMCPY(grown, p->nodes,
+			p->node_cnt * sizeof(*grown));
+		retrace_real_impls.free(p->nodes);
+		p->nodes = grown;
+		p->node_cap = want;
+	}
+	RI_MEMSET(&p->nodes[p->node_cnt], 0,
+		sizeof(struct fnode));
+	return &p->nodes[p->node_cnt++];
+}
+
+static void
+skip_ws(struct fparser *p)
+{
+	while (p->src[p->pos] == ' ' || p->src[p->pos] == '\t')
+		p->pos++;
+}
+
+/* keyword check: the identifier at src[at..] equals `kw` as a whole word */
+static int
+at_keyword(struct fparser *p, const char *kw)
+{
+	size_t klen = strlen(kw);
+
+	if (STR_NCMP(&p->src[p->pos], kw, klen) != 0)
+		return 0;
+	return !is_ident_char(p->src[p->pos + klen]);
+}
+
+static struct fnode *parse_or(struct fparser *p);
+
+static int
+parse_operand(struct fparser *p, struct foperand *out)
+{
+	skip_ws(p);
+
+	if (p->src[p->pos] == '"') {
+		size_t start = p->pos + 1;
+		size_t len = 0;
+		char *dst;
+
+		p->pos = start;
+		while (p->src[p->pos] != '"') {
+			if (p->src[p->pos] == '\\' &&
+			    p->src[p->pos + 1] != '\0') {
+				p->pos += 2;
+				len += 1;
+				continue;
+			}
+			if (p->src[p->pos] == '\0') {
+				perr(p, p->pos, "unterminated string");
+				return 0;
+			}
+			p->pos++;
+			len++;
+		}
+
+		dst = arena_push(p, len + 1);
+		if (dst == NULL)
+			return 0;
+
+		{
+			size_t r = start;
+			size_t w = 0;
+
+			while (r < p->pos) {
+				if (p->src[r] == '\\' &&
+				    p->src[r + 1] != '\0') {
+					dst[w++] = p->src[r + 1];
+					r += 2;
+				} else {
+					dst[w++] = p->src[r++];
+				}
+			}
+			dst[w] = '\0';
+		}
+		p->pos++;	/* closing quote */
+
+		out->kind = FO_STR;
+		out->str = dst;
+		out->str_len = len;
+		return 1;
+	}
+
+	if (is_digit(p->src[p->pos]) ||
+	    (p->src[p->pos] == '-' && is_digit(p->src[p->pos + 1]))) {
+		int neg = p->src[p->pos] == '-';
+		long long v = 0;
+		size_t start = p->pos;
+
+		p->pos += neg ? 1 : 0;
+		while (is_digit(p->src[p->pos])) {
+			v = v * 10 + (p->src[p->pos] - '0');
+			p->pos++;
+		}
+		if (p->pos == start + (neg ? 1 : 0)) {
+			p->pos = start;
+			perr(p, start, "bad number");
+			return 0;
+		}
+		out->kind = FO_NUM;
+		out->num = neg ? -v : v;
+		return 1;
+	}
+
+	if (at_keyword(p, "and") || at_keyword(p, "or") ||
+	    at_keyword(p, "not")) {
+		perr(p, p->pos, "expected operand (name, number, or \"string\")");
+		return 0;
+	}
+
+	if (is_alpha(p->src[p->pos]) || p->src[p->pos] == '_') {
+		size_t start = p->pos;
+
+		while (is_ident_char(p->src[p->pos]))
+			p->pos++;
+
+		{
+			size_t len = p->pos - start;
+			char *dst = arena_push(p, len + 1);
+
+			if (dst == NULL)
+				return 0;
+			RI_MEMCPY(dst, &p->src[start], len);
+			dst[len] = '\0';
+
+			if (STR_EQ(dst, "func"))
+				out->kind = FO_FUNC;
+			else if (STR_EQ(dst, "ret"))
+				out->kind = FO_RET;
+			else if (STR_EQ(dst, "caller"))
+				out->kind = FO_CALLER;
+			else
+				out->kind = FO_PARAM;
+			out->str = dst;
+			out->str_len = len;
+			return 1;
+		}
+	}
+
+	perr(p, p->pos, "expected operand (name, number, or \"string\")");
+	return 0;
+}
+
+static struct fnode *
+parse_primary(struct fparser *p)
+{
+	struct fnode *n;
+
+	skip_ws(p);
+
+	if (p->src[p->pos] == '(') {
+		p->pos++;
+		n = parse_or(p);
+		skip_ws(p);
+		if (p->src[p->pos] != ')') {
+			perr(p, p->pos, "expected ')'");
+			return NULL;
+		}
+		p->pos++;
+		return n;
+	}
+
+	n = node_new(p);
+	if (n == NULL)
+		return NULL;
+	n->kind = FN_CMP;
+
+	if (!parse_operand(p, &n->u.cmp.lhs))
+		return NULL;
+
+	skip_ws(p);
+	{
+		enum fop_kind op;
+		int oplen;
+
+		if (STR_NCMP(&p->src[p->pos], "==", 2) == 0) {
+			op = FO_EQ;
+			oplen = 2;
+		} else if (STR_NCMP(&p->src[p->pos], "!=", 2) == 0) {
+			op = FO_NE;
+			oplen = 2;
+		} else if (STR_NCMP(&p->src[p->pos], "<=", 2) == 0) {
+			op = FO_LE;
+			oplen = 2;
+		} else if (STR_NCMP(&p->src[p->pos], ">=", 2) == 0) {
+			op = FO_GE;
+			oplen = 2;
+		} else if (p->src[p->pos] == '<') {
+			op = FO_LT;
+			oplen = 1;
+		} else if (p->src[p->pos] == '>') {
+			op = FO_GT;
+			oplen = 1;
+		} else if (STR_NCMP(&p->src[p->pos], "!~", 2) == 0) {
+			op = FO_NGLOB;
+			oplen = 2;
+		} else if (p->src[p->pos] == '~') {
+			op = FO_GLOB;
+			oplen = 1;
+		} else {
+			perr(p, p->pos,
+			      "expected operator (== != < <= > >= ~ !~)");
+			return NULL;
+		}
+		p->pos += (size_t) oplen;
+		n->u.cmp.op = op;
+	}
+
+	if (!parse_operand(p, &n->u.cmp.rhs))
+		return NULL;
+
+	/* Type rule: relational operators need numeric operands;
+	 * glob needs a string RHS (pattern); == / != compare
+	 * like-typed operands.
+	 */
+	{
+		int str_lhs = (n->u.cmp.lhs.kind == FO_STR ||
+			       n->u.cmp.lhs.kind == FO_FUNC ||
+			       n->u.cmp.lhs.kind == FO_CALLER);
+		int str_rhs = (n->u.cmp.rhs.kind == FO_STR ||
+			       n->u.cmp.rhs.kind == FO_FUNC ||
+			       n->u.cmp.rhs.kind == FO_CALLER);
+		enum fop_kind op = n->u.cmp.op;
+
+		if ((op == FO_LT || op == FO_LE || op == FO_GT ||
+		     op == FO_GE) && (str_lhs || str_rhs)) {
+			perr(p, p->pos,
+			      "relational operators need numeric operands");
+			return NULL;
+		}
+		if ((op == FO_GLOB || op == FO_NGLOB) &&
+		    n->u.cmp.rhs.kind != FO_STR) {
+			perr(p, p->pos,
+			      "glob pattern must be a string literal");
+			return NULL;
+		}
+	}
+
+	return n;
+}
+
+static struct fnode *
+parse_not(struct fparser *p)
+{
+	skip_ws(p);
+
+	if (at_keyword(p, "not")) {
+		struct fnode *n;
+
+		p->pos += 3;
+		n = node_new(p);
+		if (n == NULL)
+			return NULL;
+		n->kind = FN_NOT;
+		n->u.child = parse_not(p);
+		if (n->u.child == NULL)
+			return NULL;
+		return n;
+	}
+	return parse_primary(p);
+}
+
+static struct fnode *
+parse_and(struct fparser *p)
+{
+	struct fnode *lhs = parse_not(p);
+
+	if (lhs == NULL)
+		return NULL;
+
+	for (;;) {
+		skip_ws(p);
+		if (!at_keyword(p, "and"))
+			return lhs;
+		p->pos += 3;
+		{
+			struct fnode *rhs = parse_not(p);
+			struct fnode *n;
+
+			if (rhs == NULL)
+				return NULL;
+			n = node_new(p);
+			if (n == NULL)
+				return NULL;
+			n->kind = FN_AND;
+			n->u.bin.lhs = lhs;
+			n->u.bin.rhs = rhs;
+			lhs = n;
+		}
+	}
+}
+
+static struct fnode *
+parse_or(struct fparser *p)
+{
+	struct fnode *lhs = parse_and(p);
+
+	if (lhs == NULL)
+		return NULL;
+
+	for (;;) {
+		skip_ws(p);
+		if (!at_keyword(p, "or"))
+			return lhs;
+		p->pos += 2;
+		{
+			struct fnode *rhs = parse_and(p);
+			struct fnode *n;
+
+			if (rhs == NULL)
+				return NULL;
+			n = node_new(p);
+			if (n == NULL)
+				return NULL;
+			n->kind = FN_OR;
+			n->u.bin.lhs = lhs;
+			n->u.bin.rhs = rhs;
+			lhs = n;
+		}
+	}
+}
+
+struct retrace_filter_ast *
+retrace_filter_compile(const char *expr, char *err, size_t err_cap)
+{
+	struct fparser p;
+	struct fnode *root;
+	struct retrace_filter_ast *ast;
+
+	RI_MEMSET(&p, 0, sizeof(p));
+	p.src = expr;
+	p.err = err;
+	p.err_cap = err_cap;
+	if (err != NULL && err_cap > 0)
+		err[0] = '\0';
+
+	if (expr == NULL || expr[0] == '\0') {
+		perr(&p, 0, "empty expression");
+		return NULL;
+	}
+
+	/* seed the arenas */
+	p.arena = (char *) retrace_real_impls.malloc(128);
+	p.nodes = (struct fnode *) retrace_real_impls.malloc(
+		16 * sizeof(struct fnode));
+	if (p.arena == NULL || p.nodes == NULL) {
+		retrace_real_impls.free(p.arena);
+		retrace_real_impls.free(p.nodes);
+		perr(&p, 0, "out of memory");
+		return NULL;
+	}
+	p.arena_cap = 128;
+	p.node_cap = 16;
+
+	root = parse_or(&p);
+	if (root == NULL || p.failed) {
+		retrace_real_impls.free(p.arena);
+		retrace_real_impls.free(p.nodes);
+		return NULL;
+	}
+
+	skip_ws(&p);
+	if (p.src[p.pos] != '\0') {
+		perr(&p, p.pos, "unexpected trailing input");
+		retrace_real_impls.free(p.arena);
+		retrace_real_impls.free(p.nodes);
+		return NULL;
+	}
+
+	/* the final AST owns the strings + nodes in one arena */
+	ast = (struct retrace_filter_ast *)
+		retrace_real_impls.malloc(sizeof(*ast));
+	if (ast == NULL) {
+		retrace_real_impls.free(p.arena);
+		retrace_real_impls.free(p.nodes);
+		perr(&p, 0, "out of memory");
+		return NULL;
+	}
+
+	/* relocate nodes into the string arena's tail so one free()
+	 * releases everything: copy node array, fix nothing (node
+	 * pointers are RELATIVE to the nodes array base -- rebuild
+	 * by copying in order; children were allocated after their
+	 * parents, so a stable copy preserves relative order).
+	 */
+	{
+		size_t nodes_bytes = p.node_cnt * sizeof(struct fnode);
+		char *all = (char *) retrace_real_impls.malloc(
+			p.arena_len + nodes_bytes);
+		struct fnode *new_nodes;
+
+		if (all == NULL) {
+			retrace_real_impls.free(p.arena);
+			retrace_real_impls.free(p.nodes);
+			retrace_real_impls.free(ast);
+			perr(&p, 0, "out of memory");
+			return NULL;
+		}
+		RI_MEMCPY(all, p.arena, p.arena_len);
+		new_nodes = (struct fnode *) (all + p.arena_len);
+		RI_MEMCPY(new_nodes, p.nodes, nodes_bytes);
+
+		/* pointers inside operands referenced the OLD arena --
+		 * strings moved by (new_base - old_base).
+		 */
+		{
+			ptrdiff_t shift = (char *) all - p.arena;
+			size_t i;
+
+			for (i = 0; i < p.node_cnt; i++) {
+				struct fnode *n = &new_nodes[i];
+
+				if (n->kind == FN_CMP) {
+					if (n->u.cmp.lhs.str != NULL)
+						n->u.cmp.lhs.str += shift;
+					if (n->u.cmp.rhs.str != NULL)
+						n->u.cmp.rhs.str += shift;
+				}
+			}
+			/* node-to-node pointers referenced the old
+			 * nodes array -- shift by their delta.
+			 */
+			shift = (char *) new_nodes - (char *) p.nodes;
+			for (i = 0; i < p.node_cnt; i++) {
+				struct fnode *n = &new_nodes[i];
+
+				if (n->kind == FN_CMP)
+					continue;
+				if (n->kind == FN_NOT) {
+					if (n->u.child != NULL)
+						n->u.child = (struct fnode *)
+							((char *) n->u.child + shift);
+				} else {
+					if (n->u.bin.lhs != NULL)
+						n->u.bin.lhs = (struct fnode *)
+							((char *) n->u.bin.lhs + shift);
+					if (n->u.bin.rhs != NULL)
+						n->u.bin.rhs = (struct fnode *)
+							((char *) n->u.bin.rhs + shift);
+				}
+			}
+			/* root was the LAST allocated top-level node...
+			 * no: root is the outermost, allocated last in
+			 * the or/and chains. Recompute by pointer shift
+			 * from the old array.
+			 */
+			root = (struct fnode *)
+				((char *) root + shift);
+		}
+
+		retrace_real_impls.free(p.arena);
+		retrace_real_impls.free(p.nodes);
+
+		ast->arena = all;
+		ast->arena_len = p.arena_len + nodes_bytes;
+		ast->root = root;
+		ast->node_cnt = p.node_cnt;
+	}
+
+	return ast;
+}
+
+void
+retrace_filter_free(struct retrace_filter_ast *ast)
+{
+	if (ast == NULL)
+		return;
+	retrace_real_impls.free(ast->arena);
+	retrace_real_impls.free(ast);
+}
+
+/* ---- evaluation --------------------------------------------------------- */
+
+/* Resolve an operand to a string (returns NULL when it is not
+ * string-typed or the value is unavailable).
+ */
+static const char *
+operand_str(const struct foperand *o, const struct ThreadContext *t_ctx,
+	    const char *func_name)
+{
+	switch (o->kind) {
+	case FO_STR:
+	case FO_FUNC:
+		return o->kind == FO_FUNC ? func_name : o->str;
+	case FO_CALLER:
+		return NULL;	/* resolved by the action layer */
+	case FO_PARAM: {
+		int i;
+
+		for (i = 0; i < t_ctx->params_cnt; i++) {
+			const struct FuncParam *fp = &t_ctx->params[i];
+
+			if (STR_EQ(fp->param_meta.name, o->str)) {
+				if ((fp->param_meta.modifiers &
+				     0x1 /* CDM_POINTER */) &&
+				    fp->val != 0 &&
+				    STR_EQ(fp->param_meta.ref_type_name, "sz"))
+					return (const char *)
+						(intptr_t) fp->val;
+				return NULL;
+			}
+		}
+		return NULL;
+	}
+	default:
+		return NULL;
+	}
+}
+
+static int
+operand_num(const struct foperand *o, const struct ThreadContext *t_ctx,
+	    long long *out, int *known)
+{
+	switch (o->kind) {
+	case FO_NUM:
+		*out = o->num;
+		*known = 1;
+		return 1;
+	case FO_RET:
+		*out = (long long) t_ctx->ret_val;
+		*known = 1;
+		return 1;
+	case FO_PARAM: {
+		int i;
+
+		for (i = 0; i < t_ctx->params_cnt; i++) {
+			const struct FuncParam *fp = &t_ctx->params[i];
+
+			if (STR_EQ(fp->param_meta.name, o->str)) {
+				/*
+				 * string params are compared with ~ /
+				 * == on strings, never as numbers
+				 */
+				if ((fp->param_meta.modifiers & 0x1) &&
+				    fp->val != 0 &&
+				    STR_EQ(fp->param_meta.ref_type_name,
+					   "sz"))
+					return 0;
+				*out = (long long) fp->val;
+				*known = 1;
+				return 1;
+			}
+		}
+		*known = 0;
+		return 1;
+	}
+	default:
+		return 0;	/* string-typed operand: not numeric */
+	}
+}
+
+static int
+eval_node(const struct fnode *n, const struct ThreadContext *t_ctx,
+	  const char *func_name)
+{
+	switch (n->kind) {
+	case FN_OR:
+		return eval_node(n->u.bin.lhs, t_ctx, func_name) ||
+		       eval_node(n->u.bin.rhs, t_ctx, func_name);
+	case FN_AND:
+		return eval_node(n->u.bin.lhs, t_ctx, func_name) &&
+		       eval_node(n->u.bin.rhs, t_ctx, func_name);
+	case FN_NOT:
+		return !eval_node(n->u.child, t_ctx, func_name);
+	case FN_CMP: {
+		const struct foperand *lhs = &n->u.cmp.lhs;
+		const struct foperand *rhs = &n->u.cmp.rhs;
+		enum fop_kind op = n->u.cmp.op;
+		long long l, r;
+		int lknown = 1, rknown = 1;
+
+		switch (op) {
+		case FO_GLOB:
+		case FO_NGLOB: {
+			const char *s = operand_str(lhs, t_ctx, func_name);
+			int m;
+
+			if (s == NULL)
+				return 0;
+			m = retrace_filter_glob_match(rhs->str, s);
+			return op == FO_GLOB ? m : !m;
+		}
+		default:
+			break;
+		}
+
+		if (!operand_num(lhs, t_ctx, &l, &lknown) ||
+		    !operand_num(rhs, t_ctx, &r, &rknown))
+			return 0;	/* string vs relational/typed mix */
+		if (!lknown || !rknown)
+			return 0;	/* unknown param: no match */
+
+		switch (op) {
+		case FO_EQ: return l == r;
+		case FO_NE: return l != r;
+		case FO_LT: return l < r;
+		case FO_LE: return l <= r;
+		case FO_GT: return l > r;
+		case FO_GE: return l >= r;
+		default: return 0;
+		}
+	}
+	}
+	return 0;
+}
+
+int
+retrace_filter_eval(const struct retrace_filter_ast *ast,
+		    const struct ThreadContext *t_ctx,
+		    const char *func_name)
+{
+	if (ast == NULL)
+		return 1;
+	if (t_ctx == NULL)
+		return 0;
+	return eval_node(ast->root, t_ctx, func_name);
+}

--- a/src/core/filter_dsl.h
+++ b/src/core/filter_dsl.h
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef RETRACE_CORE_FILTER_DSL_H_
+#define RETRACE_CORE_FILTER_DSL_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+/* Forward declaration only: the config validator compiles
+ * expressions without evaluating them, so the header carries
+ * no engine dependency (the .c file owns the ThreadContext).
+ */
+struct ThreadContext;
+
+/*
+ * The filter expression language (TODO.impl/08, ADR-0016's
+ * grammar-family sibling): the `filter` action's `expr` param.
+ *
+ *   disj   := conj ("or" conj)*
+ *   conj   := neg  ("and" neg)*
+ *   neg    := "not" neg | primary
+ *   primary:= "(" disj ")" | operand OP operand
+ *   OP     := == != < <= > >= ~ !~
+ *
+ * with `expr` = disj (the start production).
+ *   operand:= ident | number | "quoted string"
+ *
+ * Operands: a param NAME (evaluated against the call's params;
+ * string-typed params compare as strings, others as integers),
+ * a number, or a quoted string. Builtins: `func` (the current
+ * function's name, glob-comparable), `ret` (the thread
+ * context's ret_val -- meaningful after a call_real action),
+ * `caller` (the caller's symbol via dladdr, glob-comparable).
+ * `~` is a glob match (`*`, `?`, `[...]`; no fnmatch -- this
+ * is the portable matcher every lane shares).
+ *
+ * Relational operators (< <= > >=) require numeric operands;
+ * mixing a string with them is a COMPILE error, not a runtime
+ * surprise. An ident the call does not have (unknown param)
+ * evaluates FALSE -- the filter aborts the script, same as the
+ * legacy single-comparison form.
+ *
+ * A compiled predicate is an opaque tree, arena-allocated in
+ * one block: compile once (at config validation), evaluate per
+ * call. Errors report a message and the 1-based character
+ * offset in the source expression.
+ */
+
+struct retrace_filter_ast;
+
+/* Compile `expr`. Returns NULL on error and fills `err`
+ * (reason + offset) when `err_cap` > 0. The result is freed
+ * with retrace_filter_free().
+ */
+struct retrace_filter_ast *retrace_filter_compile(
+	const char *expr, char *err, size_t err_cap);
+
+void retrace_filter_free(struct retrace_filter_ast *ast);
+
+/* Evaluate against a call. `func_name` is the intercepted
+ * function (t_ctx->prototype->name on the engine path).
+ * Returns 1 (match -- continue the script) or 0 (no match).
+ * NULL ast matches everything (zero-cost when absent).
+ */
+int retrace_filter_eval(const struct retrace_filter_ast *ast,
+	const struct ThreadContext *t_ctx, const char *func_name);
+
+/*
+ * Portable glob: `*`, `?`, `[...]` classes with `!`/`^`
+ * negation and `-` ranges; `\` escapes. This is the single
+ * matcher for expressions, caller globs, and anything else
+ * that grows the grammar family (no fnmatch -- Windows).
+ */
+int retrace_filter_glob_match(const char *pattern, const char *text);
+
+#endif /* RETRACE_CORE_FILTER_DSL_H_ */

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -392,6 +392,17 @@ if(Python3_Interpreter_FOUND)
 		LABELS "integration"
 		TIMEOUT 120)
 
+	# The filter expression language (TODO.impl/08): only
+	# matching calls reach the log; a bad expression refuses
+	# the config at boot. Runs on every preload lane.
+	add_test(NAME integration-filter-expr
+		COMMAND ${Python3_EXECUTABLE}
+			${CMAKE_SOURCE_DIR}/test/integration/test_filter_expr.py
+			$<TARGET_FILE:retrace_v2>)
+	set_tests_properties(integration-filter-expr PROPERTIES
+		LABELS "integration"
+		TIMEOUT 60)
+
 	# The reference compose stack (TODO.impl/16): CI validates
 	# the compose file; the full up/down flow is the README's
 	# laptop path (verified live on this stack's bring-up).

--- a/test/integration/test_filter_expr.py
+++ b/test/integration/test_filter_expr.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""
+E2E: the filter expression language (TODO.impl/08) on the live
+preload lane. A target opens .log and .txt files; a filter
+expression admits only the .log opens to log_params -- the log
+carries foo.log, never foo.txt. A second run pins the config
+contract: a bad expression is a CONFIG ERROR (refused at boot,
+error in the evidence), not a silent no-match.
+
+Usage: test_filter_expr.py <lib-path>
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+TARGET_SRC = r"""
+#include <fcntl.h>
+#include <stdio.h>
+#include <unistd.h>
+
+int main(void)
+{
+	int i;
+
+	for (i = 0; i < 3; i++) {
+		int a = open("foo.log", O_RDONLY);
+		int b = open("foo.txt", O_RDONLY);
+		int c = open("bar.log", O_RDONLY);
+
+		if (a >= 0) close(a);
+		if (b >= 0) close(b);
+		if (c >= 0) close(c);
+	}
+	printf("done\n");
+	return 0;
+}
+"""
+
+
+def run_with_config(lib, work, cfg_obj):
+    cfg = os.path.join(work, "cfg.json")
+    with open(cfg, "w") as f:
+        json.dump(cfg_obj, f)
+
+    log = os.path.join(work, "evidence.log")
+    env = dict(os.environ)
+    env["RETRACE_JSON_CONFIG"] = cfg
+    env["RETRACE_LOGGER_DEF_ENA"] = "1"
+    env["RETRACE_LOGGER_DEF_STDOUT_ENA"] = "0"
+    env["RETRACE_LOGGER_DEF_FN"] = log
+    if sys.platform == "darwin":
+        env["DYLD_INSERT_LIBRARIES"] = lib
+    else:
+        env["LD_PRELOAD"] = lib
+    return subprocess.run([os.path.join(work, "target")],
+                          env=env, stdout=subprocess.PIPE,
+                          stderr=subprocess.STDOUT,
+                          timeout=30), log
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("usage: test_filter_expr.py <lib-path>", file=sys.stderr)
+        return 2
+
+    lib = os.path.abspath(sys.argv[1])
+    work = tempfile.mkdtemp(prefix="filter-expr-")
+
+    with open(os.path.join(work, "target.c"), "w") as f:
+        f.write(TARGET_SRC)
+    build = subprocess.run(
+        ["cc", "-o", os.path.join(work, "target"),
+         os.path.join(work, "target.c")],
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    if build.returncode != 0:
+        print("FAIL: target build failed", file=sys.stderr)
+        return 1
+
+    script = {
+        "func_name": "open",
+        "actions": [
+            {"action_name": "filter",
+             "action_params": {"expr": "path ~ \"*.log\""}},
+            {"action_name": "log_params"},
+            {"action_name": "call_real"}]}
+    p, log = run_with_config(lib, work, {"intercept_scripts": [script]})
+    if p.returncode != 0 or b"done" not in p.stdout:
+        print(f"FAIL: target died:\n{p.stdout.decode()[-500:]}",
+              file=sys.stderr)
+        return 1
+
+    with open(log, "r", errors="replace") as f:
+        ev = f.read().replace("\\/", "/")
+
+    logged_opens = ev.count('"func": "open"')
+    if logged_opens == 0:
+        print("FAIL: nothing logged (filter matched nothing)",
+              file=sys.stderr)
+        return 1
+    if "foo.txt" in ev:
+        print("FAIL: foo.txt was logged -- the expression let it "
+              "through", file=sys.stderr)
+        return 1
+    if "foo.log" not in ev or "bar.log" not in ev:
+        print("FAIL: the .log opens were not logged", file=sys.stderr)
+        return 1
+    print(f"filter held: {logged_opens} .log opens logged, "
+          "foo.txt absent")
+
+    bad = {"intercept_scripts": [{
+        "func_name": "open",
+        "actions": [
+            {"action_name": "filter",
+             "action_params": {"expr": "path ~ "}},
+            {"action_name": "call_real"}]}]}
+    p, log = run_with_config(lib, work, bad)
+    with open(log, "r", errors="replace") as f:
+        ev = f.read()
+
+    if "filter expr" not in ev:
+        print(f"FAIL: bad expression accepted silently:\n{ev[-500:]}",
+              file=sys.stderr)
+        return 1
+    print("config contract held: bad expression refused at boot")
+    print("PASS: filter expression language works end to end")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -668,6 +668,18 @@ endif()
 # mapping (deny -> -errno, DEFERRED sentinel, exit override) are
 # pure-frame semantics -- the E2E rides them against a live tracee.
 #
+#
+# Filter DSL unit tests (TODO.impl/08): STANDALONE -- the parser
+# and evaluator against fakes, no engine link (the card-06
+# lesson: engine-linked test binaries interpose themselves).
+# Includes the property suite (seeded random trees, truth by
+# construction).
+#
+retrace_add_unit_test(filter_dsl
+    STANDALONE
+    EXTRA_SOURCES ${CMAKE_SOURCE_DIR}/src/core/filter_dsl.c
+    EXTRA_INCLUDES ${CMAKE_SOURCE_DIR}/src/core ${_unit_arch_include})
+
 if(RETRACE_PLATFORM_LINUX)
     # STANDALONE: compiles the dispatcher + the syscall-lane table
     # against fakes -- no engine link, no constructor, no

--- a/test/unit/test_filter_dsl.c
+++ b/test/unit/test_filter_dsl.c
@@ -1,0 +1,434 @@
+/*
+ * Copyright (c) 2017, [Ribose Inc](https://www.ribose.com).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * Unit: the filter expression language (TODO.impl/08) --
+ * STANDALONE, the card-06 lesson: the parser and evaluator are
+ * compiled against fakes, no engine link, no interposition.
+ *
+ * Fixed cases pin the glob matcher, precedence, parens, not,
+ * builtins, typing rules, and error offsets. The property part
+ * builds random boolean trees over numeric params, renders
+ * each tree to a random-shaped expression string, compiles it,
+ * and evaluates over generated calls -- asserting the compiled
+ * predicate agrees with the truth computed from the same tree
+ * by construction. Deterministic (fixed seed).
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "engine.h"
+#include "filter_dsl.h"
+#include "real_impls.h"
+
+static int tests_run;
+static int tests_pass;
+static int tests_fail;
+
+#define TEST(name) do { \
+	tests_run++; \
+	printf("  TEST %s ... ", #name); \
+	test_##name(); \
+	tests_pass++; \
+	printf("OK\n"); \
+} while (0)
+
+#define CHECK(cond) do { \
+	if (!(cond)) { \
+		printf("FAIL [%s:%d] %s\n", __FILE__, __LINE__, #cond); \
+		tests_fail++; \
+		return; \
+	} \
+} while (0)
+
+/* ---- fakes ------------------------------------------------------------- */
+
+struct RetraceRealImpls retrace_real_impls;
+
+static void *fake_malloc(size_t n) { return malloc(n); }
+static void fake_free(void *p) { free(p); }
+static void *fake_memset(void *d, int c, size_t n) { return memset(d, c, n); }
+static void *fake_memcpy(void *d, const void *s, size_t n) { return memcpy(d, s, n); }
+static int fake_strcmp(const char *a, const char *b) { return strcmp(a, b); }
+static int fake_strncmp(const char *a, const char *b, size_t n) { return strncmp(a, b, n); }
+static size_t fake_strlen(const char *s) { return strlen(s); }
+static int fake_snprintf(char *s, size_t n, const char *f, ...)
+{
+	int rc;
+	va_list ap;
+
+	va_start(ap, f);
+	rc = vsnprintf(s, n, f, ap);
+	va_end(ap);
+	return rc;
+}
+
+/* ---- glob --------------------------------------------------------------- */
+
+static void test_glob_basics(void)
+{
+	CHECK(retrace_filter_glob_match("*.log", "app.log"));
+	CHECK(!retrace_filter_glob_match("*.log", "app.txt"));
+	CHECK(retrace_filter_glob_match("a?c", "abc"));
+	CHECK(!retrace_filter_glob_match("a?c", "abbc"));
+	CHECK(retrace_filter_glob_match("*", ""));
+	CHECK(retrace_filter_glob_match("[a-c]x", "bx"));
+	CHECK(!retrace_filter_glob_match("[a-c]x", "dx"));
+	CHECK(retrace_filter_glob_match("[!a-c]x", "dx"));
+	CHECK(!retrace_filter_glob_match("[!a-c]x", "ax"));
+	CHECK(retrace_filter_glob_match("[]]x", "]x"));
+	CHECK(retrace_filter_glob_match("\\*x", "*x"));
+	CHECK(!retrace_filter_glob_match("\\*x", "ax"));
+	CHECK(retrace_filter_glob_match("*.*.conf", "a.b.conf"));
+	CHECK(retrace_filter_glob_match("etc/*", "etc/"));
+}
+
+/* ---- parse errors ------------------------------------------------------- */
+
+static void expect_compile_fails(const char *expr, const char *needle)
+{
+	char err[128];
+	struct retrace_filter_ast *ast = retrace_filter_compile(
+		expr, err, sizeof(err));
+
+	if (ast != NULL) {
+		printf("FAIL: '%s' compiled but should not\n", expr);
+		tests_fail++;
+		retrace_filter_free(ast);
+		return;
+	}
+	if (strstr(err, needle) == NULL) {
+		printf("FAIL: '%s': error '%s' lacks '%s'\n",
+			expr, err, needle);
+		tests_fail++;
+		return;
+	}
+}
+
+static void expect_compiles(const char *expr)
+{
+	char err[128];
+	struct retrace_filter_ast *ast = retrace_filter_compile(
+		expr, err, sizeof(err));
+
+	if (ast == NULL) {
+		printf("FAIL: '%s': %s\n", expr, err);
+		tests_fail++;
+		return;
+	}
+	retrace_filter_free(ast);
+}
+
+static void test_compile_errors(void)
+{
+	expect_compile_fails("", "empty");
+	expect_compile_fails("a ==", "expected operand");
+	expect_compile_fails("(a == 1", "expected ')'");
+	expect_compile_fails("a == 1)", "trailing");
+	expect_compile_fails("\"unterminated == 1", "unterminated string");
+	/*
+	 * a STRING param under a relational op compiles (params
+	 * are dynamically typed) and evaluates FALSE at runtime
+	 * -- pinned in eval_basics, not here
+	 */
+	expect_compiles("s < 3");
+	expect_compile_fails("3 > \"x\"", "numeric");
+	expect_compile_fails("a ~ b", "string literal");
+	expect_compile_fails("and", "expected operand");
+	expect_compiles("a == 1");
+	expect_compiles("not (a == 1 or b != 2) and c <= 3");
+	expect_compiles("func ~ \"open*\" and path ~ \"*.log\"");
+	expect_compiles("ret >= 0 or ret == -1");
+}
+
+/* ---- evaluation --------------------------------------------------------- */
+
+/* a call with two numeric params (a, b) and one string param (s) */
+static struct ThreadContext *mkcall(long long a, long long b,
+				    const char *s, const char *func)
+{
+	static struct ThreadContext ctx;
+	static char sbuf[64];
+
+	memset(&ctx, 0, sizeof(ctx));
+	strncpy(sbuf, s ? s : "", sizeof(sbuf) - 1);
+
+	ctx.prototype = NULL;
+	ctx.params_cnt = 3;
+	ctx.params[0].param_meta.name[0] = 'a';
+	ctx.params[0].param_meta.name[1] = '\0';
+	ctx.params[0].val = (intptr_t) a;
+	ctx.params[1].param_meta.name[0] = 'b';
+	ctx.params[1].param_meta.name[1] = '\0';
+	ctx.params[1].val = (intptr_t) b;
+	ctx.params[2].param_meta.name[0] = 's';
+	ctx.params[2].param_meta.name[1] = '\0';
+	ctx.params[2].param_meta.modifiers = 0x1;	/* CDM_POINTER */
+	strcpy(ctx.params[2].param_meta.ref_type_name, "sz");
+	ctx.params[2].val = (intptr_t) (s != NULL ? sbuf : 0);
+	ctx.ret_val = a;
+	(void) func;
+	return &ctx;
+}
+
+static int evals(const char *expr, struct ThreadContext *c,
+		 const char *func)
+{
+	char err[128];
+	struct retrace_filter_ast *ast = retrace_filter_compile(
+		expr, err, sizeof(err));
+	int r;
+
+	if (ast == NULL) {
+		printf("FAIL compile '%s': %s\n", expr, err);
+		tests_fail++;
+		return -1;
+	}
+	r = retrace_filter_eval(ast, c, func);
+	retrace_filter_free(ast);
+	return r;
+}
+
+static void test_eval_basics(void)
+{
+	CHECK(evals("a == 1", mkcall(1, 0, NULL, "open"), "open") == 1);
+	CHECK(evals("a == 1", mkcall(2, 0, NULL, "open"), "open") == 0);
+	CHECK(evals("a != 1", mkcall(2, 0, NULL, "open"), "open") == 1);
+	CHECK(evals("a < b", mkcall(1, 2, NULL, "open"), "open") == 1);
+	CHECK(evals("a >= b", mkcall(1, 2, NULL, "open"), "open") == 0);
+	CHECK(evals("s ~ \"*.log\"", mkcall(0, 0, "app.log", "open"),
+		    "open") == 1);
+	CHECK(evals("s ~ \"*.log\"", mkcall(0, 0, "app.txt", "open"),
+		    "open") == 0);
+	CHECK(evals("func ~ \"open*\"", mkcall(0, 0, NULL, "openat"),
+		    "openat") == 1);
+	CHECK(evals("ret == 5", mkcall(5, 0, NULL, "x"), "x") == 1);
+	/* unknown param: no match, never an error */
+	CHECK(evals("zz == 1", mkcall(1, 0, NULL, "open"), "open") == 0);
+	/* precedence: and binds tighter than or */
+	CHECK(evals("a == 1 or a == 2 and b == 3",
+		    mkcall(1, 0, NULL, "f"), "f") == 1);
+	CHECK(evals("(a == 1 or a == 2) and b == 3",
+		    mkcall(1, 0, NULL, "f"), "f") == 0);
+	/* not */
+	CHECK(evals("not a == 1", mkcall(2, 0, NULL, "f"), "f") == 1);
+	CHECK(evals("not not a == 1", mkcall(2, 0, NULL, "f"), "f") == 0);
+	/* string param under relational: runtime-false, never true */
+	CHECK(evals("s < 3", mkcall(0, 0, "x", "f"), "f") == 0);
+}
+
+/* ---- property part: random trees, truth by construction ---------------- */
+
+static unsigned long long rng_state = 0x5eed1234ULL;
+
+static unsigned long long rng(void)
+{
+	rng_state = rng_state * 6364136223846793005ULL + 1442695040888963407ULL;
+	return rng_state >> 17;
+}
+
+static long long rng_num(void)
+{
+	return (long long) (rng() % 21) - 10;
+}
+
+/* a generated tree node */
+enum gkind { G_CMP, G_NOT, G_AND, G_OR };
+enum gop { G_EQ, G_NE, G_LT, G_LE, G_GT, G_GE };
+
+struct gtree {
+	enum gkind kind;
+	/* G_CMP */
+	int lhs_param;		/* 0=a, 1=b */
+	enum gop op;
+	long long rhs;
+	/* G_NOT/G_AND/G_OR */
+	struct gtree *l, *r;
+};
+
+static int gdepth;
+
+static void gtree_gen(struct gtree *out)
+{
+	if (gdepth >= 3 || (rng() % 100) < 45) {
+		out->kind = G_CMP;
+		out->lhs_param = (int) (rng() % 2);
+		out->op = (enum gop) (rng() % 6);
+		out->rhs = rng_num();
+		out->l = out->r = NULL;
+		return;
+	}
+
+	gdepth++;
+	out->l = malloc(sizeof(struct gtree));
+	out->r = malloc(sizeof(struct gtree));
+	out->kind = (rng() % 100) < 25 ? G_NOT : (rng() % 2 ? G_AND : G_OR);
+	if (out->kind == G_NOT) {
+		gtree_gen(out->l);
+		free(out->r);
+		out->r = NULL;
+	} else {
+		gtree_gen(out->l);
+		gtree_gen(out->r);
+	}
+	gdepth--;
+}
+
+static void gtree_free(struct gtree *t)
+{
+	if (t == NULL)
+		return;
+	gtree_free(t->l);
+	gtree_free(t->r);
+	free(t);
+}
+
+static const char *gop_str[] = { "==", "!=", "<", "<=", ">", ">=" };
+
+static void gtree_render(const struct gtree *t, char *buf, size_t cap)
+{
+	if (t->kind == G_CMP) {
+		snprintf(buf, cap, "%s %s %lld",
+			t->lhs_param == 0 ? "a" : "b",
+			gop_str[t->op], t->rhs);
+		return;
+	}
+	if (t->kind == G_NOT) {
+		snprintf(buf, cap, "not ");
+		gtree_render(t->l, buf + 4, cap - 4);
+		return;
+	}
+	{
+		size_t half = cap / 2;
+
+		snprintf(buf, cap, "(");
+		gtree_render(t->l, buf + 1, half);
+		strcat(buf, t->kind == G_AND ? " and " : " or ");
+		gtree_render(t->r, buf + strlen(buf), cap - strlen(buf) - 1);
+		strcat(buf, ")");
+	}
+}
+
+static int gtree_truth(const struct gtree *t, long long a, long long b)
+{
+	long long l;
+
+	switch (t->kind) {
+	case G_CMP:
+		l = t->lhs_param == 0 ? a : b;
+		switch (t->op) {
+		case G_EQ: return l == t->rhs;
+		case G_NE: return l != t->rhs;
+		case G_LT: return l < t->rhs;
+		case G_LE: return l <= t->rhs;
+		case G_GT: return l > t->rhs;
+		case G_GE: return l >= t->rhs;
+		}
+		return 0;
+	case G_NOT: return !gtree_truth(t->l, a, b);
+	case G_AND:
+		return gtree_truth(t->l, a, b) && gtree_truth(t->r, a, b);
+	case G_OR:
+		return gtree_truth(t->l, a, b) || gtree_truth(t->r, a, b);
+	}
+	return 0;
+}
+
+static void test_property_truth_tables(void)
+{
+	int tree_i;
+
+	for (tree_i = 0; tree_i < 60; tree_i++) {
+		struct gtree t;
+		char expr[256];
+		char err[128];
+		struct retrace_filter_ast *ast;
+		int call_i;
+		int bad = 0;
+
+		gdepth = 0;
+		gtree_gen(&t);
+		gtree_render(&t, expr, sizeof(expr));
+
+		ast = retrace_filter_compile(expr, err, sizeof(err));
+		if (ast == NULL) {
+			printf("FAIL compile '%s': %s\n", expr, err);
+			tests_fail++;
+			gtree_free(t.l);
+			gtree_free(t.r);
+			continue;
+		}
+
+		for (call_i = 0; call_i < 40; call_i++) {
+			long long a = rng_num();
+			long long b = rng_num();
+			struct ThreadContext *c = mkcall(a, b, NULL, "f");
+			int want = gtree_truth(&t, a, b);
+			int got = retrace_filter_eval(ast, c, "f");
+
+			if (want != got) {
+				printf("FAIL '%s' a=%lld b=%lld: want %d "
+				       "got %d\n", expr, a, b, want, got);
+				bad = 1;
+				break;
+			}
+		}
+
+		retrace_filter_free(ast);
+		gtree_free(t.l);
+		gtree_free(t.r);
+		if (bad) {
+			tests_fail++;
+			return;
+		}
+	}
+}
+
+int
+main(void)
+{
+	memset(&retrace_real_impls, 0, sizeof(retrace_real_impls));
+	retrace_real_impls.malloc = fake_malloc;
+	retrace_real_impls.free = fake_free;
+	retrace_real_impls.memset = fake_memset;
+	retrace_real_impls.memcpy = fake_memcpy;
+	retrace_real_impls.strcmp = fake_strcmp;
+	retrace_real_impls.strncmp = fake_strncmp;
+	retrace_real_impls.strlen = fake_strlen;
+	retrace_real_impls.real_snprintf = fake_snprintf;
+
+	printf("filter DSL (TODO.impl/08)\n");
+
+	TEST(glob_basics);
+	TEST(compile_errors);
+	TEST(eval_basics);
+	TEST(property_truth_tables);
+
+	printf("%d run, %d pass, %d fail\n",
+		tests_run, tests_pass, tests_fail);
+	return tests_fail == 0 ? 0 : 1;
+}


### PR DESCRIPTION
TODO.impl/08 — **the filter expression language: queries as config**.

## The language

The `filter` action gains an `expr` param — a small predicate language:

```
expr   := or
or     := and ("or" and)*
and    := not ("and" not)*
not    := "not" not | primary
primary:= "(" expr ")" | operand OP operand
OP     := == != < <= > >= ~ !~
```

Operands: params by name (`path`, `flags`, …), numbers, quoted strings, and the builtins `func` / `ret` / `caller`. `~` is a glob match (`*`, `?`, `[a-z]`). The legacy `param_name`/`op`/`value` triple stays, unchanged.

## The module

`src/core/filter_dsl.{c,h}` — self-contained: recursive-descent parser building one arena-allocated tree, a portable glob matcher (no fnmatch; Windows rides along), zero libc calls (everything through `retrace_real_impls` — the parser runs inside the engine). Compiled once, cached on the expression string's identity + content guard (the sandbox compiled-set lesson).

**Typing is honest**: string params compare with `~`/`==`/`!=`; a relational on a string param is runtime-false; an unknown param is false, never an error; a relational on a *literal* string is a compile error. **A bad expression refuses the whole config at boot** with a reason and character offset — never a silent no-match.

## Specs

- `unit-test-filter-dsl` — STANDALONE (the card-06 lesson: engine-linked test binaries interpose themselves): glob classes, error offsets, precedence, builtins, plus a seeded **property suite** — random boolean trees rendered to expressions, truth asserted by construction over generated calls.
- `integration-filter-expr` — live on the preload lane: only `*.log` opens reach the log, `foo.txt` never does; a broken expression refuses the config.

Docs: cookbook recipe 43 + the `configuration.md` action reference. Recipe count honestly 43.
