### PR TITLE
v2.93.0 version bump

### DIFF
--- a/include/retrace/version.h
+++ b/include/retrace/version.h
@@ -38,10 +38,10 @@
 
 #define RETRACE_VERSION_MAJOR 2
 #define RETRACE_VERSION_MAJOR 2
-#define RETRACE_VERSION_MINOR 92
+#define RETRACE_VERSION_MINOR 93
 #define RETRACE_VERSION_PATCH 0
 
-#define RETRACE_VERSION_STRING "2.92.0"
+#define RETRACE_VERSION_STRING "2.93.0"
 
 #define RETRACE_VERSION_ATLEAST(maj, min, pat)                  \
 	(RETRACE_VERSION_MAJOR > (maj) ||                       \


### PR DESCRIPTION
Version bump to 2.93.0.

Releases the filter expression language (PR #827): **queries as config**.

- `filter`'s `expr` param: params by name, numbers, strings, `func`/`ret`/`caller` builtins, globs (`~`, `!~`), comparisons, `and`/`or`/`not`, parentheses
- Compiled once (arena-allocated predicate tree, cached on the expression's identity); portable glob matcher — Windows rides along
- Honest typing: strings compare with `~`/`==`/`!=`; relational-on-string is runtime-false; unknown params are false, never errors
- A bad expression REFUSES the whole config at boot with reason and offset — never a silent no-match
- Recipe 43, the `configuration.md` action reference, a seeded property suite (truth by construction), and the live E2E on every preload lane

- `RETRACE_VERSION_MINOR` 92 → 93
- `RETRACE_VERSION_STRING` "2.92.0" → "2.93.0"
